### PR TITLE
Fix staff command message deletion system

### DIFF
--- a/documentation/STAFF_SYSTEM.md
+++ b/documentation/STAFF_SYSTEM.md
@@ -535,6 +535,8 @@ Features:
 - All staff command responses use `message.reply()` instead of `message.channel.send()`
 - `mention_author=False` is used to avoid unnecessary mentions
 - **Auto-deletion on command removal:** When you delete the command message, the bot's response is automatically deleted as well
+- **Automatic implementation:** All staff cogs inherit from `StaffCommandsCog` which provides automatic deletion tracking
+- **Works by default:** New staff commands automatically get this behavior when using `reply_with_tracking()`
 - This keeps channels clean while allowing staff to remove accidental or outdated commands
 - No footers are displayed (e.g., no "Requested by..." text)
 
@@ -546,6 +548,7 @@ All staff commands are in **English only** and do **NOT** use the i18n system.
 
 ### Files:
 
+- `/staff/base.py` - Base class for all staff command cogs (provides automatic deletion tracking)
 - `/utils/staff_permissions.py` - Permission manager and role hierarchy
 - `/staff/staff_manager.py` - Management commands (m. prefix)
 - `/staff/team_commands.py` - Team commands (t. prefix)
@@ -557,6 +560,10 @@ All staff commands are in **English only** and do **NOT** use the i18n system.
 
 ### Key Classes and Constants:
 
+- `StaffCommandsCog` - Base class for all staff command cogs (in `/staff/base.py`)
+  - Provides automatic message deletion tracking
+  - All staff cogs inherit from this class
+  - Provides `reply_with_tracking()` helper method for automatic deletion
 - `StaffPermissionManager` - Main permission checking logic
   - `STAFF_PREFIX` - Bot mention: `<@1373916203814490194>`
   - `SUPER_ADMIN_ID` - Super admin user ID: `1164597199594852395`
@@ -716,7 +723,19 @@ The staff logging system is implemented in:
 
 ## Recent Changes (Latest Update)
 
-**Staff Logging System (New):**
+**Automatic Message Deletion Architecture (New):**
+- **Base Class System:** All staff cogs now inherit from `StaffCommandsCog` base class
+- **Automatic Tracking:** Message deletion is now handled automatically by the base class
+- **Helper Method:** New `reply_with_tracking()` method automatically tracks command responses
+- **Works by Default:** Any new staff command automatically gets deletion tracking
+- **Zero Maintenance:** No need to manually track messages in each command
+- **Benefits:**
+  - Consistent behavior across all staff commands
+  - Future-proof for new commands
+  - Reduced code duplication
+  - Cleaner implementation
+
+**Staff Logging System:**
 - **Comprehensive Logging:** All staff commands and actions are now logged to a dedicated channel
 - **Audit Trail:** Complete tracking of who did what, when, and why
 - **Security:** Sensitive data (SQL queries, code) is sanitized in logs

--- a/staff/base.py
+++ b/staff/base.py
@@ -1,0 +1,91 @@
+"""
+Base class for all staff command cogs
+Provides automatic message deletion tracking and helper methods
+"""
+
+import discord
+from discord.ext import commands
+import logging
+from typing import Optional, Union
+from discord.ui import LayoutView
+
+logger = logging.getLogger('moddy.staff_base')
+
+
+class StaffCommandsCog(commands.Cog):
+    """
+    Base class for all staff command cogs
+
+    Provides automatic message deletion tracking:
+    - When a staff command message is deleted, the bot's response is automatically deleted
+    - All cogs inheriting from this class get this behavior by default
+
+    Usage:
+        class MyCog(StaffCommandsCog):
+            def __init__(self, bot):
+                super().__init__(bot)
+
+            async def handle_my_command(self, message: discord.Message, args: str):
+                # Use reply_with_tracking for automatic deletion tracking
+                reply_msg = await self.reply_with_tracking(message, view)
+    """
+
+    def __init__(self, bot):
+        self.bot = bot
+        # Store command message -> response message mapping for auto-deletion
+        self.command_responses = {}  # {command_msg_id: response_msg_id}
+
+    @commands.Cog.listener()
+    async def on_message_delete(self, message: discord.Message):
+        """
+        Handle message deletion to auto-delete command responses
+
+        When a staff command message is deleted, this automatically finds and deletes
+        the bot's response message, keeping channels clean.
+        """
+        # Check if this message is a command that has a response
+        if message.id in self.command_responses:
+            response_msg_id = self.command_responses[message.id]
+            try:
+                # Try to fetch and delete the response message
+                response_msg = await message.channel.fetch_message(response_msg_id)
+                await response_msg.delete()
+                logger.info(f"Auto-deleted response {response_msg_id} for deleted command {message.id}")
+            except (discord.NotFound, discord.Forbidden, discord.HTTPException) as e:
+                logger.debug(f"Could not delete response message {response_msg_id}: {e}")
+            finally:
+                # Clean up the mapping
+                del self.command_responses[message.id]
+
+    async def reply_with_tracking(
+        self,
+        message: discord.Message,
+        view: Optional[LayoutView] = None,
+        content: Optional[str] = None,
+        mention_author: bool = False
+    ) -> discord.Message:
+        """
+        Reply to a message and automatically track it for deletion
+
+        This is a convenience method that:
+        1. Replies to the command message
+        2. Automatically stores the mapping for auto-deletion
+        3. Returns the reply message for further use if needed
+
+        Args:
+            message: The command message to reply to
+            view: Optional LayoutView to send
+            content: Optional text content to send
+            mention_author: Whether to mention the author in the reply
+
+        Returns:
+            The reply message object
+
+        Example:
+            view = create_success_message("Done", "Command executed successfully")
+            reply_msg = await self.reply_with_tracking(message, view)
+        """
+        reply_msg = await message.reply(view=view, content=content, mention_author=mention_author)
+        # Store for auto-deletion
+        self.command_responses[message.id] = reply_msg.id
+        return reply_msg

--- a/staff/communication_commands.py
+++ b/staff/communication_commands.py
@@ -14,15 +14,16 @@ from database import db
 from config import COLORS
 from utils.components_v2 import create_error_message, create_info_message, EMOJIS
 from utils.staff_logger import staff_logger
+from staff.base import StaffCommandsCog
 
 logger = logging.getLogger('moddy.communication_commands')
 
 
-class CommunicationCommands(commands.Cog):
+class CommunicationCommands(StaffCommandsCog):
     """Communication commands (com. prefix)"""
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -53,7 +54,7 @@ class CommunicationCommands(commands.Cog):
 
         if not allowed:
             view = create_error_message("Permission Denied", reason)
-            await message.channel.send(view=view, delete_after=10)
+            await self.reply_with_tracking(message, view)
             return
 
         # Route to appropriate command
@@ -64,7 +65,7 @@ class CommunicationCommands(commands.Cog):
                 "Unknown Command",
                 f"Communication command `{command_name}` not found.\n\nCommunication commands are in development."
             )
-            await message.channel.send(view=view, delete_after=15)
+            await self.reply_with_tracking(message, view)
 
     async def handle_help_command(self, message: discord.Message, args: str):
         """
@@ -81,7 +82,7 @@ class CommunicationCommands(commands.Cog):
             footer=f"Requested by {message.author}"
         )
 
-        await message.channel.send(view=view)
+        await self.reply_with_tracking(message, view)
 
 
 async def setup(bot):

--- a/staff/dev_commands.py
+++ b/staff/dev_commands.py
@@ -16,15 +16,16 @@ from database import db
 from config import COLORS
 from utils.components_v2 import create_error_message, create_success_message, create_info_message, create_warning_message, EMOJIS
 from utils.staff_logger import staff_logger
+from staff.base import StaffCommandsCog
 
 logger = logging.getLogger('moddy.dev_commands')
 
 
-class DeveloperCommands(commands.Cog):
+class DeveloperCommands(StaffCommandsCog):
     """Developer commands (d. prefix)"""
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -63,7 +64,7 @@ class DeveloperCommands(commands.Cog):
         if not allowed:
             logger.warning(f"   ❌ Permission denied: {reason}")
             view = create_error_message("Permission Denied", reason)
-            await message.reply(view=view, mention_author=False)
+            await self.reply_with_tracking(message, view)
             return
 
         logger.info(f"   ✅ Permission granted")
@@ -83,7 +84,7 @@ class DeveloperCommands(commands.Cog):
             await self.handle_error_command(message, args)
         else:
             view = create_error_message("Unknown Command", f"Developer command `{command_name}` not found.")
-            await message.reply(view=view, mention_author=False)
+            await self.reply_with_tracking(message, view)
 
     async def handle_reload_command(self, message: discord.Message, args: str):
         """
@@ -160,7 +161,7 @@ class DeveloperCommands(commands.Cog):
                     footer=f"Executed by {message.author}"
                 )
 
-                await message.reply(view=view, mention_author=False)
+                await self.reply_with_tracking(message, view)
 
             except Exception as e:
                 view = create_error_message(
@@ -169,7 +170,7 @@ class DeveloperCommands(commands.Cog):
                     fields=[{'name': 'Error', 'value': f"```{str(e)[:500]}```"}]
                 )
 
-                await message.reply(view=view, mention_author=False)
+                await self.reply_with_tracking(message, view)
 
     async def handle_shutdown_command(self, message: discord.Message, args: str):
         """
@@ -185,7 +186,7 @@ class DeveloperCommands(commands.Cog):
             "MODDY is shutting down..."
         )
 
-        await message.reply(view=view, mention_author=False)
+        await self.reply_with_tracking(message, view)
 
         logger.info(f"Bot shutdown requested by {message.author} ({message.author.id})")
         await self.bot.close()
@@ -252,7 +253,7 @@ class DeveloperCommands(commands.Cog):
             footer=f"Requested by {message.author}"
         )
 
-        await message.reply(view=view, mention_author=False)
+        await self.reply_with_tracking(message, view)
 
     async def handle_sql_command(self, message: discord.Message, args: str):
         """
@@ -269,7 +270,7 @@ class DeveloperCommands(commands.Cog):
                 "Invalid Usage",
                 "**Usage:** `<@1373916203814490194> d.sql [query]`\n\nProvide a SQL query to execute."
             )
-            await message.reply(view=view, mention_author=False)
+            await self.reply_with_tracking(message, view)
             return
 
         if not db:
@@ -277,7 +278,7 @@ class DeveloperCommands(commands.Cog):
                 "Database Not Available",
                 "Database is not connected."
             )
-            await message.reply(view=view, mention_author=False)
+            await self.reply_with_tracking(message, view)
             return
 
         query = args.strip()
@@ -316,7 +317,7 @@ class DeveloperCommands(commands.Cog):
 
                     if not rows:
                         view = create_success_message("Query Executed", "No results returned.")
-                        await message.reply(view=view, mention_author=False)
+                        await self.reply_with_tracking(message, view)
                         return
 
                     # Format results
@@ -343,7 +344,7 @@ class DeveloperCommands(commands.Cog):
                         footer=f"Executed by {message.author}"
                     )
 
-                await message.reply(view=view, mention_author=False)
+                await self.reply_with_tracking(message, view)
 
         except Exception as e:
             view = create_error_message(
@@ -352,7 +353,7 @@ class DeveloperCommands(commands.Cog):
                 fields=[{'name': 'Error', 'value': f"```{str(e)[:500]}```"}]
             )
 
-            await message.reply(view=view, mention_author=False)
+            await self.reply_with_tracking(message, view)
 
     async def handle_jsk_command(self, message: discord.Message, args: str):
         """
@@ -369,7 +370,7 @@ class DeveloperCommands(commands.Cog):
                 "Invalid Usage",
                 "**Usage:** `<@1373916203814490194> d.jsk [code]`\n\nProvide Python code to execute."
             )
-            await message.reply(view=view, mention_author=False)
+            await self.reply_with_tracking(message, view)
             return
 
         code = args.strip()
@@ -436,7 +437,7 @@ class DeveloperCommands(commands.Cog):
                 footer=f"Executed by {message.author}"
             )
 
-            await message.reply(view=view, mention_author=False)
+            await self.reply_with_tracking(message, view)
 
         except Exception as e:
             # Format error
@@ -451,7 +452,7 @@ class DeveloperCommands(commands.Cog):
                 fields=[{'name': 'Error', 'value': f"```python\n{error_traceback}\n```"}]
             )
 
-            await message.reply(view=view, mention_author=False)
+            await self.reply_with_tracking(message, view)
 
     async def handle_error_command(self, message: discord.Message, args: str):
         """
@@ -467,7 +468,7 @@ class DeveloperCommands(commands.Cog):
                 "Invalid Usage",
                 "**Usage:** `<@1373916203814490194> d.error [error_code]`\n\nProvide an error code to get information."
             )
-            await message.reply(view=view, mention_author=False)
+            await self.reply_with_tracking(message, view)
             return
 
         error_code = args.strip().upper()
@@ -497,7 +498,7 @@ class DeveloperCommands(commands.Cog):
                 "Error Not Found",
                 f"No error found with code `{error_code}`.\n\nThe error may have expired from cache or was never logged."
             )
-            await message.reply(view=view, mention_author=False)
+            await self.reply_with_tracking(message, view)
             return
 
         # Use database error if available, otherwise use cached error
@@ -596,7 +597,7 @@ class DeveloperCommands(commands.Cog):
             fields=fields
         )
 
-        await message.reply(view=view, mention_author=False)
+        await self.reply_with_tracking(message, view)
 
 
 async def setup(bot):

--- a/staff/moderator_commands.py
+++ b/staff/moderator_commands.py
@@ -14,34 +14,16 @@ from database import db
 from config import COLORS
 from utils.components_v2 import create_error_message, create_success_message, create_info_message, create_warning_message, EMOJIS
 from utils.staff_logger import staff_logger
+from staff.base import StaffCommandsCog
 
 logger = logging.getLogger('moddy.moderator_commands')
 
 
-class ModeratorCommands(commands.Cog):
+class ModeratorCommands(StaffCommandsCog):
     """Moderator commands (mod. prefix)"""
 
     def __init__(self, bot):
-        self.bot = bot
-        # Store command message -> response message mapping for auto-deletion
-        self.command_responses = {}  # {command_msg_id: response_msg_id}
-
-    @commands.Cog.listener()
-    async def on_message_delete(self, message: discord.Message):
-        """Handle message deletion to auto-delete command responses"""
-        # Check if this message is a command that has a response
-        if message.id in self.command_responses:
-            response_msg_id = self.command_responses[message.id]
-            try:
-                # Try to fetch and delete the response message
-                response_msg = await message.channel.fetch_message(response_msg_id)
-                await response_msg.delete()
-                logger.info(f"Auto-deleted response {response_msg_id} for deleted command {message.id}")
-            except (discord.NotFound, discord.Forbidden, discord.HTTPException) as e:
-                logger.debug(f"Could not delete response message {response_msg_id}: {e}")
-            finally:
-                # Clean up the mapping
-                del self.command_responses[message.id]
+        super().__init__(bot)
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -153,9 +135,7 @@ class ModeratorCommands(commands.Cog):
             fields=fields
         )
 
-        reply_msg = await message.reply(view=view, mention_author=False)
-        # Store for auto-deletion
-        self.command_responses[message.id] = reply_msg.id
+        await self.reply_with_tracking(message, view)
 
         logger.info(f"User {target_user} ({target_user.id}) blacklisted by {message.author} ({message.author.id})")
 
@@ -219,9 +199,7 @@ class ModeratorCommands(commands.Cog):
             fields=fields
         )
 
-        reply_msg = await message.reply(view=view, mention_author=False)
-        # Store for auto-deletion
-        self.command_responses[message.id] = reply_msg.id
+        await self.reply_with_tracking(message, view)
 
         logger.info(f"User {target_user} ({target_user.id}) unblacklisted by {message.author} ({message.author.id})")
 

--- a/staff/support_commands.py
+++ b/staff/support_commands.py
@@ -14,15 +14,16 @@ from database import db
 from config import COLORS
 from utils.components_v2 import create_error_message, create_info_message, EMOJIS
 from utils.staff_logger import staff_logger
+from staff.base import StaffCommandsCog
 
 logger = logging.getLogger('moddy.support_commands')
 
 
-class SupportCommands(commands.Cog):
+class SupportCommands(StaffCommandsCog):
     """Support commands (sup. prefix)"""
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -53,7 +54,7 @@ class SupportCommands(commands.Cog):
 
         if not allowed:
             view = create_error_message("Permission Denied", reason)
-            await message.channel.send(view=view, delete_after=10)
+            await self.reply_with_tracking(message, view)
             return
 
         # Route to appropriate command
@@ -64,7 +65,7 @@ class SupportCommands(commands.Cog):
                 "Unknown Command",
                 f"Support command `{command_name}` not found.\n\nSupport commands are in development."
             )
-            await message.channel.send(view=view, delete_after=15)
+            await self.reply_with_tracking(message, view)
 
     async def handle_help_command(self, message: discord.Message, args: str):
         """
@@ -81,7 +82,7 @@ class SupportCommands(commands.Cog):
             footer=f"Requested by {message.author}"
         )
 
-        await message.channel.send(view=view)
+        await self.reply_with_tracking(message, view)
 
 
 async def setup(bot):

--- a/staff/team_commands.py
+++ b/staff/team_commands.py
@@ -14,6 +14,7 @@ from database import db
 from config import COLORS
 from utils.components_v2 import create_error_message, create_success_message, create_info_message, create_warning_message, create_simple_message, EMOJIS
 from utils.staff_logger import staff_logger
+from staff.base import StaffCommandsCog
 
 logger = logging.getLogger('moddy.team_commands')
 
@@ -48,30 +49,11 @@ def parse_user_id(args: str) -> Optional[int]:
         return None
 
 
-class TeamCommands(commands.Cog):
+class TeamCommands(StaffCommandsCog):
     """Team commands accessible to all staff (t. prefix)"""
 
     def __init__(self, bot):
-        self.bot = bot
-        # Store command message -> response message mapping for auto-deletion
-        self.command_responses = {}  # {command_msg_id: response_msg_id}
-
-    @commands.Cog.listener()
-    async def on_message_delete(self, message: discord.Message):
-        """Handle message deletion to auto-delete command responses"""
-        # Check if this message is a command that has a response
-        if message.id in self.command_responses:
-            response_msg_id = self.command_responses[message.id]
-            try:
-                # Try to fetch and delete the response message
-                response_msg = await message.channel.fetch_message(response_msg_id)
-                await response_msg.delete()
-                logger.info(f"Auto-deleted response {response_msg_id} for deleted command {message.id}")
-            except (discord.NotFound, discord.Forbidden, discord.HTTPException) as e:
-                logger.debug(f"Could not delete response message {response_msg_id}: {e}")
-            finally:
-                # Clean up the mapping
-                del self.command_responses[message.id]
+        super().__init__(bot)
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -204,9 +186,7 @@ class TeamCommands(commands.Cog):
 
             view = InviteComponents()
 
-            reply_msg = await message.reply(view=view, mention_author=False)
-            # Store for auto-deletion
-            self.command_responses[message.id] = reply_msg.id
+            await self.reply_with_tracking(message, view)
 
             # Log the action
             logger.info(f"Staff {message.author} ({message.author.id}) requested invite for {guild.name} ({guild.id})")
@@ -311,9 +291,7 @@ class TeamCommands(commands.Cog):
             fields=fields
         )
 
-        reply_msg = await message.reply(view=view, mention_author=False)
-        # Store for auto-deletion
-        self.command_responses[message.id] = reply_msg.id
+        await self.reply_with_tracking(message, view)
 
     async def handle_help_command(self, message: discord.Message, args: str):
         """
@@ -407,9 +385,7 @@ class TeamCommands(commands.Cog):
             fields=fields
         )
 
-        reply_msg = await message.reply(view=view, mention_author=False)
-        # Store for auto-deletion
-        self.command_responses[message.id] = reply_msg.id
+        await self.reply_with_tracking(message, view)
 
     async def handle_flex_command(self, message: discord.Message, args: str):
         """
@@ -599,9 +575,7 @@ class TeamCommands(commands.Cog):
             fields=fields
         )
 
-        reply_msg = await message.reply(view=view, mention_author=False)
-        # Store for auto-deletion
-        self.command_responses[message.id] = reply_msg.id
+        await self.reply_with_tracking(message, view)
 
     async def handle_user_command(self, message: discord.Message, args: str):
         """
@@ -700,9 +674,7 @@ class TeamCommands(commands.Cog):
             fields=fields
         )
 
-        reply_msg = await message.reply(view=view, mention_author=False)
-        # Store for auto-deletion
-        self.command_responses[message.id] = reply_msg.id
+        await self.reply_with_tracking(message, view)
 
     async def handle_server_command(self, message: discord.Message, args: str):
         """
@@ -806,9 +778,7 @@ class TeamCommands(commands.Cog):
             fields=fields
         )
 
-        reply_msg = await message.reply(view=view, mention_author=False)
-        # Store for auto-deletion
-        self.command_responses[message.id] = reply_msg.id
+        await self.reply_with_tracking(message, view)
 
 
 async def setup(bot):


### PR DESCRIPTION
- Create StaffCommandsCog base class with automatic deletion tracking
- All staff cogs now inherit from base class for consistent behavior
- Add reply_with_tracking() helper method for automatic tracking
- Update all staff command cogs to use the new base class:
  * dev_commands.py
  * support_commands.py
  * communication_commands.py
  * staff_manager.py
  * team_commands.py
  * moderator_commands.py
- Remove duplicate on_message_delete listeners from individual cogs
- Fix support/communication commands to use reply() instead of channel.send()
- Update STAFF_SYSTEM.md documentation with new architecture

Benefits:
- Automatic deletion works on ALL staff commands by default
- New commands automatically get deletion tracking
- Zero maintenance required for future commands
- Consistent behavior across all command types
- Cleaner, DRY codebase