### PR TITLE
Refactor staff system with role-based permissions UI

### DIFF
--- a/utils/staff_role_permissions.py
+++ b/utils/staff_role_permissions.py
@@ -1,0 +1,121 @@
+"""
+Staff Role Permissions Configuration
+Defines available permissions for each role
+"""
+
+from enum import Enum
+from typing import List, Dict
+
+# Common permissions available to all staff members
+COMMON_PERMISSIONS = [
+    "flex",          # Use t.flex command
+    "invite",        # Create server invites
+    "serverinfo",    # View server information
+]
+
+# Permissions specific to Moderator role
+MODERATOR_PERMISSIONS = [
+    "blacklist",     # Blacklist users
+    "unblacklist",   # Unblacklist users
+    "userinfo",      # View user information
+    "guildinfo",     # View guild information
+]
+
+# Permissions specific to Support role
+SUPPORT_PERMISSIONS = [
+    "ticket_view",   # View support tickets
+    "ticket_close",  # Close support tickets
+    "ticket_create", # Create support tickets
+]
+
+# Permissions specific to Communication role
+COMMUNICATION_PERMISSIONS = [
+    "announce",      # Send announcements
+    "broadcast",     # Broadcast messages
+]
+
+# Permissions specific to Supervisor_Mod role
+SUPERVISOR_MOD_PERMISSIONS = MODERATOR_PERMISSIONS + [
+    "manage_mod",    # Manage moderators
+]
+
+# Permissions specific to Supervisor_Sup role
+SUPERVISOR_SUP_PERMISSIONS = SUPPORT_PERMISSIONS + [
+    "manage_sup",    # Manage support agents
+]
+
+# Permissions specific to Supervisor_Com role
+SUPERVISOR_COM_PERMISSIONS = COMMUNICATION_PERMISSIONS + [
+    "manage_com",    # Manage communication team
+]
+
+# Permissions specific to Manager role
+MANAGER_PERMISSIONS = [
+    "rank",          # Add staff members
+    "unrank",        # Remove staff members
+    "setstaff",      # Manage staff permissions
+    "stafflist",     # View staff list
+    "staffinfo",     # View staff information
+]
+
+# Map role names to their available permissions
+ROLE_PERMISSIONS_MAP: Dict[str, List[str]] = {
+    "Moderator": MODERATOR_PERMISSIONS,
+    "Support": SUPPORT_PERMISSIONS,
+    "Communication": COMMUNICATION_PERMISSIONS,
+    "Supervisor_Mod": SUPERVISOR_MOD_PERMISSIONS,
+    "Supervisor_Sup": SUPERVISOR_SUP_PERMISSIONS,
+    "Supervisor_Com": SUPERVISOR_COM_PERMISSIONS,
+    "Manager": MANAGER_PERMISSIONS,
+}
+
+def get_permission_label(permission: str) -> str:
+    """Get human-readable label for a permission"""
+    labels = {
+        # Common
+        "flex": "Flex (Team Verification)",
+        "invite": "Server Invites",
+        "serverinfo": "Server Information",
+
+        # Moderator
+        "blacklist": "Blacklist Users",
+        "unblacklist": "Unblacklist Users",
+        "userinfo": "User Information",
+        "guildinfo": "Guild Information",
+
+        # Support
+        "ticket_view": "View Tickets",
+        "ticket_close": "Close Tickets",
+        "ticket_create": "Create Tickets",
+
+        # Communication
+        "announce": "Send Announcements",
+        "broadcast": "Broadcast Messages",
+
+        # Supervisor specific
+        "manage_mod": "Manage Moderators",
+        "manage_sup": "Manage Support Agents",
+        "manage_com": "Manage Communication Team",
+
+        # Manager
+        "rank": "Add Staff Members",
+        "unrank": "Remove Staff Members",
+        "setstaff": "Manage Staff Permissions",
+        "stafflist": "View Staff List",
+        "staffinfo": "View Staff Information",
+    }
+    return labels.get(permission, permission.replace("_", " ").title())
+
+def get_role_display_name(role: str) -> str:
+    """Get human-readable display name for a role"""
+    names = {
+        "Moderator": "Moderator",
+        "Support": "Support Agent",
+        "Communication": "Communication",
+        "Supervisor_Mod": "Moderation Supervisor",
+        "Supervisor_Sup": "Support Supervisor",
+        "Supervisor_Com": "Communication Supervisor",
+        "Manager": "Manager",
+        "Dev": "Developer",
+    }
+    return names.get(role, role)


### PR DESCRIPTION
…ntrol

This major update completely redesigns the staff permission system with the following changes:

**Permission System Overhaul:**
- Roles now have no power by default and require explicit permission grants
- Added granular permission control with dropdown menus for each role
- Implemented common permissions system (flex, invite, serverinfo) available to all roles
- Created role-specific permissions (Moderator: blacklist, unblacklist, userinfo, guildinfo; Support: ticket operations; Communication: announce, broadcast; Manager: staff management)
- New interactive Components V2 interface with dynamic dropdown menus that update in real-time

**Message Behavior Improvements:**
- Implemented auto-deletion: bot responses are automatically deleted when command messages are deleted
- Removed all footers ("Requested by...", "Removed by...", etc.) for cleaner interface
- Added message tracking system across all staff command cogs

**Database Changes:**
- Added role_permissions JSONB column to staff_permissions table
- Stores permissions for each role and common permissions separately
- Automatic migration on bot startup

**Code Architecture:**
- Created utils/staff_role_permissions.py for centralized permission definitions
- Added StaffPermissionsManagementView class for comprehensive permission management
- Implemented message deletion tracking in StaffManagement, TeamCommands, and ModeratorCommands cogs
- Added database methods: set_role_permissions() and get_role_permissions()

**Documentation:**
- Updated STAFF_SYSTEM.md with complete documentation of new permission system
- Added detailed explanation of role permissions format and usage
- Documented auto-deletion feature and message behavior changes

Breaking changes:
- Staff roles require explicit permission assignment through m.setstaff
- Old denied_commands system deprecated in favor of role permissions