### PR TITLE
Fix timezone handling for embed timestamps

### DIFF
--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for direct imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from utils.embeds import ModdyEmbed
+
+def test_timestamp_is_timezone_aware():
+    embed = ModdyEmbed.create(description="desc", timestamp=True)
+    assert embed.timestamp is not None
+    assert embed.timestamp.tzinfo is not None

--- a/utils/embeds.py
+++ b/utils/embeds.py
@@ -5,7 +5,7 @@ Style moderne avec couleurs élégantes
 
 import discord
 from typing import List, Optional, Dict, Any, Union
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class ModdyColors:
@@ -95,7 +95,8 @@ class ModdyEmbed:
             embed.set_image(url=image)
 
         if timestamp:
-            embed.timestamp = datetime.utcnow()
+            # Utilise un datetime timezone-aware pour éviter les avertissements
+            embed.timestamp = datetime.now(timezone.utc)
 
         return embed
 
@@ -197,7 +198,7 @@ def format_diagnostic_embed(data: dict) -> discord.Embed:
     embed = discord.Embed(
         title="Diagnostic Système",
         color=ModdyColors.PRIMARY,
-        timestamp=datetime.utcnow()
+        timestamp=datetime.now(timezone.utc)
     )
 
     # Section Discord API


### PR DESCRIPTION
## Summary
- ensure embed timestamps use timezone-aware `datetime`
- add regression test for embed timestamp timezone awareness

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895076f7250832fa1670f6050930a7d