### PR TITLE
Create Discord invite lookup command

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -112,6 +112,57 @@
         "range": "-# {max}-sided die (1-{max})"
       }
     },
+    "invite": {
+      "description": "Lookup information about a Discord invite",
+      "params": {
+        "invite_code": "The Discord invite code (e.g., 'discord' or 'https://discord.gg/discord')",
+        "incognito": "Make response visible only to you"
+      },
+      "loading": "<a:loading:1395047662092550194> **Fetching invite information...**",
+      "view": {
+        "guild": {
+          "title": "Server Invite Information",
+          "name": "Server Name",
+          "id": "Server ID",
+          "description": "Description",
+          "members": "Members",
+          "online": "Online",
+          "channel": "Channel",
+          "channel_type": "Channel Type",
+          "inviter": "Inviter",
+          "inviter_id": "Inviter ID",
+          "expires": "Expires",
+          "features": "Server Features",
+          "verification": "Verification Level",
+          "nsfw": "NSFW Server",
+          "invite_code": "Invite Code"
+        },
+        "group_dm": {
+          "title": "Group DM Invite",
+          "name": "Group Name",
+          "id": "Group ID",
+          "members": "Members",
+          "inviter": "Inviter",
+          "inviter_id": "Inviter ID",
+          "invite_code": "Invite Code"
+        },
+        "friend": {
+          "title": "Friend Invite",
+          "display_name": "Display Name",
+          "username": "Username",
+          "id": "User ID",
+          "invite_code": "Invite Code"
+        }
+      },
+      "errors": {
+        "not_found": "<:undone:1398729502028333218> **Invite Not Found**\n\nThe invite code `{code}` is invalid, expired, or doesn't exist.",
+        "rate_limit": "<:undone:1398729502028333218> **Rate Limit**\n\nToo many requests. Please try again later.",
+        "api_error": "<:undone:1398729502028333218> **API Error**\n\nFailed to fetch invite information. Status: `{status}`",
+        "network_error": "<:undone:1398729502028333218> **Network Error**\n\nCouldn't connect to Discord API. Please try again.",
+        "generic": "<:undone:1398729502028333218> **Error**\n\nAn error occurred: `{error}`",
+        "unknown_type": "<:undone:1398729502028333218> **Unknown Invite Type**\n\nThis invite type (`{type}`) is not recognized."
+      }
+    },
     "user": {
       "description": "Display detailed information about a Discord user",
       "params": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -112,6 +112,57 @@
         "range": "-# Dé à {max} faces (1-{max})"
       }
     },
+    "invite": {
+      "description": "Recherche des informations sur une invitation Discord",
+      "params": {
+        "invite_code": "Le code d'invitation Discord (ex: 'discord' ou 'https://discord.gg/discord')",
+        "incognito": "Rendre la réponse visible uniquement pour vous"
+      },
+      "loading": "<a:loading:1395047662092550194> **Récupération des informations de l'invitation...**",
+      "view": {
+        "guild": {
+          "title": "Informations sur l'invitation du serveur",
+          "name": "Nom du serveur",
+          "id": "ID du serveur",
+          "description": "Description",
+          "members": "Membres",
+          "online": "En ligne",
+          "channel": "Salon",
+          "channel_type": "Type de salon",
+          "inviter": "Inviteur",
+          "inviter_id": "ID de l'inviteur",
+          "expires": "Expire",
+          "features": "Fonctionnalités du serveur",
+          "verification": "Niveau de vérification",
+          "nsfw": "Serveur NSFW",
+          "invite_code": "Code d'invitation"
+        },
+        "group_dm": {
+          "title": "Invitation de groupe MP",
+          "name": "Nom du groupe",
+          "id": "ID du groupe",
+          "members": "Membres",
+          "inviter": "Inviteur",
+          "inviter_id": "ID de l'inviteur",
+          "invite_code": "Code d'invitation"
+        },
+        "friend": {
+          "title": "Invitation d'ami",
+          "display_name": "Nom d'affichage",
+          "username": "Nom d'utilisateur",
+          "id": "ID de l'utilisateur",
+          "invite_code": "Code d'invitation"
+        }
+      },
+      "errors": {
+        "not_found": "<:undone:1398729502028333218> **Invitation introuvable**\n\nLe code d'invitation `{code}` est invalide, expiré ou n'existe pas.",
+        "rate_limit": "<:undone:1398729502028333218> **Limite atteinte**\n\nTrop de requêtes. Veuillez réessayer plus tard.",
+        "api_error": "<:undone:1398729502028333218> **Erreur API**\n\nImpossible de récupérer les informations de l'invitation. Statut : `{status}`",
+        "network_error": "<:undone:1398729502028333218> **Erreur réseau**\n\nImpossible de se connecter à l'API Discord. Veuillez réessayer.",
+        "generic": "<:undone:1398729502028333218> **Erreur**\n\nUne erreur est survenue : `{error}`",
+        "unknown_type": "<:undone:1398729502028333218> **Type d'invitation inconnu**\n\nCe type d'invitation (`{type}`) n'est pas reconnu."
+      }
+    },
     "user": {
       "description": "Affiche des informations détaillées sur un utilisateur Discord",
       "params": {


### PR DESCRIPTION
- Add new invite command that supports Server, Group DM, and Friend invites
- Display detailed information including member counts, channel info, and expiration
- Support multiple invite formats (URL or code)
- Add i18n translations for English and French
- Use Components V2 for UI display
- Follow Moddy's design guidelines with custom emojis