### PR TITLE
Fix webhook command display issue

### DIFF
--- a/cogs/webhook.py
+++ b/cogs/webhook.py
@@ -59,11 +59,15 @@ class WebhookView(ui.LayoutView):
         refresh_btn = ui.Button(label="Refresh", style=discord.ButtonStyle.secondary, emoji="🔄", custom_id="refresh_webhook")
         refresh_btn.callback = self.refresh_webhook
 
-        # Add buttons directly to the view
-        self.add_item(delete_btn)
-        self.add_item(edit_btn)
-        self.add_item(send_btn)
-        self.add_item(refresh_btn)
+        # Create ActionRow for buttons (required for Components V2)
+        button_row = ui.ActionRow()
+        button_row.add_item(delete_btn)
+        button_row.add_item(edit_btn)
+        button_row.add_item(send_btn)
+        button_row.add_item(refresh_btn)
+
+        # Add button row to the view
+        self.add_item(button_row)
 
     def format_webhook_info(self) -> str:
         """Formats webhook information for display"""
@@ -129,10 +133,12 @@ class WebhookView(ui.LayoutView):
                             f"The webhook **{self.webhook_data.get('name')}** has been successfully deleted."
                         )
 
-                        # Disable all buttons
+                        # Disable all buttons (they're inside an ActionRow)
                         for item in self.children:
-                            if isinstance(item, ui.Button):
-                                item.disabled = True
+                            if isinstance(item, ui.ActionRow):
+                                for button in item.children:
+                                    if isinstance(button, ui.Button):
+                                        button.disabled = True
 
                         await interaction.edit_original_response(view=self)
                         await interaction.followup.send(embed=success_embed, ephemeral=True)


### PR DESCRIPTION
The webhook command was failing with HTTP 400 error because buttons were added directly to the LayoutView instead of being wrapped in an ActionRow. In Discord Components V2, buttons (type 2) must be contained within an ActionRow (type 1).

Changes:
- Wrap all 4 buttons (delete, edit, send, refresh) in ui.ActionRow
- Update delete_webhook method to properly disable buttons inside ActionRow

Fixes error F1082D4E: "Value of field 'type' must be one of (1, 9, 10, 12, 13, 14, 17)"