### PR TITLE
Create /tra command functionality

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -32,6 +32,7 @@
         "rate_limit": "Rate limit reached! Maximum 20 translations per minute. Try again in {seconds} seconds",
         "too_long": "Text is too long (maximum 3000 characters)",
         "no_text": "No text provided to translate",
+        "no_content": "This message has no content to translate",
         "api_error": "Unable to contact translation API"
       },
       "view": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -32,6 +32,7 @@
         "rate_limit": "Limite atteinte ! Maximum 20 traductions par minute. Réessayez dans {seconds} secondes",
         "too_long": "Le texte est trop long (maximum 3000 caractères)",
         "no_text": "Aucun texte fourni à traduire",
+        "no_content": "Ce message n'a aucun contenu à traduire",
         "api_error": "Impossible de contacter l'API de traduction"
       },
       "view": {


### PR DESCRIPTION
- Add Message Context Menu Command "Translate" for right-click translation
- Refactor translation logic into shared _perform_translation method
- Add "no_content" error translation for empty messages
- Context menu uses user's Discord locale by default
- Response is always ephemeral for context menu usage

This allows users to translate messages either via:
1. /translate slash command (with optional target language selection)
2. Right-click > Apps > Translate on any message