### PR TITLE
feat: Improve saved messages library with enhanced UI and features

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -381,41 +381,47 @@
       "modals": {
         "add_note_title": "Add a note",
         "edit_note_title": "Edit note",
+        "view_title": "View a message",
         "note_label": "Note (optional)",
-        "note_placeholder": "Add a note to remember this message..."
+        "note_placeholder": "Add a note to remember this message...",
+        "id_label": "Moddy message ID"
       },
       "success": {
         "saved": "<:done:1398729525277229066> Message saved successfully! ID: #{id}",
         "deleted": "<:done:1398729525277229066> Message removed from your library.",
-        "note_updated": "<:done:1398729525277229066> Note updated successfully!"
+        "note_updated": "<:done:1398729525277229066> Note updated successfully!",
+        "exported": "<:done:1398729525277229066> JSON data exported!"
       },
       "errors": {
         "max_messages": "<:undone:1398729502028333218> You've reached the limit of 500 saved messages.",
-        "author_only": "Only the command author can use this interface."
+        "author_only": "Only the command author can use this interface.",
+        "not_found": "<:undone:1398729502028333218> Message not found in your library.",
+        "invalid_id": "<:undone:1398729502028333218> Invalid ID. Please enter a number."
       },
       "library": {
         "title": "### <:save:1401600534296993812> Message Library ({count})",
         "empty": "Your library is empty.\nUse the **Save Message** context menu on a message to save it!",
-        "page_info": "-# Page {page}/{total}"
+        "page_label": "Page {page}/{total}"
       },
       "detail": {
         "title": "### <:save:1401600534296993812> Message Details",
-        "author": "**Author:** <@{author_id}>",
-        "dates": "**Created:** {created} • **Saved:** {saved}",
+        "author_label": "Author",
+        "created": "Created",
+        "saved": "Saved",
+        "content": "Content",
+        "content_truncated": "Content truncated (too long)",
         "no_content": "*Message with no text content*",
-        "note": "📝 **Note:** {note}",
-        "attachments": "📎 **Attachments:** {count}",
-        "link": "[➜ View original message]({url})"
+        "note_label": "Note",
+        "attachments_label": "Attachments",
+        "embeds_label": "Embeds",
+        "view_original": "View original message"
       },
       "buttons": {
         "edit_note": "Edit note",
         "delete": "Delete",
-        "previous": "Previous",
-        "next": "Next"
-      },
-      "select": {
-        "placeholder": "Select a message to view details",
-        "no_preview": "Message with no preview"
+        "back": "Back",
+        "view_message": "View a message",
+        "export_json": "Export JSON"
       }
     }
   },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -380,41 +380,47 @@
       "modals": {
         "add_note_title": "Ajouter une note",
         "edit_note_title": "Modifier la note",
+        "view_title": "Voir un message",
         "note_label": "Note (optionnelle)",
-        "note_placeholder": "Ajoutez une note pour vous souvenir de ce message..."
+        "note_placeholder": "Ajoutez une note pour vous souvenir de ce message...",
+        "id_label": "ID du message Moddy"
       },
       "success": {
         "saved": "<:done:1398729525277229066> Message sauvegardé avec succès ! ID: #{id}",
         "deleted": "<:done:1398729525277229066> Message supprimé de votre bibliothèque.",
-        "note_updated": "<:done:1398729525277229066> Note mise à jour avec succès !"
+        "note_updated": "<:done:1398729525277229066> Note mise à jour avec succès !",
+        "exported": "<:done:1398729525277229066> Données JSON exportées !"
       },
       "errors": {
         "max_messages": "<:undone:1398729502028333218> Vous avez atteint la limite de 500 messages sauvegardés.",
-        "author_only": "Seul l'auteur de la commande peut utiliser cette interface."
+        "author_only": "Seul l'auteur de la commande peut utiliser cette interface.",
+        "not_found": "<:undone:1398729502028333218> Message introuvable dans votre bibliothèque.",
+        "invalid_id": "<:undone:1398729502028333218> ID invalide. Veuillez entrer un nombre."
       },
       "library": {
         "title": "### <:save:1401600534296993812> Bibliothèque de messages ({count})",
         "empty": "Votre bibliothèque est vide.\nUtilisez le menu contextuel **Save Message** sur un message pour le sauvegarder !",
-        "page_info": "-# Page {page}/{total}"
+        "page_label": "Page {page}/{total}"
       },
       "detail": {
         "title": "### <:save:1401600534296993812> Détails du message",
-        "author": "**Auteur :** <@{author_id}>",
-        "dates": "**Créé :** {created} • **Sauvegardé :** {saved}",
+        "author_label": "Auteur",
+        "created": "Créé",
+        "saved": "Sauvegardé",
+        "content": "Contenu",
+        "content_truncated": "Contenu tronqué (trop long)",
         "no_content": "*Message sans contenu textuel*",
-        "note": "📝 **Note :** {note}",
-        "attachments": "📎 **Pièces jointes :** {count}",
-        "link": "[➜ Voir le message original]({url})"
+        "note_label": "Note",
+        "attachments_label": "Pièces jointes",
+        "embeds_label": "Embeds",
+        "view_original": "Voir le message original"
       },
       "buttons": {
         "edit_note": "Modifier la note",
         "delete": "Supprimer",
-        "previous": "Précédent",
-        "next": "Suivant"
-      },
-      "select": {
-        "placeholder": "Sélectionnez un message pour voir les détails",
-        "no_preview": "Message sans aperçu"
+        "back": "Retour",
+        "view_message": "Voir un message",
+        "export_json": "Export JSON"
       }
     }
   },


### PR DESCRIPTION
Major improvements to the saved messages library system:

**Database Changes:**
- Add author_username field to saved_messages table
- Add raw_message_data JSONB field to store complete Discord message data
- Add migration for backward compatibility
- Update save_message() to accept and store raw message data

**UI Improvements:**
- Replace dropdown menu with modal-based message selection (enter ID #1, #2, etc.)
- Redesign /library list view:
  * Display: ID Moddy (#1), author mention, saved date (relative)
  * Show note preview or Discord message ID
  * Clean, minimal design similar to /reminders
- Implement icon-only pagination buttons:
  * Previous: <:back:> emoji
  * Next: <:arrow_forward:1443745574972031067> emoji
  * Middle: disabled "Page 1/3" button
- Single-view navigation: detail view updates in-place (no new messages)

**Detail View Enhancements:**
- Complete message information display:
  * Moddy ID and Discord ID
  * Author mention and username
  * Creation and save timestamps
  * Message content in code blocks (truncated if >1800 chars)
  * Note, attachments count, embeds count
  * Link to original message
- New "Export JSON" button with data_object emoji
  * Exports complete raw Discord message data
  * Format matches Discord.js message structure
  * Sent as downloadable .json file

**Bug Fixes:**
- Fix delete button interaction error
- Fix view refresh after note edit
- Improve error handling for all interactions

**I18n Updates:**
- Add translations for new modal (view_title, id_label)
- Add translations for new error messages (not_found, invalid_id)
- Add translations for detail view labels
- Add translation for export success message
- Update button labels (back, view_message, export_json)
- Add page_label translation

All changes maintain Components V2 architecture and custom emoji system.