### PR TITLE
Fix missing app attribute in main module

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python main.py


### PR DESCRIPTION
Railway was auto-detecting uvicorn and trying to launch with 'uvicorn main:app', causing the error: "Attribute 'app' not found in module 'main'".

The bot should be launched with 'python main.py' instead.