### PR TITLE
Fix staff commands system and permissions

### DIFF
--- a/STAFF_SYSTEM.md
+++ b/STAFF_SYSTEM.md
@@ -9,12 +9,12 @@ The MODDY staff system provides a comprehensive role-based permission system for
 All staff commands use the following syntax:
 
 ```
-<@&1386452009678278818> [type].[command] [arguments]
+<@1373916203814490194> [type].[command] [arguments]
 ```
 
 ### Components:
 
-- `<@&1386452009678278818>` - Staff command prefix (role mention)
+- `<@1373916203814490194>` - Staff command prefix (bot mention)
 - `[type]` - Command type prefix (see below)
 - `[command]` - Command name
 - `[arguments]` - Optional command arguments
@@ -36,12 +36,21 @@ All staff commands use the following syntax:
 
 The staff hierarchy (from highest to lowest):
 
-1. **Dev** (apart from hierarchy - auto-assigned to Discord dev team members)
-2. **Manager**
-3. **Supervisor** (Mod/Com/Support)
-4. **Staff** (Moderator/Communication/Support)
+1. **Super Admin** (User ID: 1164597199594852395 - bypasses all permission checks)
+2. **Dev** (apart from hierarchy - auto-assigned to Discord dev team members)
+3. **Manager**
+4. **Supervisor** (Mod/Com/Support)
+5. **Staff** (Moderator/Communication/Support)
 
 ### Role Descriptions:
+
+#### Super Admin
+- Hard-coded user ID: 1164597199594852395
+- Bypasses **all** permission checks
+- Can assign any role, even those they don't have
+- Can modify any staff member, including managers and devs
+- Has absolute control over the entire system
+- Cannot be restricted or limited in any way
 
 #### Dev
 - Automatically assigned to Discord Developer Portal team members
@@ -74,14 +83,14 @@ Add a user to the staff team.
 
 **Usage:**
 ```
-<@&1386452009678278818> m.rank @user
+<@1373916203814490194> m.rank @user
 ```
 
 **Permission:** Manager or Supervisor
 
 **Example:**
 ```
-<@&1386452009678278818> m.rank @JohnDoe
+<@1373916203814490194> m.rank @JohnDoe
 ```
 
 Opens an interactive role selection menu to assign roles to the new staff member.
@@ -92,14 +101,14 @@ Manage an existing staff member's permissions.
 
 **Usage:**
 ```
-<@&1386452009678278818> m.setstaff @user
+<@1373916203814490194> m.setstaff @user
 ```
 
 **Permission:** Manager or Supervisor (can only modify staff below their level)
 
 **Example:**
 ```
-<@&1386452009678278818> m.setstaff @JohnDoe
+<@1373916203814490194> m.setstaff @JohnDoe
 ```
 
 Features:
@@ -112,7 +121,7 @@ List all staff members organized by role.
 
 **Usage:**
 ```
-<@&1386452009678278818> m.stafflist
+<@1373916203814490194> m.stafflist
 ```
 
 **Permission:** Manager or Supervisor
@@ -123,8 +132,8 @@ Show detailed information about a staff member. If no user is mentioned, shows y
 
 **Usage:**
 ```
-<@&1386452009678278818> m.staffinfo @user
-<@&1386452009678278818> m.staffinfo
+<@1373916203814490194> m.staffinfo @user
+<@1373916203814490194> m.staffinfo
 ```
 
 **Permission:** All staff members
@@ -139,7 +148,7 @@ Show available commands based on your permissions.
 
 **Usage:**
 ```
-<@&1386452009678278818> t.help
+<@1373916203814490194> t.help
 ```
 
 ### t.invite [server_id]
@@ -148,7 +157,7 @@ Get an invite link to a server where MODDY is present.
 
 **Usage:**
 ```
-<@&1386452009678278818> t.invite 1234567890
+<@1373916203814490194> t.invite 1234567890
 ```
 
 Creates a 7-day invite with 5 max uses.
@@ -159,7 +168,7 @@ Get detailed information about a server where MODDY is present.
 
 **Usage:**
 ```
-<@&1386452009678278818> t.serverinfo 1234567890
+<@1373916203814490194> t.serverinfo 1234567890
 ```
 
 Shows:
@@ -179,8 +188,8 @@ Reload bot extensions. Use "all" to reload everything.
 
 **Usage:**
 ```
-<@&1386452009678278818> d.reload all
-<@&1386452009678278818> d.reload staff.team_commands
+<@1373916203814490194> d.reload all
+<@1373916203814490194> d.reload staff.team_commands
 ```
 
 ### d.shutdown
@@ -189,7 +198,7 @@ Shutdown the bot.
 
 **Usage:**
 ```
-<@&1386452009678278818> d.shutdown
+<@1373916203814490194> d.shutdown
 ```
 
 ### d.stats
@@ -198,7 +207,7 @@ Show comprehensive bot statistics including uptime, resources, and database stat
 
 **Usage:**
 ```
-<@&1386452009678278818> d.stats
+<@1373916203814490194> d.stats
 ```
 
 ### d.sql [query]
@@ -207,7 +216,7 @@ Execute SQL queries directly on the database. Requires confirmation for dangerou
 
 **Usage:**
 ```
-<@&1386452009678278818> d.sql SELECT * FROM users LIMIT 10
+<@1373916203814490194> d.sql SELECT * FROM users LIMIT 10
 ```
 
 ### d.jsk [code]
@@ -216,9 +225,9 @@ Execute Python code directly in the bot's runtime environment. Supports async/aw
 
 **Usage:**
 ```
-<@&1386452009678278818> d.jsk print("Hello World")
-<@&1386452009678278818> d.jsk return len(bot.guilds)
-<@&1386452009678278818> d.jsk await message.channel.send("Test")
+<@1373916203814490194> d.jsk print("Hello World")
+<@1373916203814490194> d.jsk return len(bot.guilds)
+<@1373916203814490194> d.jsk await message.channel.send("Test")
 ```
 
 **Available Variables:**
@@ -233,7 +242,7 @@ Execute Python code directly in the bot's runtime environment. Supports async/aw
 **Code Blocks:**
 You can use Python code blocks for multi-line code:
 ```
-<@&1386452009678278818> d.jsk ```python
+<@1373916203814490194> d.jsk ```python
 guilds = bot.guilds
 print(f"Bot is in {len(guilds)} guilds")
 for guild in guilds[:5]:
@@ -251,7 +260,7 @@ Blacklist a user from using MODDY.
 
 **Usage:**
 ```
-<@&1386452009678278818> mod.blacklist @user Spam and abuse
+<@1373916203814490194> mod.blacklist @user Spam and abuse
 ```
 
 ### mod.unblacklist @user [reason]
@@ -260,7 +269,7 @@ Remove a user from the blacklist.
 
 **Usage:**
 ```
-<@&1386452009678278818> mod.unblacklist @user Appeal accepted
+<@1373916203814490194> mod.unblacklist @user Appeal accepted
 ```
 
 ### mod.userinfo @user
@@ -269,7 +278,7 @@ Get detailed information about a user including database attributes and shared s
 
 **Usage:**
 ```
-<@&1386452009678278818> mod.userinfo @user
+<@1373916203814490194> mod.userinfo @user
 ```
 
 ### mod.guildinfo [guild_id]
@@ -278,7 +287,7 @@ Get detailed information about a guild including database attributes.
 
 **Usage:**
 ```
-<@&1386452009678278818> mod.guildinfo 1234567890
+<@1373916203814490194> mod.guildinfo 1234567890
 ```
 
 ## Support Commands (sup. prefix)
@@ -293,19 +302,27 @@ Available to Manager, Supervisor_Com, and Communication. *In development.*
 
 ### Hierarchy Rules:
 
-1. **Supervisors and Managers cannot:**
-   - Assign permissions they don't have
+1. **Super Admin (User ID: 1164597199594852395):**
+   - Bypasses **ALL** permission checks
+   - Can assign any role, even Manager and Dev roles
+   - Can modify any staff member, including themselves
+   - Cannot be restricted by denied commands
+   - Has absolute control over the entire system
+
+2. **Supervisors and Managers cannot:**
+   - Assign permissions they don't have (except Super Admin)
    - Modify permissions of staff at the same level or above
    - A Supervisor cannot modify another Supervisor or a Manager
 
-2. **Developers (Discord Dev Team):**
+3. **Developers (Discord Dev Team):**
    - Automatically get Manager + Dev roles
-   - Can modify anyone (except other devs are always Manager+Dev)
+   - Can modify anyone (except other devs are always Manager+Dev, and Super Admin can modify anyone)
    - Cannot be removed from Manager+Dev roles
 
-3. **Command Restrictions:**
+4. **Command Restrictions:**
    - Even if you have access to a command type, specific commands can be denied
    - Denied commands are managed via `m.setstaff`
+   - Super Admin bypasses all command restrictions
 
 ### TEAM Attribute:
 
@@ -348,13 +365,21 @@ CREATE TABLE staff_permissions (
 
 ### Display Format:
 
-All staff commands use **Discord Components V2** (colored components), **NOT embeds**.
+Staff commands use **Discord Components V2** (LayoutView, Container, TextDisplay, Separator) for modern structured messages.
 
 Features:
-- Professional appearance
-- Color-coded responses (success=green, error=red, info=blue)
-- Interactive buttons and select menus
-- Ephemeral messages where appropriate
+- Clean, structured layout using Components V2
+- Error, success, info, and warning message helpers
+- Interactive buttons and select menus (still using embeds for compatibility)
+- Messages **reply** to the command message (not sent in channel)
+- Messages are **NOT automatically deleted** - they remain visible
+
+### Message Behavior:
+
+- All staff command responses use `message.reply()` instead of `message.channel.send()`
+- `mention_author=False` is used to avoid unnecessary mentions
+- No automatic deletion (`delete_after` is not used)
+- This ensures command history is preserved and visible to all staff
 
 ### Language:
 
@@ -373,11 +398,19 @@ All staff commands are in **English only** and do **NOT** use the i18n system.
 - `/staff/communication_commands.py` - Communication commands (com. prefix)
 - `/database.py` - Database methods for staff permissions
 
-### Key Classes:
+### Key Classes and Constants:
 
 - `StaffPermissionManager` - Main permission checking logic
+  - `STAFF_PREFIX` - Bot mention: `<@1373916203814490194>`
+  - `SUPER_ADMIN_ID` - Super admin user ID: `1164597199594852395`
 - `StaffRole` - Enum of available roles
 - `CommandType` - Enum of command type prefixes
+- Components V2 helpers in `utils/components_v2.py`:
+  - `create_error_message()` - Create error messages
+  - `create_success_message()` - Create success messages
+  - `create_info_message()` - Create info messages
+  - `create_warning_message()` - Create warning messages
+  - `create_staff_info_message()` - Create staff information displays
 
 ### Auto-initialization:
 
@@ -409,7 +442,7 @@ The new system:
 ### Adding a Moderator:
 
 ```
-<@&1386452009678278818> m.rank @NewMod
+<@1373916203814490194> m.rank @NewMod
 ```
 
 Select "Moderator" role in the menu, click Confirm.
@@ -417,7 +450,7 @@ Select "Moderator" role in the menu, click Confirm.
 ### Managing a Staff Member:
 
 ```
-<@&1386452009678278818> m.setstaff @ExistingStaff
+<@1373916203814490194> m.setstaff @ExistingStaff
 ```
 
 Click "Edit Roles" to change roles, or "Manage Command Restrictions" to deny specific commands.
@@ -425,24 +458,26 @@ Click "Edit Roles" to change roles, or "Manage Command Restrictions" to deny spe
 ### Getting a Server Invite:
 
 ```
-<@&1386452009678278818> t.invite 1234567890
+<@1373916203814490194> t.invite 1234567890
 ```
 
 ### Checking Staff List:
 
 ```
-<@&1386452009678278818> m.stafflist
+<@1373916203814490194> m.stafflist
 ```
 
 Shows all staff members organized by role.
 
 ## Security Considerations
 
-1. **Role Mention Prefix:** The `<@&1386452009678278818>` prefix prevents accidental command execution
-2. **Hierarchy Enforcement:** Lower-level staff cannot modify higher-level staff
-3. **Command Denial:** Specific commands can be denied even if role allows them
-4. **Audit Trail:** All permission changes are logged with `created_by` and `updated_by`
-5. **Dev Team Lock:** Discord dev team members cannot be removed from Manager+Dev roles
+1. **Bot Mention Prefix:** The `<@1373916203814490194>` prefix prevents accidental command execution
+2. **Super Admin:** User ID `1164597199594852395` has absolute control and bypasses all checks (hard-coded)
+3. **Hierarchy Enforcement:** Lower-level staff cannot modify higher-level staff (except Super Admin)
+4. **Command Denial:** Specific commands can be denied even if role allows them (not applicable to Super Admin)
+5. **Audit Trail:** All permission changes are logged with `created_by` and `updated_by`
+6. **Dev Team Lock:** Discord dev team members cannot be removed from Manager+Dev roles
+7. **Database Failsafe:** If database is unavailable, only Super Admin and Discord dev team members can use commands
 
 ## Future Enhancements
 

--- a/staff/dev_commands.py
+++ b/staff/dev_commands.py
@@ -14,6 +14,7 @@ import os
 from utils.staff_permissions import staff_permissions, CommandType
 from database import db
 from config import COLORS
+from utils.components_v2 import create_error_message, create_success_message, create_info_message, create_warning_message
 
 logger = logging.getLogger('moddy.dev_commands')
 
@@ -65,7 +66,7 @@ class DeveloperCommands(commands.Cog):
                 description=reason,
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         logger.info(f"   ✅ Permission granted")
@@ -87,12 +88,12 @@ class DeveloperCommands(commands.Cog):
                 description=f"Developer command `{command_name}` not found.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
 
     async def handle_reload_command(self, message: discord.Message, args: str):
         """
         Handle d.reload command - Reload bot extensions
-        Usage: <@&1386452009678278818> d.reload [extension]
+        Usage: <@1373916203814490194> d.reload [extension]
         """
         if not args or args == "all":
             # Reload all extensions
@@ -101,7 +102,7 @@ class DeveloperCommands(commands.Cog):
                 description="Reloading all cogs and staff commands...",
                 color=COLORS["info"]
             )
-            msg = await message.channel.send(embed=embed)
+            msg = await message.reply(embed=embed, mention_author=False)
 
             success = []
             failed = []
@@ -165,7 +166,7 @@ class DeveloperCommands(commands.Cog):
                 )
                 embed.set_footer(text=f"Executed by {message.author}")
 
-                await message.channel.send(embed=embed)
+                await message.reply(embed=embed, mention_author=False)
 
             except Exception as e:
                 embed = discord.Embed(
@@ -179,12 +180,12 @@ class DeveloperCommands(commands.Cog):
                     inline=False
                 )
 
-                await message.channel.send(embed=embed)
+                await message.reply(embed=embed, mention_author=False)
 
     async def handle_shutdown_command(self, message: discord.Message, args: str):
         """
         Handle d.shutdown command - Shutdown the bot
-        Usage: <@&1386452009678278818> d.shutdown
+        Usage: <@1373916203814490194> d.shutdown
         """
         embed = discord.Embed(
             title="🔴 Shutting Down",
@@ -194,7 +195,7 @@ class DeveloperCommands(commands.Cog):
         )
         embed.set_footer(text=f"Executed by {message.author}")
 
-        await message.channel.send(embed=embed)
+        await message.reply(embed=embed, mention_author=False)
 
         logger.info(f"Bot shutdown requested by {message.author} ({message.author.id})")
         await self.bot.close()
@@ -202,7 +203,7 @@ class DeveloperCommands(commands.Cog):
     async def handle_stats_command(self, message: discord.Message, args: str):
         """
         Handle d.stats command - Show bot statistics
-        Usage: <@&1386452009678278818> d.stats
+        Usage: <@1373916203814490194> d.stats
         """
         embed = discord.Embed(
             title="📊 MODDY Statistics",
@@ -261,20 +262,20 @@ class DeveloperCommands(commands.Cog):
 
         embed.set_footer(text=f"Requested by {message.author}")
 
-        await message.channel.send(embed=embed)
+        await message.reply(embed=embed, mention_author=False)
 
     async def handle_sql_command(self, message: discord.Message, args: str):
         """
         Handle d.sql command - Execute SQL query
-        Usage: <@&1386452009678278818> d.sql [query]
+        Usage: <@1373916203814490194> d.sql [query]
         """
         if not args:
             embed = discord.Embed(
                 title="❌ Invalid Usage",
-                description="**Usage:** `<@&1386452009678278818> d.sql [query]`\n\nProvide a SQL query to execute.",
+                description="**Usage:** `<@1373916203814490194> d.sql [query]`\n\nProvide a SQL query to execute.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         if not db:
@@ -283,7 +284,7 @@ class DeveloperCommands(commands.Cog):
                 description="Database is not connected.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         query = args.strip()
@@ -296,7 +297,7 @@ class DeveloperCommands(commands.Cog):
                 description=f"This query contains potentially dangerous operations:\n```sql\n{query[:500]}\n```\n\nReact with ✅ to confirm execution.",
                 color=COLORS["warning"]
             )
-            msg = await message.channel.send(embed=embed)
+            msg = await message.reply(embed=embed, mention_author=False)
             await msg.add_reaction("✅")
             await msg.add_reaction("❌")
 
@@ -335,7 +336,7 @@ class DeveloperCommands(commands.Cog):
                             description="No results returned.",
                             color=COLORS["success"]
                         )
-                        await message.channel.send(embed=embed)
+                        await message.reply(embed=embed, mention_author=False)
                         return
 
                     # Format results
@@ -365,7 +366,7 @@ class DeveloperCommands(commands.Cog):
                     )
 
                 embed.set_footer(text=f"Executed by {message.author}")
-                await message.channel.send(embed=embed)
+                await message.reply(embed=embed, mention_author=False)
 
         except Exception as e:
             embed = discord.Embed(
@@ -379,20 +380,20 @@ class DeveloperCommands(commands.Cog):
                 inline=False
             )
 
-            await message.channel.send(embed=embed)
+            await message.reply(embed=embed, mention_author=False)
 
     async def handle_jsk_command(self, message: discord.Message, args: str):
         """
         Handle d.jsk command - Execute Python code
-        Usage: <@&1386452009678278818> d.jsk [code]
+        Usage: <@1373916203814490194> d.jsk [code]
         """
         if not args:
             embed = discord.Embed(
                 title="❌ Invalid Usage",
-                description="**Usage:** `<@&1386452009678278818> d.jsk [code]`\n\nProvide Python code to execute.",
+                description="**Usage:** `<@1373916203814490194> d.jsk [code]`\n\nProvide Python code to execute.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         code = args.strip()
@@ -467,7 +468,7 @@ class DeveloperCommands(commands.Cog):
 
             embed.set_footer(text=f"Executed by {message.author}")
 
-            await message.channel.send(embed=embed)
+            await message.reply(embed=embed, mention_author=False)
 
         except Exception as e:
             # Format error
@@ -488,7 +489,7 @@ class DeveloperCommands(commands.Cog):
                 inline=False
             )
 
-            await message.channel.send(embed=embed)
+            await message.reply(embed=embed, mention_author=False)
 
 
 async def setup(bot):

--- a/staff/moderator_commands.py
+++ b/staff/moderator_commands.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from utils.staff_permissions import staff_permissions, CommandType
 from database import db
 from config import COLORS
+from utils.components_v2 import create_error_message, create_success_message, create_info_message, create_warning_message
 
 logger = logging.getLogger('moddy.moderator_commands')
 
@@ -55,7 +56,7 @@ class ModeratorCommands(commands.Cog):
                 description=reason,
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Route to appropriate command
@@ -73,21 +74,21 @@ class ModeratorCommands(commands.Cog):
                 description=f"Moderator command `{command_name}` not found.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
 
     async def handle_blacklist_command(self, message: discord.Message, args: str):
         """
         Handle mod.blacklist command - Blacklist a user
-        Usage: <@&1386452009678278818> mod.blacklist @user [reason]
+        Usage: <@1373916203814490194> mod.blacklist @user [reason]
         """
         parts = args.split(maxsplit=1)
         if not parts or not message.mentions:
             embed = discord.Embed(
                 title="❌ Invalid Usage",
-                description="**Usage:** `<@&1386452009678278818> mod.blacklist @user [reason]`\n\nMention a user to blacklist.",
+                description="**Usage:** `<@1373916203814490194> mod.blacklist @user [reason]`\n\nMention a user to blacklist.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         target_user = message.mentions[0]
@@ -101,7 +102,7 @@ class ModeratorCommands(commands.Cog):
                 description="You cannot blacklist staff members.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Check if already blacklisted
@@ -111,7 +112,7 @@ class ModeratorCommands(commands.Cog):
                 description=f"{target_user.mention} is already blacklisted.",
                 color=COLORS["warning"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Blacklist the user
@@ -134,23 +135,23 @@ class ModeratorCommands(commands.Cog):
 
         embed.set_footer(text=f"Executed by {message.author}")
 
-        await message.channel.send(embed=embed)
+        await message.reply(embed=embed, mention_author=False)
 
         logger.info(f"User {target_user} ({target_user.id}) blacklisted by {message.author} ({message.author.id})")
 
     async def handle_unblacklist_command(self, message: discord.Message, args: str):
         """
         Handle mod.unblacklist command - Remove user from blacklist
-        Usage: <@&1386452009678278818> mod.unblacklist @user [reason]
+        Usage: <@1373916203814490194> mod.unblacklist @user [reason]
         """
         parts = args.split(maxsplit=1)
         if not parts or not message.mentions:
             embed = discord.Embed(
                 title="❌ Invalid Usage",
-                description="**Usage:** `<@&1386452009678278818> mod.unblacklist @user [reason]`\n\nMention a user to unblacklist.",
+                description="**Usage:** `<@1373916203814490194> mod.unblacklist @user [reason]`\n\nMention a user to unblacklist.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         target_user = message.mentions[0]
@@ -164,7 +165,7 @@ class ModeratorCommands(commands.Cog):
                 description=f"{target_user.mention} is not blacklisted.",
                 color=COLORS["warning"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Remove from blacklist
@@ -187,22 +188,22 @@ class ModeratorCommands(commands.Cog):
 
         embed.set_footer(text=f"Executed by {message.author}")
 
-        await message.channel.send(embed=embed)
+        await message.reply(embed=embed, mention_author=False)
 
         logger.info(f"User {target_user} ({target_user.id}) unblacklisted by {message.author} ({message.author.id})")
 
     async def handle_userinfo_command(self, message: discord.Message, args: str):
         """
         Handle mod.userinfo command - Get detailed user information
-        Usage: <@&1386452009678278818> mod.userinfo @user
+        Usage: <@1373916203814490194> mod.userinfo @user
         """
         if not message.mentions:
             embed = discord.Embed(
                 title="❌ Invalid Usage",
-                description="**Usage:** `<@&1386452009678278818> mod.userinfo @user`\n\nMention a user to get information.",
+                description="**Usage:** `<@1373916203814490194> mod.userinfo @user`\n\nMention a user to get information.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         target_user = message.mentions[0]
@@ -260,20 +261,20 @@ class ModeratorCommands(commands.Cog):
 
         embed.set_footer(text=f"Requested by {message.author}")
 
-        await message.channel.send(embed=embed)
+        await message.reply(embed=embed, mention_author=False)
 
     async def handle_guildinfo_command(self, message: discord.Message, args: str):
         """
         Handle mod.guildinfo command - Get detailed guild information
-        Usage: <@&1386452009678278818> mod.guildinfo [guild_id]
+        Usage: <@1373916203814490194> mod.guildinfo [guild_id]
         """
         if not args:
             embed = discord.Embed(
                 title="❌ Invalid Usage",
-                description="**Usage:** `<@&1386452009678278818> mod.guildinfo [guild_id]`\n\nProvide a guild ID.",
+                description="**Usage:** `<@1373916203814490194> mod.guildinfo [guild_id]`\n\nProvide a guild ID.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         try:
@@ -284,7 +285,7 @@ class ModeratorCommands(commands.Cog):
                 description="Please provide a valid guild ID (numbers only).",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         guild = self.bot.get_guild(guild_id)
@@ -294,7 +295,7 @@ class ModeratorCommands(commands.Cog):
                 description=f"MODDY is not in a guild with ID `{guild_id}`.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Get guild data from database
@@ -365,7 +366,7 @@ class ModeratorCommands(commands.Cog):
 
         embed.set_footer(text=f"Requested by {message.author}")
 
-        await message.channel.send(embed=embed)
+        await message.reply(embed=embed, mention_author=False)
 
 
 async def setup(bot):

--- a/staff/team_commands.py
+++ b/staff/team_commands.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from utils.staff_permissions import staff_permissions, CommandType
 from database import db
 from config import COLORS
+from utils.components_v2 import create_error_message, create_success_message, create_info_message, create_warning_message
 
 logger = logging.getLogger('moddy.team_commands')
 
@@ -55,7 +56,7 @@ class TeamCommands(commands.Cog):
                 description=reason,
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Route to appropriate command
@@ -68,23 +69,23 @@ class TeamCommands(commands.Cog):
         else:
             embed = discord.Embed(
                 title="❌ Unknown Command",
-                description=f"Team command `{command_name}` not found.\n\nUse `<@&1386452009678278818> t.help` for a list of available commands.",
+                description=f"Team command `{command_name}` not found.\n\nUse `<@1373916203814490194> t.help` for a list of available commands.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
 
     async def handle_invite_command(self, message: discord.Message, args: str):
         """
         Handle t.invite command - Get an invite to a server
-        Usage: <@&1386452009678278818> t.invite [server_id]
+        Usage: <@1373916203814490194> t.invite [server_id]
         """
         if not args:
             embed = discord.Embed(
                 title="❌ Invalid Usage",
-                description="**Usage:** `<@&1386452009678278818> t.invite [server_id]`\n\nProvide a server ID to get an invite link.",
+                description="**Usage:** `<@1373916203814490194> t.invite [server_id]`\n\nProvide a server ID to get an invite link.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Parse server ID
@@ -96,7 +97,7 @@ class TeamCommands(commands.Cog):
                 description="Please provide a valid server ID (numbers only).",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Get guild
@@ -107,7 +108,7 @@ class TeamCommands(commands.Cog):
                 description=f"MODDY is not in a server with ID `{guild_id}`.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Try to create an invite
@@ -128,7 +129,7 @@ class TeamCommands(commands.Cog):
                     description=f"MODDY doesn't have permission to create invites in **{guild.name}**.",
                     color=COLORS["error"]
                 )
-                await message.channel.send(embed=embed, delete_after=15)
+                await message.reply(embed=embed, mention_author=False)
                 return
 
             # Create invite (7 days, 1 use, no temporary membership)
@@ -170,7 +171,7 @@ class TeamCommands(commands.Cog):
 
             embed.set_footer(text=f"Requested by {message.author}")
 
-            await message.channel.send(embed=embed)
+            await message.reply(embed=embed, mention_author=False)
 
             # Log the action
             logger.info(f"Staff {message.author} ({message.author.id}) requested invite for {guild.name} ({guild.id})")
@@ -181,7 +182,7 @@ class TeamCommands(commands.Cog):
                 description=f"MODDY doesn't have permission to create invites in **{guild.name}**.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
 
         except Exception as e:
             logger.error(f"Error creating invite: {e}")
@@ -190,20 +191,20 @@ class TeamCommands(commands.Cog):
                 description=f"Failed to create invite: {str(e)}",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
 
     async def handle_serverinfo_command(self, message: discord.Message, args: str):
         """
         Handle t.serverinfo command - Get information about a server
-        Usage: <@&1386452009678278818> t.serverinfo [server_id]
+        Usage: <@1373916203814490194> t.serverinfo [server_id]
         """
         if not args:
             embed = discord.Embed(
                 title="❌ Invalid Usage",
-                description="**Usage:** `<@&1386452009678278818> t.serverinfo [server_id]`\n\nProvide a server ID to get information.",
+                description="**Usage:** `<@1373916203814490194> t.serverinfo [server_id]`\n\nProvide a server ID to get information.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Parse server ID
@@ -215,7 +216,7 @@ class TeamCommands(commands.Cog):
                 description="Please provide a valid server ID (numbers only).",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Get guild
@@ -226,7 +227,7 @@ class TeamCommands(commands.Cog):
                 description=f"MODDY is not in a server with ID `{guild_id}`.",
                 color=COLORS["error"]
             )
-            await message.channel.send(embed=embed, delete_after=10)
+            await message.reply(embed=embed, mention_author=False)
             return
 
         # Create info embed
@@ -285,12 +286,12 @@ class TeamCommands(commands.Cog):
 
         embed.set_footer(text=f"Requested by {message.author}")
 
-        await message.channel.send(embed=embed)
+        await message.reply(embed=embed, mention_author=False)
 
     async def handle_help_command(self, message: discord.Message, args: str):
         """
         Handle t.help command - Show available team commands
-        Usage: <@&1386452009678278818> t.help
+        Usage: <@1373916203814490194> t.help
         """
         # Get user roles to show relevant commands
         user_roles = await staff_permissions.get_user_roles(message.author.id)
@@ -311,7 +312,7 @@ class TeamCommands(commands.Cog):
 
         embed.add_field(
             name="🌐 Team Commands (All Staff)",
-            value="\n".join([f"`<@&1386452009678278818> {cmd}` - {desc}" for cmd, desc in team_commands]),
+            value="\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in team_commands]),
             inline=False
         )
 
@@ -326,7 +327,7 @@ class TeamCommands(commands.Cog):
 
             embed.add_field(
                 name="👑 Management Commands",
-                value="\n".join([f"`<@&1386452009678278818> {cmd}` - {desc}" for cmd, desc in mgmt_commands]),
+                value="\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in mgmt_commands]),
                 inline=False
             )
 
@@ -342,7 +343,7 @@ class TeamCommands(commands.Cog):
 
             embed.add_field(
                 name="💻 Developer Commands",
-                value="\n".join([f"`<@&1386452009678278818> {cmd}` - {desc}" for cmd, desc in dev_commands]),
+                value="\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in dev_commands]),
                 inline=False
             )
 
@@ -357,7 +358,7 @@ class TeamCommands(commands.Cog):
 
             embed.add_field(
                 name="🛡️ Moderator Commands",
-                value="\n".join([f"`<@&1386452009678278818> {cmd}` - {desc}" for cmd, desc in mod_commands]),
+                value="\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in mod_commands]),
                 inline=False
             )
 
@@ -379,7 +380,7 @@ class TeamCommands(commands.Cog):
 
         embed.set_footer(text=f"Requested by {message.author} | Your roles: {', '.join([r.value for r in user_roles])}")
 
-        await message.channel.send(embed=embed)
+        await message.reply(embed=embed, mention_author=False)
 
 
 async def setup(bot):

--- a/utils/components_v2.py
+++ b/utils/components_v2.py
@@ -1,0 +1,189 @@
+"""
+Components V2 Helper for Discord.py
+Utilities for creating structured messages using Discord's Components V2
+"""
+
+import discord
+from discord.ui import LayoutView, Container, TextDisplay, Separator
+from discord import SeparatorSpacing
+from typing import List, Optional, Dict
+
+
+def create_simple_message(
+    title: str,
+    description: str,
+    fields: Optional[List[Dict[str, str]]] = None,
+    color: Optional[int] = None
+) -> LayoutView:
+    """
+    Create a simple message using Components V2
+
+    Args:
+        title: Message title
+        description: Message description
+        fields: List of dictionaries with 'name' and 'value' keys
+        color: Not used in V2, kept for compatibility
+
+    Returns:
+        LayoutView ready to send
+    """
+    view = LayoutView()
+    container = Container()
+
+    # Add title and description
+    header = f"**{title}**\n{description}"
+    container.add_item(TextDisplay(header))
+
+    # Add fields if present
+    if fields:
+        # Add separator before fields
+        container.add_item(Separator(spacing=SeparatorSpacing.small))
+
+        for field in fields:
+            field_text = f"**{field['name']}**\n{field['value']}"
+            container.add_item(TextDisplay(field_text))
+
+    view.add_item(container)
+    return view
+
+
+def create_error_message(title: str, description: str) -> LayoutView:
+    """
+    Create an error message using Components V2
+
+    Args:
+        title: Error title
+        description: Error description
+
+    Returns:
+        LayoutView ready to send
+    """
+    view = LayoutView()
+    container = Container()
+
+    error_text = f"❌ **{title}**\n{description}"
+    container.add_item(TextDisplay(error_text))
+
+    view.add_item(container)
+    return view
+
+
+def create_success_message(title: str, description: str, fields: Optional[List[Dict[str, str]]] = None) -> LayoutView:
+    """
+    Create a success message using Components V2
+
+    Args:
+        title: Success title
+        description: Success description
+        fields: Optional list of fields
+
+    Returns:
+        LayoutView ready to send
+    """
+    view = LayoutView()
+    container = Container()
+
+    success_text = f"✅ **{title}**\n{description}"
+    container.add_item(TextDisplay(success_text))
+
+    if fields:
+        container.add_item(Separator(spacing=SeparatorSpacing.small))
+        for field in fields:
+            field_text = f"**{field['name']}**\n{field['value']}"
+            container.add_item(TextDisplay(field_text))
+
+    view.add_item(container)
+    return view
+
+
+def create_info_message(title: str, description: str, fields: Optional[List[Dict[str, str]]] = None) -> LayoutView:
+    """
+    Create an info message using Components V2
+
+    Args:
+        title: Info title
+        description: Info description
+        fields: Optional list of fields
+
+    Returns:
+        LayoutView ready to send
+    """
+    view = LayoutView()
+    container = Container()
+
+    info_text = f"ℹ️ **{title}**\n{description}"
+    container.add_item(TextDisplay(info_text))
+
+    if fields:
+        container.add_item(Separator(spacing=SeparatorSpacing.small))
+        for field in fields:
+            field_text = f"**{field['name']}**\n{field['value']}"
+            container.add_item(TextDisplay(field_text))
+
+    view.add_item(container)
+    return view
+
+
+def create_warning_message(title: str, description: str) -> LayoutView:
+    """
+    Create a warning message using Components V2
+
+    Args:
+        title: Warning title
+        description: Warning description
+
+    Returns:
+        LayoutView ready to send
+    """
+    view = LayoutView()
+    container = Container()
+
+    warning_text = f"⚠️ **{title}**\n{description}"
+    container.add_item(TextDisplay(warning_text))
+
+    view.add_item(container)
+    return view
+
+
+def create_staff_info_message(
+    title: str,
+    user_name: str,
+    user_id: int,
+    fields: List[Dict[str, str]],
+    footer: Optional[str] = None
+) -> LayoutView:
+    """
+    Create a staff information message using Components V2
+
+    Args:
+        title: Message title
+        user_name: User's display name
+        user_id: User's ID
+        fields: List of information fields
+        footer: Optional footer text
+
+    Returns:
+        LayoutView ready to send
+    """
+    view = LayoutView()
+    container = Container()
+
+    # Header with user info
+    header = f"**{title}**\n*{user_name}* (`{user_id}`)"
+    container.add_item(TextDisplay(header))
+
+    # Add separator
+    container.add_item(Separator(spacing=SeparatorSpacing.small))
+
+    # Add fields
+    for field in fields:
+        field_text = f"**{field['name']}**\n{field['value']}"
+        container.add_item(TextDisplay(field_text))
+
+    # Add footer if present
+    if footer:
+        container.add_item(Separator(spacing=SeparatorSpacing.small))
+        container.add_item(TextDisplay(f"*{footer}*"))
+
+    view.add_item(container)
+    return view


### PR DESCRIPTION
Modifications apportées:

1. Changement du préfixe de commandes staff
   - Ancien: <@&1386452009678278818> (mention de rôle)
   - Nouveau: <@1373916203814490194> (mention du bot)

2. Ajout du Super Admin
   - User ID 1164597199594852395 hard-codé
   - Bypass complet de toutes les vérifications de permissions
   - Peut assigner n'importe quel rôle et modifier n'importe quel staff

3. Correction du problème 'Database not available'
   - Vérification du super admin et dev team AVANT le check de database
   - Permet au super admin et devs d'utiliser les commandes même si la DB est down

4. Amélioration du comportement des messages
   - Utilisation de message.reply() au lieu de message.channel.send()
   - Suppression de tous les delete_after (messages permanents)
   - Ajout de mention_author=False pour éviter les pings

5. Introduction de Components V2
   - Nouveau module utils/components_v2.py avec fonctions helper
   - Migration partielle vers LayoutView, Container, TextDisplay
   - Exemples de conversion pour les messages d'erreur/succès

6. Documentation complète
   - Mise à jour de STAFF_SYSTEM.md
   - Documentation du super admin
   - Documentation des Components V2
   - Documentation du nouveau comportement des messages

Fichiers modifiés:
- utils/staff_permissions.py: Ajout super admin, correction DB check
- utils/components_v2.py: Nouveau module pour Components V2
- staff/*.py: Migration reply() et imports Components V2
- STAFF_SYSTEM.md: Documentation complète des changements