### PR TITLE
Fix sticky message infinite loop on bot restart

### DIFF
--- a/modules/interserver.py
+++ b/modules/interserver.py
@@ -67,13 +67,6 @@ class InterServerModule(ModuleBase):
             if self.enabled:
                 await self._setup_slowmode()
 
-                # Recrée le sticky message au démarrage
-                guild = self.bot.get_guild(self.guild_id)
-                if guild:
-                    channel = guild.get_channel(self.channel_id)
-                    if channel and isinstance(channel, discord.TextChannel):
-                        await self._manage_sticky_message(channel)
-
             return True
         except Exception as e:
             logger.error(f"Error loading interserver config: {e}")


### PR DESCRIPTION
Problem:
- Sticky message was being recreated on every bot restart
- This created an infinite loop of delete/recreate
- The sticky_message_id is already loaded from DB

Solution:
- Remove the _manage_sticky_message() call from load_config()
- The sticky_message_id persists in DB across restarts
- _manage_sticky_message() is only called when new messages are sent
- This keeps the sticky at the bottom without recreating on restart

The sticky message now works correctly:
- Persists across restarts (ID stored in DB)
- Only managed when new messages are sent
- No infinite loop or duplication