### PR TITLE
Add inter-server channel configuration feature

### DIFF
--- a/cogs/config.py
+++ b/cogs/config.py
@@ -116,6 +116,15 @@ class ConfigMainView(ui.LayoutView):
                 self.locale,
                 module_config
             )
+        elif module_id == 'interserver':
+            from modules.configs.interserver_config import InterServerConfigView
+            config_view = InterServerConfigView(
+                self.bot,
+                self.guild_id,
+                self.user_id,
+                self.locale,
+                module_config
+            )
         # Ajouter d'autres modules ici au fur et à mesure
         # elif module_id == 'ticket':
         #     from modules.configs.ticket_config import TicketConfigView

--- a/cogs/module_events.py
+++ b/cogs/module_events.py
@@ -54,14 +54,32 @@ class ModuleEvents(commands.Cog):
     async def on_message(self, message: discord.Message):
         """
         Événement déclenché pour chaque message
-        Peut être utilisé pour les modules de modération, etc.
+        Peut être utilisé pour les modules de modération, inter-serveur, etc.
         """
         # Ignore les messages du bot
         if message.author.bot:
             return
 
-        # À implémenter si besoin pour d'autres modules (modération, auto-réponses, etc.)
-        pass
+        # Ignore les DMs
+        if not message.guild:
+            return
+
+        if not self.bot.module_manager:
+            return
+
+        try:
+            # Récupère l'instance du module Inter-Server pour ce serveur
+            interserver_module = await self.bot.module_manager.get_module_instance(
+                message.guild.id,
+                'interserver'
+            )
+
+            # Si le module est actif, appelle sa méthode
+            if interserver_module and interserver_module.enabled:
+                await interserver_module.on_message(message)
+
+        except Exception as e:
+            logger.error(f"Error in on_message for guild {message.guild.id}: {e}", exc_info=True)
 
 
 async def setup(bot):

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -526,6 +526,32 @@
           "label": "Use an embed"
         }
       }
+    },
+    "interserver": {
+      "config": {
+        "title": "Inter-Server Module Configuration",
+        "description": "Connect your server with other Discord servers to create an inter-server communication portal.",
+        "channel": {
+          "section_title": "Inter-server channel",
+          "section_description": "Select the channel that will be connected to other servers",
+          "placeholder": "Select a channel"
+        },
+        "options": {
+          "section_title": "Display options",
+          "section_description": "Configure how messages are displayed in other servers",
+          "placeholder": "Select options to enable",
+          "show_server_name": "Show server name",
+          "show_server_name_desc": "Adds the server name next to the username",
+          "show_avatar": "Show avatar",
+          "show_avatar_desc": "Displays the original author's avatar",
+          "allowed_mentions": "Allow mentions",
+          "allowed_mentions_desc": "Allows @mentions in inter-server messages"
+        },
+        "warning": {
+          "title": "Security warning",
+          "description": "Messages sent in this channel will be visible to all connected servers. Make sure your members understand this."
+        }
+      }
     }
   },
   "languages": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -525,6 +525,32 @@
           "label": "Utiliser un embed"
         }
       }
+    },
+    "interserver": {
+      "config": {
+        "title": "Configuration du module Inter-Server",
+        "description": "Connectez votre serveur avec d'autres serveurs Discord pour créer un portail de communication inter-serveurs.",
+        "channel": {
+          "section_title": "Salon inter-serveur",
+          "section_description": "Sélectionnez le salon qui sera connecté aux autres serveurs",
+          "placeholder": "Sélectionnez un salon"
+        },
+        "options": {
+          "section_title": "Options d'affichage",
+          "section_description": "Configurez comment les messages sont affichés dans les autres serveurs",
+          "placeholder": "Sélectionnez les options à activer",
+          "show_server_name": "Afficher le nom du serveur",
+          "show_server_name_desc": "Ajoute le nom du serveur à côté du nom d'utilisateur",
+          "show_avatar": "Afficher l'avatar",
+          "show_avatar_desc": "Affiche l'avatar de l'auteur original",
+          "allowed_mentions": "Autoriser les mentions",
+          "allowed_mentions_desc": "Permet les @mentions dans les messages inter-serveurs"
+        },
+        "warning": {
+          "title": "Avertissement de sécurité",
+          "description": "Les messages envoyés dans ce salon seront visibles par tous les serveurs connectés. Assurez-vous que vos membres comprennent cela."
+        }
+      }
     }
   },
   "languages": {

--- a/modules/configs/interserver_config.py
+++ b/modules/configs/interserver_config.py
@@ -1,0 +1,402 @@
+"""
+Configuration UI pour le module Inter-Server
+Utilise les Composants V2 pour une interface moderne
+"""
+
+import discord
+from discord import ui
+from typing import Optional, Dict, Any
+import logging
+
+from utils.i18n import t
+
+logger = logging.getLogger('moddy.modules.interserver_config')
+
+
+class InterServerConfigView(ui.LayoutView):
+    """
+    Interface de configuration du module Inter-Server
+    Permet de configurer le salon de communication inter-serveurs
+    """
+
+    def __init__(self, bot, guild_id: int, user_id: int, locale: str, current_config: Optional[Dict[str, Any]] = None):
+        """
+        Initialise la vue de configuration
+
+        Args:
+            bot: Instance du bot
+            guild_id: ID du serveur
+            user_id: ID de l'utilisateur qui configure
+            locale: Langue de l'utilisateur
+            current_config: Configuration actuelle du module (None si première config)
+        """
+        super().__init__(timeout=300)
+        self.bot = bot
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.locale = locale
+
+        # Configuration actuelle (ou par défaut)
+        # Vérifie si on a une vraie config sauvegardée en regardant channel_id
+        if current_config and current_config.get('channel_id') is not None:
+            self.current_config = current_config.copy()
+            self.has_existing_config = True
+        else:
+            # Utilise la config par défaut du module
+            from modules.interserver import InterServerModule
+            self.current_config = InterServerModule(bot, guild_id).get_default_config()
+            self.has_existing_config = False
+
+        # Configuration en cours de modification (copie de travail)
+        self.working_config = self.current_config.copy()
+
+        # État de modification
+        self.has_changes = False
+
+        self._build_view()
+
+    def _build_view(self):
+        """Construit l'interface de configuration"""
+        self.clear_items()
+
+        container = ui.Container()
+
+        # Titre et description
+        container.add_item(ui.TextDisplay(
+            f"### {t('modules.interserver.config.title', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            t('modules.interserver.config.description', locale=self.locale)
+        ))
+
+        # État du module
+        is_configured = self.has_existing_config and self.working_config.get('channel_id') is not None
+        status_text = t('modules.config.status.enabled', locale=self.locale) if is_configured else t('modules.config.status.disabled', locale=self.locale)
+        status_emoji = "✅" if is_configured else "❌"
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.config.status.label', locale=self.locale)}** {status_emoji} {status_text}"
+        ))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # Section : Salon inter-serveur
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.interserver.config.channel.section_title', locale=self.locale)}**"
+        ))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.interserver.config.channel.section_description', locale=self.locale)}"
+        ))
+
+        # Affichage du salon actuel
+        if self.working_config.get('channel_id'):
+            channel = self.bot.get_channel(self.working_config['channel_id'])
+            if channel:
+                channel_display = f"{channel.mention}"
+            else:
+                channel_display = f"{t('modules.config.errors.channel_not_found', locale=self.locale)} (ID: {self.working_config['channel_id']})"
+            container.add_item(ui.TextDisplay(
+                f"{t('modules.config.current_value', locale=self.locale)} {channel_display}"
+            ))
+
+        # Sélecteur de salon
+        channel_row = ui.ActionRow()
+        channel_select = ui.ChannelSelect(
+            placeholder=t('modules.interserver.config.channel.placeholder', locale=self.locale),
+            channel_types=[discord.ChannelType.text],
+            min_values=0,
+            max_values=1
+        )
+
+        # Pré-sélectionne le salon actuel si configuré
+        if self.working_config.get('channel_id'):
+            channel = self.bot.get_channel(self.working_config['channel_id'])
+            if channel:
+                channel_select.default_values = [channel]
+
+        channel_select.callback = self.on_channel_select
+        channel_row.add_item(channel_select)
+        container.add_item(channel_row)
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # Section : Options d'affichage
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.interserver.config.options.section_title', locale=self.locale)}**"
+        ))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.interserver.config.options.section_description', locale=self.locale)}"
+        ))
+
+        # Option : Afficher le nom du serveur
+        show_server_status = t('common.yes', locale=self.locale) if self.working_config.get('show_server_name', True) else t('common.no', locale=self.locale)
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.interserver.config.options.show_server_name', locale=self.locale)}:** {show_server_status}"
+        ))
+
+        # Option : Afficher l'avatar
+        show_avatar_status = t('common.yes', locale=self.locale) if self.working_config.get('show_avatar', True) else t('common.no', locale=self.locale)
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.interserver.config.options.show_avatar', locale=self.locale)}:** {show_avatar_status}"
+        ))
+
+        # Option : Autoriser les mentions
+        mentions_status = t('common.yes', locale=self.locale) if self.working_config.get('allowed_mentions', False) else t('common.no', locale=self.locale)
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.interserver.config.options.allowed_mentions', locale=self.locale)}:** {mentions_status}"
+        ))
+
+        # Sélecteur pour les options
+        options_row = ui.ActionRow()
+        options_select = ui.Select(
+            placeholder=t('modules.interserver.config.options.placeholder', locale=self.locale),
+            options=[
+                discord.SelectOption(
+                    label=t('modules.interserver.config.options.show_server_name', locale=self.locale),
+                    value="show_server_name",
+                    description=t('modules.interserver.config.options.show_server_name_desc', locale=self.locale),
+                    emoji="🏷️",
+                    default=self.working_config.get('show_server_name', True)
+                ),
+                discord.SelectOption(
+                    label=t('modules.interserver.config.options.show_avatar', locale=self.locale),
+                    value="show_avatar",
+                    description=t('modules.interserver.config.options.show_avatar_desc', locale=self.locale),
+                    emoji="👤",
+                    default=self.working_config.get('show_avatar', True)
+                ),
+                discord.SelectOption(
+                    label=t('modules.interserver.config.options.allowed_mentions', locale=self.locale),
+                    value="allowed_mentions",
+                    description=t('modules.interserver.config.options.allowed_mentions_desc', locale=self.locale),
+                    emoji="📢",
+                    default=self.working_config.get('allowed_mentions', False)
+                )
+            ],
+            min_values=0,
+            max_values=3
+        )
+        options_select.callback = self.on_options_select
+        options_row.add_item(options_select)
+        container.add_item(options_row)
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # Avertissement de sécurité
+        container.add_item(ui.TextDisplay(
+            f"⚠️ **{t('modules.interserver.config.warning.title', locale=self.locale)}**\n"
+            f"-# {t('modules.interserver.config.warning.description', locale=self.locale)}"
+        ))
+
+        self.add_item(container)
+
+        # Boutons d'action en bas
+        self._add_action_buttons()
+
+    def _add_action_buttons(self):
+        """Ajoute les boutons d'action en bas de la vue"""
+        button_row = ui.ActionRow()
+
+        # Bouton Back (toujours présent, désactivé si modifications en cours)
+        back_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str("<:back:1401600847733067806>"),
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            custom_id="back_btn",
+            disabled=self.has_changes
+        )
+        back_btn.callback = self.on_back
+        button_row.add_item(back_btn)
+
+        # Bouton Save (visible uniquement si modifications)
+        if self.has_changes:
+            save_btn = ui.Button(
+                emoji=discord.PartialEmoji.from_str("<:save:1444101502154182778>"),
+                label=t('modules.config.buttons.save', locale=self.locale),
+                style=discord.ButtonStyle.success,
+                custom_id="save_btn"
+            )
+            save_btn.callback = self.on_save
+            button_row.add_item(save_btn)
+
+            # Bouton Annuler
+            cancel_btn = ui.Button(
+                emoji=discord.PartialEmoji.from_str("<:undone:1398729502028333218>"),
+                label=t('modules.config.buttons.cancel', locale=self.locale),
+                style=discord.ButtonStyle.danger,
+                custom_id="cancel_btn"
+            )
+            cancel_btn.callback = self.on_cancel
+            button_row.add_item(cancel_btn)
+        else:
+            # Bouton Supprimer la configuration (si config existe)
+            if self.has_existing_config:
+                delete_btn = ui.Button(
+                    emoji=discord.PartialEmoji.from_str("<:delete:1401600770431909939>"),
+                    label=t('modules.config.buttons.delete', locale=self.locale),
+                    style=discord.ButtonStyle.danger,
+                    custom_id="delete_btn"
+                )
+                delete_btn.callback = self.on_delete
+                button_row.add_item(delete_btn)
+
+        self.add_item(button_row)
+
+    async def on_channel_select(self, interaction: discord.Interaction):
+        """Callback quand un salon est sélectionné"""
+        if not await self.check_user(interaction):
+            return
+
+        # Récupère le salon sélectionné (ou None si désélectionné)
+        if interaction.data['values']:
+            channel_id = int(interaction.data['values'][0])
+            self.working_config['channel_id'] = channel_id
+        else:
+            self.working_config['channel_id'] = None
+
+        # Marque comme modifié
+        self.has_changes = True
+
+        # Reconstruit la vue
+        self._build_view()
+
+        # Met à jour le message
+        await interaction.response.edit_message(view=self)
+
+    async def on_options_select(self, interaction: discord.Interaction):
+        """Callback quand des options sont sélectionnées"""
+        if not await self.check_user(interaction):
+            return
+
+        # Récupère les options sélectionnées
+        selected_options = interaction.data['values']
+
+        # Met à jour les options
+        self.working_config['show_server_name'] = 'show_server_name' in selected_options
+        self.working_config['show_avatar'] = 'show_avatar' in selected_options
+        self.working_config['allowed_mentions'] = 'allowed_mentions' in selected_options
+
+        # Marque comme modifié
+        self.has_changes = True
+
+        # Reconstruit la vue
+        self._build_view()
+
+        # Met à jour le message
+        await interaction.response.edit_message(view=self)
+
+    async def on_back(self, interaction: discord.Interaction):
+        """Retour au menu principal"""
+        if not await self.check_user(interaction):
+            return
+
+        # Importe et affiche le menu principal
+        from cogs.config import ConfigMainView
+        main_view = ConfigMainView(self.bot, self.guild_id, self.user_id, self.locale)
+        await interaction.response.edit_message(view=main_view)
+
+    async def on_save(self, interaction: discord.Interaction):
+        """Sauvegarde la configuration"""
+        if not await self.check_user(interaction):
+            return
+
+        # Désactive temporairement les boutons
+        await interaction.response.defer()
+
+        # Récupère le gestionnaire de modules
+        module_manager = self.bot.module_manager
+
+        # Sauvegarde la configuration
+        success, error_msg = await module_manager.save_module_config(
+            self.guild_id,
+            'interserver',
+            self.working_config
+        )
+
+        if success:
+            # Met à jour l'état
+            self.current_config = self.working_config.copy()
+            self.has_changes = False
+            self.has_existing_config = True
+
+            # Reconstruit la vue
+            self._build_view()
+
+            # Met à jour le message avec un feedback
+            await interaction.followup.send(
+                t('modules.config.save.success', locale=self.locale),
+                ephemeral=True
+            )
+            await interaction.edit_original_response(view=self)
+        else:
+            # Affiche l'erreur
+            await interaction.followup.send(
+                t('modules.config.save.error', locale=self.locale, error=error_msg),
+                ephemeral=True
+            )
+
+    async def on_cancel(self, interaction: discord.Interaction):
+        """Annule les modifications"""
+        if not await self.check_user(interaction):
+            return
+
+        # Restaure la configuration originale
+        self.working_config = self.current_config.copy()
+        self.has_changes = False
+
+        # Reconstruit la vue
+        self._build_view()
+
+        # Met à jour le message
+        await interaction.response.edit_message(view=self)
+
+    async def on_delete(self, interaction: discord.Interaction):
+        """Supprime la configuration"""
+        if not await self.check_user(interaction):
+            return
+
+        # Désactive temporairement les boutons
+        await interaction.response.defer()
+
+        # Récupère le gestionnaire de modules
+        module_manager = self.bot.module_manager
+
+        # Supprime la configuration
+        success = await module_manager.delete_module_config(self.guild_id, 'interserver')
+
+        if success:
+            # Met à jour l'état
+            from modules.interserver import InterServerModule
+            self.current_config = InterServerModule(self.bot, self.guild_id).get_default_config()
+            self.working_config = self.current_config.copy()
+            self.has_changes = False
+            self.has_existing_config = False
+
+            # Reconstruit la vue
+            self._build_view()
+
+            # Met à jour le message avec un feedback
+            await interaction.followup.send(
+                t('modules.config.delete.success', locale=self.locale),
+                ephemeral=True
+            )
+            await interaction.edit_original_response(view=self)
+        else:
+            # Affiche l'erreur
+            await interaction.followup.send(
+                t('modules.config.delete.error', locale=self.locale),
+                ephemeral=True
+            )
+
+    async def check_user(self, interaction: discord.Interaction) -> bool:
+        """Vérifie que c'est le bon utilisateur"""
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                t('modules.config.errors.wrong_user', locale=self.locale),
+                ephemeral=True
+            )
+            return False
+        return True
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        """Vérifie les permissions pour chaque interaction"""
+        return await self.check_user(interaction)

--- a/modules/interserver.py
+++ b/modules/interserver.py
@@ -1,0 +1,258 @@
+"""
+Module Inter-Server - Système de communication inter-serveurs
+Permet de connecter plusieurs serveurs Discord via des salons dédiés
+"""
+
+import discord
+from typing import Dict, Any, Optional, List
+import logging
+
+from modules.module_manager import ModuleBase
+
+logger = logging.getLogger('moddy.modules.interserver')
+
+
+class InterServerModule(ModuleBase):
+    """
+    Module de communication inter-serveurs
+    Connecte des salons de différents serveurs pour créer un portail de communication
+    """
+
+    MODULE_ID = "interserver"
+    MODULE_NAME = "Inter-Server"
+    MODULE_DESCRIPTION = "Connecte plusieurs serveurs via des salons dédiés"
+    MODULE_EMOJI = "🌐"
+
+    def __init__(self, bot, guild_id: int):
+        super().__init__(bot, guild_id)
+        self.channel_id: Optional[int] = None
+        self.show_server_name: bool = True
+        self.show_avatar: bool = True
+        self.allowed_mentions: bool = False
+
+    async def load_config(self, config_data: Dict[str, Any]) -> bool:
+        """Charge la configuration depuis la DB"""
+        try:
+            self.config = config_data
+            self.channel_id = config_data.get('channel_id')
+            self.show_server_name = config_data.get('show_server_name', True)
+            self.show_avatar = config_data.get('show_avatar', True)
+            self.allowed_mentions = config_data.get('allowed_mentions', False)
+
+            # Le module est activé si un salon est configuré
+            self.enabled = self.channel_id is not None
+
+            return True
+        except Exception as e:
+            logger.error(f"Error loading interserver config: {e}")
+            return False
+
+    async def validate_config(self, config_data: Dict[str, Any]) -> tuple[bool, Optional[str]]:
+        """Valide la configuration"""
+        # Vérifie que le salon existe si spécifié
+        if 'channel_id' in config_data and config_data['channel_id']:
+            try:
+                guild = self.bot.get_guild(self.guild_id)
+                if not guild:
+                    return False, "Serveur introuvable"
+
+                channel = guild.get_channel(config_data['channel_id'])
+                if not channel:
+                    return False, "Salon introuvable"
+
+                if not isinstance(channel, discord.TextChannel):
+                    return False, "Le salon doit être un salon textuel"
+
+                # Vérifie les permissions
+                perms = channel.permissions_for(guild.me)
+                if not perms.send_messages:
+                    return False, f"Je n'ai pas la permission d'envoyer des messages dans {channel.mention}"
+
+                if not perms.manage_webhooks:
+                    return False, f"Je n'ai pas la permission de gérer les webhooks dans {channel.mention}"
+
+            except Exception as e:
+                return False, f"Erreur de validation : {str(e)}"
+
+        return True, None
+
+    def get_default_config(self) -> Dict[str, Any]:
+        """Retourne la configuration par défaut"""
+        return {
+            'channel_id': None,
+            'show_server_name': True,
+            'show_avatar': True,
+            'allowed_mentions': False
+        }
+
+    async def on_message(self, message: discord.Message):
+        """
+        Appelé quand un message est envoyé dans un salon inter-serveur
+        Relaie le message vers tous les autres salons inter-serveur
+        """
+        if not self.enabled or not self.channel_id:
+            return
+
+        # Ignore les messages qui ne sont pas dans le salon configuré
+        if message.channel.id != self.channel_id:
+            return
+
+        # Ignore les messages des bots (évite les boucles infinies)
+        if message.author.bot:
+            return
+
+        # Ignore les messages vides sans pièces jointes
+        if not message.content and not message.attachments and not message.embeds:
+            return
+
+        try:
+            # Récupère tous les autres salons inter-serveur actifs
+            target_channels = await self._get_all_interserver_channels()
+
+            # Retire le salon actuel de la liste
+            target_channels = [ch for ch in target_channels if ch.id != message.channel.id]
+
+            if not target_channels:
+                logger.debug(f"No target channels found for interserver relay from guild {self.guild_id}")
+                return
+
+            # Prépare le contenu du message
+            await self._relay_message(message, target_channels)
+
+            logger.info(f"✅ Relayed message from {message.guild.name} to {len(target_channels)} servers")
+
+        except Exception as e:
+            logger.error(f"Error relaying interserver message: {e}", exc_info=True)
+
+    async def _get_all_interserver_channels(self) -> List[discord.TextChannel]:
+        """
+        Récupère tous les salons inter-serveur actifs
+        """
+        channels = []
+
+        # Parcourt tous les serveurs où le bot est présent
+        for guild in self.bot.guilds:
+            # Récupère le module inter-serveur pour ce serveur
+            module = await self.bot.module_manager.get_module_instance(
+                guild.id,
+                'interserver'
+            )
+
+            # Si le module est actif et configuré
+            if module and module.enabled and module.channel_id:
+                channel = guild.get_channel(module.channel_id)
+                if channel and isinstance(channel, discord.TextChannel):
+                    # Vérifie les permissions
+                    perms = channel.permissions_for(guild.me)
+                    if perms.send_messages and perms.manage_webhooks:
+                        channels.append(channel)
+
+        return channels
+
+    async def _relay_message(self, message: discord.Message, target_channels: List[discord.TextChannel]):
+        """
+        Relaie un message vers les salons cibles en utilisant des webhooks
+        """
+        # Prépare le nom d'affichage
+        if self.show_server_name:
+            username = f"{message.author.display_name} ({message.guild.name})"
+        else:
+            username = message.author.display_name
+
+        # Limite la longueur du nom (max 80 caractères pour Discord)
+        if len(username) > 80:
+            username = username[:77] + "..."
+
+        # Prépare l'avatar
+        avatar_url = message.author.display_avatar.url if self.show_avatar else None
+
+        # Prépare le contenu
+        content = message.content
+
+        # Gère les mentions si désactivées
+        if not self.allowed_mentions:
+            allowed_mentions = discord.AllowedMentions.none()
+        else:
+            allowed_mentions = discord.AllowedMentions.all()
+
+        # Prépare les fichiers (pièces jointes)
+        files = []
+        if message.attachments:
+            for attachment in message.attachments[:10]:  # Limite à 10 fichiers
+                try:
+                    # Télécharge le fichier
+                    file_data = await attachment.read()
+                    files.append(discord.File(
+                        fp=discord.utils.BytesIO(file_data),
+                        filename=attachment.filename,
+                        spoiler=attachment.is_spoiler()
+                    ))
+                except Exception as e:
+                    logger.warning(f"Failed to download attachment {attachment.filename}: {e}")
+
+        # Prépare les embeds
+        embeds = []
+        if message.embeds:
+            # Limite à 10 embeds (limite Discord)
+            embeds = message.embeds[:10]
+
+        # Envoie le message via webhook dans chaque salon cible
+        for channel in target_channels:
+            try:
+                # Récupère ou crée un webhook pour ce salon
+                webhook = await self._get_or_create_webhook(channel)
+
+                if not webhook:
+                    logger.warning(f"Could not get webhook for channel {channel.id} in guild {channel.guild.id}")
+                    continue
+
+                # Envoie le message via le webhook
+                await webhook.send(
+                    content=content or None,
+                    username=username,
+                    avatar_url=avatar_url,
+                    embeds=embeds if embeds else None,
+                    files=files if files else None,
+                    allowed_mentions=allowed_mentions,
+                    wait=False
+                )
+
+            except discord.Forbidden:
+                logger.warning(f"Missing permissions to send webhook in channel {channel.id}")
+            except discord.HTTPException as e:
+                logger.error(f"HTTP error sending webhook to channel {channel.id}: {e}")
+            except Exception as e:
+                logger.error(f"Error sending webhook to channel {channel.id}: {e}", exc_info=True)
+
+    async def _get_or_create_webhook(self, channel: discord.TextChannel) -> Optional[discord.Webhook]:
+        """
+        Récupère ou crée un webhook pour le salon inter-serveur
+        """
+        try:
+            # Récupère les webhooks existants
+            webhooks = await channel.webhooks()
+
+            # Cherche un webhook créé par Moddy pour l'inter-serveur
+            moddy_webhook = None
+            for webhook in webhooks:
+                if webhook.user and webhook.user.id == self.bot.user.id:
+                    if webhook.name == "Moddy Inter-Server":
+                        moddy_webhook = webhook
+                        break
+
+            # Si aucun webhook trouvé, en créer un
+            if not moddy_webhook:
+                moddy_webhook = await channel.create_webhook(
+                    name="Moddy Inter-Server",
+                    reason="Webhook for inter-server communication"
+                )
+                logger.info(f"Created webhook for inter-server in channel {channel.id}")
+
+            return moddy_webhook
+
+        except discord.Forbidden:
+            logger.error(f"Missing permissions to manage webhooks in channel {channel.id}")
+            return None
+        except Exception as e:
+            logger.error(f"Error getting/creating webhook: {e}", exc_info=True)
+            return None


### PR DESCRIPTION
Implements a new inter-server module that allows different Discord servers to communicate through connected channels. Messages sent in one server's inter-server channel are relayed to all other configured inter-server channels using webhooks to preserve the original author's name and avatar.

Features:
- Configure a dedicated inter-server channel via /config
- Messages are relayed using webhooks with original author info
- Optional display of server name in relayed messages
- Optional display of author avatar
- Optional allow/disallow mentions in relayed messages
- Security warning to inform users about cross-server visibility
- Full i18n support (FR/EN)

Technical implementation:
- New module: modules/interserver.py
- Config UI: modules/configs/interserver_config.py
- Event listener for on_message in module_events.py
- Translations added to locales/fr.json and locales/en-US.json
- Module registered in cogs/config.py