### PR TITLE
Fix welcome config not displaying when reopening /config

### DIFF
--- a/modules/configs/welcome_config.py
+++ b/modules/configs/welcome_config.py
@@ -37,7 +37,9 @@ class WelcomeConfigView(ui.LayoutView):
         self.locale = locale
 
         # Configuration actuelle (ou par défaut)
-        if current_config and current_config.get('enabled') is not None:
+        # Check if we have a real saved config by looking for channel_id
+        # (enabled is calculated dynamically and not saved in the config)
+        if current_config and current_config.get('channel_id') is not None:
             self.current_config = current_config.copy()
             self.has_existing_config = True
         else:


### PR DESCRIPTION
Root cause: WelcomeConfigView was checking for 'enabled' key to detect existing configuration, but WelcomeModule doesn't save 'enabled' in the config - it calculates it dynamically from channel_id.

Result: Even with a valid saved config in DB, the UI would show default values as if no config existed.

Solution: Changed detection logic to check for 'channel_id' instead of 'enabled', since channel_id is always saved in the config and indicates a configured module.

Now when reopening /config:
1. get_module_config() returns the saved config with channel_id
2. WelcomeConfigView detects channel_id is not None
3. has_existing_config = True
4. UI displays the actual saved configuration

This fixes the issue where users would see empty config despite having configured the welcome module successfully.