### PR TITLE
Split welcome message into private and channel

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -509,61 +509,67 @@
       "description": "Send a welcome message to new members",
       "config": {
         "title": "Welcome Module Configuration",
-        "description": "Configure welcome messages for new members on your server.",
-        "send_mode": {
-          "section_title": "Send Mode",
-          "send_dm": "Send as private message",
-          "send_dm_desc": "Sends the welcome message as a DM instead of a public channel"
-        },
+        "description": "Configure welcome messages for new members. You can enable a public channel message and/or a private DM message.",
         "channel": {
-          "section_title": "Send Channel",
-          "section_description": "In which channel should the welcome message be sent?",
-          "label": "Welcome channel",
-          "placeholder": "Select a channel"
-        },
-        "message": {
-          "section_title": "Welcome Message",
-          "section_description": "Customize the welcome message. Variables: {user}, {username}, {server}, {member_count}",
-          "label": "Welcome message",
-          "edit_button": "Edit message",
+          "section_title": "Public Message (in a channel)",
+          "section_description": "Welcome message sent in a server channel",
+          "enable": "Enable public message",
+          "channel_placeholder": "Select a channel",
+          "message_label": "Message",
+          "edit_message": "Edit message",
           "mention_user": "Mention user",
-          "modal": {
-            "label": "Welcome message",
+          "embed_toggle": "Enable embed",
+          "edit_embed_title": "Embed title",
+          "edit_embed_description": "Embed description",
+          "edit_embed_color": "Color",
+          "embed_thumbnail": "Avatar",
+          "embed_author": "Author",
+          "message_modal": {
+            "label": "Public welcome message",
             "placeholder": "Welcome {user} to {server}!"
-          }
-        },
-        "embed": {
-          "section_title": "Embed Options",
-          "section_description": "Customize the embed appearance",
-          "toggle": "Enable embed",
-          "edit_title": "Edit title",
-          "edit_description": "Edit description",
-          "edit_color": "Edit color",
-          "edit_footer": "Edit footer",
-          "edit_image": "Edit image",
-          "thumbnail": "Show avatar",
-          "author": "Show as author",
-          "title_modal": {
-            "label": "Embed title",
+          },
+          "embed_title_modal": {
+            "label": "Public embed title",
             "placeholder": "Welcome!"
           },
-          "description_modal": {
-            "label": "Embed description",
+          "embed_description_modal": {
+            "label": "Public embed description",
             "placeholder": "Leave empty to use the welcome message"
           },
-          "color_modal": {
-            "label": "Embed color (hex)",
+          "embed_color_modal": {
+            "label": "Public embed color (hex)",
             "placeholder": "#5865F2",
             "error": "Invalid color! Use the #RRGGBB format"
+          }
+        },
+        "dm": {
+          "section_title": "Private Message (DM)",
+          "section_description": "Welcome message sent privately to the new member",
+          "enable": "Enable private message",
+          "message_label": "Message",
+          "edit_message": "Edit message",
+          "embed_toggle": "Enable embed",
+          "edit_embed_title": "Embed title",
+          "edit_embed_description": "Embed description",
+          "edit_embed_color": "Color",
+          "embed_thumbnail": "Avatar",
+          "embed_author": "Author",
+          "message_modal": {
+            "label": "Private welcome message",
+            "placeholder": "Welcome to {server}!"
           },
-          "footer_modal": {
-            "label": "Embed footer",
-            "placeholder": "Leave empty to not display a footer"
+          "embed_title_modal": {
+            "label": "Private embed title",
+            "placeholder": "Welcome!"
           },
-          "image_modal": {
-            "label": "Image URL",
-            "placeholder": "https://example.com/image.png",
-            "error": "Invalid URL! The URL must start with http:// or https://"
+          "embed_description_modal": {
+            "label": "Private embed description",
+            "placeholder": "Leave empty to use the welcome message"
+          },
+          "embed_color_modal": {
+            "label": "Private embed color (hex)",
+            "placeholder": "#5865F2",
+            "error": "Invalid color! Use the #RRGGBB format"
           }
         }
       }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -508,61 +508,67 @@
       "description": "Envoie un message de bienvenue aux nouveaux membres",
       "config": {
         "title": "Configuration du module Welcome",
-        "description": "Configurez les messages de bienvenue pour les nouveaux membres de votre serveur.",
-        "send_mode": {
-          "section_title": "Mode d'envoi",
-          "send_dm": "Envoyer en message privé",
-          "send_dm_desc": "Envoie le message de bienvenue en DM au lieu d'un salon public"
-        },
+        "description": "Configurez les messages de bienvenue pour les nouveaux membres. Vous pouvez activer un message dans un salon public et/ou un message privé en DM.",
         "channel": {
-          "section_title": "Salon d'envoi",
-          "section_description": "Dans quel salon doit être envoyé le message de bienvenue ?",
-          "label": "Salon de bienvenue",
-          "placeholder": "Sélectionnez un salon"
-        },
-        "message": {
-          "section_title": "Message de bienvenue",
-          "section_description": "Personnalisez le message de bienvenue. Variables : {user}, {username}, {server}, {member_count}",
-          "label": "Message de bienvenue",
-          "edit_button": "Modifier le message",
+          "section_title": "Message public (dans un salon)",
+          "section_description": "Message de bienvenue envoyé dans un salon du serveur",
+          "enable": "Activer le message public",
+          "channel_placeholder": "Sélectionnez un salon",
+          "message_label": "Message",
+          "edit_message": "Modifier le message",
           "mention_user": "Mentionner l'utilisateur",
-          "modal": {
-            "label": "Message de bienvenue",
+          "embed_toggle": "Activer l'embed",
+          "edit_embed_title": "Titre de l'embed",
+          "edit_embed_description": "Description de l'embed",
+          "edit_embed_color": "Couleur",
+          "embed_thumbnail": "Avatar",
+          "embed_author": "Auteur",
+          "message_modal": {
+            "label": "Message de bienvenue public",
             "placeholder": "Bienvenue {user} sur {server} !"
-          }
-        },
-        "embed": {
-          "section_title": "Options d'embed",
-          "section_description": "Personnalisez l'apparence de l'embed",
-          "toggle": "Activer l'embed",
-          "edit_title": "Modifier le titre",
-          "edit_description": "Modifier la description",
-          "edit_color": "Modifier la couleur",
-          "edit_footer": "Modifier le footer",
-          "edit_image": "Modifier l'image",
-          "thumbnail": "Afficher l'avatar",
-          "author": "Afficher comme auteur",
-          "title_modal": {
-            "label": "Titre de l'embed",
+          },
+          "embed_title_modal": {
+            "label": "Titre de l'embed public",
             "placeholder": "Bienvenue !"
           },
-          "description_modal": {
-            "label": "Description de l'embed",
+          "embed_description_modal": {
+            "label": "Description de l'embed public",
             "placeholder": "Laissez vide pour utiliser le message de bienvenue"
           },
-          "color_modal": {
-            "label": "Couleur de l'embed (hex)",
+          "embed_color_modal": {
+            "label": "Couleur de l'embed public (hex)",
             "placeholder": "#5865F2",
             "error": "Couleur invalide ! Utilisez le format #RRGGBB"
+          }
+        },
+        "dm": {
+          "section_title": "Message privé (DM)",
+          "section_description": "Message de bienvenue envoyé en privé au nouveau membre",
+          "enable": "Activer le message privé",
+          "message_label": "Message",
+          "edit_message": "Modifier le message",
+          "embed_toggle": "Activer l'embed",
+          "edit_embed_title": "Titre de l'embed",
+          "edit_embed_description": "Description de l'embed",
+          "edit_embed_color": "Couleur",
+          "embed_thumbnail": "Avatar",
+          "embed_author": "Auteur",
+          "message_modal": {
+            "label": "Message de bienvenue privé",
+            "placeholder": "Bienvenue sur le serveur {server} !"
           },
-          "footer_modal": {
-            "label": "Footer de l'embed",
-            "placeholder": "Laissez vide pour ne pas afficher de footer"
+          "embed_title_modal": {
+            "label": "Titre de l'embed privé",
+            "placeholder": "Bienvenue !"
           },
-          "image_modal": {
-            "label": "URL de l'image",
-            "placeholder": "https://exemple.com/image.png",
-            "error": "URL invalide ! L'URL doit commencer par http:// ou https://"
+          "embed_description_modal": {
+            "label": "Description de l'embed privé",
+            "placeholder": "Laissez vide pour utiliser le message de bienvenue"
+          },
+          "embed_color_modal": {
+            "label": "Couleur de l'embed privé (hex)",
+            "placeholder": "#5865F2",
+            "error": "Couleur invalide ! Utilisez le format #RRGGBB"
           }
         }
       }

--- a/modules/configs/welcome_config.py
+++ b/modules/configs/welcome_config.py
@@ -1,6 +1,6 @@
 """
 Configuration UI pour le module Welcome
-Utilise les Composants V2 pour une interface moderne
+Interface séparée pour les messages de bienvenue en DM et dans un salon
 """
 
 import discord
@@ -13,18 +13,19 @@ from utils.i18n import t
 logger = logging.getLogger('moddy.modules.welcome_config')
 
 
-class MessageEditModal(ui.Modal, title="Modifier le message"):
-    """Modal pour éditer le message de bienvenue"""
+# === MODALS FOR CHANNEL WELCOME ===
+
+class ChannelMessageEditModal(ui.Modal, title="Message de bienvenue public"):
+    """Modal pour éditer le message de bienvenue dans le salon"""
 
     def __init__(self, locale: str, current_value: str, callback_func):
         super().__init__(timeout=300)
         self.locale = locale
         self.callback_func = callback_func
 
-        # Champ de texte pour le message
         self.message_input = ui.TextInput(
-            label=t('modules.welcome.config.message.modal.label', locale=locale),
-            placeholder=t('modules.welcome.config.message.modal.placeholder', locale=locale),
+            label=t('modules.welcome.config.channel.message_modal.label', locale=locale),
+            placeholder=t('modules.welcome.config.channel.message_modal.placeholder', locale=locale),
             default=current_value,
             style=discord.TextStyle.paragraph,
             max_length=2000,
@@ -36,8 +37,8 @@ class MessageEditModal(ui.Modal, title="Modifier le message"):
         await self.callback_func(interaction, self.message_input.value)
 
 
-class EmbedTitleModal(ui.Modal, title="Modifier le titre de l'embed"):
-    """Modal pour éditer le titre de l'embed"""
+class ChannelEmbedTitleModal(ui.Modal, title="Titre embed public"):
+    """Modal pour éditer le titre de l'embed du salon"""
 
     def __init__(self, locale: str, current_value: str, callback_func):
         super().__init__(timeout=300)
@@ -45,8 +46,8 @@ class EmbedTitleModal(ui.Modal, title="Modifier le titre de l'embed"):
         self.callback_func = callback_func
 
         self.title_input = ui.TextInput(
-            label=t('modules.welcome.config.embed.title_modal.label', locale=locale),
-            placeholder=t('modules.welcome.config.embed.title_modal.placeholder', locale=locale),
+            label=t('modules.welcome.config.channel.embed_title_modal.label', locale=locale),
+            placeholder=t('modules.welcome.config.channel.embed_title_modal.placeholder', locale=locale),
             default=current_value,
             style=discord.TextStyle.short,
             max_length=256,
@@ -58,8 +59,8 @@ class EmbedTitleModal(ui.Modal, title="Modifier le titre de l'embed"):
         await self.callback_func(interaction, self.title_input.value)
 
 
-class EmbedDescriptionModal(ui.Modal, title="Modifier la description de l'embed"):
-    """Modal pour éditer la description de l'embed"""
+class ChannelEmbedDescriptionModal(ui.Modal, title="Description embed public"):
+    """Modal pour éditer la description de l'embed du salon"""
 
     def __init__(self, locale: str, current_value: Optional[str], callback_func):
         super().__init__(timeout=300)
@@ -67,8 +68,8 @@ class EmbedDescriptionModal(ui.Modal, title="Modifier la description de l'embed"
         self.callback_func = callback_func
 
         self.desc_input = ui.TextInput(
-            label=t('modules.welcome.config.embed.description_modal.label', locale=locale),
-            placeholder=t('modules.welcome.config.embed.description_modal.placeholder', locale=locale),
+            label=t('modules.welcome.config.channel.embed_description_modal.label', locale=locale),
+            placeholder=t('modules.welcome.config.channel.embed_description_modal.placeholder', locale=locale),
             default=current_value or "",
             style=discord.TextStyle.paragraph,
             max_length=4096,
@@ -80,20 +81,19 @@ class EmbedDescriptionModal(ui.Modal, title="Modifier la description de l'embed"
         await self.callback_func(interaction, self.desc_input.value if self.desc_input.value else None)
 
 
-class EmbedColorModal(ui.Modal, title="Modifier la couleur de l'embed"):
-    """Modal pour éditer la couleur de l'embed"""
+class ChannelEmbedColorModal(ui.Modal, title="Couleur embed public"):
+    """Modal pour éditer la couleur de l'embed du salon"""
 
     def __init__(self, locale: str, current_value: int, callback_func):
         super().__init__(timeout=300)
         self.locale = locale
         self.callback_func = callback_func
 
-        # Convertir int en hex string
         hex_color = f"#{current_value:06X}"
 
         self.color_input = ui.TextInput(
-            label=t('modules.welcome.config.embed.color_modal.label', locale=locale),
-            placeholder=t('modules.welcome.config.embed.color_modal.placeholder', locale=locale),
+            label=t('modules.welcome.config.channel.embed_color_modal.label', locale=locale),
+            placeholder=t('modules.welcome.config.channel.embed_color_modal.placeholder', locale=locale),
             default=hex_color,
             style=discord.TextStyle.short,
             max_length=7,
@@ -102,7 +102,6 @@ class EmbedColorModal(ui.Modal, title="Modifier la couleur de l'embed"):
         self.add_item(self.color_input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        # Convertir hex string en int
         color_str = self.color_input.value.strip()
         if not color_str.startswith('#'):
             color_str = '#' + color_str
@@ -112,66 +111,117 @@ class EmbedColorModal(ui.Modal, title="Modifier la couleur de l'embed"):
             await self.callback_func(interaction, color_int)
         except ValueError:
             await interaction.response.send_message(
-                t('modules.welcome.config.embed.color_modal.error', locale=self.locale),
+                t('modules.welcome.config.channel.embed_color_modal.error', locale=self.locale),
                 ephemeral=True
             )
 
 
-class EmbedFooterModal(ui.Modal, title="Modifier le footer de l'embed"):
-    """Modal pour éditer le footer de l'embed"""
+# === MODALS FOR DM WELCOME ===
+
+class DmMessageEditModal(ui.Modal, title="Message de bienvenue privé"):
+    """Modal pour éditer le message de bienvenue en DM"""
+
+    def __init__(self, locale: str, current_value: str, callback_func):
+        super().__init__(timeout=300)
+        self.locale = locale
+        self.callback_func = callback_func
+
+        self.message_input = ui.TextInput(
+            label=t('modules.welcome.config.dm.message_modal.label', locale=locale),
+            placeholder=t('modules.welcome.config.dm.message_modal.placeholder', locale=locale),
+            default=current_value,
+            style=discord.TextStyle.paragraph,
+            max_length=2000,
+            required=True
+        )
+        self.add_item(self.message_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await self.callback_func(interaction, self.message_input.value)
+
+
+class DmEmbedTitleModal(ui.Modal, title="Titre embed privé"):
+    """Modal pour éditer le titre de l'embed DM"""
+
+    def __init__(self, locale: str, current_value: str, callback_func):
+        super().__init__(timeout=300)
+        self.locale = locale
+        self.callback_func = callback_func
+
+        self.title_input = ui.TextInput(
+            label=t('modules.welcome.config.dm.embed_title_modal.label', locale=locale),
+            placeholder=t('modules.welcome.config.dm.embed_title_modal.placeholder', locale=locale),
+            default=current_value,
+            style=discord.TextStyle.short,
+            max_length=256,
+            required=True
+        )
+        self.add_item(self.title_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await self.callback_func(interaction, self.title_input.value)
+
+
+class DmEmbedDescriptionModal(ui.Modal, title="Description embed privé"):
+    """Modal pour éditer la description de l'embed DM"""
 
     def __init__(self, locale: str, current_value: Optional[str], callback_func):
         super().__init__(timeout=300)
         self.locale = locale
         self.callback_func = callback_func
 
-        self.footer_input = ui.TextInput(
-            label=t('modules.welcome.config.embed.footer_modal.label', locale=locale),
-            placeholder=t('modules.welcome.config.embed.footer_modal.placeholder', locale=locale),
+        self.desc_input = ui.TextInput(
+            label=t('modules.welcome.config.dm.embed_description_modal.label', locale=locale),
+            placeholder=t('modules.welcome.config.dm.embed_description_modal.placeholder', locale=locale),
             default=current_value or "",
-            style=discord.TextStyle.short,
-            max_length=2048,
+            style=discord.TextStyle.paragraph,
+            max_length=4096,
             required=False
         )
-        self.add_item(self.footer_input)
+        self.add_item(self.desc_input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        await self.callback_func(interaction, self.footer_input.value if self.footer_input.value else None)
+        await self.callback_func(interaction, self.desc_input.value if self.desc_input.value else None)
 
 
-class EmbedImageModal(ui.Modal, title="Modifier l'image de l'embed"):
-    """Modal pour éditer l'URL de l'image de l'embed"""
+class DmEmbedColorModal(ui.Modal, title="Couleur embed privé"):
+    """Modal pour éditer la couleur de l'embed DM"""
 
-    def __init__(self, locale: str, current_value: Optional[str], callback_func):
+    def __init__(self, locale: str, current_value: int, callback_func):
         super().__init__(timeout=300)
         self.locale = locale
         self.callback_func = callback_func
 
-        self.image_input = ui.TextInput(
-            label=t('modules.welcome.config.embed.image_modal.label', locale=locale),
-            placeholder=t('modules.welcome.config.embed.image_modal.placeholder', locale=locale),
-            default=current_value or "",
+        hex_color = f"#{current_value:06X}"
+
+        self.color_input = ui.TextInput(
+            label=t('modules.welcome.config.dm.embed_color_modal.label', locale=locale),
+            placeholder=t('modules.welcome.config.dm.embed_color_modal.placeholder', locale=locale),
+            default=hex_color,
             style=discord.TextStyle.short,
-            max_length=512,
-            required=False
+            max_length=7,
+            required=True
         )
-        self.add_item(self.image_input)
+        self.add_item(self.color_input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        url = self.image_input.value.strip() if self.image_input.value else None
-        if url and not url.startswith(('http://', 'https://')):
+        color_str = self.color_input.value.strip()
+        if not color_str.startswith('#'):
+            color_str = '#' + color_str
+
+        try:
+            color_int = int(color_str[1:], 16)
+            await self.callback_func(interaction, color_int)
+        except ValueError:
             await interaction.response.send_message(
-                t('modules.welcome.config.embed.image_modal.error', locale=self.locale),
+                t('modules.welcome.config.dm.embed_color_modal.error', locale=self.locale),
                 ephemeral=True
             )
-            return
-        await self.callback_func(interaction, url)
 
 
 class WelcomeConfigView(ui.LayoutView):
     """
-    Interface de configuration du module Welcome
-    Utilise les Composants V2 pour une UI moderne et interactive
+    Interface de configuration du module Welcome avec sections séparées pour DM et salon
     """
 
     def __init__(self, bot, guild_id: int, user_id: int, locale: str, current_config: Optional[Dict[str, Any]] = None):
@@ -183,7 +233,7 @@ class WelcomeConfigView(ui.LayoutView):
             guild_id: ID du serveur
             user_id: ID de l'utilisateur qui configure
             locale: Langue de l'utilisateur
-            current_config: Configuration actuelle du module (None si première config)
+            current_config: Configuration actuelle du module
         """
         super().__init__(timeout=300)
         self.bot = bot
@@ -191,36 +241,37 @@ class WelcomeConfigView(ui.LayoutView):
         self.user_id = user_id
         self.locale = locale
 
-        # Configuration actuelle (ou par défaut)
+        # Load default config
         from modules.welcome import WelcomeModule
         default_config = WelcomeModule(bot, guild_id).get_default_config()
 
-        # Check if we have a real saved config by looking for channel_id or send_dm
-        if current_config and (current_config.get('channel_id') is not None or current_config.get('send_dm') is True):
-            # Merge current config with defaults to ensure all keys exist
+        # Check if we have a real saved config
+        if current_config and (
+            current_config.get('channel_enabled') is True or
+            current_config.get('dm_enabled') is True
+        ):
+            # Merge with defaults to ensure all keys exist
             self.current_config = default_config.copy()
             self.current_config.update(current_config)
             self.has_existing_config = True
         else:
-            # Utilise la config par défaut du module
+            # Use default config
             self.current_config = default_config
             self.has_existing_config = False
 
-        # Configuration en cours de modification (copie de travail)
+        # Working copy
         self.working_config = self.current_config.copy()
-
-        # État de modification
         self.has_changes = False
 
         self._build_view()
 
     def _build_view(self):
-        """Construit l'interface de configuration"""
+        """Construit l'interface de configuration avec deux sections distinctes"""
         self.clear_items()
 
         container = ui.Container()
 
-        # Titre et description
+        # === HEADER ===
         container.add_item(ui.TextDisplay(
             f"### <:waving_hand:1446127491004760184> {t('modules.welcome.config.title', locale=self.locale)}"
         ))
@@ -228,47 +279,40 @@ class WelcomeConfigView(ui.LayoutView):
             t('modules.welcome.config.description', locale=self.locale)
         ))
 
-        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.large))
 
-        # === SECTION: MODE D'ENVOI ===
+        # === SECTION 1: CHANNEL WELCOME (Public) ===
         container.add_item(ui.TextDisplay(
-            f"**{t('modules.welcome.config.send_mode.section_title', locale=self.locale)}**"
+            f"## {t('modules.welcome.config.channel.section_title', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.welcome.config.channel.section_description', locale=self.locale)}"
         ))
 
-        # Toggle Send DM
-        send_dm_row = ui.ActionRow()
-        send_dm_btn = ui.Button(
-            label=t('modules.welcome.config.send_mode.send_dm', locale=self.locale),
-            style=discord.ButtonStyle.success if self.working_config['send_dm'] else discord.ButtonStyle.secondary,
-            emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['send_dm'] else "<:undone:1398729502028333218>"),
-            custom_id="toggle_send_dm"
+        # Toggle Channel Welcome
+        channel_enabled_row = ui.ActionRow()
+        channel_enabled_btn = ui.Button(
+            label=t('modules.welcome.config.channel.enable', locale=self.locale),
+            style=discord.ButtonStyle.success if self.working_config['channel_enabled'] else discord.ButtonStyle.secondary,
+            emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['channel_enabled'] else "<:undone:1398729502028333218>"),
+            custom_id="toggle_channel_enabled"
         )
-        send_dm_btn.callback = self.on_toggle_send_dm
-        send_dm_row.add_item(send_dm_btn)
-        container.add_item(send_dm_row)
+        channel_enabled_btn.callback = self.on_toggle_channel_enabled
+        channel_enabled_row.add_item(channel_enabled_btn)
+        container.add_item(channel_enabled_row)
 
-        container.add_item(ui.TextDisplay(
-            f"-# {t('modules.welcome.config.send_mode.send_dm_desc', locale=self.locale)}"
-        ))
-
-        # Sélecteur de salon (uniquement si send_dm est désactivé)
-        if not self.working_config['send_dm']:
-            container.add_item(ui.TextDisplay(
-                f"**{t('modules.welcome.config.channel.section_title', locale=self.locale)}**"
-            ))
-            container.add_item(ui.TextDisplay(
-                f"-# {t('modules.welcome.config.channel.section_description', locale=self.locale)}"
-            ))
-
+        # Channel configuration (only if enabled)
+        if self.working_config['channel_enabled']:
+            # Channel selector
             channel_row = ui.ActionRow()
             channel_select = ui.ChannelSelect(
-                placeholder=t('modules.welcome.config.channel.placeholder', locale=self.locale),
+                placeholder=t('modules.welcome.config.channel.channel_placeholder', locale=self.locale),
                 channel_types=[discord.ChannelType.text],
                 min_values=0,
                 max_values=1
             )
 
-            # Pré-sélectionne le salon actuel si configuré
+            # Pre-select current channel if set
             if self.working_config.get('channel_id'):
                 channel = self.bot.get_channel(self.working_config['channel_id'])
                 if channel:
@@ -278,173 +322,244 @@ class WelcomeConfigView(ui.LayoutView):
             channel_row.add_item(channel_select)
             container.add_item(channel_row)
 
-        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
-
-        # === SECTION: MESSAGE ===
-        container.add_item(ui.TextDisplay(
-            f"**{t('modules.welcome.config.message.section_title', locale=self.locale)}**"
-        ))
-        container.add_item(ui.TextDisplay(
-            f"-# {t('modules.welcome.config.message.section_description', locale=self.locale)}"
-        ))
-
-        # Affichage du message actuel
-        container.add_item(ui.TextDisplay(
-            f"-# {t('modules.config.current_value', locale=self.locale)} `{self.working_config['message_template'][:100]}{'...' if len(self.working_config['message_template']) > 100 else ''}`"
-        ))
-
-        # Boutons pour éditer le message et toggle mention
-        message_row = ui.ActionRow()
-
-        edit_message_btn = ui.Button(
-            label=t('modules.welcome.config.message.edit_button', locale=self.locale),
-            style=discord.ButtonStyle.primary,
-            emoji=discord.PartialEmoji.from_str("<:edit:1401600709824086169>"),
-            custom_id="edit_message"
-        )
-        edit_message_btn.callback = self.on_edit_message
-        message_row.add_item(edit_message_btn)
-
-        mention_btn = ui.Button(
-            label=t('modules.welcome.config.message.mention_user', locale=self.locale),
-            style=discord.ButtonStyle.success if self.working_config['mention_user'] else discord.ButtonStyle.secondary,
-            emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['mention_user'] else "<:undone:1398729502028333218>"),
-            custom_id="toggle_mention"
-        )
-        mention_btn.callback = self.on_toggle_mention
-        message_row.add_item(mention_btn)
-
-        container.add_item(message_row)
-
-        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
-
-        # === SECTION: EMBED ===
-        container.add_item(ui.TextDisplay(
-            f"**{t('modules.welcome.config.embed.section_title', locale=self.locale)}**"
-        ))
-
-        # Toggle Embed
-        embed_toggle_row = ui.ActionRow()
-        embed_btn = ui.Button(
-            label=t('modules.welcome.config.embed.toggle', locale=self.locale),
-            style=discord.ButtonStyle.success if self.working_config['embed_enabled'] else discord.ButtonStyle.secondary,
-            emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['embed_enabled'] else "<:undone:1398729502028333218>"),
-            custom_id="toggle_embed"
-        )
-        embed_btn.callback = self.on_toggle_embed
-        embed_toggle_row.add_item(embed_btn)
-        container.add_item(embed_toggle_row)
-
-        # Options d'embed (uniquement si embed activé)
-        if self.working_config['embed_enabled']:
+            # Message configuration
             container.add_item(ui.TextDisplay(
-                f"-# {t('modules.welcome.config.embed.section_description', locale=self.locale)}"
+                f"-# **{t('modules.welcome.config.channel.message_label', locale=self.locale)}:** `{self.working_config['channel_message_template'][:80]}{'...' if len(self.working_config['channel_message_template']) > 80 else ''}`"
             ))
 
-            # Boutons pour éditer le titre et la couleur
-            embed_row1 = ui.ActionRow()
+            # Buttons for message and mention
+            channel_msg_row = ui.ActionRow()
 
-            edit_title_btn = ui.Button(
-                label=t('modules.welcome.config.embed.edit_title', locale=self.locale),
+            edit_channel_msg_btn = ui.Button(
+                label=t('modules.welcome.config.channel.edit_message', locale=self.locale),
                 style=discord.ButtonStyle.primary,
                 emoji=discord.PartialEmoji.from_str("<:edit:1401600709824086169>"),
-                custom_id="edit_embed_title"
+                custom_id="edit_channel_message"
             )
-            edit_title_btn.callback = self.on_edit_embed_title
-            embed_row1.add_item(edit_title_btn)
+            edit_channel_msg_btn.callback = self.on_edit_channel_message
+            channel_msg_row.add_item(edit_channel_msg_btn)
 
-            edit_color_btn = ui.Button(
-                label=t('modules.welcome.config.embed.edit_color', locale=self.locale),
-                style=discord.ButtonStyle.primary,
-                emoji=discord.PartialEmoji.from_str("<:color:1398729435565396008>"),
-                custom_id="edit_embed_color"
+            mention_channel_btn = ui.Button(
+                label=t('modules.welcome.config.channel.mention_user', locale=self.locale),
+                style=discord.ButtonStyle.success if self.working_config['channel_mention_user'] else discord.ButtonStyle.secondary,
+                emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['channel_mention_user'] else "<:undone:1398729502028333218>"),
+                custom_id="toggle_channel_mention"
             )
-            edit_color_btn.callback = self.on_edit_embed_color
-            embed_row1.add_item(edit_color_btn)
+            mention_channel_btn.callback = self.on_toggle_channel_mention
+            channel_msg_row.add_item(mention_channel_btn)
 
-            container.add_item(embed_row1)
+            container.add_item(channel_msg_row)
 
-            # Bouton pour éditer la description
-            embed_row2 = ui.ActionRow()
+            # Embed toggle
+            channel_embed_row = ui.ActionRow()
+            channel_embed_btn = ui.Button(
+                label=t('modules.welcome.config.channel.embed_toggle', locale=self.locale),
+                style=discord.ButtonStyle.success if self.working_config['channel_embed_enabled'] else discord.ButtonStyle.secondary,
+                emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['channel_embed_enabled'] else "<:undone:1398729502028333218>"),
+                custom_id="toggle_channel_embed"
+            )
+            channel_embed_btn.callback = self.on_toggle_channel_embed
+            channel_embed_row.add_item(channel_embed_btn)
+            container.add_item(channel_embed_row)
 
-            edit_desc_btn = ui.Button(
-                label=t('modules.welcome.config.embed.edit_description', locale=self.locale),
+            # Embed options (only if embed enabled)
+            if self.working_config['channel_embed_enabled']:
+                channel_embed_opts_row1 = ui.ActionRow()
+
+                edit_channel_embed_title_btn = ui.Button(
+                    label=t('modules.welcome.config.channel.edit_embed_title', locale=self.locale),
+                    style=discord.ButtonStyle.primary,
+                    emoji=discord.PartialEmoji.from_str("<:edit:1401600709824086169>"),
+                    custom_id="edit_channel_embed_title"
+                )
+                edit_channel_embed_title_btn.callback = self.on_edit_channel_embed_title
+                channel_embed_opts_row1.add_item(edit_channel_embed_title_btn)
+
+                edit_channel_embed_color_btn = ui.Button(
+                    label=t('modules.welcome.config.channel.edit_embed_color', locale=self.locale),
+                    style=discord.ButtonStyle.primary,
+                    emoji=discord.PartialEmoji.from_str("<:color:1398729435565396008>"),
+                    custom_id="edit_channel_embed_color"
+                )
+                edit_channel_embed_color_btn.callback = self.on_edit_channel_embed_color
+                channel_embed_opts_row1.add_item(edit_channel_embed_color_btn)
+
+                container.add_item(channel_embed_opts_row1)
+
+                # Edit description button
+                channel_embed_opts_row2 = ui.ActionRow()
+
+                edit_channel_embed_desc_btn = ui.Button(
+                    label=t('modules.welcome.config.channel.edit_embed_description', locale=self.locale),
+                    style=discord.ButtonStyle.primary,
+                    emoji=discord.PartialEmoji.from_str("<:edit:1401600709824086169>"),
+                    custom_id="edit_channel_embed_description"
+                )
+                edit_channel_embed_desc_btn.callback = self.on_edit_channel_embed_description
+                channel_embed_opts_row2.add_item(edit_channel_embed_desc_btn)
+
+                container.add_item(channel_embed_opts_row2)
+
+                # Thumbnail and author toggles
+                channel_embed_opts_row3 = ui.ActionRow()
+
+                channel_thumbnail_btn = ui.Button(
+                    label=t('modules.welcome.config.channel.embed_thumbnail', locale=self.locale),
+                    style=discord.ButtonStyle.success if self.working_config['channel_embed_thumbnail_enabled'] else discord.ButtonStyle.secondary,
+                    emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['channel_embed_thumbnail_enabled'] else "<:undone:1398729502028333218>"),
+                    custom_id="toggle_channel_thumbnail"
+                )
+                channel_thumbnail_btn.callback = self.on_toggle_channel_thumbnail
+                channel_embed_opts_row3.add_item(channel_thumbnail_btn)
+
+                channel_author_btn = ui.Button(
+                    label=t('modules.welcome.config.channel.embed_author', locale=self.locale),
+                    style=discord.ButtonStyle.success if self.working_config['channel_embed_author_enabled'] else discord.ButtonStyle.secondary,
+                    emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['channel_embed_author_enabled'] else "<:undone:1398729502028333218>"),
+                    custom_id="toggle_channel_author"
+                )
+                channel_author_btn.callback = self.on_toggle_channel_author
+                channel_embed_opts_row3.add_item(channel_author_btn)
+
+                container.add_item(channel_embed_opts_row3)
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.large))
+
+        # === SECTION 2: DM WELCOME (Private) ===
+        container.add_item(ui.TextDisplay(
+            f"## {t('modules.welcome.config.dm.section_title', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.welcome.config.dm.section_description', locale=self.locale)}"
+        ))
+
+        # Toggle DM Welcome
+        dm_enabled_row = ui.ActionRow()
+        dm_enabled_btn = ui.Button(
+            label=t('modules.welcome.config.dm.enable', locale=self.locale),
+            style=discord.ButtonStyle.success if self.working_config['dm_enabled'] else discord.ButtonStyle.secondary,
+            emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['dm_enabled'] else "<:undone:1398729502028333218>"),
+            custom_id="toggle_dm_enabled"
+        )
+        dm_enabled_btn.callback = self.on_toggle_dm_enabled
+        dm_enabled_row.add_item(dm_enabled_btn)
+        container.add_item(dm_enabled_row)
+
+        # DM configuration (only if enabled)
+        if self.working_config['dm_enabled']:
+            # Message configuration
+            container.add_item(ui.TextDisplay(
+                f"-# **{t('modules.welcome.config.dm.message_label', locale=self.locale)}:** `{self.working_config['dm_message_template'][:80]}{'...' if len(self.working_config['dm_message_template']) > 80 else ''}`"
+            ))
+
+            # Button for message
+            dm_msg_row = ui.ActionRow()
+
+            edit_dm_msg_btn = ui.Button(
+                label=t('modules.welcome.config.dm.edit_message', locale=self.locale),
                 style=discord.ButtonStyle.primary,
                 emoji=discord.PartialEmoji.from_str("<:edit:1401600709824086169>"),
-                custom_id="edit_embed_description"
+                custom_id="edit_dm_message"
             )
-            edit_desc_btn.callback = self.on_edit_embed_description
-            embed_row2.add_item(edit_desc_btn)
+            edit_dm_msg_btn.callback = self.on_edit_dm_message
+            dm_msg_row.add_item(edit_dm_msg_btn)
 
-            container.add_item(embed_row2)
+            container.add_item(dm_msg_row)
 
-            # Boutons pour footer et image
-            embed_row3 = ui.ActionRow()
-
-            edit_footer_btn = ui.Button(
-                label=t('modules.welcome.config.embed.edit_footer', locale=self.locale),
-                style=discord.ButtonStyle.primary,
-                emoji=discord.PartialEmoji.from_str("<:edit:1401600709824086169>"),
-                custom_id="edit_embed_footer"
+            # Embed toggle
+            dm_embed_row = ui.ActionRow()
+            dm_embed_btn = ui.Button(
+                label=t('modules.welcome.config.dm.embed_toggle', locale=self.locale),
+                style=discord.ButtonStyle.success if self.working_config['dm_embed_enabled'] else discord.ButtonStyle.secondary,
+                emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['dm_embed_enabled'] else "<:undone:1398729502028333218>"),
+                custom_id="toggle_dm_embed"
             )
-            edit_footer_btn.callback = self.on_edit_embed_footer
-            embed_row3.add_item(edit_footer_btn)
+            dm_embed_btn.callback = self.on_toggle_dm_embed
+            dm_embed_row.add_item(dm_embed_btn)
+            container.add_item(dm_embed_row)
 
-            edit_image_btn = ui.Button(
-                label=t('modules.welcome.config.embed.edit_image', locale=self.locale),
-                style=discord.ButtonStyle.primary,
-                emoji=discord.PartialEmoji.from_str("<:edit:1401600709824086169>"),
-                custom_id="edit_embed_image"
-            )
-            edit_image_btn.callback = self.on_edit_embed_image
-            embed_row3.add_item(edit_image_btn)
+            # Embed options (only if embed enabled)
+            if self.working_config['dm_embed_enabled']:
+                dm_embed_opts_row1 = ui.ActionRow()
 
-            container.add_item(embed_row3)
+                edit_dm_embed_title_btn = ui.Button(
+                    label=t('modules.welcome.config.dm.edit_embed_title', locale=self.locale),
+                    style=discord.ButtonStyle.primary,
+                    emoji=discord.PartialEmoji.from_str("<:edit:1401600709824086169>"),
+                    custom_id="edit_dm_embed_title"
+                )
+                edit_dm_embed_title_btn.callback = self.on_edit_dm_embed_title
+                dm_embed_opts_row1.add_item(edit_dm_embed_title_btn)
 
-            # Toggles pour thumbnail et author
-            embed_row4 = ui.ActionRow()
+                edit_dm_embed_color_btn = ui.Button(
+                    label=t('modules.welcome.config.dm.edit_embed_color', locale=self.locale),
+                    style=discord.ButtonStyle.primary,
+                    emoji=discord.PartialEmoji.from_str("<:color:1398729435565396008>"),
+                    custom_id="edit_dm_embed_color"
+                )
+                edit_dm_embed_color_btn.callback = self.on_edit_dm_embed_color
+                dm_embed_opts_row1.add_item(edit_dm_embed_color_btn)
 
-            thumbnail_btn = ui.Button(
-                label=t('modules.welcome.config.embed.thumbnail', locale=self.locale),
-                style=discord.ButtonStyle.success if self.working_config['embed_thumbnail_enabled'] else discord.ButtonStyle.secondary,
-                emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['embed_thumbnail_enabled'] else "<:undone:1398729502028333218>"),
-                custom_id="toggle_thumbnail"
-            )
-            thumbnail_btn.callback = self.on_toggle_thumbnail
-            embed_row4.add_item(thumbnail_btn)
+                container.add_item(dm_embed_opts_row1)
 
-            author_btn = ui.Button(
-                label=t('modules.welcome.config.embed.author', locale=self.locale),
-                style=discord.ButtonStyle.success if self.working_config['embed_author_enabled'] else discord.ButtonStyle.secondary,
-                emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['embed_author_enabled'] else "<:undone:1398729502028333218>"),
-                custom_id="toggle_author"
-            )
-            author_btn.callback = self.on_toggle_author
-            embed_row4.add_item(author_btn)
+                # Edit description button
+                dm_embed_opts_row2 = ui.ActionRow()
 
-            container.add_item(embed_row4)
+                edit_dm_embed_desc_btn = ui.Button(
+                    label=t('modules.welcome.config.dm.edit_embed_description', locale=self.locale),
+                    style=discord.ButtonStyle.primary,
+                    emoji=discord.PartialEmoji.from_str("<:edit:1401600709824086169>"),
+                    custom_id="edit_dm_embed_description"
+                )
+                edit_dm_embed_desc_btn.callback = self.on_edit_dm_embed_description
+                dm_embed_opts_row2.add_item(edit_dm_embed_desc_btn)
+
+                container.add_item(dm_embed_opts_row2)
+
+                # Thumbnail and author toggles
+                dm_embed_opts_row3 = ui.ActionRow()
+
+                dm_thumbnail_btn = ui.Button(
+                    label=t('modules.welcome.config.dm.embed_thumbnail', locale=self.locale),
+                    style=discord.ButtonStyle.success if self.working_config['dm_embed_thumbnail_enabled'] else discord.ButtonStyle.secondary,
+                    emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['dm_embed_thumbnail_enabled'] else "<:undone:1398729502028333218>"),
+                    custom_id="toggle_dm_thumbnail"
+                )
+                dm_thumbnail_btn.callback = self.on_toggle_dm_thumbnail
+                dm_embed_opts_row3.add_item(dm_thumbnail_btn)
+
+                dm_author_btn = ui.Button(
+                    label=t('modules.welcome.config.dm.embed_author', locale=self.locale),
+                    style=discord.ButtonStyle.success if self.working_config['dm_embed_author_enabled'] else discord.ButtonStyle.secondary,
+                    emoji=discord.PartialEmoji.from_str("<:done:1398729525277229066>" if self.working_config['dm_embed_author_enabled'] else "<:undone:1398729502028333218>"),
+                    custom_id="toggle_dm_author"
+                )
+                dm_author_btn.callback = self.on_toggle_dm_author
+                dm_embed_opts_row3.add_item(dm_author_btn)
+
+                container.add_item(dm_embed_opts_row3)
 
         self.add_item(container)
 
-        # Boutons d'action en bas
+        # Add action buttons at the bottom
         self._add_action_buttons()
 
     def _add_action_buttons(self):
         """Ajoute les boutons d'action en bas de la vue"""
         button_row = ui.ActionRow()
 
-        # Bouton Back (toujours présent, désactivé si modifications en cours)
+        # Back button (disabled if changes pending)
         back_btn = ui.Button(
             emoji=discord.PartialEmoji.from_str("<:back:1401600847733067806>"),
             label=t('modules.config.buttons.back', locale=self.locale),
             style=discord.ButtonStyle.secondary,
             custom_id="back_btn",
-            disabled=self.has_changes  # Désactivé si modifications en cours
+            disabled=self.has_changes
         )
         back_btn.callback = self.on_back
         button_row.add_item(back_btn)
 
-        # Bouton Save (visible uniquement si modifications)
+        # Save button (only if changes)
         if self.has_changes:
             save_btn = ui.Button(
                 emoji=discord.PartialEmoji.from_str("<:save:1444101502154182778>"),
@@ -455,7 +570,7 @@ class WelcomeConfigView(ui.LayoutView):
             save_btn.callback = self.on_save
             button_row.add_item(save_btn)
 
-            # Bouton Annuler
+            # Cancel button
             cancel_btn = ui.Button(
                 emoji=discord.PartialEmoji.from_str("<:undone:1398729502028333218>"),
                 label=t('modules.config.buttons.cancel', locale=self.locale),
@@ -465,7 +580,7 @@ class WelcomeConfigView(ui.LayoutView):
             cancel_btn.callback = self.on_cancel
             button_row.add_item(cancel_btn)
         else:
-            # Bouton Supprimer la configuration (si config existe)
+            # Delete button (if config exists)
             if self.has_existing_config:
                 delete_btn = ui.Button(
                     emoji=discord.PartialEmoji.from_str("<:delete:1401600770431909939>"),
@@ -478,215 +593,287 @@ class WelcomeConfigView(ui.LayoutView):
 
         self.add_item(button_row)
 
-    # === CALLBACKS ===
+    # === CHANNEL WELCOME CALLBACKS ===
 
-    async def on_toggle_send_dm(self, interaction: discord.Interaction):
-        """Toggle pour envoyer en DM"""
+    async def on_toggle_channel_enabled(self, interaction: discord.Interaction):
+        """Toggle channel welcome"""
         if not await self.check_user(interaction):
             return
 
-        self.working_config['send_dm'] = not self.working_config['send_dm']
+        self.working_config['channel_enabled'] = not self.working_config['channel_enabled']
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
 
     async def on_channel_select(self, interaction: discord.Interaction):
-        """Callback quand un salon est sélectionné"""
+        """Channel selector callback"""
         if not await self.check_user(interaction):
             return
 
-        # Récupère le salon sélectionné (ou None si désélectionné)
         if interaction.data['values']:
             channel_id = int(interaction.data['values'][0])
             self.working_config['channel_id'] = channel_id
         else:
             self.working_config['channel_id'] = None
 
-        # Marque comme modifié
         self.has_changes = True
-
-        # Reconstruit la vue
         self._build_view()
-
-        # Met à jour le message
         await interaction.response.edit_message(view=self)
 
-    async def on_edit_message(self, interaction: discord.Interaction):
-        """Ouvre le modal pour éditer le message"""
+    async def on_edit_channel_message(self, interaction: discord.Interaction):
+        """Edit channel message"""
         if not await self.check_user(interaction):
             return
 
-        modal = MessageEditModal(
+        modal = ChannelMessageEditModal(
             self.locale,
-            self.working_config['message_template'],
-            self._on_message_edited
+            self.working_config['channel_message_template'],
+            self._on_channel_message_edited
         )
         await interaction.response.send_modal(modal)
 
-    async def _on_message_edited(self, interaction: discord.Interaction, new_message: str):
-        """Callback après édition du message"""
-        self.working_config['message_template'] = new_message
+    async def _on_channel_message_edited(self, interaction: discord.Interaction, new_message: str):
+        """Callback after channel message edit"""
+        self.working_config['channel_message_template'] = new_message
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
 
-    async def on_toggle_mention(self, interaction: discord.Interaction):
-        """Toggle pour mentionner l'utilisateur"""
+    async def on_toggle_channel_mention(self, interaction: discord.Interaction):
+        """Toggle channel mention"""
         if not await self.check_user(interaction):
             return
 
-        self.working_config['mention_user'] = not self.working_config['mention_user']
+        self.working_config['channel_mention_user'] = not self.working_config['channel_mention_user']
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
 
-    async def on_toggle_embed(self, interaction: discord.Interaction):
-        """Toggle pour activer l'embed"""
+    async def on_toggle_channel_embed(self, interaction: discord.Interaction):
+        """Toggle channel embed"""
         if not await self.check_user(interaction):
             return
 
-        self.working_config['embed_enabled'] = not self.working_config['embed_enabled']
+        self.working_config['channel_embed_enabled'] = not self.working_config['channel_embed_enabled']
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
 
-    async def on_edit_embed_title(self, interaction: discord.Interaction):
-        """Ouvre le modal pour éditer le titre de l'embed"""
+    async def on_edit_channel_embed_title(self, interaction: discord.Interaction):
+        """Edit channel embed title"""
         if not await self.check_user(interaction):
             return
 
-        modal = EmbedTitleModal(
+        modal = ChannelEmbedTitleModal(
             self.locale,
-            self.working_config['embed_title'],
-            self._on_embed_title_edited
+            self.working_config['channel_embed_title'],
+            self._on_channel_embed_title_edited
         )
         await interaction.response.send_modal(modal)
 
-    async def _on_embed_title_edited(self, interaction: discord.Interaction, new_title: str):
-        """Callback après édition du titre"""
-        self.working_config['embed_title'] = new_title
+    async def _on_channel_embed_title_edited(self, interaction: discord.Interaction, new_title: str):
+        """Callback after channel embed title edit"""
+        self.working_config['channel_embed_title'] = new_title
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
 
-    async def on_edit_embed_description(self, interaction: discord.Interaction):
-        """Ouvre le modal pour éditer la description de l'embed"""
+    async def on_edit_channel_embed_description(self, interaction: discord.Interaction):
+        """Edit channel embed description"""
         if not await self.check_user(interaction):
             return
 
-        modal = EmbedDescriptionModal(
+        modal = ChannelEmbedDescriptionModal(
             self.locale,
-            self.working_config.get('embed_description'),
-            self._on_embed_description_edited
+            self.working_config.get('channel_embed_description'),
+            self._on_channel_embed_description_edited
         )
         await interaction.response.send_modal(modal)
 
-    async def _on_embed_description_edited(self, interaction: discord.Interaction, new_desc: Optional[str]):
-        """Callback après édition de la description"""
-        self.working_config['embed_description'] = new_desc
+    async def _on_channel_embed_description_edited(self, interaction: discord.Interaction, new_desc: Optional[str]):
+        """Callback after channel embed description edit"""
+        self.working_config['channel_embed_description'] = new_desc
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
 
-    async def on_edit_embed_color(self, interaction: discord.Interaction):
-        """Ouvre le modal pour éditer la couleur de l'embed"""
+    async def on_edit_channel_embed_color(self, interaction: discord.Interaction):
+        """Edit channel embed color"""
         if not await self.check_user(interaction):
             return
 
-        modal = EmbedColorModal(
+        modal = ChannelEmbedColorModal(
             self.locale,
-            self.working_config['embed_color'],
-            self._on_embed_color_edited
+            self.working_config['channel_embed_color'],
+            self._on_channel_embed_color_edited
         )
         await interaction.response.send_modal(modal)
 
-    async def _on_embed_color_edited(self, interaction: discord.Interaction, new_color: int):
-        """Callback après édition de la couleur"""
-        self.working_config['embed_color'] = new_color
+    async def _on_channel_embed_color_edited(self, interaction: discord.Interaction, new_color: int):
+        """Callback after channel embed color edit"""
+        self.working_config['channel_embed_color'] = new_color
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
 
-    async def on_edit_embed_footer(self, interaction: discord.Interaction):
-        """Ouvre le modal pour éditer le footer de l'embed"""
+    async def on_toggle_channel_thumbnail(self, interaction: discord.Interaction):
+        """Toggle channel thumbnail"""
         if not await self.check_user(interaction):
             return
 
-        modal = EmbedFooterModal(
+        self.working_config['channel_embed_thumbnail_enabled'] = not self.working_config['channel_embed_thumbnail_enabled']
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    async def on_toggle_channel_author(self, interaction: discord.Interaction):
+        """Toggle channel author"""
+        if not await self.check_user(interaction):
+            return
+
+        self.working_config['channel_embed_author_enabled'] = not self.working_config['channel_embed_author_enabled']
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    # === DM WELCOME CALLBACKS ===
+
+    async def on_toggle_dm_enabled(self, interaction: discord.Interaction):
+        """Toggle DM welcome"""
+        if not await self.check_user(interaction):
+            return
+
+        self.working_config['dm_enabled'] = not self.working_config['dm_enabled']
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    async def on_edit_dm_message(self, interaction: discord.Interaction):
+        """Edit DM message"""
+        if not await self.check_user(interaction):
+            return
+
+        modal = DmMessageEditModal(
             self.locale,
-            self.working_config.get('embed_footer'),
-            self._on_embed_footer_edited
+            self.working_config['dm_message_template'],
+            self._on_dm_message_edited
         )
         await interaction.response.send_modal(modal)
 
-    async def _on_embed_footer_edited(self, interaction: discord.Interaction, new_footer: Optional[str]):
-        """Callback après édition du footer"""
-        self.working_config['embed_footer'] = new_footer
+    async def _on_dm_message_edited(self, interaction: discord.Interaction, new_message: str):
+        """Callback after DM message edit"""
+        self.working_config['dm_message_template'] = new_message
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
 
-    async def on_edit_embed_image(self, interaction: discord.Interaction):
-        """Ouvre le modal pour éditer l'URL de l'image"""
+    async def on_toggle_dm_embed(self, interaction: discord.Interaction):
+        """Toggle DM embed"""
         if not await self.check_user(interaction):
             return
 
-        modal = EmbedImageModal(
+        self.working_config['dm_embed_enabled'] = not self.working_config['dm_embed_enabled']
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    async def on_edit_dm_embed_title(self, interaction: discord.Interaction):
+        """Edit DM embed title"""
+        if not await self.check_user(interaction):
+            return
+
+        modal = DmEmbedTitleModal(
             self.locale,
-            self.working_config.get('embed_image_url'),
-            self._on_embed_image_edited
+            self.working_config['dm_embed_title'],
+            self._on_dm_embed_title_edited
         )
         await interaction.response.send_modal(modal)
 
-    async def _on_embed_image_edited(self, interaction: discord.Interaction, new_url: Optional[str]):
-        """Callback après édition de l'URL de l'image"""
-        self.working_config['embed_image_url'] = new_url
+    async def _on_dm_embed_title_edited(self, interaction: discord.Interaction, new_title: str):
+        """Callback after DM embed title edit"""
+        self.working_config['dm_embed_title'] = new_title
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
 
-    async def on_toggle_thumbnail(self, interaction: discord.Interaction):
-        """Toggle pour afficher la thumbnail"""
+    async def on_edit_dm_embed_description(self, interaction: discord.Interaction):
+        """Edit DM embed description"""
         if not await self.check_user(interaction):
             return
 
-        self.working_config['embed_thumbnail_enabled'] = not self.working_config['embed_thumbnail_enabled']
+        modal = DmEmbedDescriptionModal(
+            self.locale,
+            self.working_config.get('dm_embed_description'),
+            self._on_dm_embed_description_edited
+        )
+        await interaction.response.send_modal(modal)
+
+    async def _on_dm_embed_description_edited(self, interaction: discord.Interaction, new_desc: Optional[str]):
+        """Callback after DM embed description edit"""
+        self.working_config['dm_embed_description'] = new_desc
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
 
-    async def on_toggle_author(self, interaction: discord.Interaction):
-        """Toggle pour afficher l'auteur"""
+    async def on_edit_dm_embed_color(self, interaction: discord.Interaction):
+        """Edit DM embed color"""
         if not await self.check_user(interaction):
             return
 
-        self.working_config['embed_author_enabled'] = not self.working_config['embed_author_enabled']
+        modal = DmEmbedColorModal(
+            self.locale,
+            self.working_config['dm_embed_color'],
+            self._on_dm_embed_color_edited
+        )
+        await interaction.response.send_modal(modal)
+
+    async def _on_dm_embed_color_edited(self, interaction: discord.Interaction, new_color: int):
+        """Callback after DM embed color edit"""
+        self.working_config['dm_embed_color'] = new_color
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)
+
+    async def on_toggle_dm_thumbnail(self, interaction: discord.Interaction):
+        """Toggle DM thumbnail"""
+        if not await self.check_user(interaction):
+            return
+
+        self.working_config['dm_embed_thumbnail_enabled'] = not self.working_config['dm_embed_thumbnail_enabled']
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    async def on_toggle_dm_author(self, interaction: discord.Interaction):
+        """Toggle DM author"""
+        if not await self.check_user(interaction):
+            return
+
+        self.working_config['dm_embed_author_enabled'] = not self.working_config['dm_embed_author_enabled']
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    # === ACTION BUTTON CALLBACKS ===
 
     async def on_back(self, interaction: discord.Interaction):
-        """Retour au menu principal"""
+        """Return to main menu"""
         if not await self.check_user(interaction):
             return
 
-        # Importe et affiche le menu principal
         from cogs.config import ConfigMainView
         main_view = ConfigMainView(self.bot, self.guild_id, self.user_id, self.locale)
         await interaction.response.edit_message(view=main_view)
 
     async def on_save(self, interaction: discord.Interaction):
-        """Sauvegarde la configuration"""
+        """Save configuration"""
         if not await self.check_user(interaction):
             return
 
-        # Désactive temporairement les boutons
         await interaction.response.defer()
 
-        # Récupère le gestionnaire de modules
         module_manager = self.bot.module_manager
 
-        # Sauvegarde la configuration
         success, error_msg = await module_manager.save_module_config(
             self.guild_id,
             'welcome',
@@ -694,82 +881,67 @@ class WelcomeConfigView(ui.LayoutView):
         )
 
         if success:
-            # Met à jour l'état
             self.current_config = self.working_config.copy()
             self.has_changes = False
             self.has_existing_config = True
 
-            # Reconstruit la vue
             self._build_view()
 
-            # Met à jour le message avec un feedback
             await interaction.followup.send(
                 t('modules.config.save.success', locale=self.locale),
                 ephemeral=True
             )
             await interaction.edit_original_response(view=self)
         else:
-            # Affiche l'erreur
             await interaction.followup.send(
                 t('modules.config.save.error', locale=self.locale, error=error_msg),
                 ephemeral=True
             )
 
     async def on_cancel(self, interaction: discord.Interaction):
-        """Annule les modifications"""
+        """Cancel changes"""
         if not await self.check_user(interaction):
             return
 
-        # Restaure la configuration originale
         self.working_config = self.current_config.copy()
         self.has_changes = False
 
-        # Reconstruit la vue
         self._build_view()
-
-        # Met à jour le message
         await interaction.response.edit_message(view=self)
 
     async def on_delete(self, interaction: discord.Interaction):
-        """Supprime la configuration"""
+        """Delete configuration"""
         if not await self.check_user(interaction):
             return
 
-        # Désactive temporairement les boutons
         await interaction.response.defer()
 
-        # Récupère le gestionnaire de modules
         module_manager = self.bot.module_manager
 
-        # Supprime la configuration
         success = await module_manager.delete_module_config(self.guild_id, 'welcome')
 
         if success:
-            # Met à jour l'état
             from modules.welcome import WelcomeModule
             self.current_config = WelcomeModule(self.bot, self.guild_id).get_default_config()
             self.working_config = self.current_config.copy()
             self.has_changes = False
             self.has_existing_config = False
 
-            # Reconstruit la vue
             self._build_view()
 
-            # Met à jour le message avec un feedback
             await interaction.followup.send(
                 t('modules.config.delete.success', locale=self.locale),
                 ephemeral=True
             )
             await interaction.edit_original_response(view=self)
         else:
-            # Affiche l'erreur
             await interaction.followup.send(
                 t('modules.config.delete.error', locale=self.locale),
                 ephemeral=True
             )
 
     async def check_user(self, interaction: discord.Interaction) -> bool:
-        """Vérifie que c'est le bon utilisateur"""
+        """Check if the user is the one who started the config"""
         if interaction.user.id != self.user_id:
             await interaction.response.send_message(
                 t('modules.config.errors.wrong_user', locale=self.locale),
@@ -779,5 +951,5 @@ class WelcomeConfigView(ui.LayoutView):
         return True
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        """Vérifie les permissions pour chaque interaction"""
+        """Check permissions for each interaction"""
         return await self.check_user(interaction)

--- a/modules/welcome.py
+++ b/modules/welcome.py
@@ -15,6 +15,7 @@ class WelcomeModule(ModuleBase):
     """
     Module de messages de bienvenue
     Envoie un message personnalisé quand un nouveau membre rejoint le serveur
+    Supporte l'envoi simultané de messages en DM et dans un salon
     """
 
     MODULE_ID = "welcome"
@@ -24,49 +25,68 @@ class WelcomeModule(ModuleBase):
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)
-        # Channel configuration
+
+        # === CHANNEL WELCOME (Public message in a channel) ===
+        self.channel_enabled: bool = False
         self.channel_id: Optional[int] = None
-        self.send_dm: bool = False  # Send welcome message as DM instead of channel
+        self.channel_message_template: str = "Bienvenue {user} sur le serveur !"
+        self.channel_mention_user: bool = True
+        self.channel_embed_enabled: bool = False
+        self.channel_embed_title: str = "Bienvenue !"
+        self.channel_embed_description: Optional[str] = None
+        self.channel_embed_color: int = 0x5865F2
+        self.channel_embed_footer: Optional[str] = None
+        self.channel_embed_image_url: Optional[str] = None
+        self.channel_embed_thumbnail_enabled: bool = True
+        self.channel_embed_author_enabled: bool = False
 
-        # Message configuration
-        self.message_template: str = "Bienvenue {user} sur le serveur !"
-        self.mention_user: bool = True
-
-        # Embed configuration
-        self.embed_enabled: bool = False
-        self.embed_title: str = "Bienvenue !"
-        self.embed_description: Optional[str] = None  # Separate description for embed (uses message_template if None)
-        self.embed_color: int = 0x5865F2
-        self.embed_footer: Optional[str] = None
-        self.embed_image_url: Optional[str] = None
-        self.embed_thumbnail_enabled: bool = True  # Show user's avatar as thumbnail
-        self.embed_author_enabled: bool = False  # Show user as embed author
+        # === DM WELCOME (Private message) ===
+        self.dm_enabled: bool = False
+        self.dm_message_template: str = "Bienvenue sur le serveur {server} !"
+        self.dm_mention_user: bool = False  # Mentions don't work in DMs
+        self.dm_embed_enabled: bool = False
+        self.dm_embed_title: str = "Bienvenue !"
+        self.dm_embed_description: Optional[str] = None
+        self.dm_embed_color: int = 0x5865F2
+        self.dm_embed_footer: Optional[str] = None
+        self.dm_embed_image_url: Optional[str] = None
+        self.dm_embed_thumbnail_enabled: bool = True
+        self.dm_embed_author_enabled: bool = False
 
     async def load_config(self, config_data: Dict[str, Any]) -> bool:
         """Charge la configuration depuis la DB"""
         try:
             self.config = config_data
 
-            # Channel configuration
+            # === CHANNEL WELCOME CONFIGURATION ===
+            self.channel_enabled = config_data.get('channel_enabled', False)
             self.channel_id = config_data.get('channel_id')
-            self.send_dm = config_data.get('send_dm', False)
+            self.channel_message_template = config_data.get('channel_message_template', "Bienvenue {user} sur le serveur !")
+            self.channel_mention_user = config_data.get('channel_mention_user', True)
+            self.channel_embed_enabled = config_data.get('channel_embed_enabled', False)
+            self.channel_embed_title = config_data.get('channel_embed_title', "Bienvenue !")
+            self.channel_embed_description = config_data.get('channel_embed_description')
+            self.channel_embed_color = config_data.get('channel_embed_color', 0x5865F2)
+            self.channel_embed_footer = config_data.get('channel_embed_footer')
+            self.channel_embed_image_url = config_data.get('channel_embed_image_url')
+            self.channel_embed_thumbnail_enabled = config_data.get('channel_embed_thumbnail_enabled', True)
+            self.channel_embed_author_enabled = config_data.get('channel_embed_author_enabled', False)
 
-            # Message configuration
-            self.message_template = config_data.get('message_template', "Bienvenue {user} sur le serveur !")
-            self.mention_user = config_data.get('mention_user', True)
+            # === DM WELCOME CONFIGURATION ===
+            self.dm_enabled = config_data.get('dm_enabled', False)
+            self.dm_message_template = config_data.get('dm_message_template', "Bienvenue sur le serveur {server} !")
+            self.dm_mention_user = config_data.get('dm_mention_user', False)
+            self.dm_embed_enabled = config_data.get('dm_embed_enabled', False)
+            self.dm_embed_title = config_data.get('dm_embed_title', "Bienvenue !")
+            self.dm_embed_description = config_data.get('dm_embed_description')
+            self.dm_embed_color = config_data.get('dm_embed_color', 0x5865F2)
+            self.dm_embed_footer = config_data.get('dm_embed_footer')
+            self.dm_embed_image_url = config_data.get('dm_embed_image_url')
+            self.dm_embed_thumbnail_enabled = config_data.get('dm_embed_thumbnail_enabled', True)
+            self.dm_embed_author_enabled = config_data.get('dm_embed_author_enabled', False)
 
-            # Embed configuration
-            self.embed_enabled = config_data.get('embed_enabled', False)
-            self.embed_title = config_data.get('embed_title', "Bienvenue !")
-            self.embed_description = config_data.get('embed_description')
-            self.embed_color = config_data.get('embed_color', 0x5865F2)
-            self.embed_footer = config_data.get('embed_footer')
-            self.embed_image_url = config_data.get('embed_image_url')
-            self.embed_thumbnail_enabled = config_data.get('embed_thumbnail_enabled', True)
-            self.embed_author_enabled = config_data.get('embed_author_enabled', False)
-
-            # Le module est activé si la config est valide (channel_id présent OU send_dm activé)
-            self.enabled = self.channel_id is not None or self.send_dm
+            # Module is enabled if at least one of the welcome types is enabled
+            self.enabled = self.channel_enabled or self.dm_enabled
 
             return True
         except Exception as e:
@@ -75,15 +95,20 @@ class WelcomeModule(ModuleBase):
 
     async def validate_config(self, config_data: Dict[str, Any]) -> tuple[bool, Optional[str]]:
         """Valide la configuration"""
-        send_dm = config_data.get('send_dm', False)
+        channel_enabled = config_data.get('channel_enabled', False)
+        dm_enabled = config_data.get('dm_enabled', False)
 
-        # Si send_dm est désactivé, le channel_id est requis
-        if not send_dm:
+        # At least one welcome type must be enabled
+        if not channel_enabled and not dm_enabled:
+            return False, "Au moins un type de message de bienvenue doit être activé (salon ou DM)"
+
+        # === VALIDATE CHANNEL WELCOME ===
+        if channel_enabled:
+            # Channel ID is required if channel welcome is enabled
             if not config_data.get('channel_id'):
-                return False, "Un salon de bienvenue est requis si l'envoi en DM est désactivé"
+                return False, "Un salon est requis pour le message de bienvenue public"
 
-        # Vérifie que le salon existe si spécifié (et send_dm désactivé)
-        if 'channel_id' in config_data and config_data['channel_id'] and not send_dm:
+            # Verify channel exists and bot has permissions
             try:
                 guild = self.bot.get_guild(self.guild_id)
                 if not guild:
@@ -96,78 +121,108 @@ class WelcomeModule(ModuleBase):
                 if not isinstance(channel, discord.TextChannel):
                     return False, "Le salon doit être un salon textuel"
 
-                # Vérifie les permissions
+                # Check permissions
                 perms = channel.permissions_for(guild.me)
                 if not perms.send_messages:
                     return False, f"Je n'ai pas la permission d'envoyer des messages dans {channel.mention}"
 
-                if config_data.get('embed_enabled', False) and not perms.embed_links:
+                if config_data.get('channel_embed_enabled', False) and not perms.embed_links:
                     return False, f"Je n'ai pas la permission d'envoyer des embeds dans {channel.mention}"
 
             except Exception as e:
-                return False, f"Erreur de validation : {str(e)}"
+                return False, f"Erreur de validation du salon : {str(e)}"
 
-        # Vérifie que le message template est valide
-        if 'message_template' in config_data:
-            template = config_data['message_template']
-            if not template or len(template.strip()) == 0:
-                return False, "Le message de bienvenue ne peut pas être vide"
+            # Validate channel message template
+            channel_template = config_data.get('channel_message_template', '')
+            if not channel_template or len(channel_template.strip()) == 0:
+                return False, "Le message de bienvenue public ne peut pas être vide"
+            if len(channel_template) > 2000:
+                return False, "Le message de bienvenue public ne peut pas dépasser 2000 caractères"
 
-            if len(template) > 2000:
-                return False, "Le message de bienvenue ne peut pas dépasser 2000 caractères"
+            # Validate channel embed settings
+            if config_data.get('channel_embed_enabled'):
+                if 'channel_embed_title' in config_data and len(config_data['channel_embed_title']) > 256:
+                    return False, "Le titre de l'embed public ne peut pas dépasser 256 caractères"
+                if 'channel_embed_description' in config_data and config_data['channel_embed_description']:
+                    if len(config_data['channel_embed_description']) > 4096:
+                        return False, "La description de l'embed public ne peut pas dépasser 4096 caractères"
+                if 'channel_embed_footer' in config_data and config_data['channel_embed_footer']:
+                    if len(config_data['channel_embed_footer']) > 2048:
+                        return False, "Le footer de l'embed public ne peut pas dépasser 2048 caractères"
+                if 'channel_embed_image_url' in config_data and config_data['channel_embed_image_url']:
+                    url = config_data['channel_embed_image_url']
+                    if not url.startswith(('http://', 'https://')):
+                        return False, "L'URL de l'image publique doit commencer par http:// ou https://"
+                if 'channel_embed_color' in config_data:
+                    color = config_data['channel_embed_color']
+                    if not isinstance(color, int) or color < 0 or color > 0xFFFFFF:
+                        return False, "La couleur de l'embed public est invalide"
 
-        # Vérifie la couleur de l'embed
-        if 'embed_color' in config_data:
-            color = config_data['embed_color']
-            if not isinstance(color, int) or color < 0 or color > 0xFFFFFF:
-                return False, "La couleur de l'embed doit être un nombre hexadécimal valide (0x000000 - 0xFFFFFF)"
+        # === VALIDATE DM WELCOME ===
+        if dm_enabled:
+            # Validate DM message template
+            dm_template = config_data.get('dm_message_template', '')
+            if not dm_template or len(dm_template.strip()) == 0:
+                return False, "Le message de bienvenue privé ne peut pas être vide"
+            if len(dm_template) > 2000:
+                return False, "Le message de bienvenue privé ne peut pas dépasser 2000 caractères"
 
-        # Vérifie l'URL de l'image si fournie
-        if 'embed_image_url' in config_data and config_data['embed_image_url']:
-            url = config_data['embed_image_url']
-            if not url.startswith(('http://', 'https://')):
-                return False, "L'URL de l'image doit commencer par http:// ou https://"
-
-        # Vérifie les longueurs des champs d'embed
-        if 'embed_title' in config_data and len(config_data['embed_title']) > 256:
-            return False, "Le titre de l'embed ne peut pas dépasser 256 caractères"
-
-        if 'embed_description' in config_data and config_data['embed_description']:
-            if len(config_data['embed_description']) > 4096:
-                return False, "La description de l'embed ne peut pas dépasser 4096 caractères"
-
-        if 'embed_footer' in config_data and config_data['embed_footer']:
-            if len(config_data['embed_footer']) > 2048:
-                return False, "Le footer de l'embed ne peut pas dépasser 2048 caractères"
+            # Validate DM embed settings
+            if config_data.get('dm_embed_enabled'):
+                if 'dm_embed_title' in config_data and len(config_data['dm_embed_title']) > 256:
+                    return False, "Le titre de l'embed privé ne peut pas dépasser 256 caractères"
+                if 'dm_embed_description' in config_data and config_data['dm_embed_description']:
+                    if len(config_data['dm_embed_description']) > 4096:
+                        return False, "La description de l'embed privé ne peut pas dépasser 4096 caractères"
+                if 'dm_embed_footer' in config_data and config_data['dm_embed_footer']:
+                    if len(config_data['dm_embed_footer']) > 2048:
+                        return False, "Le footer de l'embed privé ne peut pas dépasser 2048 caractères"
+                if 'dm_embed_image_url' in config_data and config_data['dm_embed_image_url']:
+                    url = config_data['dm_embed_image_url']
+                    if not url.startswith(('http://', 'https://')):
+                        return False, "L'URL de l'image privée doit commencer par http:// ou https://"
+                if 'dm_embed_color' in config_data:
+                    color = config_data['dm_embed_color']
+                    if not isinstance(color, int) or color < 0 or color > 0xFFFFFF:
+                        return False, "La couleur de l'embed privé est invalide"
 
         return True, None
 
     def get_default_config(self) -> Dict[str, Any]:
         """Retourne la configuration par défaut"""
         return {
-            # Channel configuration
+            # === CHANNEL WELCOME (Public message in a channel) ===
+            'channel_enabled': False,
             'channel_id': None,
-            'send_dm': False,
+            'channel_message_template': "Bienvenue {user} sur le serveur !",
+            'channel_mention_user': True,
+            'channel_embed_enabled': False,
+            'channel_embed_title': "Bienvenue !",
+            'channel_embed_description': None,
+            'channel_embed_color': 0x5865F2,
+            'channel_embed_footer': None,
+            'channel_embed_image_url': None,
+            'channel_embed_thumbnail_enabled': True,
+            'channel_embed_author_enabled': False,
 
-            # Message configuration
-            'message_template': "Bienvenue {user} sur le serveur !",
-            'mention_user': True,
-
-            # Embed configuration
-            'embed_enabled': False,
-            'embed_title': "Bienvenue !",
-            'embed_description': None,
-            'embed_color': 0x5865F2,
-            'embed_footer': None,
-            'embed_image_url': None,
-            'embed_thumbnail_enabled': True,
-            'embed_author_enabled': False
+            # === DM WELCOME (Private message) ===
+            'dm_enabled': False,
+            'dm_message_template': "Bienvenue sur le serveur {server} !",
+            'dm_mention_user': False,
+            'dm_embed_enabled': False,
+            'dm_embed_title': "Bienvenue !",
+            'dm_embed_description': None,
+            'dm_embed_color': 0x5865F2,
+            'dm_embed_footer': None,
+            'dm_embed_image_url': None,
+            'dm_embed_thumbnail_enabled': True,
+            'dm_embed_author_enabled': False
         }
 
     async def on_member_join(self, member: discord.Member):
         """
         Appelé quand un membre rejoint le serveur
-        Cette méthode sera appelée par un event listener dans le cog
+        Envoie les messages de bienvenue configurés (DM et/ou salon)
         """
         if not self.enabled:
             return
@@ -177,82 +232,161 @@ class WelcomeModule(ModuleBase):
             if not guild:
                 return
 
-            # Determine where to send the message
-            if self.send_dm:
-                destination = member
-            else:
-                if not self.channel_id:
-                    logger.warning(f"Welcome module enabled but no channel_id set for guild {self.guild_id}")
-                    return
+            # Send channel welcome if enabled
+            if self.channel_enabled and self.channel_id:
+                await self._send_channel_welcome(member, guild)
 
-                channel = guild.get_channel(self.channel_id)
-                if not channel or not isinstance(channel, discord.TextChannel):
-                    logger.warning(f"Welcome channel {self.channel_id} not found or not a text channel")
-                    return
-                destination = channel
+            # Send DM welcome if enabled
+            if self.dm_enabled:
+                await self._send_dm_welcome(member, guild)
+
+        except Exception as e:
+            logger.error(f"Error in welcome module for guild {self.guild_id}: {e}", exc_info=True)
+
+    async def _send_channel_welcome(self, member: discord.Member, guild: discord.Guild):
+        """Send welcome message in the configured channel"""
+        try:
+            channel = guild.get_channel(self.channel_id)
+            if not channel or not isinstance(channel, discord.TextChannel):
+                logger.warning(f"Welcome channel {self.channel_id} not found or not a text channel")
+                return
 
             # Prepare message variables
-            user_mention = member.mention if self.mention_user else member.name
-            message_content = self.message_template.format(
+            user_mention = member.mention if self.channel_mention_user else member.name
+            message_content = self.channel_message_template.format(
                 user=user_mention,
                 username=member.name,
                 server=guild.name,
                 member_count=guild.member_count
             )
 
-            # Send the message
-            if self.embed_enabled:
-                # Use embed_description if set, otherwise use message_content
-                embed_desc = self.embed_description if self.embed_description else message_content
-                embed_desc = embed_desc.format(
-                    user=user_mention,
-                    username=member.name,
-                    server=guild.name,
-                    member_count=guild.member_count
+            # Send with or without embed
+            if self.channel_embed_enabled:
+                embed = self._create_embed(
+                    member=member,
+                    guild=guild,
+                    title=self.channel_embed_title,
+                    description=self.channel_embed_description,
+                    color=self.channel_embed_color,
+                    footer=self.channel_embed_footer,
+                    image_url=self.channel_embed_image_url,
+                    thumbnail_enabled=self.channel_embed_thumbnail_enabled,
+                    author_enabled=self.channel_embed_author_enabled,
+                    default_description=message_content,
+                    mention_user=self.channel_mention_user
                 )
 
-                embed = discord.Embed(
-                    title=self.embed_title,
-                    description=embed_desc,
-                    color=self.embed_color
-                )
-
-                # Add author if enabled
-                if self.embed_author_enabled:
-                    embed.set_author(
-                        name=member.display_name,
-                        icon_url=member.display_avatar.url
-                    )
-
-                # Add thumbnail if enabled
-                if self.embed_thumbnail_enabled:
-                    embed.set_thumbnail(url=member.display_avatar.url)
-
-                # Add image if URL provided
-                if self.embed_image_url:
-                    embed.set_image(url=self.embed_image_url)
-
-                # Add footer if provided
-                if self.embed_footer:
-                    footer_text = self.embed_footer.format(
-                        user=user_mention,
-                        username=member.name,
-                        server=guild.name,
-                        member_count=guild.member_count
-                    )
-                    embed.set_footer(text=footer_text)
-
-                # Send embed (if not using embed_description, send message_content as regular text)
-                if self.embed_description:
-                    await destination.send(embed=embed)
+                # Send with content if no custom embed description
+                if self.channel_embed_description:
+                    await channel.send(embed=embed)
                 else:
-                    await destination.send(content=message_content if not self.send_dm else None, embed=embed)
+                    await channel.send(content=message_content, embed=embed)
             else:
-                await destination.send(message_content)
+                await channel.send(message_content)
 
-            logger.info(f"✅ Welcome message sent for {member.name} in guild {self.guild_id} ({'DM' if self.send_dm else f'channel {self.channel_id}'})")
+            logger.info(f"✅ Channel welcome sent for {member.name} in channel {self.channel_id} (guild {self.guild_id})")
 
         except discord.Forbidden:
-            logger.warning(f"Missing permissions to send welcome message in guild {self.guild_id}")
+            logger.warning(f"Missing permissions to send channel welcome in guild {self.guild_id}")
         except Exception as e:
-            logger.error(f"Error sending welcome message: {e}", exc_info=True)
+            logger.error(f"Error sending channel welcome: {e}", exc_info=True)
+
+    async def _send_dm_welcome(self, member: discord.Member, guild: discord.Guild):
+        """Send welcome message as DM to the member"""
+        try:
+            # Prepare message variables (no mention in DMs)
+            message_content = self.dm_message_template.format(
+                user=member.name,
+                username=member.name,
+                server=guild.name,
+                member_count=guild.member_count
+            )
+
+            # Send with or without embed
+            if self.dm_embed_enabled:
+                embed = self._create_embed(
+                    member=member,
+                    guild=guild,
+                    title=self.dm_embed_title,
+                    description=self.dm_embed_description,
+                    color=self.dm_embed_color,
+                    footer=self.dm_embed_footer,
+                    image_url=self.dm_embed_image_url,
+                    thumbnail_enabled=self.dm_embed_thumbnail_enabled,
+                    author_enabled=self.dm_embed_author_enabled,
+                    default_description=message_content,
+                    mention_user=False  # Never mention in DMs
+                )
+
+                # Send with content if no custom embed description
+                if self.dm_embed_description:
+                    await member.send(embed=embed)
+                else:
+                    await member.send(content=message_content, embed=embed)
+            else:
+                await member.send(message_content)
+
+            logger.info(f"✅ DM welcome sent to {member.name} (guild {self.guild_id})")
+
+        except discord.Forbidden:
+            logger.warning(f"Cannot send DM welcome to {member.name} - DMs disabled")
+        except Exception as e:
+            logger.error(f"Error sending DM welcome: {e}", exc_info=True)
+
+    def _create_embed(
+        self,
+        member: discord.Member,
+        guild: discord.Guild,
+        title: str,
+        description: Optional[str],
+        color: int,
+        footer: Optional[str],
+        image_url: Optional[str],
+        thumbnail_enabled: bool,
+        author_enabled: bool,
+        default_description: str,
+        mention_user: bool
+    ) -> discord.Embed:
+        """Create an embed for welcome message"""
+        # Use custom description or default message content
+        user_ref = member.mention if mention_user else member.name
+        embed_desc = description if description else default_description
+        embed_desc = embed_desc.format(
+            user=user_ref,
+            username=member.name,
+            server=guild.name,
+            member_count=guild.member_count
+        )
+
+        embed = discord.Embed(
+            title=title,
+            description=embed_desc,
+            color=color
+        )
+
+        # Add author if enabled
+        if author_enabled:
+            embed.set_author(
+                name=member.display_name,
+                icon_url=member.display_avatar.url
+            )
+
+        # Add thumbnail if enabled
+        if thumbnail_enabled:
+            embed.set_thumbnail(url=member.display_avatar.url)
+
+        # Add image if URL provided
+        if image_url:
+            embed.set_image(url=image_url)
+
+        # Add footer if provided
+        if footer:
+            footer_text = footer.format(
+                user=user_ref,
+                username=member.name,
+                server=guild.name,
+                member_count=guild.member_count
+            )
+            embed.set_footer(text=footer_text)
+
+        return embed


### PR DESCRIPTION
Major changes:
- Separate welcome messages: now supports both DM and channel messages simultaneously
- Channel welcome: public message sent in a server channel with full customization
- DM welcome: private message sent to new members with independent settings
- Each message type has its own configuration: message, embed, colors, thumbnail, etc.
- Updated validation to require at least one welcome type enabled
- Refactored on_member_join to send both messages when configured
- Added helper methods _send_channel_welcome and _send_dm_welcome
- Created _create_embed helper for DRY code

Files modified:
- modules/welcome.py: Core module with dual message support
- modules/configs/welcome_config.py: Complete UI rewrite with two separate sections
- locales/fr.json: French translations for new interface
- locales/en-US.json: English translations for new interface

This allows server admins to configure independent welcome messages for both public announcements in channels and private greetings via DM.