### PR TITLE
Fix library message details form error

### DIFF
--- a/cogs/saved_messages.py
+++ b/cogs/saved_messages.py
@@ -247,7 +247,6 @@ class SavedMessagesLibraryView(LayoutView):
             container.add_item(TextDisplay(t('commands.saved_messages.detail.title', locale=self.locale)))
 
             # === MODDY INFO ===
-            container.add_item(TextDisplay(""))
 
             # MODDY ID
             moddy_id_label = t('commands.saved_messages.detail.moddy_id', locale=self.locale)
@@ -270,7 +269,6 @@ class SavedMessagesLibraryView(LayoutView):
             container.add_item(Separator(spacing=SeparatorSpacing.small))
 
             # === DISCORD MESSAGE INFO ===
-            container.add_item(TextDisplay(""))
 
             # Message ID
             message_id_label = t('commands.saved_messages.detail.message_id', locale=self.locale)


### PR DESCRIPTION
…omponents

Discord API requires TextDisplay content to be between 1-4000 characters. The detail view had two empty TextDisplay("") components that violated this constraint, causing a 400 Bad Request error when viewing message details.

Removed the two empty TextDisplay components at lines 250 and 273 that were used for visual spacing, as they're not necessary and caused the form validation to fail.