### PR TITLE
Clear guild commands before syncing to fix DM availability

### DIFF
--- a/staff/dev_commands.py
+++ b/staff/dev_commands.py
@@ -630,11 +630,16 @@ class DeveloperCommands(StaffCommandsCog):
                     guild_id = int(args.strip())
                     guild = discord.Object(id=guild_id)
 
+                    # Clear old commands first to remove any previously synced commands
+                    # This allows Discord to use global commands
+                    self.bot.tree.clear_commands(guild=guild)
+
                     # Add ONLY guild-only commands to this guild (not global commands)
                     # Global commands are already available everywhere without copy_global_to()
                     # Using copy_global_to() would make Discord ignore global commands for this guild
-                    for command in self.bot._guild_only_commands:
-                        self.bot.tree.add_command(command, guild=guild)
+                    if self.bot._guild_only_commands:
+                        for command in self.bot._guild_only_commands:
+                            self.bot.tree.add_command(command, guild=guild)
 
                     synced = await self.bot.tree.sync(guild=guild)
 


### PR DESCRIPTION
The previous fix wasn't working because old commands synced with copy_global_to() were still present on Discord. Even after changing the code, Discord still thought these guilds had their own commands and ignored global commands.

Solution:
- Call tree.clear_commands(guild=guild) before syncing
- This removes all previously synced guild commands
- Allows Discord to use global commands again
- Then sync only guild-only commands (or empty if none)

Changes:
- bot.py: Added clear_commands() in sync_all_guild_commands()
- bot.py: Added clear_commands() in sync_guild_commands()
- staff/dev_commands.py: Added clear_commands() in d.sync command

After bot restart, global commands should work in DMs.