### PR TITLE
Fix button creation in Components V2 ActionRow

### DIFF
--- a/staff/staff_manager.py
+++ b/staff/staff_manager.py
@@ -401,24 +401,25 @@ class StaffPermissionsManagementView(ui.LayoutView):
 
         buttons_row = ui.ActionRow()
 
-        # Save button
-        @buttons_row.button(
+        # Create buttons explicitly
+        save_btn = ui.Button(
             label="Save Changes",
             style=discord.ButtonStyle.green,
-            emoji=discord.PartialEmoji(name="done", id=1398729525277229066)
+            emoji=discord.PartialEmoji(name="done", id=1398729525277229066),
+            custom_id=f"save_perms_{self.target_user.id}"
         )
-        async def save_button(interaction: discord.Interaction, button: ui.Button):
-            await self.save_callback(interaction)
+        save_btn.callback = self.save_callback
 
-        # Cancel button
-        @buttons_row.button(
+        cancel_btn = ui.Button(
             label="Cancel",
             style=discord.ButtonStyle.red,
-            emoji=discord.PartialEmoji(name="undone", id=1398729502028333218)
+            emoji=discord.PartialEmoji(name="undone", id=1398729502028333218),
+            custom_id=f"cancel_perms_{self.target_user.id}"
         )
-        async def cancel_button(interaction: discord.Interaction, button: ui.Button):
-            await self.cancel_callback(interaction)
+        cancel_btn.callback = self.cancel_callback
 
+        buttons_row.add_item(save_btn)
+        buttons_row.add_item(cancel_btn)
         container.add_item(buttons_row)
 
         # Add container to view


### PR DESCRIPTION
Changed from decorator-based button creation to explicit button instantiation. The @button_row.button() decorator pattern was causing issues with ActionRow in dynamic contexts. Now buttons are created explicitly with Button() constructor and added to the ActionRow with add_item().

This fixes the 400 Bad Request error: 'Must be between 1 and 5 in length' for ActionRow components.