### PR TITLE
Update inter-server module text display format

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -494,6 +494,7 @@
         "bot_not_in_guild": "<:error:1444049460924776478> Moddy must be present on this server to use this command.",
         "wrong_user": "<:error:1444049460924776478> Only the user who started the configuration can use this interface.",
         "no_user_perms": "<:error:1444049460924776478> You must have the **Manage Server** permission to use this command.",
+        "required_fields": "<:error:1444049460924776478> The following fields are required: {fields}",
         "channel_not_found": "Channel not found",
         "no_admin_perms": {
           "title": "Insufficient Permissions",
@@ -599,6 +600,15 @@
           "section_description": "Select the channel that will be connected to other servers",
           "placeholder": "Select a channel"
         },
+        "type": {
+          "section_title": "Inter-server type",
+          "section_description": "Choose which inter-server you want to join",
+          "placeholder": "Select a type",
+          "english": "English inter-server",
+          "english_desc": "Join the international English inter-server",
+          "french": "French inter-server",
+          "french_desc": "Join the French-speaking inter-server"
+        },
         "options": {
           "section_title": "Display options",
           "section_description": "Configure how messages are displayed in other servers",
@@ -614,6 +624,10 @@
           "title": "Security warning",
           "description": "Messages sent in this channel will be visible to all connected servers. Make sure your members understand this."
         }
+      },
+      "sticky_message": {
+        "english": "**Inter-Server Channel**\n\n<:flag:1446197210198048778> This is an international inter-server channel connecting multiple Discord servers.\n\n<:warning:1446108410092195902> Please follow the [Inter-Server Guidelines](https://moddy.app/interserver-guidelines) and Discord's Terms of Service.\n\n<:verified:1398729677601902635> This channel is moderated by Moddy's moderation team.",
+        "french": "**Salon Inter-Serveur**\n\n<:flag:1446197210198048778> Ceci est un salon inter-serveur francophone connectant plusieurs serveurs Discord.\n\n<:warning:1446108410092195902> Veuillez respecter les [Règles Inter-Serveur](https://moddy.app/interserver-guidelines) et les Conditions d'Utilisation de Discord.\n\n<:verified:1398729677601902635> Ce salon est modéré par l'équipe de modération de Moddy."
       }
     },
     "starboard": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -493,6 +493,7 @@
         "bot_not_in_guild": "<:error:1444049460924776478> Moddy doit être présent sur ce serveur pour utiliser cette commande.",
         "wrong_user": "<:error:1444049460924776478> Seul l'utilisateur qui a lancé la configuration peut utiliser cette interface.",
         "no_user_perms": "<:error:1444049460924776478> Vous devez avoir la permission **Gérer le serveur** pour utiliser cette commande.",
+        "required_fields": "<:error:1444049460924776478> Les champs suivants sont obligatoires : {fields}",
         "channel_not_found": "Salon introuvable",
         "no_admin_perms": {
           "title": "Permissions insuffisantes",
@@ -598,6 +599,15 @@
           "section_description": "Sélectionnez le salon qui sera connecté aux autres serveurs",
           "placeholder": "Sélectionnez un salon"
         },
+        "type": {
+          "section_title": "Type d'inter-serveur",
+          "section_description": "Choisissez quel inter-serveur vous souhaitez rejoindre",
+          "placeholder": "Sélectionnez un type",
+          "english": "Inter-serveur anglais",
+          "english_desc": "Rejoindre l'inter-serveur anglais international",
+          "french": "Inter-serveur français",
+          "french_desc": "Rejoindre l'inter-serveur français francophone"
+        },
         "options": {
           "section_title": "Options d'affichage",
           "section_description": "Configurez comment les messages sont affichés dans les autres serveurs",
@@ -613,6 +623,11 @@
           "title": "Avertissement de sécurité",
           "description": "Les messages envoyés dans ce salon seront visibles par tous les serveurs connectés. Assurez-vous que vos membres comprennent cela."
         }
+      },
+      "sticky_message": {
+        "english": "**Inter-Server Channel**\n\n<:flag:1446197210198048778> This is an international inter-server channel connecting multiple Discord servers.\n\n<:warning:1446108410092195902> Please follow the [Inter-Server Guidelines](https://moddy.app/interserver-guidelines) and Discord's Terms of Service.\n\n<:verified:1398729677601902635> This channel is moderated by Moddy's moderation team.",
+        "french": "**Salon Inter-Serveur**\n\n<:flag:1446197210198048778> Ceci est un salon inter-serveur francophone connectant plusieurs serveurs Discord.\n\n<:warning:1446108410092195902> Veuillez respecter les [Règles Inter-Serveur](https://moddy.app/interserver-guidelines) et les Conditions d'Utilisation de Discord.\n\n<:verified:1398729677601902635> Ce salon est modéré par l'équipe de modération de Moddy."
+      }
       }
     },
     "starboard": {

--- a/modules/configs/interserver_config.py
+++ b/modules/configs/interserver_config.py
@@ -74,9 +74,7 @@ class InterServerConfigView(BaseView):
 
         # Section : Salon inter-serveur
         container.add_item(ui.TextDisplay(
-            f"**{t('modules.interserver.config.channel.section_title', locale=self.locale)}**"
-        ))
-        container.add_item(ui.TextDisplay(
+            f"**{t('modules.interserver.config.channel.section_title', locale=self.locale)}**<:required_fields:1446549185385074769>\n"
             f"-# {t('modules.interserver.config.channel.section_description', locale=self.locale)}"
         ))
 
@@ -99,11 +97,42 @@ class InterServerConfigView(BaseView):
         channel_row.add_item(channel_select)
         container.add_item(channel_row)
 
+        # Section : Type d'inter-serveur
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.interserver.config.type.section_title', locale=self.locale)}**<:required_fields:1446549185385074769>\n"
+            f"-# {t('modules.interserver.config.type.section_description', locale=self.locale)}"
+        ))
+
+        # Sélecteur de type d'inter-serveur
+        type_row = ui.ActionRow()
+        type_select = ui.Select(
+            placeholder=t('modules.interserver.config.type.placeholder', locale=self.locale),
+            options=[
+                discord.SelectOption(
+                    label=t('modules.interserver.config.type.english', locale=self.locale),
+                    value="english",
+                    description=t('modules.interserver.config.type.english_desc', locale=self.locale),
+                    emoji=discord.PartialEmoji.from_str("<:flag:1446197210198048778>"),
+                    default=self.working_config.get('interserver_type', 'english') == 'english'
+                ),
+                discord.SelectOption(
+                    label=t('modules.interserver.config.type.french', locale=self.locale),
+                    value="french",
+                    description=t('modules.interserver.config.type.french_desc', locale=self.locale),
+                    emoji=discord.PartialEmoji.from_str("<:flag:1446197210198048778>"),
+                    default=self.working_config.get('interserver_type', 'english') == 'french'
+                )
+            ],
+            min_values=1,
+            max_values=1
+        )
+        type_select.callback = self.on_type_select
+        type_row.add_item(type_select)
+        container.add_item(type_row)
+
         # Section : Options d'affichage
         container.add_item(ui.TextDisplay(
-            f"**{t('modules.interserver.config.options.section_title', locale=self.locale)}**"
-        ))
-        container.add_item(ui.TextDisplay(
+            f"**{t('modules.interserver.config.options.section_title', locale=self.locale)}**\n"
             f"-# {t('modules.interserver.config.options.section_description', locale=self.locale)}"
         ))
 
@@ -236,6 +265,24 @@ class InterServerConfigView(BaseView):
         self.working_config['show_server_name'] = 'show_server_name' in selected_options
         self.working_config['show_avatar'] = 'show_avatar' in selected_options
         self.working_config['allowed_mentions'] = 'allowed_mentions' in selected_options
+
+        # Marque comme modifié
+        self.has_changes = True
+
+        # Reconstruit la vue
+        self._build_view()
+
+        # Met à jour le message
+        await interaction.response.edit_message(view=self)
+
+    async def on_type_select(self, interaction: discord.Interaction):
+        """Callback quand un type d'inter-serveur est sélectionné"""
+        if not await self.check_user(interaction):
+            return
+
+        # Récupère le type sélectionné
+        selected_type = interaction.data['values'][0]
+        self.working_config['interserver_type'] = selected_type
 
         # Marque comme modifié
         self.has_changes = True


### PR DESCRIPTION
- Combine title and description in single TextDisplay using \n
- Fix display options (show_server_name, show_avatar, allowed_mentions) to be applied per target server
- Update reply links to point to local server messages instead of original
- Add ban/timeout check for message authors before relaying to target servers
- Create 2 separate inter-servers (English and French) with type selection in config
- Add required_fields emoji to required config fields
- Implement global validation system for required fields before saving
- Add sticky message at bottom of inter-server channels with guidelines
- Update translations for new features in both French and English

The inter-server module now:
- Properly respects each server's display preferences
- Blocks messages from banned/timed-out users on target servers
- Maintains separate English and French inter-server networks
- Shows required fields with emoji indicators
- Validates required fields before saving configuration
- Displays persistent guidelines message at bottom of channels