### PR TITLE
Fix import error in configs __init__.py after module split

### DIFF
--- a/modules/configs/__init__.py
+++ b/modules/configs/__init__.py
@@ -3,6 +3,7 @@ Configurations UI pour les modules de serveur
 Ce package contient les interfaces de configuration pour chaque module
 """
 
-from .welcome_config import WelcomeConfigView
+from .welcome_channel_config import WelcomeChannelConfigView
+from .welcome_dm_config import WelcomeDmConfigView
 
-__all__ = ['WelcomeConfigView']
+__all__ = ['WelcomeChannelConfigView', 'WelcomeDmConfigView']


### PR DESCRIPTION
Update imports to reference new welcome_channel_config and welcome_dm_config modules instead of the deleted welcome_config module.