### PR TITLE
Migrate staff command embeds to Components V2

### DIFF
--- a/staff/communication_commands.py
+++ b/staff/communication_commands.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from utils.staff_permissions import staff_permissions, CommandType
 from database import db
 from config import COLORS
+from utils.components_v2 import create_error_message, create_info_message, EMOJIS
 
 logger = logging.getLogger('moddy.communication_commands')
 
@@ -50,40 +51,32 @@ class CommunicationCommands(commands.Cog):
         )
 
         if not allowed:
-            embed = discord.Embed(
-                title="❌ Permission Denied",
-                description=reason,
-                color=COLORS["error"]
-            )
-            await message.channel.send(embed=embed, delete_after=10)
+            view = create_error_message("Permission Denied", reason)
+            await message.channel.send(view=view, delete_after=10)
             return
 
         # Route to appropriate command
         if command_name == "help":
             await self.handle_help_command(message, args)
         else:
-            embed = discord.Embed(
-                title="❌ Unknown Command",
-                description=f"Communication command `{command_name}` not found.\n\nCommunication commands are in development.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Unknown Command",
+                f"Communication command `{command_name}` not found.\n\nCommunication commands are in development."
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.channel.send(view=view, delete_after=15)
 
     async def handle_help_command(self, message: discord.Message, args: str):
         """
         Handle com.help command - Show available communication commands
         Usage: <@&1386452009678278818> com.help
         """
-        embed = discord.Embed(
-            title="💬 Communication Commands",
-            description="Communication command system is in development.\n\nAvailable commands will be added soon.",
-            color=COLORS["info"],
-            timestamp=datetime.now(timezone.utc)
+        view = create_info_message(
+            "💬 Communication Commands",
+            "Communication command system is in development.\n\nAvailable commands will be added soon.",
+            footer=f"Requested by {message.author}"
         )
 
-        embed.set_footer(text=f"Requested by {message.author}")
-
-        await message.channel.send(embed=embed)
+        await message.channel.send(view=view)
 
 
 async def setup(bot):

--- a/staff/dev_commands.py
+++ b/staff/dev_commands.py
@@ -14,7 +14,7 @@ import os
 from utils.staff_permissions import staff_permissions, CommandType
 from database import db
 from config import COLORS
-from utils.components_v2 import create_error_message, create_success_message, create_info_message, create_warning_message
+from utils.components_v2 import create_error_message, create_success_message, create_info_message, create_warning_message, EMOJIS
 
 logger = logging.getLogger('moddy.dev_commands')
 
@@ -61,12 +61,8 @@ class DeveloperCommands(commands.Cog):
 
         if not allowed:
             logger.warning(f"   ❌ Permission denied: {reason}")
-            embed = discord.Embed(
-                title="❌ Permission Denied",
-                description=reason,
-                color=COLORS["error"]
-            )
-            await message.reply(embed=embed, mention_author=False)
+            view = create_error_message("Permission Denied", reason)
+            await message.reply(view=view, mention_author=False)
             return
 
         logger.info(f"   ✅ Permission granted")
@@ -83,12 +79,8 @@ class DeveloperCommands(commands.Cog):
         elif command_name == "jsk":
             await self.handle_jsk_command(message, args)
         else:
-            embed = discord.Embed(
-                title="❌ Unknown Command",
-                description=f"Developer command `{command_name}` not found.",
-                color=COLORS["error"]
-            )
-            await message.reply(embed=embed, mention_author=False)
+            view = create_error_message("Unknown Command", f"Developer command `{command_name}` not found.")
+            await message.reply(view=view, mention_author=False)
 
     async def handle_reload_command(self, message: discord.Message, args: str):
         """
@@ -97,12 +89,8 @@ class DeveloperCommands(commands.Cog):
         """
         if not args or args == "all":
             # Reload all extensions
-            embed = discord.Embed(
-                title="🔄 Reloading All Extensions",
-                description="Reloading all cogs and staff commands...",
-                color=COLORS["info"]
-            )
-            msg = await message.reply(embed=embed, mention_author=False)
+            view = create_info_message(f"{EMOJIS['sync']} Reloading All Extensions", "Reloading all cogs and staff commands...")
+            msg = await message.reply(view=view, mention_author=False)
 
             success = []
             failed = []
@@ -116,30 +104,31 @@ class DeveloperCommands(commands.Cog):
                 except Exception as e:
                     failed.append(f"{ext}: {str(e)}")
 
-            # Create result embed
-            result_embed = discord.Embed(
-                title="✅ Reload Complete" if not failed else "⚠️ Reload Complete with Errors",
-                color=COLORS["success"] if not failed else COLORS["warning"],
-                timestamp=datetime.now(timezone.utc)
-            )
+            # Create result view
+            title = f"{EMOJIS['done']} Reload Complete" if not failed else "⚠️ Reload Complete with Errors"
+            description = "Extensions reloaded successfully." if not failed else "Some extensions failed to reload."
 
+            fields = []
             if success:
-                result_embed.add_field(
-                    name=f"✅ Reloaded ({len(success)})",
-                    value="\n".join([f"• `{ext}`" for ext in success[:10]]) + (f"\n*...and {len(success) - 10} more*" if len(success) > 10 else ""),
-                    inline=False
-                )
+                fields.append({
+                    'name': f"{EMOJIS['done']} Reloaded ({len(success)})",
+                    'value': "\n".join([f"• `{ext}`" for ext in success[:10]]) + (f"\n*...and {len(success) - 10} more*" if len(success) > 10 else "")
+                })
 
             if failed:
-                result_embed.add_field(
-                    name=f"❌ Failed ({len(failed)})",
-                    value="\n".join([f"• {f}" for f in failed[:5]]) + (f"\n*...and {len(failed) - 5} more*" if len(failed) > 5 else ""),
-                    inline=False
-                )
+                fields.append({
+                    'name': f"{EMOJIS['undone']} Failed ({len(failed)})",
+                    'value': "\n".join([f"• {f}" for f in failed[:5]]) + (f"\n*...and {len(failed) - 5} more*" if len(failed) > 5 else "")
+                })
 
-            result_embed.set_footer(text=f"Executed by {message.author}")
+            footer = f"Executed by {message.author}"
 
-            await msg.edit(embed=result_embed)
+            if failed:
+                result_view = create_warning_message(title, description, fields)
+            else:
+                result_view = create_success_message(title, description, fields, footer)
+
+            await msg.edit(view=result_view)
 
         else:
             # Reload specific extension
@@ -158,44 +147,34 @@ class DeveloperCommands(commands.Cog):
             try:
                 await self.bot.reload_extension(ext_name)
 
-                embed = discord.Embed(
-                    title="✅ Extension Reloaded",
-                    description=f"Successfully reloaded `{ext_name}`",
-                    color=COLORS["success"],
-                    timestamp=datetime.now(timezone.utc)
+                view = create_success_message(
+                    "Extension Reloaded",
+                    f"Successfully reloaded `{ext_name}`",
+                    footer=f"Executed by {message.author}"
                 )
-                embed.set_footer(text=f"Executed by {message.author}")
 
-                await message.reply(embed=embed, mention_author=False)
+                await message.reply(view=view, mention_author=False)
 
             except Exception as e:
-                embed = discord.Embed(
-                    title="❌ Reload Failed",
-                    description=f"Failed to reload `{ext_name}`",
-                    color=COLORS["error"]
-                )
-                embed.add_field(
-                    name="Error",
-                    value=f"```{str(e)[:500]}```",
-                    inline=False
+                view = create_error_message(
+                    "Reload Failed",
+                    f"Failed to reload `{ext_name}`",
+                    fields=[{'name': 'Error', 'value': f"```{str(e)[:500]}```"}]
                 )
 
-                await message.reply(embed=embed, mention_author=False)
+                await message.reply(view=view, mention_author=False)
 
     async def handle_shutdown_command(self, message: discord.Message, args: str):
         """
         Handle d.shutdown command - Shutdown the bot
         Usage: <@1373916203814490194> d.shutdown
         """
-        embed = discord.Embed(
-            title="🔴 Shutting Down",
-            description="MODDY is shutting down...",
-            color=COLORS["error"],
-            timestamp=datetime.now(timezone.utc)
+        view = create_error_message(
+            f"{EMOJIS['logout']} Shutting Down" if 'logout' in EMOJIS else "🔴 Shutting Down",
+            "MODDY is shutting down..."
         )
-        embed.set_footer(text=f"Executed by {message.author}")
 
-        await message.reply(embed=embed, mention_author=False)
+        await message.reply(view=view, mention_author=False)
 
         logger.info(f"Bot shutdown requested by {message.author} ({message.author.id})")
         await self.bot.close()
@@ -205,40 +184,33 @@ class DeveloperCommands(commands.Cog):
         Handle d.stats command - Show bot statistics
         Usage: <@1373916203814490194> d.stats
         """
-        embed = discord.Embed(
-            title="📊 MODDY Statistics",
-            color=COLORS["developer"],
-            timestamp=datetime.now(timezone.utc)
-        )
-
         # Bot info
         uptime = datetime.now(timezone.utc) - self.bot.launch_time
         days = uptime.days
         hours, remainder = divmod(uptime.seconds, 3600)
         minutes, seconds = divmod(remainder, 60)
 
-        embed.add_field(
-            name="Bot Information",
-            value=f"**Uptime:** {days}d {hours}h {minutes}m {seconds}s\n**Latency:** {round(self.bot.latency * 1000)}ms",
-            inline=False
-        )
+        fields = []
+
+        fields.append({
+            'name': f"{EMOJIS['moddy']} Bot Information",
+            'value': f"**Uptime:** {days}d {hours}h {minutes}m {seconds}s\n**Latency:** {round(self.bot.latency * 1000)}ms"
+        })
 
         # Server stats
-        embed.add_field(
-            name="Discord Statistics",
-            value=f"**Guilds:** {len(self.bot.guilds):,}\n**Users:** {len(self.bot.users):,}\n**Commands:** {len(self.bot.tree.get_commands())}",
-            inline=True
-        )
+        fields.append({
+            'name': f"{EMOJIS['web']} Discord Statistics",
+            'value': f"**Guilds:** {len(self.bot.guilds):,}\n**Users:** {len(self.bot.users):,}\n**Commands:** {len(self.bot.tree.get_commands())}"
+        })
 
         # Database stats
         if db:
             try:
                 stats = await db.get_stats()
-                embed.add_field(
-                    name="Database Statistics",
-                    value=f"**Users:** {stats.get('users', 0):,}\n**Guilds:** {stats.get('guilds', 0):,}\n**Errors:** {stats.get('errors', 0):,}",
-                    inline=True
-                )
+                fields.append({
+                    'name': "Database Statistics",
+                    'value': f"**Users:** {stats.get('users', 0):,}\n**Guilds:** {stats.get('guilds', 0):,}\n**Errors:** {stats.get('errors', 0):,}"
+                })
             except:
                 pass
 
@@ -247,22 +219,25 @@ class DeveloperCommands(commands.Cog):
         process = psutil.Process()
         memory_info = process.memory_info()
 
-        embed.add_field(
-            name="System Resources",
-            value=f"**RAM:** {memory_info.rss / 1024 / 1024:.2f} MB\n**CPU:** {process.cpu_percent()}%\n**Threads:** {process.num_threads()}",
-            inline=True
-        )
+        fields.append({
+            'name': "System Resources",
+            'value': f"**RAM:** {memory_info.rss / 1024 / 1024:.2f} MB\n**CPU:** {process.cpu_percent()}%\n**Threads:** {process.num_threads()}"
+        })
 
         # Extensions
-        embed.add_field(
-            name="Extensions",
-            value=f"**Loaded:** {len(self.bot.extensions)}\n**Cogs:** {len(self.bot.cogs)}",
-            inline=True
+        fields.append({
+            'name': "Extensions",
+            'value': f"**Loaded:** {len(self.bot.extensions)}\n**Cogs:** {len(self.bot.cogs)}"
+        })
+
+        view = create_info_message(
+            f"{EMOJIS['info']} MODDY Statistics",
+            "Statistiques actuelles du bot",
+            fields=fields,
+            footer=f"Requested by {message.author}"
         )
 
-        embed.set_footer(text=f"Requested by {message.author}")
-
-        await message.reply(embed=embed, mention_author=False)
+        await message.reply(view=view, mention_author=False)
 
     async def handle_sql_command(self, message: discord.Message, args: str):
         """
@@ -270,21 +245,19 @@ class DeveloperCommands(commands.Cog):
         Usage: <@1373916203814490194> d.sql [query]
         """
         if not args:
-            embed = discord.Embed(
-                title="❌ Invalid Usage",
-                description="**Usage:** `<@1373916203814490194> d.sql [query]`\n\nProvide a SQL query to execute.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Invalid Usage",
+                "**Usage:** `<@1373916203814490194> d.sql [query]`\n\nProvide a SQL query to execute."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
             return
 
         if not db:
-            embed = discord.Embed(
-                title="❌ Database Not Available",
-                description="Database is not connected.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Database Not Available",
+                "Database is not connected."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
             return
 
         query = args.strip()
@@ -292,12 +265,11 @@ class DeveloperCommands(commands.Cog):
         # Warning for dangerous queries
         dangerous_keywords = ["DROP", "DELETE", "TRUNCATE", "ALTER"]
         if any(keyword in query.upper() for keyword in dangerous_keywords):
-            embed = discord.Embed(
-                title="⚠️ Dangerous Query",
-                description=f"This query contains potentially dangerous operations:\n```sql\n{query[:500]}\n```\n\nReact with ✅ to confirm execution.",
-                color=COLORS["warning"]
+            view = create_warning_message(
+                "Dangerous Query",
+                f"This query contains potentially dangerous operations:\n```sql\n{query[:500]}\n```\n\nReact with ✅ to confirm execution."
             )
-            msg = await message.reply(embed=embed, mention_author=False)
+            msg = await message.reply(view=view, mention_author=False)
             await msg.add_reaction("✅")
             await msg.add_reaction("❌")
 
@@ -308,20 +280,12 @@ class DeveloperCommands(commands.Cog):
                 reaction, user = await self.bot.wait_for('reaction_add', timeout=30.0, check=check)
 
                 if str(reaction.emoji) == "❌":
-                    embed = discord.Embed(
-                        title="❌ Cancelled",
-                        description="Query execution cancelled.",
-                        color=COLORS["error"]
-                    )
-                    await msg.edit(embed=embed)
+                    cancel_view = create_error_message("Cancelled", "Query execution cancelled.")
+                    await msg.edit(view=cancel_view)
                     return
             except:
-                embed = discord.Embed(
-                    title="⏱️ Timeout",
-                    description="Query confirmation timed out.",
-                    color=COLORS["error"]
-                )
-                await msg.edit(embed=embed)
+                timeout_view = create_error_message(f"{EMOJIS['time']} Timeout", "Query confirmation timed out.")
+                await msg.edit(view=timeout_view)
                 return
 
         try:
@@ -331,12 +295,8 @@ class DeveloperCommands(commands.Cog):
                     rows = await conn.fetch(query)
 
                     if not rows:
-                        embed = discord.Embed(
-                            title="✅ Query Executed",
-                            description="No results returned.",
-                            color=COLORS["success"]
-                        )
-                        await message.reply(embed=embed, mention_author=False)
+                        view = create_success_message("Query Executed", "No results returned.")
+                        await message.reply(view=view, mention_author=False)
                         return
 
                     # Format results
@@ -348,39 +308,31 @@ class DeveloperCommands(commands.Cog):
                     if len(rows) > 10:
                         result_text += f"\n*...and {len(rows) - 10} more rows*"
 
-                    embed = discord.Embed(
-                        title="✅ Query Executed",
-                        description=f"**Rows:** {len(rows)}\n\n{result_text}",
-                        color=COLORS["success"],
-                        timestamp=datetime.now(timezone.utc)
+                    view = create_success_message(
+                        "Query Executed",
+                        f"**Rows:** {len(rows)}\n\n{result_text}",
+                        footer=f"Executed by {message.author}"
                     )
                 else:
                     # Execute non-SELECT query
                     result = await conn.execute(query)
 
-                    embed = discord.Embed(
-                        title="✅ Query Executed",
-                        description=f"```sql\n{query[:500]}\n```\n\n**Result:** {result}",
-                        color=COLORS["success"],
-                        timestamp=datetime.now(timezone.utc)
+                    view = create_success_message(
+                        "Query Executed",
+                        f"```sql\n{query[:500]}\n```\n\n**Result:** {result}",
+                        footer=f"Executed by {message.author}"
                     )
 
-                embed.set_footer(text=f"Executed by {message.author}")
-                await message.reply(embed=embed, mention_author=False)
+                await message.reply(view=view, mention_author=False)
 
         except Exception as e:
-            embed = discord.Embed(
-                title="❌ Query Failed",
-                description=f"```sql\n{query[:500]}\n```",
-                color=COLORS["error"]
-            )
-            embed.add_field(
-                name="Error",
-                value=f"```{str(e)[:500]}```",
-                inline=False
+            view = create_error_message(
+                "Query Failed",
+                f"```sql\n{query[:500]}\n```",
+                fields=[{'name': 'Error', 'value': f"```{str(e)[:500]}```"}]
             )
 
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
 
     async def handle_jsk_command(self, message: discord.Message, args: str):
         """
@@ -388,12 +340,11 @@ class DeveloperCommands(commands.Cog):
         Usage: <@1373916203814490194> d.jsk [code]
         """
         if not args:
-            embed = discord.Embed(
-                title="❌ Invalid Usage",
-                description="**Usage:** `<@1373916203814490194> d.jsk [code]`\n\nProvide Python code to execute.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Invalid Usage",
+                "**Usage:** `<@1373916203814490194> d.jsk [code]`\n\nProvide Python code to execute."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
             return
 
         code = args.strip()
@@ -447,28 +398,20 @@ class DeveloperCommands(commands.Cog):
                 output += f"\n{repr(result)}"
 
             if not output:
-                output = "✅ Code executed successfully (no output)"
+                output = f"{EMOJIS['done']} Code executed successfully (no output)"
 
             # Limit output length
             if len(output) > 1900:
                 output = output[:1900] + "\n... (output truncated)"
 
-            embed = discord.Embed(
-                title="✅ Code Executed",
-                description=f"```python\n{code[:500]}\n```",
-                color=COLORS["success"],
-                timestamp=datetime.now(timezone.utc)
+            view = create_success_message(
+                f"{EMOJIS['code']} Code Executed",
+                f"```python\n{code[:500]}\n```",
+                fields=[{'name': 'Output', 'value': f"```python\n{output}\n```"}],
+                footer=f"Executed by {message.author}"
             )
 
-            embed.add_field(
-                name="Output",
-                value=f"```python\n{output}\n```",
-                inline=False
-            )
-
-            embed.set_footer(text=f"Executed by {message.author}")
-
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
 
         except Exception as e:
             # Format error
@@ -477,19 +420,13 @@ class DeveloperCommands(commands.Cog):
             if len(error_traceback) > 1900:
                 error_traceback = error_traceback[-1900:]
 
-            embed = discord.Embed(
-                title="❌ Execution Failed",
-                description=f"```python\n{code[:500]}\n```",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Execution Failed",
+                f"```python\n{code[:500]}\n```",
+                fields=[{'name': 'Error', 'value': f"```python\n{error_traceback}\n```"}]
             )
 
-            embed.add_field(
-                name="Error",
-                value=f"```python\n{error_traceback}\n```",
-                inline=False
-            )
-
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
 
 
 async def setup(bot):

--- a/staff/support_commands.py
+++ b/staff/support_commands.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from utils.staff_permissions import staff_permissions, CommandType
 from database import db
 from config import COLORS
+from utils.components_v2 import create_error_message, create_info_message, EMOJIS
 
 logger = logging.getLogger('moddy.support_commands')
 
@@ -50,40 +51,32 @@ class SupportCommands(commands.Cog):
         )
 
         if not allowed:
-            embed = discord.Embed(
-                title="❌ Permission Denied",
-                description=reason,
-                color=COLORS["error"]
-            )
-            await message.channel.send(embed=embed, delete_after=10)
+            view = create_error_message("Permission Denied", reason)
+            await message.channel.send(view=view, delete_after=10)
             return
 
         # Route to appropriate command
         if command_name == "help":
             await self.handle_help_command(message, args)
         else:
-            embed = discord.Embed(
-                title="❌ Unknown Command",
-                description=f"Support command `{command_name}` not found.\n\nSupport commands are in development.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Unknown Command",
+                f"Support command `{command_name}` not found.\n\nSupport commands are in development."
             )
-            await message.channel.send(embed=embed, delete_after=15)
+            await message.channel.send(view=view, delete_after=15)
 
     async def handle_help_command(self, message: discord.Message, args: str):
         """
         Handle sup.help command - Show available support commands
         Usage: <@&1386452009678278818> sup.help
         """
-        embed = discord.Embed(
-            title="🎧 Support Commands",
-            description="Support command system is in development.\n\nAvailable commands will be added soon.",
-            color=COLORS["info"],
-            timestamp=datetime.now(timezone.utc)
+        view = create_info_message(
+            "🎧 Support Commands",
+            "Support command system is in development.\n\nAvailable commands will be added soon.",
+            footer=f"Requested by {message.author}"
         )
 
-        embed.set_footer(text=f"Requested by {message.author}")
-
-        await message.channel.send(embed=embed)
+        await message.channel.send(view=view)
 
 
 async def setup(bot):

--- a/staff/team_commands.py
+++ b/staff/team_commands.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 from utils.staff_permissions import staff_permissions, CommandType
 from database import db
 from config import COLORS
-from utils.components_v2 import create_error_message, create_success_message, create_info_message, create_warning_message
+from utils.components_v2 import create_error_message, create_success_message, create_info_message, create_warning_message, create_simple_message, EMOJIS
 
 logger = logging.getLogger('moddy.team_commands')
 
@@ -51,12 +51,8 @@ class TeamCommands(commands.Cog):
         )
 
         if not allowed:
-            embed = discord.Embed(
-                title="❌ Permission Denied",
-                description=reason,
-                color=COLORS["error"]
-            )
-            await message.reply(embed=embed, mention_author=False)
+            view = create_error_message("Permission Denied", reason)
+            await message.reply(view=view, mention_author=False)
             return
 
         # Route to appropriate command
@@ -67,12 +63,11 @@ class TeamCommands(commands.Cog):
         elif command_name == "help":
             await self.handle_help_command(message, args)
         else:
-            embed = discord.Embed(
-                title="❌ Unknown Command",
-                description=f"Team command `{command_name}` not found.\n\nUse `<@1373916203814490194> t.help` for a list of available commands.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Unknown Command",
+                f"Team command `{command_name}` not found.\n\nUse `<@1373916203814490194> t.help` for a list of available commands."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
 
     async def handle_invite_command(self, message: discord.Message, args: str):
         """
@@ -80,35 +75,32 @@ class TeamCommands(commands.Cog):
         Usage: <@1373916203814490194> t.invite [server_id]
         """
         if not args:
-            embed = discord.Embed(
-                title="❌ Invalid Usage",
-                description="**Usage:** `<@1373916203814490194> t.invite [server_id]`\n\nProvide a server ID to get an invite link.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Invalid Usage",
+                "**Usage:** `<@1373916203814490194> t.invite [server_id]`\n\nProvide a server ID to get an invite link."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
             return
 
         # Parse server ID
         try:
             guild_id = int(args.strip())
         except ValueError:
-            embed = discord.Embed(
-                title="❌ Invalid Server ID",
-                description="Please provide a valid server ID (numbers only).",
-                color=COLORS["error"]
+            view = create_error_message(
+                f"{EMOJIS['snowflake']} Invalid Server ID",
+                "Please provide a valid server ID (numbers only)."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
             return
 
         # Get guild
         guild = self.bot.get_guild(guild_id)
         if not guild:
-            embed = discord.Embed(
-                title="❌ Server Not Found",
-                description=f"MODDY is not in a server with ID `{guild_id}`.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Server Not Found",
+                f"MODDY is not in a server with ID `{guild_id}`."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
             return
 
         # Try to create an invite
@@ -124,12 +116,11 @@ class TeamCommands(commands.Cog):
                         break
 
             if not invite_channel:
-                embed = discord.Embed(
-                    title="❌ Cannot Create Invite",
-                    description=f"MODDY doesn't have permission to create invites in **{guild.name}**.",
-                    color=COLORS["error"]
+                view = create_error_message(
+                    "Cannot Create Invite",
+                    f"MODDY doesn't have permission to create invites in **{guild.name}**."
                 )
-                await message.reply(embed=embed, mention_author=False)
+                await message.reply(view=view, mention_author=False)
                 return
 
             # Create invite (7 days, 1 use, no temporary membership)
@@ -140,58 +131,48 @@ class TeamCommands(commands.Cog):
                 reason=f"Staff invite requested by {message.author}"
             )
 
-            # Create success embed
-            embed = discord.Embed(
-                title="✅ Server Invite Created",
-                description=f"Invite link for **{guild.name}**",
-                color=COLORS["success"],
-                timestamp=datetime.now(timezone.utc)
+            # Create success view
+            fields = [
+                {
+                    'name': f"{EMOJIS['web']} Server Information",
+                    'value': f"**Name:** {guild.name}\n**ID:** `{guild.id}`\n**Members:** {guild.member_count:,}"
+                },
+                {
+                    'name': "Invite Link",
+                    'value': f"[Click here to join]({invite.url})\n`{invite.url}`"
+                },
+                {
+                    'name': f"{EMOJIS['time']} Invite Details",
+                    'value': f"**Channel:** {invite_channel.mention}\n**Expires:** <t:{int((datetime.now(timezone.utc).timestamp() + 604800))}:R>\n**Max Uses:** 5"
+                }
+            ]
+
+            view = create_success_message(
+                "Server Invite Created",
+                f"Invite link for **{guild.name}**",
+                fields=fields,
+                footer=f"Requested by {message.author}"
             )
 
-            embed.add_field(
-                name="Server Information",
-                value=f"**Name:** {guild.name}\n**ID:** `{guild.id}`\n**Members:** {guild.member_count:,}",
-                inline=False
-            )
-
-            embed.add_field(
-                name="Invite Link",
-                value=f"[Click here to join]({invite.url})\n`{invite.url}`",
-                inline=False
-            )
-
-            embed.add_field(
-                name="Invite Details",
-                value=f"**Channel:** {invite_channel.mention}\n**Expires:** <t:{int((datetime.now(timezone.utc).timestamp() + 604800))}:R>\n**Max Uses:** 5",
-                inline=False
-            )
-
-            if guild.icon:
-                embed.set_thumbnail(url=guild.icon.url)
-
-            embed.set_footer(text=f"Requested by {message.author}")
-
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
 
             # Log the action
             logger.info(f"Staff {message.author} ({message.author.id}) requested invite for {guild.name} ({guild.id})")
 
         except discord.Forbidden:
-            embed = discord.Embed(
-                title="❌ Permission Denied",
-                description=f"MODDY doesn't have permission to create invites in **{guild.name}**.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Permission Denied",
+                f"MODDY doesn't have permission to create invites in **{guild.name}**."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
 
         except Exception as e:
             logger.error(f"Error creating invite: {e}")
-            embed = discord.Embed(
-                title="❌ Error",
-                description=f"Failed to create invite: {str(e)}",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Error",
+                f"Failed to create invite: {str(e)}"
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
 
     async def handle_serverinfo_command(self, message: discord.Message, args: str):
         """
@@ -199,94 +180,83 @@ class TeamCommands(commands.Cog):
         Usage: <@1373916203814490194> t.serverinfo [server_id]
         """
         if not args:
-            embed = discord.Embed(
-                title="❌ Invalid Usage",
-                description="**Usage:** `<@1373916203814490194> t.serverinfo [server_id]`\n\nProvide a server ID to get information.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Invalid Usage",
+                "**Usage:** `<@1373916203814490194> t.serverinfo [server_id]`\n\nProvide a server ID to get information."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
             return
 
         # Parse server ID
         try:
             guild_id = int(args.strip())
         except ValueError:
-            embed = discord.Embed(
-                title="❌ Invalid Server ID",
-                description="Please provide a valid server ID (numbers only).",
-                color=COLORS["error"]
+            view = create_error_message(
+                f"{EMOJIS['snowflake']} Invalid Server ID",
+                "Please provide a valid server ID (numbers only)."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
             return
 
         # Get guild
         guild = self.bot.get_guild(guild_id)
         if not guild:
-            embed = discord.Embed(
-                title="❌ Server Not Found",
-                description=f"MODDY is not in a server with ID `{guild_id}`.",
-                color=COLORS["error"]
+            view = create_error_message(
+                "Server Not Found",
+                f"MODDY is not in a server with ID `{guild_id}`."
             )
-            await message.reply(embed=embed, mention_author=False)
+            await message.reply(view=view, mention_author=False)
             return
 
-        # Create info embed
-        embed = discord.Embed(
-            title=f"📊 Server Information",
-            color=COLORS["info"],
-            timestamp=datetime.now(timezone.utc)
-        )
+        # Create info view
+        fields = []
 
         # Basic info
-        embed.add_field(
-            name="Basic Information",
-            value=f"**Name:** {guild.name}\n**ID:** `{guild.id}`\n**Owner:** {guild.owner.mention if guild.owner else 'Unknown'} (`{guild.owner_id}`)\n**Created:** <t:{int(guild.created_at.timestamp())}:R>",
-            inline=False
-        )
+        fields.append({
+            'name': f"{EMOJIS['info']} Basic Information",
+            'value': f"**Name:** {guild.name}\n**ID:** `{guild.id}`\n**Owner:** {guild.owner.mention if guild.owner else 'Unknown'} (`{guild.owner_id}`)\n**Created:** <t:{int(guild.created_at.timestamp())}:R>"
+        })
 
         # Member stats
-        embed.add_field(
-            name="Members",
-            value=f"**Total:** {guild.member_count:,}\n**Humans:** {len([m for m in guild.members if not m.bot]):,}\n**Bots:** {len([m for m in guild.members if m.bot]):,}",
-            inline=True
-        )
+        fields.append({
+            'name': f"{EMOJIS['user']} Members",
+            'value': f"**Total:** {guild.member_count:,}\n**Humans:** {len([m for m in guild.members if not m.bot]):,}\n**Bots:** {len([m for m in guild.members if m.bot]):,}"
+        })
 
         # Channel stats
-        embed.add_field(
-            name="Channels",
-            value=f"**Text:** {len(guild.text_channels)}\n**Voice:** {len(guild.voice_channels)}\n**Categories:** {len(guild.categories)}",
-            inline=True
-        )
+        fields.append({
+            'name': "Channels",
+            'value': f"**Text:** {len(guild.text_channels)}\n**Voice:** {len(guild.voice_channels)}\n**Categories:** {len(guild.categories)}"
+        })
 
         # Role count
-        embed.add_field(
-            name="Roles",
-            value=f"**Total:** {len(guild.roles)}",
-            inline=True
-        )
+        fields.append({
+            'name': "Roles",
+            'value': f"**Total:** {len(guild.roles)}"
+        })
 
         # Boost info
-        embed.add_field(
-            name="Boost Status",
-            value=f"**Level:** {guild.premium_tier}\n**Boosts:** {guild.premium_subscription_count}",
-            inline=True
-        )
+        fields.append({
+            'name': "Boost Status",
+            'value': f"**Level:** {guild.premium_tier}\n**Boosts:** {guild.premium_subscription_count}"
+        })
 
         # Features
         if guild.features:
             features = [f.replace('_', ' ').title() for f in guild.features[:10]]
-            embed.add_field(
-                name="Features",
-                value=", ".join(features),
-                inline=False
-            )
+            fields.append({
+                'name': "Features",
+                'value': ", ".join(features)
+            })
 
-        if guild.icon:
-            embed.set_thumbnail(url=guild.icon.url)
+        view = create_info_message(
+            f"{EMOJIS['web']} Server Information - {guild.name}",
+            f"Detailed information about **{guild.name}**",
+            fields=fields,
+            footer=f"Requested by {message.author}"
+        )
 
-        embed.set_footer(text=f"Requested by {message.author}")
-
-        await message.reply(embed=embed, mention_author=False)
+        await message.reply(view=view, mention_author=False)
 
     async def handle_help_command(self, message: discord.Message, args: str):
         """
@@ -296,12 +266,7 @@ class TeamCommands(commands.Cog):
         # Get user roles to show relevant commands
         user_roles = await staff_permissions.get_user_roles(message.author.id)
 
-        embed = discord.Embed(
-            title="📚 MODDY Staff Commands",
-            description="Available staff commands based on your permissions.",
-            color=COLORS["primary"],
-            timestamp=datetime.now(timezone.utc)
-        )
+        fields = []
 
         # Team commands (available to all staff)
         team_commands = [
@@ -310,11 +275,10 @@ class TeamCommands(commands.Cog):
             ("t.serverinfo [server_id]", "Get detailed information about a server")
         ]
 
-        embed.add_field(
-            name="🌐 Team Commands (All Staff)",
-            value="\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in team_commands]),
-            inline=False
-        )
+        fields.append({
+            'name': f"{EMOJIS['commands']} Team Commands (All Staff)",
+            'value': "\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in team_commands])
+        })
 
         # Management commands
         if await staff_permissions.can_use_command_type(message.author.id, CommandType.MANAGEMENT):
@@ -325,11 +289,10 @@ class TeamCommands(commands.Cog):
                 ("m.staffinfo [@user]", "Show staff member information")
             ]
 
-            embed.add_field(
-                name="👑 Management Commands",
-                value="\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in mgmt_commands]),
-                inline=False
-            )
+            fields.append({
+                'name': "👑 Management Commands",
+                'value': "\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in mgmt_commands])
+            })
 
         # Developer commands
         if await staff_permissions.can_use_command_type(message.author.id, CommandType.DEV):
@@ -341,11 +304,10 @@ class TeamCommands(commands.Cog):
                 ("d.jsk [code]", "Execute Python code")
             ]
 
-            embed.add_field(
-                name="💻 Developer Commands",
-                value="\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in dev_commands]),
-                inline=False
-            )
+            fields.append({
+                'name': f"{EMOJIS['dev']} Developer Commands",
+                'value': "\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in dev_commands])
+            })
 
         # Moderator commands
         if await staff_permissions.can_use_command_type(message.author.id, CommandType.MODERATOR):
@@ -356,31 +318,33 @@ class TeamCommands(commands.Cog):
                 ("mod.guildinfo [guild_id]", "Get detailed guild information")
             ]
 
-            embed.add_field(
-                name="🛡️ Moderator Commands",
-                value="\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in mod_commands]),
-                inline=False
-            )
+            fields.append({
+                'name': "🛡️ Moderator Commands",
+                'value': "\n".join([f"`<@1373916203814490194> {cmd}` - {desc}" for cmd, desc in mod_commands])
+            })
 
         # Support commands
         if await staff_permissions.can_use_command_type(message.author.id, CommandType.SUPPORT):
-            embed.add_field(
-                name="🎧 Support Commands",
-                value="Support commands are in development.",
-                inline=False
-            )
+            fields.append({
+                'name': "🎧 Support Commands",
+                'value': "Support commands are in development."
+            })
 
         # Communication commands
         if await staff_permissions.can_use_command_type(message.author.id, CommandType.COMMUNICATION):
-            embed.add_field(
-                name="💬 Communication Commands",
-                value="Communication commands are in development.",
-                inline=False
-            )
+            fields.append({
+                'name': "💬 Communication Commands",
+                'value': "Communication commands are in development."
+            })
 
-        embed.set_footer(text=f"Requested by {message.author} | Your roles: {', '.join([r.value for r in user_roles])}")
+        view = create_info_message(
+            f"{EMOJIS['commands']} MODDY Staff Commands",
+            "Available staff commands based on your permissions.",
+            fields=fields,
+            footer=f"Requested by {message.author} | Your roles: {', '.join([r.value for r in user_roles])}"
+        )
 
-        await message.reply(embed=embed, mention_author=False)
+        await message.reply(view=view, mention_author=False)
 
 
 async def setup(bot):

--- a/utils/components_v2.py
+++ b/utils/components_v2.py
@@ -8,12 +8,36 @@ from discord.ui import LayoutView, Container, TextDisplay, Separator
 from discord import SeparatorSpacing
 from typing import List, Optional, Dict
 
+# Emojis personnalisés du bot
+EMOJIS = {
+    'done': '<:done:1398729525277229066>',
+    'undone': '<:undone:1398729502028333218>',
+    'info': '<:info:1401614681440784477>',
+    'sync': '<:sync:1398729150885269546>',
+    'user': '<:user:1398729712204779571>',
+    'dev': '<:dev:1398729645557285066>',
+    'settings': '<:settings:1398729549323440208>',
+    'blacklist': '<:blacklist:1401596864784777363>',
+    'time': '<:time:1398729780723060736>',
+    'snowflake': '<:snowflake:1398729841938792458>',
+    'web': '<:web:1398729801061240883>',
+    'moddy': '<:moddy:1396880909117947924>',
+    'loading': '<:loading:1395047662092550194>',
+    'history': '<:history:1401600464587456512>',
+    'delete': '<:delete:1401600770431909939>',
+    'commands': '<:commands:1401610449136648283>',
+    'code': '<:code:1401610523803652196>',
+    'bug': '<:bug:1401614189482475551>',
+    'logout': '<:logout:1401603690858676224>',
+}
+
 
 def create_simple_message(
     title: str,
     description: str,
     fields: Optional[List[Dict[str, str]]] = None,
-    color: Optional[int] = None
+    color: Optional[int] = None,
+    footer: Optional[str] = None
 ) -> LayoutView:
     """
     Create a simple message using Components V2
@@ -23,6 +47,7 @@ def create_simple_message(
         description: Message description
         fields: List of dictionaries with 'name' and 'value' keys
         color: Not used in V2, kept for compatibility
+        footer: Optional footer text
 
     Returns:
         LayoutView ready to send
@@ -43,38 +68,22 @@ def create_simple_message(
             field_text = f"**{field['name']}**\n{field['value']}"
             container.add_item(TextDisplay(field_text))
 
+    # Add footer if present
+    if footer:
+        container.add_item(Separator(spacing=SeparatorSpacing.small))
+        container.add_item(TextDisplay(f"*{footer}*"))
+
     view.add_item(container)
     return view
 
 
-def create_error_message(title: str, description: str) -> LayoutView:
+def create_error_message(title: str, description: str, fields: Optional[List[Dict[str, str]]] = None) -> LayoutView:
     """
     Create an error message using Components V2
 
     Args:
         title: Error title
         description: Error description
-
-    Returns:
-        LayoutView ready to send
-    """
-    view = LayoutView()
-    container = Container()
-
-    error_text = f"❌ **{title}**\n{description}"
-    container.add_item(TextDisplay(error_text))
-
-    view.add_item(container)
-    return view
-
-
-def create_success_message(title: str, description: str, fields: Optional[List[Dict[str, str]]] = None) -> LayoutView:
-    """
-    Create a success message using Components V2
-
-    Args:
-        title: Success title
-        description: Success description
         fields: Optional list of fields
 
     Returns:
@@ -83,7 +92,36 @@ def create_success_message(title: str, description: str, fields: Optional[List[D
     view = LayoutView()
     container = Container()
 
-    success_text = f"✅ **{title}**\n{description}"
+    error_text = f"{EMOJIS['undone']} **{title}**\n{description}"
+    container.add_item(TextDisplay(error_text))
+
+    if fields:
+        container.add_item(Separator(spacing=SeparatorSpacing.small))
+        for field in fields:
+            field_text = f"**{field['name']}**\n{field['value']}"
+            container.add_item(TextDisplay(field_text))
+
+    view.add_item(container)
+    return view
+
+
+def create_success_message(title: str, description: str, fields: Optional[List[Dict[str, str]]] = None, footer: Optional[str] = None) -> LayoutView:
+    """
+    Create a success message using Components V2
+
+    Args:
+        title: Success title
+        description: Success description
+        fields: Optional list of fields
+        footer: Optional footer text
+
+    Returns:
+        LayoutView ready to send
+    """
+    view = LayoutView()
+    container = Container()
+
+    success_text = f"{EMOJIS['done']} **{title}**\n{description}"
     container.add_item(TextDisplay(success_text))
 
     if fields:
@@ -92,11 +130,15 @@ def create_success_message(title: str, description: str, fields: Optional[List[D
             field_text = f"**{field['name']}**\n{field['value']}"
             container.add_item(TextDisplay(field_text))
 
+    if footer:
+        container.add_item(Separator(spacing=SeparatorSpacing.small))
+        container.add_item(TextDisplay(f"*{footer}*"))
+
     view.add_item(container)
     return view
 
 
-def create_info_message(title: str, description: str, fields: Optional[List[Dict[str, str]]] = None) -> LayoutView:
+def create_info_message(title: str, description: str, fields: Optional[List[Dict[str, str]]] = None, footer: Optional[str] = None) -> LayoutView:
     """
     Create an info message using Components V2
 
@@ -104,6 +146,7 @@ def create_info_message(title: str, description: str, fields: Optional[List[Dict
         title: Info title
         description: Info description
         fields: Optional list of fields
+        footer: Optional footer text
 
     Returns:
         LayoutView ready to send
@@ -111,7 +154,7 @@ def create_info_message(title: str, description: str, fields: Optional[List[Dict
     view = LayoutView()
     container = Container()
 
-    info_text = f"ℹ️ **{title}**\n{description}"
+    info_text = f"{EMOJIS['info']} **{title}**\n{description}"
     container.add_item(TextDisplay(info_text))
 
     if fields:
@@ -120,17 +163,22 @@ def create_info_message(title: str, description: str, fields: Optional[List[Dict
             field_text = f"**{field['name']}**\n{field['value']}"
             container.add_item(TextDisplay(field_text))
 
+    if footer:
+        container.add_item(Separator(spacing=SeparatorSpacing.small))
+        container.add_item(TextDisplay(f"*{footer}*"))
+
     view.add_item(container)
     return view
 
 
-def create_warning_message(title: str, description: str) -> LayoutView:
+def create_warning_message(title: str, description: str, fields: Optional[List[Dict[str, str]]] = None) -> LayoutView:
     """
     Create a warning message using Components V2
 
     Args:
         title: Warning title
         description: Warning description
+        fields: Optional list of fields
 
     Returns:
         LayoutView ready to send
@@ -140,6 +188,12 @@ def create_warning_message(title: str, description: str) -> LayoutView:
 
     warning_text = f"⚠️ **{title}**\n{description}"
     container.add_item(TextDisplay(warning_text))
+
+    if fields:
+        container.add_item(Separator(spacing=SeparatorSpacing.small))
+        for field in fields:
+            field_text = f"**{field['name']}**\n{field['value']}"
+            container.add_item(TextDisplay(field_text))
 
     view.add_item(container)
     return view


### PR DESCRIPTION
- Ajout des émojis personnalisés dans utils/components_v2.py (EMOJIS dict)
- Amélioration des fonctions helpers pour supporter footer et fields
- Migration de dev_commands.py: d.reload, d.shutdown, d.stats, d.sql, d.jsk
- Migration de moderator_commands.py: mod.blacklist, mod.unblacklist, mod.userinfo, mod.guildinfo
- Migration de team_commands.py: t.invite, t.serverinfo, t.help
- Migration de staff_manager.py: m.stafflist, m.staffinfo
- Migration de communication_commands.py et support_commands.py

Note: Les commandes avec composants interactifs (buttons, selects) conservent les embeds Discord classiques car incompatibles avec Components V2 LayoutView.

Tous les embeds utilisent maintenant les émojis personnalisés du bot au lieu des émojis unicode standard.