### PR TITLE
Add missing i18n translations for welcome_channel config

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -172,7 +172,7 @@
         "generic": "<:undone:1398729502028333218> **Error**\n\nAn error occurred: `{error}`"
       }
     },
-"reminder": {
+    "reminder": {
       "description": "Add a new reminder",
       "manage_description": "Manage your reminders",
       "params": {
@@ -512,7 +512,9 @@
         "title": "Welcome Channel Configuration",
         "description": "Configure the welcome message sent in a public channel when a new member joins the server.",
         "channel": {
-          "placeholder": "Select a channel"
+          "placeholder": "Select a channel",
+          "section_title": "Welcome channel",
+          "section_description": "Select the channel where welcome messages will be sent"
         },
         "message": {
           "section_title": "Welcome message",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -172,7 +172,7 @@
         "generic": "<:undone:1398729502028333218> **Erreur**\n\nUne erreur est survenue : `{error}`"
       }
     },
-"reminder": {
+    "reminder": {
       "description": "Ajouter un nouveau rappel",
       "manage_description": "Gérer vos rappels",
       "params": {
@@ -511,7 +511,9 @@
         "title": "Configuration du Welcome Channel",
         "description": "Configurez le message de bienvenue envoyé dans un salon public quand un nouveau membre rejoint le serveur.",
         "channel": {
-          "placeholder": "Sélectionnez un salon"
+          "placeholder": "Sélectionnez un salon",
+          "section_title": "Salon de bienvenue",
+          "section_description": "Sélectionnez le salon où seront envoyés les messages de bienvenue"
         },
         "message": {
           "section_title": "Message de bienvenue",


### PR DESCRIPTION
- Add section_title and section_description for channel field
- Updated both fr.json and en-US.json locale files
- Fixes i18n warnings when accessing welcome_channel configuration