### PR TITLE
Implement staff commands system

### DIFF
--- a/staff/communication_commands.py
+++ b/staff/communication_commands.py
@@ -71,7 +71,7 @@ class CommunicationCommands(commands.Cog):
         Usage: <@&1386452009678278818> com.help
         """
         view = create_info_message(
-            "💬 Communication Commands",
+            "Communication Commands",
             "Communication command system is in development.\n\nAvailable commands will be added soon.",
             footer=f"Requested by {message.author}"
         )

--- a/staff/dev_commands.py
+++ b/staff/dev_commands.py
@@ -91,7 +91,7 @@ class DeveloperCommands(commands.Cog):
         """
         if not args or args == "all":
             # Reload all extensions
-            view = create_info_message(f"{EMOJIS['sync']} Reloading All Extensions", "Reloading all cogs and staff commands...")
+            view = create_info_message("Reloading All Extensions", "Reloading all cogs and staff commands...")
             msg = await message.reply(view=view, mention_author=False)
 
             success = []
@@ -107,7 +107,7 @@ class DeveloperCommands(commands.Cog):
                     failed.append(f"{ext}: {str(e)}")
 
             # Create result view
-            title = f"{EMOJIS['done']} Reload Complete" if not failed else "⚠️ Reload Complete with Errors"
+            title = "Reload Complete" if not failed else "Reload Complete with Errors"
             description = "Extensions reloaded successfully." if not failed else "Some extensions failed to reload."
 
             fields = []
@@ -172,7 +172,7 @@ class DeveloperCommands(commands.Cog):
         Usage: <@1373916203814490194> d.shutdown
         """
         view = create_error_message(
-            f"{EMOJIS['logout']} Shutting Down" if 'logout' in EMOJIS else "🔴 Shutting Down",
+            "Shutting Down",
             "MODDY is shutting down..."
         )
 
@@ -286,7 +286,7 @@ class DeveloperCommands(commands.Cog):
                     await msg.edit(view=cancel_view)
                     return
             except:
-                timeout_view = create_error_message(f"{EMOJIS['time']} Timeout", "Query confirmation timed out.")
+                timeout_view = create_error_message("Timeout", "Query confirmation timed out.")
                 await msg.edit(view=timeout_view)
                 return
 
@@ -407,7 +407,7 @@ class DeveloperCommands(commands.Cog):
                 output = output[:1900] + "\n... (output truncated)"
 
             view = create_success_message(
-                f"{EMOJIS['code']} Code Executed",
+                "Code Executed",
                 f"```python\n{code[:500]}\n```",
                 fields=[{'name': 'Output', 'value': f"```python\n{output}\n```"}],
                 footer=f"Executed by {message.author}"

--- a/staff/moderator_commands.py
+++ b/staff/moderator_commands.py
@@ -133,7 +133,7 @@ class ModeratorCommands(commands.Cog):
         ]
 
         view = create_success_message(
-            f"{EMOJIS['blacklist']} User Blacklisted",
+            "User Blacklisted",
             f"{target_user.mention} has been blacklisted.",
             fields=fields
         )

--- a/staff/staff_manager.py
+++ b/staff/staff_manager.py
@@ -941,7 +941,7 @@ class StaffManagement(commands.Cog):
         staff_members = await db.get_all_staff_members()
 
         if not staff_members:
-            view = create_info_message("📋 Staff List", "No staff members found.")
+            view = create_info_message("Staff List", "No staff members found.")
             await message.reply(view=view, mention_author=False)
             return
 
@@ -976,7 +976,7 @@ class StaffManagement(commands.Cog):
                 })
 
         view = create_info_message(
-            "📋 MODDY Staff Team",
+            "MODDY Staff Team",
             f"Total staff members: **{len(staff_members)}**",
             fields=fields
         )
@@ -1080,7 +1080,7 @@ class StaffManagement(commands.Cog):
             })
 
         view = create_info_message(
-            f"{EMOJIS['user']} Staff Member Information - {str(target_user)}",
+            f"Staff Member Information - {str(target_user)}",
             f"Information about staff member {target_user.mention}",
             fields=fields
         )

--- a/staff/support_commands.py
+++ b/staff/support_commands.py
@@ -71,7 +71,7 @@ class SupportCommands(commands.Cog):
         Usage: <@&1386452009678278818> sup.help
         """
         view = create_info_message(
-            "🎧 Support Commands",
+            "Support Commands",
             "Support command system is in development.\n\nAvailable commands will be added soon.",
             footer=f"Requested by {message.author}"
         )

--- a/staff/team_commands.py
+++ b/staff/team_commands.py
@@ -17,6 +17,36 @@ from utils.components_v2 import create_error_message, create_success_message, cr
 logger = logging.getLogger('moddy.team_commands')
 
 
+def parse_user_id(args: str) -> Optional[int]:
+    """
+    Parse user ID from mention or direct ID
+    Accepts: @user mention (<@123456>) or direct ID (123456)
+    Returns: user ID as int, or None if invalid
+    """
+    if not args:
+        return None
+
+    args = args.strip()
+
+    # Check if it's a mention (<@123456> or <@!123456>)
+    if args.startswith('<@') and args.endswith('>'):
+        # Remove <@ and >
+        user_id_str = args[2:-1]
+        # Remove ! if present (some mentions use <@!ID>)
+        if user_id_str.startswith('!'):
+            user_id_str = user_id_str[1:]
+        try:
+            return int(user_id_str)
+        except ValueError:
+            return None
+
+    # Otherwise, try to parse as direct ID
+    try:
+        return int(args)
+    except ValueError:
+        return None
+
+
 class TeamCommands(commands.Cog):
     """Team commands accessible to all staff (t. prefix)"""
 
@@ -114,7 +144,7 @@ class TeamCommands(commands.Cog):
             guild_id = int(args.strip())
         except ValueError:
             view = create_error_message(
-                f"{EMOJIS['snowflake']} Invalid Server ID",
+                "Invalid Server ID",
                 "Please provide a valid server ID (numbers only)."
             )
             await message.reply(view=view, mention_author=False)
@@ -209,7 +239,7 @@ class TeamCommands(commands.Cog):
             guild_id = int(args.strip())
         except ValueError:
             view = create_error_message(
-                f"{EMOJIS['snowflake']} Invalid Server ID",
+                "Invalid Server ID",
                 "Please provide a valid server ID (numbers only)."
             )
             await message.reply(view=view, mention_author=False)
@@ -267,7 +297,7 @@ class TeamCommands(commands.Cog):
             })
 
         view = create_info_message(
-            f"{EMOJIS['web']} Server Information - {guild.name}",
+            f"Server Information - {guild.name}",
             f"Detailed information about **{guild.name}**",
             fields=fields
         )
@@ -359,7 +389,7 @@ class TeamCommands(commands.Cog):
             })
 
         view = create_info_message(
-            f"{EMOJIS['commands']} MODDY Staff Commands",
+            "MODDY Staff Commands",
             "Available staff commands based on your permissions.",
             fields=fields
         )
@@ -445,23 +475,22 @@ class TeamCommands(commands.Cog):
     async def handle_mutualserver_command(self, message: discord.Message, args: str):
         """
         Handle t.mutualserver command - View mutual servers with a user
-        Usage: <@1373916203814490194> t.mutualserver [user_id]
+        Usage: <@1373916203814490194> t.mutualserver [user_id or @user]
         """
         if not args:
             view = create_error_message(
                 "Invalid Usage",
-                "**Usage:** `<@1373916203814490194> t.mutualserver [user_id]`\n\nProvide a user ID to view mutual servers."
+                "**Usage:** `<@1373916203814490194> t.mutualserver [user_id]` or `<@1373916203814490194> t.mutualserver @user`\n\nProvide a user ID or mention to view mutual servers."
             )
             await message.reply(view=view, mention_author=False)
             return
 
         # Parse user ID
-        try:
-            user_id = int(args.strip())
-        except ValueError:
+        user_id = parse_user_id(args)
+        if user_id is None:
             view = create_error_message(
-                f"{EMOJIS['snowflake']} Invalid User ID",
-                "Please provide a valid user ID (numbers only)."
+                "Invalid User ID",
+                "Please provide a valid user ID or mention a user."
             )
             await message.reply(view=view, mention_author=False)
             return
@@ -544,7 +573,7 @@ class TeamCommands(commands.Cog):
             })
 
         view = create_info_message(
-            f"{EMOJIS['web']} Mutual Servers - {user}",
+            f"Mutual Servers - {user}",
             f"Found **{len(mutual_guilds)}** mutual server(s) with **{user}**",
             fields=fields
         )
@@ -556,23 +585,22 @@ class TeamCommands(commands.Cog):
     async def handle_user_command(self, message: discord.Message, args: str):
         """
         Handle t.user command - Get detailed user information
-        Usage: <@1373916203814490194> t.user [user_id]
+        Usage: <@1373916203814490194> t.user [user_id or @user]
         """
         if not args:
             view = create_error_message(
                 "Invalid Usage",
-                "**Usage:** `<@1373916203814490194> t.user [user_id]`\n\nProvide a user ID to get information."
+                "**Usage:** `<@1373916203814490194> t.user [user_id]` or `<@1373916203814490194> t.user @user`\n\nProvide a user ID or mention to get information."
             )
             await message.reply(view=view, mention_author=False)
             return
 
         # Parse user ID
-        try:
-            user_id = int(args.strip())
-        except ValueError:
+        user_id = parse_user_id(args)
+        if user_id is None:
             view = create_error_message(
-                f"{EMOJIS['snowflake']} Invalid User ID",
-                "Please provide a valid user ID (numbers only)."
+                "Invalid User ID",
+                "Please provide a valid user ID or mention a user."
             )
             await message.reply(view=view, mention_author=False)
             return
@@ -642,7 +670,7 @@ class TeamCommands(commands.Cog):
             })
 
         view = create_info_message(
-            f"{EMOJIS['user']} User Information - {str(user)}",
+            f"User Information - {str(user)}",
             f"Information about **{user}**",
             fields=fields
         )
@@ -669,7 +697,7 @@ class TeamCommands(commands.Cog):
             guild_id = int(args.strip())
         except ValueError:
             view = create_error_message(
-                f"{EMOJIS['snowflake']} Invalid Server ID",
+                "Invalid Server ID",
                 "Please provide a valid server ID (numbers only)."
             )
             await message.reply(view=view, mention_author=False)
@@ -744,7 +772,7 @@ class TeamCommands(commands.Cog):
             })
 
         view = create_info_message(
-            f"🏰 Server Information - {guild.name}",
+            f"Server Information - {guild.name}",
             f"Detailed information about **{guild.name}**",
             fields=fields
         )


### PR DESCRIPTION
- Remove duplicate emojis in Components V2 messages (done/undone/info now only appear once)
- Add parse_user_id helper function to accept both mentions (<@ID>) and direct IDs
- Update t.user and t.mutualserver commands to accept mentions in addition to IDs
- Clean up emoji usage across all staff command files:
  - team_commands.py
  - dev_commands.py
  - moderator_commands.py
  - staff_manager.py
  - support_commands.py
  - communication_commands.py