### PR TITLE
fix: Rewrite preferences using standard ui.View instead of LayoutView

### DIFF
--- a/cogs/preferences.py
+++ b/cogs/preferences.py
@@ -5,8 +5,7 @@ Allows users to customize their experience
 import discord
 from discord import app_commands, ui
 from discord.ext import commands
-from discord.ui import LayoutView, Container, TextDisplay, Separator
-from discord import SeparatorSpacing
+from discord.ui import LayoutView, Container, TextDisplay
 from typing import Optional
 
 from utils.i18n import t
@@ -70,10 +69,9 @@ def get_default_timezone(locale: str) -> str:
 class TimezoneSelect(ui.Select):
     """Select menu for timezone selection"""
 
-    def __init__(self, locale: str, current_tz: str, bot, parent_view):
+    def __init__(self, locale: str, current_tz: str, bot):
         self.locale = locale
         self.bot = bot
-        self.parent_view = parent_view
 
         options = []
         for tz_id, name in TIMEZONE_OPTIONS:
@@ -102,111 +100,67 @@ class TimezoneSelect(ui.Select):
             selected_tz
         )
 
-        # Update parent view's user_data locally
-        if 'data' not in self.parent_view.user_data:
-            self.parent_view.user_data['data'] = {}
-        self.parent_view.user_data['data']['reminder_timezone'] = selected_tz
-
         # Send confirmation
         await interaction.response.send_message(
             t("commands.preferences.timezone.success", interaction, timezone=TIMEZONE_NAMES.get(selected_tz, selected_tz)),
             ephemeral=True
         )
 
-        # Refresh the view to show the new timezone
-        self.parent_view._build_view()
-        if self.parent_view.original_interaction:
-            try:
-                await self.parent_view.original_interaction.edit_original_response(view=self.parent_view)
-            except Exception:
-                pass
+
+class TimezoneSettingsView(ui.View):
+    """View for timezone settings - uses standard View for reliability"""
+
+    def __init__(self, bot, user_id: int, locale: str, current_tz: str):
+        super().__init__(timeout=300)
+        self.bot = bot
+        self.user_id = user_id
+        self.locale = locale
+
+        # Add timezone select
+        self.add_item(TimezoneSelect(locale, current_tz, bot))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                t("commands.preferences.errors.author_only", interaction),
+                ephemeral=True
+            )
+            return False
+        return True
 
 
-class PreferencesView(LayoutView):
-    """Main preferences view with button navigation"""
+class PreferencesView(ui.View):
+    """Main preferences view - uses standard View for reliability"""
 
-    def __init__(self, bot, user_id: int, locale: str, user_data: dict,
-                 show_timezone: bool = False, original_interaction: discord.Interaction = None):
+    def __init__(self, bot, user_id: int, locale: str, user_data: dict):
         super().__init__(timeout=300)
         self.bot = bot
         self.user_id = user_id
         self.locale = locale
         self.user_data = user_data
-        self.show_timezone = show_timezone
-        self.original_interaction = original_interaction
 
-        self._build_view()
+    @ui.button(label="Manage timezone", style=discord.ButtonStyle.primary, emoji="<:time:1398729780723060736>")
+    async def timezone_button(self, interaction: discord.Interaction, button: ui.Button):
+        """Show timezone settings"""
+        current_tz = self.user_data.get('data', {}).get('reminder_timezone')
 
-    def _build_view(self):
-        # Clear existing items
-        self.clear_items()
-
-        container = Container()
-
-        if self.show_timezone:
-            # Timezone settings page
-            container.add_item(TextDisplay(t("commands.preferences.timezone.title", locale=self.locale)))
-
-            # Current timezone
-            current_tz = self.user_data.get('data', {}).get('reminder_timezone')
-            if current_tz:
-                tz_display = TIMEZONE_NAMES.get(current_tz, current_tz)
-            else:
-                # Show auto-detected timezone
-                default_tz = get_default_timezone(self.locale)
-                tz_display = f"{TIMEZONE_NAMES.get(default_tz, default_tz)} ({t('commands.preferences.timezone.auto_detected', locale=self.locale)})"
-
-            container.add_item(TextDisplay(t("commands.preferences.timezone.current", locale=self.locale, timezone=tz_display)))
-
-            # Timezone select - add directly to container (no ActionRow needed for ui.Select)
-            container.add_item(TextDisplay(t("commands.preferences.timezone.label", locale=self.locale)))
-            tz_select = TimezoneSelect(self.locale, current_tz, self.bot, self)
-            container.add_item(tz_select)
-
-            # Back button
-            back_row = discord.ui.ActionRow()
-            back_btn = discord.ui.Button(
-                emoji=discord.PartialEmoji.from_str("<:back:1401600847733067806>"),
-                label=t("commands.preferences.buttons.back", locale=self.locale),
-                style=discord.ButtonStyle.secondary,
-                custom_id="back_btn"
-            )
-            back_btn.callback = self.back_callback
-            back_row.add_item(back_btn)
-            container.add_item(back_row)
+        # Get display for current timezone
+        if current_tz:
+            tz_display = TIMEZONE_NAMES.get(current_tz, current_tz)
         else:
-            # Main preferences page
-            container.add_item(TextDisplay(t("commands.preferences.title", locale=self.locale)))
-            container.add_item(TextDisplay(t("commands.preferences.main_description", locale=self.locale)))
+            default_tz = get_default_timezone(self.locale)
+            tz_display = f"{TIMEZONE_NAMES.get(default_tz, default_tz)} ({t('commands.preferences.timezone.auto_detected', locale=self.locale)})"
 
-            # Manage timezone button
-            btn_row = discord.ui.ActionRow()
-            tz_btn = discord.ui.Button(
-                emoji=discord.PartialEmoji.from_str("<:time:1398729780723060736>"),
-                label=t("commands.preferences.buttons.manage_timezone", locale=self.locale),
-                style=discord.ButtonStyle.primary,
-                custom_id="timezone_btn"
-            )
-            tz_btn.callback = self.timezone_callback
-            btn_row.add_item(tz_btn)
-            container.add_item(btn_row)
+        # Create timezone settings view
+        view = TimezoneSettingsView(self.bot, self.user_id, self.locale, current_tz)
 
-            # Footer
-            container.add_item(TextDisplay(t("commands.preferences.footer", locale=self.locale)))
-
-        self.add_item(container)
-
-    async def timezone_callback(self, interaction: discord.Interaction):
-        """Show timezone settings page"""
-        self.show_timezone = True
-        self._build_view()
-        await interaction.response.edit_message(view=self)
-
-    async def back_callback(self, interaction: discord.Interaction):
-        """Return to main preferences page"""
-        self.show_timezone = False
-        self._build_view()
-        await interaction.response.edit_message(view=self)
+        await interaction.response.send_message(
+            f"{t('commands.preferences.timezone.title', locale=self.locale)}\n\n"
+            f"{t('commands.preferences.timezone.current', locale=self.locale, timezone=tz_display)}\n\n"
+            f"{t('commands.preferences.timezone.label', locale=self.locale)}",
+            view=view,
+            ephemeral=True
+        )
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.user_id:
@@ -250,16 +204,22 @@ class Preferences(commands.Cog):
         # Get user data
         user_data = await self.bot.db.get_user(interaction.user.id)
 
-        # Create preferences view
+        # Create preferences view (standard View, not LayoutView)
         view = PreferencesView(
             self.bot,
             interaction.user.id,
             str(interaction.locale),
-            user_data,
-            original_interaction=interaction
+            user_data
         )
 
-        await interaction.response.send_message(view=view, ephemeral=ephemeral)
+        # Build message content
+        content = (
+            f"{t('commands.preferences.title', locale=str(interaction.locale))}\n\n"
+            f"{t('commands.preferences.main_description', locale=str(interaction.locale))}\n\n"
+            f"{t('commands.preferences.footer', locale=str(interaction.locale))}"
+        )
+
+        await interaction.response.send_message(content=content, view=view, ephemeral=ephemeral)
 
 
 async def setup(bot):


### PR DESCRIPTION
- Use ui.View with @ui.button decorator for reliable callbacks
- TimezoneSelect as separate class extending ui.Select
- Send timezone settings as new ephemeral message when button clicked
- Avoid dynamic view rebuilding issues with LayoutView