### PR TITLE
Fix error handler creating unexpected codes

### DIFF
--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -56,17 +56,17 @@ class ErrorTracker(commands.Cog):
                 "user_id": None,
                 "guild_id": None,
                 "command": error_data.get("command"),
-                "context": {}
+                "context": None
             }
 
             # Add context info if available
             if ctx:
                 db_data["user_id"] = ctx.author.id
                 db_data["guild_id"] = ctx.guild.id if ctx.guild else None
-                db_data["context"] = {
+                db_data["context"] = json.dumps({
                     "channel": str(ctx.channel),
                     "message": ctx.message.content[:200] if hasattr(ctx, 'message') else None
-                }
+                })
 
             # Store in the DB
             await self.bot.db.log_error(error_code, db_data)


### PR DESCRIPTION
Le champ context était passé comme dictionnaire Python à la base de données, mais celle-ci attend une chaîne JSON. Cela causait l'erreur: "invalid input for query argument $10: expected str, got dict"

Modifications:
- Utilisation de json.dumps() pour convertir le dictionnaire context en JSON
- Changement de la valeur par défaut de {} à None pour plus de clarté