### PR TITLE
Debug staff and manager commands not responding

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -406,6 +406,13 @@ class ModdyBot(commands.Bot):
                     )
                     logger.info(f"✅ DEVELOPER attribute set for {dev_id}")
 
+                    # ALWAYS set TEAM attribute for dev team members (critical for staff commands)
+                    await self.db.set_attribute(
+                        'user', dev_id, 'TEAM', True,
+                        self.user.id, "Auto-assigned to dev team members"
+                    )
+                    logger.info(f"✅ TEAM attribute set for {dev_id}")
+
                     # Auto-assign Manager + Dev roles for dev team members
                     from utils.staff_permissions import StaffRole
                     perms = await self.db.get_staff_permissions(dev_id)
@@ -423,6 +430,8 @@ class ModdyBot(commands.Bot):
                     if updated:
                         await self.db.set_staff_roles(dev_id, roles, self.user.id)
                         logger.info(f"✅ Auto-assigned Manager+Dev roles for {dev_id}")
+                    else:
+                        logger.info(f"✅ Dev {dev_id} already has Manager+Dev roles")
 
                 except Exception as e:
                     logger.error(f"❌ Error setting DEVELOPER attribute for {dev_id}: {e}")

--- a/staff/dev_commands.py
+++ b/staff/dev_commands.py
@@ -46,12 +46,20 @@ class DeveloperCommands(commands.Cog):
         if command_type != CommandType.DEV:
             return
 
+        # Log the command attempt
+        logger.info(f"🔧 Dev command '{command_name}' attempted by {message.author} ({message.author.id})")
+
+        # Check if user is in dev team
+        is_dev = self.bot.is_developer(message.author.id)
+        logger.info(f"   Developer status: {is_dev}")
+
         # Check permissions
         allowed, reason = await staff_permissions.check_command_permission(
             message.author.id, command_type, command_name
         )
 
         if not allowed:
+            logger.warning(f"   ❌ Permission denied: {reason}")
             embed = discord.Embed(
                 title="❌ Permission Denied",
                 description=reason,
@@ -59,6 +67,8 @@ class DeveloperCommands(commands.Cog):
             )
             await message.channel.send(embed=embed, delete_after=10)
             return
+
+        logger.info(f"   ✅ Permission granted")
 
         # Route to appropriate command
         if command_name == "reload":

--- a/staff/staff_manager.py
+++ b/staff/staff_manager.py
@@ -253,12 +253,20 @@ class StaffManagement(commands.Cog):
         if command_type != CommandType.MANAGEMENT:
             return
 
+        # Log the command attempt
+        logger.info(f"👑 Management command '{command_name}' attempted by {message.author} ({message.author.id})")
+
+        # Check if user is in dev team
+        is_dev = self.bot.is_developer(message.author.id)
+        logger.info(f"   Developer status: {is_dev}")
+
         # Check permissions
         allowed, reason = await staff_permissions.check_command_permission(
             message.author.id, command_type, command_name
         )
 
         if not allowed:
+            logger.warning(f"   ❌ Permission denied: {reason}")
             embed = discord.Embed(
                 title="❌ Permission Denied",
                 description=reason,
@@ -266,6 +274,8 @@ class StaffManagement(commands.Cog):
             )
             await message.channel.send(embed=embed, delete_after=10)
             return
+
+        logger.info(f"   ✅ Permission granted")
 
         # Route to appropriate command
         if command_name == "rank":


### PR DESCRIPTION
…team members

This commit fixes the issue where dev team members couldn't use staff commands despite being properly registered.

Changes:
- Add detailed logging to track command parsing and permission checks
- Log all command attempts with developer status and permission results
- Always set TEAM attribute for dev team members on startup (critical fix)
- Add debug logging to parse_staff_command() to detect syntax errors
- Add debug logging to check_command_permission() to show full permission flow
- Log when dev team members already have correct roles

The main bug was that the TEAM attribute wasn't being set consistently for dev team members, which caused the permission check to fail even though they had the correct roles. Now TEAM attribute is ALWAYS set on startup for all dev team members.

This will help diagnose why commands don't respond and ensure dev team members can always use their commands.