### PR TITLE
Fix verification failing when data is saved as JSON string

### DIFF
--- a/database.py
+++ b/database.py
@@ -501,9 +501,15 @@ class ModdyDatabase:
             logger.info(f"[DB] After update for user {user_id}: {after['data'] if after else 'None'}")
             logger.info(f"[DB] Update result: {result}")
 
-            # Verify the path exists
+            # Verify the path exists - handle both dict and string JSON
             if after and after['data']:
-                current = after['data']
+                # Convert to dict if it's a string
+                if isinstance(after['data'], str):
+                    saved_data = json.loads(after['data'])
+                else:
+                    saved_data = after['data']
+
+                current = saved_data
                 for part in path_parts:
                     if isinstance(current, dict) and part in current:
                         current = current[part]
@@ -582,9 +588,15 @@ class ModdyDatabase:
             logger.info(f"[DB] After update for guild {guild_id}: {after['data'] if after else 'None'}")
             logger.info(f"[DB] Update result: {result}")
 
-            # Verify the path exists
+            # Verify the path exists - handle both dict and string JSON
             if after and after['data']:
-                current = after['data']
+                # Convert to dict if it's a string
+                if isinstance(after['data'], str):
+                    saved_data = json.loads(after['data'])
+                else:
+                    saved_data = after['data']
+
+                current = saved_data
                 for part in path_parts:
                     if isinstance(current, dict) and part in current:
                         current = current[part]


### PR DESCRIPTION
Issue: Verification was failing even though data was correctly saved in DB. The logs showed the data was there but verification raised "path not found".

Root cause: PostgreSQL returns JSONB fields as JSON strings in some cases. The verification code was trying to navigate a JSON string as a dict, which fails the isinstance(current, dict) check.

Fix:
- Convert after['data'] to dict if it's a string before verification
- Apply same JSON string handling to verification as we do for reading data
- Now verification correctly navigates the saved data structure

With this fix, the complete flow works:
1. Read current data (handle string/dict)
2. Update nested structure
3. Save to database
4. Verify saved data (handle string/dict) ✓

The module configuration should now save and verify successfully.