### PR TITLE
Edit /translate command

### DIFF
--- a/cogs/translate.py
+++ b/cogs/translate.py
@@ -42,6 +42,13 @@ class TranslateView(ui.LayoutView):
         # Create main container
         container = ui.Container()
 
+        # Add title at the top
+        view_title = i18n.get("commands.translate.view.title", locale=self.locale)
+        container.add_item(ui.TextDisplay(view_title))
+
+        # Add separator
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
         # Get translator cog for helper functions
         translator = self.bot.get_cog("Translate")
         if translator:
@@ -50,8 +57,8 @@ class TranslateView(ui.LayoutView):
             from_name = translator.get_language_name(self.from_lang, self.locale)
             to_name = translator.get_language_name(self.current_to_lang, self.locale)
 
-            # Create title with flags and language names
-            title = f"<:translate:1398720130950627600> ``{from_flag} {from_name}`` → ``{to_flag} {to_name}``"
+            # Create title with flags and language names (without translate emoji)
+            title = f"``{from_flag} {from_name}`` → ``{to_flag} {to_name}``"
 
             # Add translation result display
             deepl_text = i18n.get("commands.translate.deepl_attribution", locale=self.locale)
@@ -65,16 +72,16 @@ class TranslateView(ui.LayoutView):
         instruction_text = i18n.get("commands.translate.view.instruction", locale=self.locale)
         container.add_item(ui.TextDisplay(instruction_text))
 
-        # Create language select menu
-        select = self.create_select()
-
-        # Create action row for the select
-        select_row = ui.ActionRow()
-        select_row.add_item(select)
-        container.add_item(select_row)
-
         # Add container to view
         self.add_item(container)
+
+        # Create language select menu outside the container
+        select = self.create_select()
+
+        # Create action row for the select (outside container)
+        select_row = ui.ActionRow()
+        select_row.add_item(select)
+        self.add_item(select_row)
 
     def create_select(self):
         """Creates the language selection menu"""

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -35,6 +35,7 @@
         "api_error": "Unable to contact translation API"
       },
       "view": {
+        "title": "## <:translate:1398720130950627600> Text translation",
         "placeholder": "Translate to another language",
         "instruction": "**Translate to another language**\n-# Select a language below to retranslate the text",
         "author_only": "Only the command author can use this menu."

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -35,6 +35,7 @@
         "api_error": "Impossible de contacter l'API de traduction"
       },
       "view": {
+        "title": "## <:translate:1398720130950627600> Traduction de texte",
         "placeholder": "Traduire dans une autre langue",
         "instruction": "**Traduire dans une autre langue**\n-# Sélectionnez une langue ci-dessous pour retraduire le texte",
         "author_only": "Seul l'auteur de la commande peut utiliser ce menu."


### PR DESCRIPTION
- Ajouter un titre avec l'émoji translate en haut de l'embed
- Retirer l'émoji translate devant les langues pour libérer de l'espace
- Déplacer le menu déroulant de sélection de langue hors du container principal
- Internationaliser le titre avec support FR/EN