### PR TITLE
Add Starboard module for message reactions

### DIFF
--- a/cogs/config.py
+++ b/cogs/config.py
@@ -140,6 +140,15 @@ class ConfigMainView(BaseView):
                 self.locale,
                 module_config
             )
+        elif module_id == 'starboard':
+            from modules.configs.starboard_config import StarboardConfigView
+            config_view = StarboardConfigView(
+                self.bot,
+                self.guild_id,
+                self.user_id,
+                self.locale,
+                module_config
+            )
         # Ajouter d'autres modules ici au fur et à mesure
         # elif module_id == 'ticket':
         #     from modules.configs.ticket_config import TicketConfigView

--- a/cogs/module_events.py
+++ b/cogs/module_events.py
@@ -132,6 +132,68 @@ class ModuleEvents(commands.Cog):
         except Exception as e:
             logger.error(f"Error in on_message_delete for inter-server: {e}", exc_info=True)
 
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        """
+        Événement déclenché quand une réaction est ajoutée à un message
+        Transmet l'événement au module Starboard si activé
+        """
+        # Ignore les réactions du bot
+        if payload.user_id == self.bot.user.id:
+            return
+
+        # Ignore les DMs
+        if not payload.guild_id:
+            return
+
+        if not self.bot.module_manager:
+            return
+
+        try:
+            # Récupère l'instance du module Starboard pour ce serveur
+            starboard_module = await self.bot.module_manager.get_module_instance(
+                payload.guild_id,
+                'starboard'
+            )
+
+            # Si le module est actif, appelle sa méthode
+            if starboard_module and starboard_module.enabled:
+                await starboard_module.on_reaction_add(payload)
+
+        except Exception as e:
+            logger.error(f"Error in on_raw_reaction_add for guild {payload.guild_id}: {e}", exc_info=True)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        """
+        Événement déclenché quand une réaction est retirée d'un message
+        Transmet l'événement au module Starboard pour mise à jour
+        """
+        # Ignore les réactions du bot
+        if payload.user_id == self.bot.user.id:
+            return
+
+        # Ignore les DMs
+        if not payload.guild_id:
+            return
+
+        if not self.bot.module_manager:
+            return
+
+        try:
+            # Récupère l'instance du module Starboard pour ce serveur
+            starboard_module = await self.bot.module_manager.get_module_instance(
+                payload.guild_id,
+                'starboard'
+            )
+
+            # Si le module est actif, appelle sa méthode
+            if starboard_module and starboard_module.enabled:
+                await starboard_module.on_reaction_remove(payload)
+
+        except Exception as e:
+            logger.error(f"Error in on_raw_reaction_remove for guild {payload.guild_id}: {e}", exc_info=True)
+
 
 async def setup(bot):
     """Charge le cog"""

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -615,6 +615,30 @@
           "description": "Messages sent in this channel will be visible to all connected servers. Make sure your members understand this."
         }
       }
+    },
+    "starboard": {
+      "name": "Starboard",
+      "description": "Hall of fame for popular messages",
+      "config": {
+        "title": "Starboard Configuration",
+        "description": "Configure the starboard that automatically displays messages with many star reactions.",
+        "channel": {
+          "section_title": "Starboard channel",
+          "section_description": "Select the channel where popular messages will be displayed",
+          "placeholder": "Select a channel"
+        },
+        "reaction_count": {
+          "section_title": "Required reaction count",
+          "section_description": "Number of ⭐ reactions needed for a message to appear in the starboard",
+          "edit_button": "Edit threshold",
+          "modal": {
+            "label": "Reaction count",
+            "placeholder": "5",
+            "error_range": "Reaction count must be between 1 and 100",
+            "error_invalid": "Please enter a valid number"
+          }
+        }
+      }
     }
   },
   "languages": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -614,6 +614,30 @@
           "description": "Les messages envoyés dans ce salon seront visibles par tous les serveurs connectés. Assurez-vous que vos membres comprennent cela."
         }
       }
+    },
+    "starboard": {
+      "name": "Starboard",
+      "description": "Tableau d'honneur des messages populaires",
+      "config": {
+        "title": "Configuration du Starboard",
+        "description": "Configurez le tableau d'honneur qui affiche automatiquement les messages ayant reçu beaucoup de réactions étoiles.",
+        "channel": {
+          "section_title": "Salon du starboard",
+          "section_description": "Sélectionnez le salon où seront affichés les messages populaires",
+          "placeholder": "Sélectionnez un salon"
+        },
+        "reaction_count": {
+          "section_title": "Nombre de réactions requis",
+          "section_description": "Nombre de réactions ⭐ nécessaires pour qu'un message apparaisse dans le starboard",
+          "edit_button": "Modifier le seuil",
+          "modal": {
+            "label": "Nombre de réactions",
+            "placeholder": "5",
+            "error_range": "Le nombre de réactions doit être entre 1 et 100",
+            "error_invalid": "Veuillez entrer un nombre valide"
+          }
+        }
+      }
     }
   },
   "languages": {

--- a/modules/configs/__init__.py
+++ b/modules/configs/__init__.py
@@ -5,5 +5,6 @@ Ce package contient les interfaces de configuration pour chaque module
 
 from .welcome_channel_config import WelcomeChannelConfigView
 from .welcome_dm_config import WelcomeDmConfigView
+from .starboard_config import StarboardConfigView
 
-__all__ = ['WelcomeChannelConfigView', 'WelcomeDmConfigView']
+__all__ = ['WelcomeChannelConfigView', 'WelcomeDmConfigView', 'StarboardConfigView']

--- a/modules/configs/starboard_config.py
+++ b/modules/configs/starboard_config.py
@@ -1,0 +1,342 @@
+"""
+Configuration UI pour le module Starboard
+Interface pour configurer le tableau d'honneur des messages populaires
+"""
+
+import discord
+from discord import ui
+from typing import Optional, Dict, Any
+import logging
+
+from utils.i18n import t
+from cogs.error_handler import BaseView, BaseModal
+
+logger = logging.getLogger('moddy.modules.starboard_config')
+
+
+class ReactionCountModal(BaseModal, title="Nombre de réactions"):
+    """Modal pour éditer le nombre de réactions requis"""
+
+    def __init__(self, locale: str, current_value: int, callback_func):
+        super().__init__(timeout=300)
+        self.locale = locale
+        self.callback_func = callback_func
+
+        self.count_input = ui.TextInput(
+            label=t('modules.starboard.config.reaction_count.modal.label', locale=locale),
+            placeholder=t('modules.starboard.config.reaction_count.modal.placeholder', locale=locale),
+            default=str(current_value),
+            style=discord.TextStyle.short,
+            max_length=3,
+            required=True
+        )
+        self.add_item(self.count_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            count = int(self.count_input.value)
+            if count < 1 or count > 100:
+                await interaction.response.send_message(
+                    t('modules.starboard.config.reaction_count.modal.error_range', locale=self.locale),
+                    ephemeral=True
+                )
+                return
+            await self.callback_func(interaction, count)
+        except ValueError:
+            await interaction.response.send_message(
+                t('modules.starboard.config.reaction_count.modal.error_invalid', locale=self.locale),
+                ephemeral=True
+            )
+
+
+class StarboardConfigView(BaseView):
+    """
+    Interface de configuration du module Starboard
+    """
+
+    def __init__(self, bot, guild_id: int, user_id: int, locale: str, current_config: Optional[Dict[str, Any]] = None):
+        super().__init__(timeout=300)
+        self.bot = bot
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.locale = locale
+
+        # Load default config
+        from modules.starboard import StarboardModule
+        default_config = StarboardModule(bot, guild_id).get_default_config()
+
+        # Check if we have a real saved config
+        if current_config and current_config.get('channel_id') is not None:
+            # Merge with defaults to ensure all keys exist
+            self.current_config = default_config.copy()
+            self.current_config.update(current_config)
+            self.has_existing_config = True
+        else:
+            # Use default config
+            self.current_config = default_config
+            self.has_existing_config = False
+
+        # Working copy
+        self.working_config = self.current_config.copy()
+        self.has_changes = False
+
+        self._build_view()
+
+    def _build_view(self):
+        """Build configuration interface"""
+        self.clear_items()
+
+        container = ui.Container()
+
+        # Header
+        container.add_item(ui.TextDisplay(
+            f"### <:star:1446267438671859832> {t('modules.starboard.config.title', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            t('modules.starboard.config.description', locale=self.locale)
+        ))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # Channel selector
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.starboard.config.channel.section_title', locale=self.locale)}**"
+        ))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.starboard.config.channel.section_description', locale=self.locale)}"
+        ))
+
+        channel_row = ui.ActionRow()
+        channel_select = ui.ChannelSelect(
+            placeholder=t('modules.starboard.config.channel.placeholder', locale=self.locale),
+            channel_types=[discord.ChannelType.text],
+            min_values=0,
+            max_values=1
+        )
+
+        # Pre-select current channel if set
+        if self.working_config.get('channel_id'):
+            channel = self.bot.get_channel(self.working_config['channel_id'])
+            if channel:
+                channel_select.default_values = [channel]
+
+        channel_select.callback = self.on_channel_select
+        channel_row.add_item(channel_select)
+        container.add_item(channel_row)
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # Reaction count configuration
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.starboard.config.reaction_count.section_title', locale=self.locale)}**"
+        ))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.starboard.config.reaction_count.section_description', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.config.current_value', locale=self.locale)} **{self.working_config['reaction_count']}** {self.working_config['emoji']}"
+        ))
+
+        reaction_row = ui.ActionRow()
+
+        edit_count_btn = ui.Button(
+            label=t('modules.starboard.config.reaction_count.edit_button', locale=self.locale),
+            style=discord.ButtonStyle.primary,
+            emoji=discord.PartialEmoji.from_str("<:edit:1401600709824086169>"),
+            custom_id="edit_reaction_count"
+        )
+        edit_count_btn.callback = self.on_edit_reaction_count
+        reaction_row.add_item(edit_count_btn)
+
+        container.add_item(reaction_row)
+
+        self.add_item(container)
+
+        # Add action buttons at the bottom
+        self._add_action_buttons()
+
+    def _add_action_buttons(self):
+        """Add action buttons at the bottom of the view"""
+        button_row = ui.ActionRow()
+
+        # Back button (disabled if changes pending)
+        back_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str("<:back:1401600847733067806>"),
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            custom_id="back_btn",
+            disabled=self.has_changes
+        )
+        back_btn.callback = self.on_back
+        button_row.add_item(back_btn)
+
+        # Save button (only if changes)
+        if self.has_changes:
+            save_btn = ui.Button(
+                emoji=discord.PartialEmoji.from_str("<:save:1444101502154182778>"),
+                label=t('modules.config.buttons.save', locale=self.locale),
+                style=discord.ButtonStyle.success,
+                custom_id="save_btn"
+            )
+            save_btn.callback = self.on_save
+            button_row.add_item(save_btn)
+
+            # Cancel button
+            cancel_btn = ui.Button(
+                emoji=discord.PartialEmoji.from_str("<:undone:1398729502028333218>"),
+                label=t('modules.config.buttons.cancel', locale=self.locale),
+                style=discord.ButtonStyle.danger,
+                custom_id="cancel_btn"
+            )
+            cancel_btn.callback = self.on_cancel
+            button_row.add_item(cancel_btn)
+        else:
+            # Delete button (if config exists)
+            if self.has_existing_config:
+                delete_btn = ui.Button(
+                    emoji=discord.PartialEmoji.from_str("<:delete:1401600770431909939>"),
+                    label=t('modules.config.buttons.delete', locale=self.locale),
+                    style=discord.ButtonStyle.danger,
+                    custom_id="delete_btn"
+                )
+                delete_btn.callback = self.on_delete
+                button_row.add_item(delete_btn)
+
+        self.add_item(button_row)
+
+    # === CALLBACKS ===
+
+    async def on_channel_select(self, interaction: discord.Interaction):
+        """Channel selector callback"""
+        if not await self.check_user(interaction):
+            return
+
+        if interaction.data['values']:
+            channel_id = int(interaction.data['values'][0])
+            self.working_config['channel_id'] = channel_id
+        else:
+            self.working_config['channel_id'] = None
+
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    async def on_edit_reaction_count(self, interaction: discord.Interaction):
+        """Edit reaction count"""
+        if not await self.check_user(interaction):
+            return
+
+        modal = ReactionCountModal(
+            self.locale,
+            self.working_config['reaction_count'],
+            self._on_reaction_count_edited
+        )
+        modal.bot = self.bot  # Set bot for error handling
+        await interaction.response.send_modal(modal)
+
+    async def _on_reaction_count_edited(self, interaction: discord.Interaction, new_count: int):
+        """Callback after reaction count edit"""
+        self.working_config['reaction_count'] = new_count
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    # === ACTION BUTTON CALLBACKS ===
+
+    async def on_back(self, interaction: discord.Interaction):
+        """Return to main menu"""
+        if not await self.check_user(interaction):
+            return
+
+        from cogs.config import ConfigMainView
+        main_view = ConfigMainView(self.bot, self.guild_id, self.user_id, self.locale)
+        await interaction.response.edit_message(view=main_view)
+
+    async def on_save(self, interaction: discord.Interaction):
+        """Save configuration"""
+        if not await self.check_user(interaction):
+            return
+
+        await interaction.response.defer()
+
+        module_manager = self.bot.module_manager
+
+        success, error_msg = await module_manager.save_module_config(
+            self.guild_id,
+            'starboard',
+            self.working_config
+        )
+
+        if success:
+            self.current_config = self.working_config.copy()
+            self.has_changes = False
+            self.has_existing_config = True
+
+            self._build_view()
+
+            await interaction.followup.send(
+                t('modules.config.save.success', locale=self.locale),
+                ephemeral=True
+            )
+            await interaction.edit_original_response(view=self)
+        else:
+            await interaction.followup.send(
+                t('modules.config.save.error', locale=self.locale, error=error_msg),
+                ephemeral=True
+            )
+
+    async def on_cancel(self, interaction: discord.Interaction):
+        """Cancel changes"""
+        if not await self.check_user(interaction):
+            return
+
+        self.working_config = self.current_config.copy()
+        self.has_changes = False
+
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    async def on_delete(self, interaction: discord.Interaction):
+        """Delete configuration"""
+        if not await self.check_user(interaction):
+            return
+
+        await interaction.response.defer()
+
+        module_manager = self.bot.module_manager
+
+        success = await module_manager.delete_module_config(self.guild_id, 'starboard')
+
+        if success:
+            from modules.starboard import StarboardModule
+            self.current_config = StarboardModule(self.bot, self.guild_id).get_default_config()
+            self.working_config = self.current_config.copy()
+            self.has_changes = False
+            self.has_existing_config = False
+
+            self._build_view()
+
+            await interaction.followup.send(
+                t('modules.config.delete.success', locale=self.locale),
+                ephemeral=True
+            )
+            await interaction.edit_original_response(view=self)
+        else:
+            await interaction.followup.send(
+                t('modules.config.delete.error', locale=self.locale),
+                ephemeral=True
+            )
+
+    async def check_user(self, interaction: discord.Interaction) -> bool:
+        """Check if the user is the one who started the config"""
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                t('modules.config.errors.wrong_user', locale=self.locale),
+                ephemeral=True
+            )
+            return False
+        return True
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        """Check permissions for each interaction"""
+        return await self.check_user(interaction)

--- a/modules/starboard.py
+++ b/modules/starboard.py
@@ -1,0 +1,334 @@
+"""
+Module Starboard - Système de tableau d'honneur pour messages populaires
+"""
+
+import discord
+from typing import Dict, Any, Optional
+import logging
+
+from modules.module_manager import ModuleBase
+
+logger = logging.getLogger('moddy.modules.starboard')
+
+
+class StarboardModule(ModuleBase):
+    """
+    Module de starboard (tableau d'honneur)
+    Envoie automatiquement les messages qui reçoivent un nombre X de réactions étoiles
+    dans un salon dédié avec le contenu, l'auteur, le nombre de réactions et le lien
+    """
+
+    MODULE_ID = "starboard"
+    MODULE_NAME = "Starboard"
+    MODULE_DESCRIPTION = "Tableau d'honneur des messages populaires"
+    MODULE_EMOJI = "<:star:1446267438671859832>"
+
+    def __init__(self, bot, guild_id: int):
+        super().__init__(bot, guild_id)
+
+        # Channel configuration
+        self.channel_id: Optional[int] = None
+
+        # Starboard configuration
+        self.reaction_count: int = 5  # Number of star reactions required
+        self.emoji: str = "⭐"  # Star emoji
+
+        # Track sent starboard messages to update them in real-time
+        # Format: {original_message_id: starboard_message_id}
+        self.starboard_messages: Dict[int, int] = {}
+
+    async def load_config(self, config_data: Dict[str, Any]) -> bool:
+        """Load configuration from DB"""
+        try:
+            self.config = config_data
+
+            # Channel configuration
+            self.channel_id = config_data.get('channel_id')
+
+            # Starboard configuration
+            self.reaction_count = config_data.get('reaction_count', 5)
+            self.emoji = config_data.get('emoji', "⭐")
+
+            # Module is enabled if channel is configured
+            self.enabled = self.channel_id is not None
+
+            return True
+        except Exception as e:
+            logger.error(f"Error loading starboard config: {e}")
+            return False
+
+    async def validate_config(self, config_data: Dict[str, Any]) -> tuple[bool, Optional[str]]:
+        """Validate configuration"""
+        # Channel ID is required
+        if not config_data.get('channel_id'):
+            return False, "Un salon est requis pour le starboard"
+
+        # Verify channel exists and bot has permissions
+        try:
+            guild = self.bot.get_guild(self.guild_id)
+            if not guild:
+                return False, "Serveur introuvable"
+
+            channel = guild.get_channel(config_data['channel_id'])
+            if not channel:
+                return False, "Salon introuvable"
+
+            if not isinstance(channel, discord.TextChannel):
+                return False, "Le salon doit être un salon textuel"
+
+            # Check permissions
+            perms = channel.permissions_for(guild.me)
+            if not perms.send_messages:
+                return False, f"Je n'ai pas la permission d'envoyer des messages dans {channel.mention}"
+
+            if not perms.embed_links:
+                return False, f"Je n'ai pas la permission d'envoyer des embeds dans {channel.mention}"
+
+        except Exception as e:
+            return False, f"Erreur de validation du salon : {str(e)}"
+
+        # Validate reaction count
+        reaction_count = config_data.get('reaction_count', 5)
+        if not isinstance(reaction_count, int) or reaction_count < 1 or reaction_count > 100:
+            return False, "Le nombre de réactions doit être entre 1 et 100"
+
+        return True, None
+
+    def get_default_config(self) -> Dict[str, Any]:
+        """Return default configuration"""
+        return {
+            'channel_id': None,
+            'reaction_count': 5,
+            'emoji': "⭐"
+        }
+
+    async def on_reaction_add(self, payload: discord.RawReactionActionEvent):
+        """
+        Called when a reaction is added to a message
+        Checks if the message should be added to starboard
+        """
+        if not self.enabled or not self.channel_id:
+            return
+
+        # Only track star emoji
+        if str(payload.emoji) != self.emoji:
+            return
+
+        try:
+            guild = self.bot.get_guild(self.guild_id)
+            if not guild:
+                return
+
+            # Get the channel where the reaction was added
+            channel = guild.get_channel(payload.channel_id)
+            if not channel or not isinstance(channel, discord.TextChannel):
+                return
+
+            # Don't track reactions in the starboard channel itself
+            if payload.channel_id == self.channel_id:
+                return
+
+            # Get the message
+            try:
+                message = await channel.fetch_message(payload.message_id)
+            except discord.NotFound:
+                logger.warning(f"Message {payload.message_id} not found")
+                return
+
+            # Count star reactions
+            star_count = 0
+            for reaction in message.reactions:
+                if str(reaction.emoji) == self.emoji:
+                    star_count = reaction.count
+                    break
+
+            # Check if we should send/update starboard entry
+            if star_count >= self.reaction_count:
+                await self._update_starboard(message, star_count)
+
+        except discord.Forbidden:
+            logger.warning(f"Missing permissions for starboard in guild {self.guild_id}")
+        except Exception as e:
+            logger.error(f"Error processing starboard reaction: {e}", exc_info=True)
+
+    async def on_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        """
+        Called when a reaction is removed from a message
+        Updates the starboard message with the new count
+        """
+        if not self.enabled or not self.channel_id:
+            return
+
+        # Only track star emoji
+        if str(payload.emoji) != self.emoji:
+            return
+
+        # Check if this message has a starboard entry
+        if payload.message_id not in self.starboard_messages:
+            return
+
+        try:
+            guild = self.bot.get_guild(self.guild_id)
+            if not guild:
+                return
+
+            # Get the channel where the reaction was removed
+            channel = guild.get_channel(payload.channel_id)
+            if not channel or not isinstance(channel, discord.TextChannel):
+                return
+
+            # Get the message
+            try:
+                message = await channel.fetch_message(payload.message_id)
+            except discord.NotFound:
+                return
+
+            # Count star reactions
+            star_count = 0
+            for reaction in message.reactions:
+                if str(reaction.emoji) == self.emoji:
+                    star_count = reaction.count
+                    break
+
+            # Update or remove starboard entry
+            if star_count >= self.reaction_count:
+                await self._update_starboard(message, star_count)
+            else:
+                # Remove from starboard if below threshold
+                await self._remove_starboard(message)
+
+        except Exception as e:
+            logger.error(f"Error updating starboard on reaction remove: {e}", exc_info=True)
+
+    async def _update_starboard(self, message: discord.Message, star_count: int):
+        """
+        Update or create a starboard entry for a message
+        """
+        guild = self.bot.get_guild(self.guild_id)
+        if not guild:
+            return
+
+        starboard_channel = guild.get_channel(self.channel_id)
+        if not starboard_channel or not isinstance(starboard_channel, discord.TextChannel):
+            logger.warning(f"Starboard channel {self.channel_id} not found or not a text channel")
+            return
+
+        # Create embed
+        embed = await self._create_starboard_embed(message, star_count)
+
+        # Check if we already have a starboard message for this
+        if message.id in self.starboard_messages:
+            # Update existing message
+            try:
+                starboard_msg_id = self.starboard_messages[message.id]
+                starboard_msg = await starboard_channel.fetch_message(starboard_msg_id)
+                await starboard_msg.edit(embed=embed)
+                logger.info(f"Updated starboard message for {message.id} (stars: {star_count})")
+            except discord.NotFound:
+                # Message was deleted, create a new one
+                del self.starboard_messages[message.id]
+                await self._create_starboard_message(starboard_channel, message, embed)
+        else:
+            # Create new starboard message
+            await self._create_starboard_message(starboard_channel, message, embed)
+
+    async def _create_starboard_message(self, channel: discord.TextChannel,
+                                       original_message: discord.Message, embed: discord.Embed):
+        """Create a new starboard message"""
+        try:
+            # Send the starboard message
+            starboard_msg = await channel.send(embed=embed)
+
+            # Track it for future updates
+            self.starboard_messages[original_message.id] = starboard_msg.id
+
+            logger.info(f"Created starboard message for {original_message.id}")
+        except discord.Forbidden:
+            logger.warning(f"Missing permissions to send starboard message in guild {self.guild_id}")
+        except Exception as e:
+            logger.error(f"Error creating starboard message: {e}", exc_info=True)
+
+    async def _remove_starboard(self, message: discord.Message):
+        """Remove a message from starboard"""
+        if message.id not in self.starboard_messages:
+            return
+
+        guild = self.bot.get_guild(self.guild_id)
+        if not guild:
+            return
+
+        starboard_channel = guild.get_channel(self.channel_id)
+        if not starboard_channel or not isinstance(starboard_channel, discord.TextChannel):
+            return
+
+        try:
+            starboard_msg_id = self.starboard_messages[message.id]
+            starboard_msg = await starboard_channel.fetch_message(starboard_msg_id)
+            await starboard_msg.delete()
+            del self.starboard_messages[message.id]
+            logger.info(f"Removed starboard message for {message.id}")
+        except discord.NotFound:
+            # Already deleted
+            del self.starboard_messages[message.id]
+        except Exception as e:
+            logger.error(f"Error removing starboard message: {e}", exc_info=True)
+
+    async def _create_starboard_embed(self, message: discord.Message, star_count: int) -> discord.Embed:
+        """Create an embed for a starboard entry"""
+
+        # Create base embed with message content
+        embed = discord.Embed(
+            description=message.content if message.content else "*Pas de contenu texte*",
+            color=0xFFAC33,  # Gold color for starboard
+            timestamp=message.created_at
+        )
+
+        # Set author (message author)
+        embed.set_author(
+            name=message.author.display_name,
+            icon_url=message.author.display_avatar.url
+        )
+
+        # Add star count and jump link
+        embed.add_field(
+            name=f"{self.emoji} Réactions",
+            value=f"**{star_count}** {self.emoji}",
+            inline=True
+        )
+
+        embed.add_field(
+            name="<:message:1443749710073696286> Message",
+            value=f"[Aller au message]({message.jump_url})",
+            inline=True
+        )
+
+        embed.add_field(
+            name="<:text:1439692405317046372> Salon",
+            value=message.channel.mention,
+            inline=True
+        )
+
+        # Add image if the message has one
+        if message.attachments:
+            # Get the first image attachment
+            for attachment in message.attachments:
+                if attachment.content_type and attachment.content_type.startswith('image/'):
+                    embed.set_image(url=attachment.url)
+                    break
+
+        # Add embed image if the message has embeds with images
+        if not embed.image and message.embeds:
+            for msg_embed in message.embeds:
+                if msg_embed.image:
+                    embed.set_image(url=msg_embed.image.url)
+                    break
+                elif msg_embed.thumbnail:
+                    embed.set_thumbnail(url=msg_embed.thumbnail.url)
+                    break
+
+        # Add footer
+        embed.set_footer(
+            text=f"ID: {message.id}"
+        )
+
+        return embed


### PR DESCRIPTION
Implement a complete starboard system that automatically displays messages receiving a configured number of star reactions in a dedicated channel.

Features:
- Configurable reaction threshold (1-100 stars)
- Real-time updates when reactions are added/removed
- Displays message content, author, star count, and jump link
- Supports messages with images and embeds
- Full i18n support (French & English)

Technical implementation:
- New StarboardModule in modules/starboard.py
- StarboardConfigView UI in modules/configs/starboard_config.py
- on_raw_reaction_add/remove event listeners in module_events.py
- Module registration in cogs/config.py
- Translations in locales/fr.json and locales/en-US.json

The module uses Components V2 for configuration UI and follows all project standards including BaseView error handling and i18n system.