### PR TITLE
Fix blacklist system blocking user interactions

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -21,7 +21,8 @@ from config import (
     DEFAULT_PREFIX,
     DATABASE_URL,
     DEVELOPER_IDS,
-    COLORS
+    COLORS,
+    EMOJIS
 )
 from database import setup_database, db
 # Import du nouveau système i18n
@@ -458,12 +459,12 @@ class ModdyBot(commands.Bot):
                     try:
                         embed = discord.Embed(
                             description=(
-                                "<:blacklist:1401596864784777363> You cannot add Moddy to servers while blacklisted.\n"
-                                "<:blacklist:1401596864784777363> Vous ne pouvez pas ajouter Moddy à des serveurs en étant blacklisté."
+                                f"{EMOJIS['undone']} You cannot add Moddy to servers because your account has been blacklisted by our team.\n\n"
+                                f"*Vous ne pouvez pas ajouter Moddy à des serveurs car votre compte a été blacklisté par notre équipe.*"
                             ),
                             color=COLORS["error"]
                         )
-                        embed.set_footer(text=f"ID: {guild.owner_id}")
+                        embed.set_footer(text=f"User ID: {guild.owner_id}")
 
                         # Create the button
                         view = discord.ui.View()


### PR DESCRIPTION
This commit fixes a critical issue where blacklisted users could still interact with the bot through component interactions (buttons, selects, modals) even though they were blocked from using commands.

Changes:
- Enhanced on_interaction listener to actively block blacklisted users BEFORE their interactions are processed by other handlers
- Updated all blacklist messages to use the new format: "You cannot interact with Moddy because your account has been blacklisted by our team."
- Added EMOJIS import to bot.py for consistency
- Improved logging to include custom_id for component interactions

The system now blocks:
✅ Prefix commands (via @bot.check)
✅ Slash commands (via @bot.check)
✅ Button interactions (via on_interaction listener) ✅ Select menu interactions (via on_interaction listener) ✅ Modal submissions (via on_interaction listener)
✅ Guild joins by blacklisted users (via on_guild_join)

All blocked interactions now show an ephemeral message with a link to request unblacklist at moddy.app/unbl_request