### PR TITLE
Add allowed_installs and allowed_contexts to all global commands

### DIFF
--- a/cogs/avatar.py
+++ b/cogs/avatar.py
@@ -80,6 +80,8 @@ class Avatar(commands.Cog):
         name="avatar",
         description="Display a user's avatar"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         user="The user whose avatar you want to see",
         incognito="Make response visible only to you"

--- a/cogs/banner.py
+++ b/cogs/banner.py
@@ -81,6 +81,8 @@ class Banner(commands.Cog):
         name="banner",
         description="Display a user's banner"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         user="The user whose banner you want to see",
         incognito="Make response visible only to you"

--- a/cogs/emoji.py
+++ b/cogs/emoji.py
@@ -155,6 +155,8 @@ class Emoji(commands.Cog):
         name="emoji",
         description="Display information about a Discord emoji"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         emoji="The emoji to lookup",
         incognito="Make response visible only to you"

--- a/cogs/ping.py
+++ b/cogs/ping.py
@@ -26,6 +26,8 @@ class PublicPing(commands.Cog):
         name="ping",
         description="Check the bot's latency"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         incognito="Make response visible only to you"
     )

--- a/cogs/preferences.py
+++ b/cogs/preferences.py
@@ -239,6 +239,8 @@ class Preferences(commands.Cog):
         name="preferences",
         description="Manage your personal preferences"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         incognito="Make response visible only to you"
     )

--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -820,6 +820,8 @@ class Reminder(commands.Cog):
         name="reminder-add",
         description="Add a new reminder"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         message="What should I remind you?",
         time="When to remind (e.g. 1h30m, 2d, tomorrow 3pm)",
@@ -905,6 +907,8 @@ class Reminder(commands.Cog):
         name="reminders",
         description="Manage your reminders"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         incognito="Make response visible only to you"
     )

--- a/cogs/roll.py
+++ b/cogs/roll.py
@@ -62,6 +62,8 @@ class Roll(commands.Cog):
         name="roll",
         description="Roll a random dice"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         max="Maximum dice value (optional, defaults to 6)",
         incognito="Make response visible only to you"

--- a/cogs/saved_messages.py
+++ b/cogs/saved_messages.py
@@ -586,6 +586,8 @@ class SavedMessages(commands.Cog):
         name="library",
         description="View your saved messages library"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         incognito="Make response visible only to you"
     )

--- a/cogs/translate.py
+++ b/cogs/translate.py
@@ -481,6 +481,8 @@ class Translate(commands.Cog):
         name="translate",
         description="Translate text to another language"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         text="The text to translate",
         to="Target language (optional, uses your Discord language by default)",

--- a/cogs/user.py
+++ b/cogs/user.py
@@ -606,6 +606,8 @@ class User(commands.Cog):
         name="user",
         description="Display detailed information about a Discord user"
     )
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         user="The user to lookup",
         incognito="Make response visible only to you"

--- a/cogs/webhook.py
+++ b/cogs/webhook.py
@@ -405,6 +405,8 @@ class Webhook(commands.Cog):
             return None
 
     @app_commands.command(name="webhook", description="Inspect and manage Discord webhooks")
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     @app_commands.describe(
         webhook="Webhook URL or ID/Token",
         incognito="Make response visible only to you"


### PR DESCRIPTION
Root cause: Since Discord's 2024 update, commands need explicit integration contexts to be available in DMs. By default, commands are only available in guilds, even if synchronized globally.

The real issue wasn't the sync logic (which was correct), but the missing `allowed_installs` and `allowed_contexts` decorators on global commands.

Solution:
- Add @app_commands.allowed_installs(guilds=True, users=True)
- Add @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True) to all global commands (non guild_only commands)

This allows commands to be:
- Installed in both guilds and user profiles
- Used in guilds, DMs, and private channels

Commands updated:
- /user, /ping, /avatar, /banner, /webhook, /translate
- /emoji, /roll, /preferences, /library
- /reminder-add, /reminders

After bot restart and command sync, global commands will be available in DMs.