### PR TITLE
Fix role selection persistence in permission dropdown

### DIFF
--- a/staff/staff_manager.py
+++ b/staff/staff_manager.py
@@ -351,7 +351,7 @@ class StaffPermissionsManagementView(ui.LayoutView):
                             name=self._get_role_badge_name(role),
                             id=self._get_role_badge_id(role)
                         ),
-                        default=role == self.selected_role_for_config
+                        default=role.value == self.selected_role_for_config
                     )
                 )
 


### PR DESCRIPTION
Changed comparison from 'role == self.selected_role_for_config' to 'role.value == self.selected_role_for_config' to properly mark the selected role as default in the dropdown menu.

Now when you select a role (e.g., Manager), it stays visibly selected in the dropdown, just like Common Permissions does.