### PR TITLE
Restrict config command to team and beta users

### DIFF
--- a/cogs/config.py
+++ b/cogs/config.py
@@ -227,6 +227,43 @@ class Config(commands.Cog):
             )
             return
 
+        # Vérifie que l'utilisateur a l'attribut TEAM ou BETA
+        # Les modules de serveur sont en développement et réservés aux testeurs
+        has_team = await self.bot.db.has_attribute('user', interaction.user.id, 'TEAM')
+        has_beta = await self.bot.db.has_attribute('user', interaction.user.id, 'BETA')
+
+        if not (has_team or has_beta):
+            # Message d'erreur avec Components V2
+            error_view = ui.LayoutView(timeout=None)
+            error_container = ui.Container()
+
+            error_container.add_item(ui.TextDisplay(
+                f"### {EMOJIS['warning']} {t('modules.config.errors.dev_only.title', interaction)}"
+            ))
+            error_container.add_item(ui.TextDisplay(
+                t('modules.config.errors.dev_only.description', interaction)
+            ))
+
+            error_container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+            # Bouton pour rejoindre le serveur support
+            button_row = ui.ActionRow()
+            support_btn = ui.Button(
+                label=t('modules.config.errors.dev_only.button', interaction),
+                style=discord.ButtonStyle.link,
+                url="https://moddy.app/support"
+            )
+            button_row.add_item(support_btn)
+            error_container.add_item(button_row)
+
+            error_view.add_item(error_container)
+
+            await interaction.response.send_message(
+                view=error_view,
+                ephemeral=True
+            )
+            return
+
         # Vérifie que Moddy a les permissions administrateur
         bot_member = interaction.guild.me
         if not bot_member.guild_permissions.administrator:

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -500,6 +500,11 @@
           "title": "Insufficient Permissions",
           "description": "Moddy needs **administrator permissions** to manage server modules.\n\nPlease re-invite the bot with the correct permissions.",
           "button": "Re-invite Moddy"
+        },
+        "dev_only": {
+          "title": "Feature in Development",
+          "description": "Server modules are currently under development and are only accessible to Moddy team members and beta testers.\n\nJoin our support server to learn more and participate in testing!",
+          "button": "Join Support Server"
         }
       },
       "current_value": "Current value:",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -499,6 +499,11 @@
           "title": "Permissions insuffisantes",
           "description": "Moddy a besoin des **permissions administrateur** pour gérer les modules du serveur.\n\nVeuillez réinviter le bot avec les bonnes permissions.",
           "button": "Réinviter Moddy"
+        },
+        "dev_only": {
+          "title": "Fonctionnalité en développement",
+          "description": "Les modules de serveur sont actuellement en cours de développement et ne sont accessibles qu'aux membres de l'équipe Moddy et aux testeurs bêta.\n\nRejoignez notre serveur support pour en savoir plus et participer aux tests !",
+          "button": "Rejoindre le serveur support"
         }
       },
       "current_value": "Valeur actuelle :",


### PR DESCRIPTION
Server modules are currently in development and should only be accessible to Moddy team members and beta testers. This commit adds a permission check at the beginning of the /config command to restrict access.

Changes:
- Add TEAM and BETA attribute check in config.py
- Display user-friendly error message using Components V2
- Add i18n translations (fr, en-US) for the error message
- Include link to support server (moddy.app/support) for users who want to participate in testing

The check happens after basic validations but before permission checks to provide clear feedback to users about the feature status.