### PR TITLE
Fix missed reminders query error

### DIFF
--- a/database.py
+++ b/database.py
@@ -382,14 +382,13 @@ class ModdyDatabase:
         async with self.pool.acquire() as conn:
             # Utilise jsonb_set pour mettre à jour un chemin spécifique
             path_parts = path.split('.')
-            json_path = '{' + ','.join(path_parts) + '}'
             await conn.execute("""
-                UPDATE users 
+                UPDATE users
                 SET data = jsonb_set(data, $1, $2, true),
                     updated_at = NOW()
                 WHERE user_id = $3
             """,
-                json_path,
+                path_parts,
                 json.dumps(value),
                 user_id
             )
@@ -398,14 +397,13 @@ class ModdyDatabase:
         """Met à jour une partie spécifique de la data serveur"""
         async with self.pool.acquire() as conn:
             path_parts = path.split('.')
-            json_path = '{' + ','.join(path_parts) + '}'
             await conn.execute("""
-                UPDATE guilds 
+                UPDATE guilds
                 SET data = jsonb_set(data, $1, $2, true),
                     updated_at = NOW()
                 WHERE guild_id = $3
             """,
-                json_path,
+                path_parts,
                 json.dumps(value),
                 guild_id
             )


### PR DESCRIPTION
…d update_guild_data

Fixed TypeError where asyncpg expected a sized iterable container but received a string. The jsonb_set function requires an array type for the path parameter, not a text representation.

Changes:
- Remove json_path string construction in update_user_data
- Remove json_path string construction in update_guild_data
- Pass path_parts list directly to conn.execute()