### PR TITLE
Fix welcome module config not saving to database

### DIFF
--- a/database.py
+++ b/database.py
@@ -439,30 +439,36 @@ class ModdyDatabase:
         async with self.pool.acquire() as conn:
             # Utilise jsonb_set pour mettre à jour un chemin spécifique
             path_parts = path.split('.')
+            # Use UPSERT to ensure the user exists and update the data
             await conn.execute("""
-                UPDATE users
-                SET data = jsonb_set(data, $1, $2, true),
+                INSERT INTO users (user_id, data, created_at, updated_at)
+                VALUES ($1, jsonb_set('{}'::jsonb, $2, $3, true), NOW(), NOW())
+                ON CONFLICT (user_id)
+                DO UPDATE SET
+                    data = jsonb_set(users.data, $2, $3, true),
                     updated_at = NOW()
-                WHERE user_id = $3
             """,
+                user_id,
                 path_parts,
-                json.dumps(value),
-                user_id
+                json.dumps(value)
             )
 
     async def update_guild_data(self, guild_id: int, path: str, value: Any):
         """Met à jour une partie spécifique de la data serveur"""
         async with self.pool.acquire() as conn:
             path_parts = path.split('.')
+            # Use UPSERT to ensure the guild exists and update the data
             await conn.execute("""
-                UPDATE guilds
-                SET data = jsonb_set(data, $1, $2, true),
+                INSERT INTO guilds (guild_id, data, created_at, updated_at)
+                VALUES ($1, jsonb_set('{}'::jsonb, $2, $3, true), NOW(), NOW())
+                ON CONFLICT (guild_id)
+                DO UPDATE SET
+                    data = jsonb_set(guilds.data, $2, $3, true),
                     updated_at = NOW()
-                WHERE guild_id = $3
             """,
+                guild_id,
                 path_parts,
-                json.dumps(value),
-                guild_id
+                json.dumps(value)
             )
 
     # ================ REQUÊTES UTILES ================


### PR DESCRIPTION
Fixed a critical bug where module configurations (e.g., welcome module) were not being saved to the database despite showing success logs.

Problem:
- update_guild_data() and update_user_data() used simple UPDATE queries
- If the guild/user didn't exist in the table, UPDATE did nothing
- No error was raised, causing silent failures

Solution:
- Changed both functions to use UPSERT pattern (INSERT ... ON CONFLICT DO UPDATE)
- Now creates a new row if entity doesn't exist, or updates existing row
- Guarantees data is always saved correctly

This fixes the issue where /config command showed success messages but configurations were not persisted to the database.