### PR TITLE
Fix English language file loading issue

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -89,6 +89,6 @@
     "ro": "Romanian",
     "hu": "Hungarian",
     "uk": "Ukrainian",
-    "bg": "Bulgarian",
+    "bg": "Bulgarian"
   }
 }


### PR DESCRIPTION
The English locale file had an invalid trailing comma on line 93 in the "languages" object, causing JSON parsing to fail. This prevented the English translations from loading while French worked fine.