### PR TITLE
feat(staff): Add d.jsk command for live Python code execution

### DIFF
--- a/STAFF_SYSTEM.md
+++ b/STAFF_SYSTEM.md
@@ -210,6 +210,37 @@ Execute SQL queries directly on the database. Requires confirmation for dangerou
 <@&1386452009678278818> d.sql SELECT * FROM users LIMIT 10
 ```
 
+### d.jsk [code]
+
+Execute Python code directly in the bot's runtime environment. Supports async/await and has access to bot context.
+
+**Usage:**
+```
+<@&1386452009678278818> d.jsk print("Hello World")
+<@&1386452009678278818> d.jsk return len(bot.guilds)
+<@&1386452009678278818> d.jsk await message.channel.send("Test")
+```
+
+**Available Variables:**
+- `bot` - Bot instance
+- `message` - Message object
+- `channel` - Current channel
+- `author` - Command author
+- `guild` - Current guild
+- `db` - Database instance
+- `discord`, `commands`, `asyncio`, `datetime`, `timezone` - Common modules
+
+**Code Blocks:**
+You can use Python code blocks for multi-line code:
+```
+<@&1386452009678278818> d.jsk ```python
+guilds = bot.guilds
+print(f"Bot is in {len(guilds)} guilds")
+for guild in guilds[:5]:
+    print(f"- {guild.name}")
+\```
+```
+
 ## Moderator Commands (mod. prefix)
 
 Available to Manager, Supervisor_Mod, and Moderator.

--- a/staff/team_commands.py
+++ b/staff/team_commands.py
@@ -336,7 +336,8 @@ class TeamCommands(commands.Cog):
                 ("d.reload [extension]", "Reload bot extensions"),
                 ("d.shutdown", "Shutdown the bot"),
                 ("d.stats", "Show bot statistics"),
-                ("d.sql [query]", "Execute SQL query")
+                ("d.sql [query]", "Execute SQL query"),
+                ("d.jsk [code]", "Execute Python code")
             ]
 
             embed.add_field(


### PR DESCRIPTION
Added d.jsk command for developers to execute Python code in real-time within the bot's runtime environment.

Features:
- Execute Python code with async/await support
- Automatic code block parsing (```python)
- Rich execution context with bot, message, channel, author, guild, db
- Output capture with stdout redirection
- Error handling with full traceback display
- Return value display
- Output truncation for large results

Usage examples:
- <@&1386452009678278818> d.jsk print("Hello")
- <@&1386452009678278818> d.jsk return len(bot.guilds)
- <@&1386452009678278818> d.jsk await channel.send("Test")

Available context variables:
- bot, message, channel, author, guild, db
- discord, commands, asyncio, datetime, timezone

Updated:
- staff/dev_commands.py - Added handle_jsk_command()
- staff/team_commands.py - Added d.jsk to help command
- STAFF_SYSTEM.md - Complete documentation with examples

This replaces the old Jishaku integration with a native implementation integrated into the new staff permissions system.