### PR TITLE
Fix reminder sending to server channels

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -178,7 +178,8 @@
       "params": {
         "message": "What should I remind you?",
         "time": "When to remind (e.g. 1h30m, 2d, tomorrow 3pm)",
-        "send_here": "Send reminder in this channel instead of DM"
+        "send_here": "Send reminder in this channel instead of DM",
+        "incognito": "Make response visible only to you"
       },
       "timezone_setup": {
         "title": "### <:time:1398729780723060736> Timezone Setup",
@@ -199,14 +200,14 @@
       "manage": {
         "title": "### <:notifications:1402261437493022775> Your Reminders",
         "no_reminders": "You don't have any upcoming reminders.",
-        "reminder_item": "**{index}.** {message}\n-# {relative} • {time}",
-        "reminder_item_channel": "**{index}.** {message}\n-# {relative} • {time} • <#{channel_id}>",
-        "footer": "{count} upcoming reminder(s) • Timezone: {timezone}",
+        "reminder_item": "{message} | #{id}\n-# {relative} • {time}",
+        "reminder_item_channel": "{message} | #{id}\n-# {relative} • {time} • <#{channel_id}>",
+        "footer": "-# {count} upcoming reminder(s) • Timezone: {timezone}",
         "history_title": "### <:history:1401600464587456512> Past Reminders",
         "history_empty": "You don't have any past reminders.",
-        "history_item": "**{index}.** {message}\n-# Sent {time}",
-        "history_item_failed": "**{index}.** {message}\n-# Failed to send {time}",
-        "history_footer": "{count} past reminder(s)"
+        "history_item": "{message} | #{id}\n-# Sent {time}",
+        "history_item_failed": "{message} | #{id}\n-# Failed to send {time}",
+        "history_footer": "-# {count} past reminder(s)"
       },
       "buttons": {
         "add": "Add",
@@ -230,6 +231,7 @@
         "select_reminder_delete": "Select a reminder to delete..."
       },
       "success": {
+        "created": "<:done:1398729525277229066> Reminder #{id} created.",
         "deleted": "<:done:1398729525277229066> Reminder #{id} deleted.",
         "edited": "<:done:1398729525277229066> Reminder #{id} updated.",
         "timezone_changed": "<:done:1398729525277229066> Timezone changed to **{timezone}**."
@@ -253,16 +255,24 @@
     },
     "preferences": {
       "description": "Manage your personal preferences",
-      "title": "### <:settings:1398729780723060736> Preferences",
-      "description": "Customize your Moddy experience. Changes are saved automatically.",
+      "params": {
+        "incognito": "Make response visible only to you"
+      },
+      "title": "### <:settings:1398729549323440208> Preferences",
+      "main_description": "Customize your Moddy experience.",
+      "buttons": {
+        "manage_timezone": "Manage timezone",
+        "back": "Back"
+      },
       "timezone": {
-        "label": "**Timezone**",
+        "title": "### <:time:1398729780723060736> Timezone Settings",
+        "label": "**Select your timezone:**",
         "current": "Current timezone: **{timezone}**",
         "placeholder": "Select your timezone...",
         "success": "<:done:1398729525277229066> Timezone changed to **{timezone}**.",
         "auto_detected": "auto-detected"
       },
-      "footer": "-# Tip: Your timezone affects reminder times. Use /preferences to change it anytime.",
+      "footer": "-# Tip: Your timezone affects reminder times.",
       "errors": {
         "author_only": "<:undone:1398729502028333218> You can't use these buttons, they belong to another user."
       }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -178,7 +178,8 @@
       "params": {
         "message": "De quoi dois-je vous rappeler ?",
         "time": "Quand vous rappeler (ex: 1h30m, 2j, demain 15h)",
-        "send_here": "Envoyer le rappel dans ce salon au lieu des MP"
+        "send_here": "Envoyer le rappel dans ce salon au lieu des MP",
+        "incognito": "Rendre la réponse visible uniquement pour vous"
       },
       "timezone_setup": {
         "title": "### <:time:1398729780723060736> Configuration du fuseau horaire",
@@ -198,14 +199,14 @@
       "manage": {
         "title": "### <:notifications:1402261437493022775> Vos rappels",
         "no_reminders": "Vous n'avez aucun rappel à venir.",
-        "reminder_item": "**{index}.** {message}\n-# {relative} • {time}",
-        "reminder_item_channel": "**{index}.** {message}\n-# {relative} • {time} • <#{channel_id}>",
-        "footer": "{count} rappel(s) à venir • Fuseau : {timezone}",
+        "reminder_item": "{message} | #{id}\n-# {relative} • {time}",
+        "reminder_item_channel": "{message} | #{id}\n-# {relative} • {time} • <#{channel_id}>",
+        "footer": "-# {count} rappel(s) à venir • Fuseau : {timezone}",
         "history_title": "### <:history:1401600464587456512> Rappels passés",
         "history_empty": "Vous n'avez aucun rappel passé.",
-        "history_item": "**{index}.** {message}\n-# Envoyé {time}",
-        "history_item_failed": "**{index}.** {message}\n-# Échec d'envoi {time}",
-        "history_footer": "{count} rappel(s) passé(s)"
+        "history_item": "{message} | #{id}\n-# Envoyé {time}",
+        "history_item_failed": "{message} | #{id}\n-# Échec d'envoi {time}",
+        "history_footer": "-# {count} rappel(s) passé(s)"
       },
       "buttons": {
         "add": "Ajouter",
@@ -229,6 +230,7 @@
         "select_reminder_delete": "Sélectionnez un rappel à supprimer..."
       },
       "success": {
+        "created": "<:done:1398729525277229066> Rappel #{id} créé.",
         "deleted": "<:done:1398729525277229066> Rappel #{id} supprimé.",
         "edited": "<:done:1398729525277229066> Rappel #{id} mis à jour.",
         "timezone_changed": "<:done:1398729525277229066> Fuseau horaire changé en **{timezone}**."
@@ -252,16 +254,24 @@
     },
     "preferences": {
       "description": "Gérer vos préférences personnelles",
-      "title": "### <:settings:1398729780723060736> Préférences",
-      "description": "Personnalisez votre expérience Moddy. Les modifications sont sauvegardées automatiquement.",
+      "params": {
+        "incognito": "Rendre la réponse visible uniquement pour vous"
+      },
+      "title": "### <:settings:1398729549323440208> Préférences",
+      "main_description": "Personnalisez votre expérience Moddy.",
+      "buttons": {
+        "manage_timezone": "Gérer le fuseau horaire",
+        "back": "Retour"
+      },
       "timezone": {
-        "label": "**Fuseau horaire**",
+        "title": "### <:time:1398729780723060736> Réglages du fuseau horaire",
+        "label": "**Sélectionnez votre fuseau horaire :**",
         "current": "Fuseau horaire actuel : **{timezone}**",
         "placeholder": "Sélectionnez votre fuseau horaire...",
         "success": "<:done:1398729525277229066> Fuseau horaire changé en **{timezone}**.",
         "auto_detected": "auto-détecté"
       },
-      "footer": "-# Astuce : Votre fuseau horaire affecte les heures des rappels. Utilisez /preferences pour le modifier à tout moment.",
+      "footer": "-# Astuce : Votre fuseau horaire affecte les heures des rappels.",
       "errors": {
         "author_only": "<:undone:1398729502028333218> Vous ne pouvez pas utiliser ces boutons, ils appartiennent à un autre utilisateur."
       }


### PR DESCRIPTION
- Fix error when sending reminders in channels (remove content field with V2 components)
- Use Discord's relative timestamp system (<t:TIMESTAMP:R>) instead of custom formatting
- Remove unnecessary separators under titles for cleaner UI
- Auto-update container in /reminders when modifying/deleting reminders
- Simplify confirmation messages (ephemeral with emoji, no container)
- Refactor /preferences with button navigation (main page → timezone settings with back button)
- Fix timezone dropdown callback
- Add incognito parameter to /reminder-add, /reminders, and /preferences commands
- Update reminder display format: [subject] | #[ID] with relative + exact time
- Update locale files with new translation keys