### PR TITLE
Block blacklisted interactions before dispatch

### DIFF
--- a/cogs/blacklist_check.py
+++ b/cogs/blacklist_check.py
@@ -9,9 +9,13 @@ Bloque TOUTES les interactions des utilisateurs blacklistés AVANT qu'elles n'ar
 
 import discord
 from discord.ext import commands
-from typing import Union
 
-from config import COLORS, EMOJIS
+BLACKLIST_MESSAGE = (
+    "<:undone:1398729502028333218> You cannot interact with Moddy because your account "
+    "has been blacklisted by our team."
+)
+BLACKLIST_LINK = "https://moddy.app/unbl_request"
+BLACKLIST_RESPONSE = f"{BLACKLIST_MESSAGE}\n{BLACKLIST_LINK}"
 
 
 class BlacklistButton(discord.ui.View):
@@ -47,15 +51,14 @@ class BlacklistCheck(commands.Cog):
             # Vérifie si l'utilisateur est blacklisté
             if await self.is_blacklisted(interaction.user.id):
                 # Envoie le message de blacklist
-                embed = discord.Embed(
-                    description=f"{EMOJIS['undone']} You cannot interact with Moddy because your account has been blacklisted by our team.",
-                    color=COLORS["error"]
-                )
-                embed.set_footer(text=f"User ID: {interaction.user.id}")
                 view = BlacklistButton()
 
                 try:
-                    await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+                    await interaction.response.send_message(
+                        content=BLACKLIST_RESPONSE,
+                        view=view,
+                        ephemeral=True
+                    )
                 except:
                     pass
 
@@ -106,18 +109,20 @@ class BlacklistCheck(commands.Cog):
             # C'est une commande (commence par un préfixe), vérifie maintenant si l'utilisateur est blacklisté
             if await self.is_blacklisted(message.author.id):
                 # Envoie le message de blacklist
-                embed = discord.Embed(
-                    description=f"{EMOJIS['undone']} You cannot interact with Moddy because your account has been blacklisted by our team.",
-                    color=COLORS["error"]
-                )
-                embed.set_footer(text=f"User ID: {message.author.id}")
                 view = BlacklistButton()
 
                 try:
-                    await message.reply(embed=embed, view=view, mention_author=False)
+                    await message.reply(
+                        content=BLACKLIST_RESPONSE,
+                        view=view,
+                        mention_author=False
+                    )
                 except:
                     try:
-                        await message.channel.send(embed=embed, view=view)
+                        await message.channel.send(
+                            content=BLACKLIST_RESPONSE,
+                            view=view
+                        )
                     except:
                         pass
 
@@ -147,25 +152,28 @@ class BlacklistCheck(commands.Cog):
                 # BLOQUE l'interaction en y répondant immédiatement
                 try:
                     # Envoie directement le message de blacklist
-                    embed = discord.Embed(
-                        description=f"{EMOJIS['undone']} You cannot interact with Moddy because your account has been blacklisted by our team.",
-                        color=COLORS["error"]
-                    )
-                    embed.set_footer(text=f"User ID: {interaction.user.id}")
                     view = BlacklistButton()
 
                     # Vérifie si l'interaction n'a pas déjà été répondue
                     if not interaction.response.is_done():
-                        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+                        await interaction.response.send_message(
+                            content=BLACKLIST_RESPONSE,
+                            view=view,
+                            ephemeral=True
+                        )
                     else:
                         # Si déjà répondue, utilise followup
-                        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+                        await interaction.followup.send(
+                            content=BLACKLIST_RESPONSE,
+                            view=view,
+                            ephemeral=True
+                        )
                 except Exception as e:
                     # Fallback ultime si tout échoue
                     try:
                         if not interaction.response.is_done():
                             await interaction.response.send_message(
-                                f"{EMOJIS['undone']} You cannot interact with Moddy.",
+                                BLACKLIST_RESPONSE,
                                 ephemeral=True
                             )
                     except:
@@ -223,24 +231,28 @@ class BlacklistCheck(commands.Cog):
 
     async def send_blacklist_message(self, interaction: discord.Interaction):
         """Envoie le message de blacklist"""
-        embed = discord.Embed(
-            description=f"{EMOJIS['undone']} You cannot interact with Moddy because your account has been blacklisted by our team.",
-            color=COLORS["error"]
-        )
-
-        embed.set_footer(text=f"User ID: {interaction.user.id}")
-
         view = BlacklistButton()
 
         try:
             if interaction.response.is_done():
-                await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+                await interaction.followup.send(
+                    content=BLACKLIST_RESPONSE,
+                    view=view,
+                    ephemeral=True
+                )
             else:
-                await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+                await interaction.response.send_message(
+                    content=BLACKLIST_RESPONSE,
+                    view=view,
+                    ephemeral=True
+                )
         except:
             # Si tout échoue, essaye en message normal
             try:
-                await interaction.channel.send(embed=embed, view=view)
+                await interaction.channel.send(
+                    content=BLACKLIST_RESPONSE,
+                    view=view
+                )
             except:
                 pass
 
@@ -259,29 +271,12 @@ class BlacklistCheck(commands.Cog):
         if not self.bot.is_developer(ctx.author.id):
             return
 
-        # Crée une fausse interaction
-        class FakeInteraction:
-            def __init__(self, user, channel):
-                self.user = user
-                self.channel = channel
-                self.response = type('obj', (object,), {'is_done': lambda: False})()
-
-            async def response(self):
-                return self.response
-
-        fake_interaction = FakeInteraction(ctx.author, ctx.channel)
-
-        # Simule l'envoi du message
-        embed = discord.Embed(
-            description=f"{EMOJIS['undone']} You cannot interact with Moddy because your account has been blacklisted by our team.",
-            color=COLORS["error"]
-        )
-
-        embed.set_footer(text=f"User ID: {ctx.author.id}")
-
         view = BlacklistButton()
 
-        await ctx.send("**[TEST MODE]** Voici ce que verrait un utilisateur blacklisté:", embed=embed, view=view)
+        await ctx.send(
+            f"**[TEST MODE]** Voici ce que verrait un utilisateur blacklisté:\n{BLACKLIST_RESPONSE}",
+            view=view
+        )
 
 
 async def setup(bot):


### PR DESCRIPTION
## Summary
- send the standardized blacklist response from the global interaction listener before any other handlers run
- reuse a shared blacklist response payload for message, slash, and component interactions to keep messaging consistent

## Testing
- python -m compileall cogs/blacklist_check.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d6d4d82c832f929d132eed7573dc)