### PR TITLE
Fix attribution links and developer mention syntax

### DIFF
--- a/cogs/moddy.py
+++ b/cogs/moddy.py
@@ -44,19 +44,19 @@ class AttributionView(BaseView):
 
         # Google Fonts Icons
         container.add_item(ui.TextDisplay(
-            f"<:googlefonts:1451300521548972163> **@Google Fonts | Icons**\n"
+            f"<:googlefonts:1451300521548972163> [@**Google Fonts** | Icons](https://fonts.google.com/icons)\n"
             f"-# {t('commands.moddy.attribution.google_fonts', locale=self.locale)}"
         ))
 
         # Discord.py
         container.add_item(ui.TextDisplay(
-            f"<:python:1451298515199332372> **@Rapptz | Discord.py**\n"
+            f"<:python:1451298515199332372> [@**Rapptz** | Discord.py](https://github.com/Rapptz/discord.py)\n"
             f"-# {t('commands.moddy.attribution.discordpy', locale=self.locale)}"
         ))
 
         # Discord Userdoccers
         container.add_item(ui.TextDisplay(
-            f"<:discorduserdoccers:1451303689602994196> **@Discord Userdoccers | Documentation**\n"
+            f"<:discorduserdoccers:1451303689602994196> [@**Discord Userdoccers** | Documentation](https://docs.discord.food/intro)\n"
             f"-# {t('commands.moddy.attribution.userdoccers', locale=self.locale)}"
         ))
 

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -177,7 +177,7 @@
         "title": "Links"
       },
       "footer": {
-        "rights": "All rights reserved. Developed by @juthing",
+        "rights": "All rights reserved. Developed by @[**juthing**](https://github.com/juthing/)",
         "disclaimer": "Moddy is not affiliated with Discord Inc."
       },
       "buttons": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -177,7 +177,7 @@
         "title": "Liens"
       },
       "footer": {
-        "rights": "Tous droits réservés. Développé par @juthing",
+        "rights": "Tous droits réservés. Développé par @[**juthing**](https://github.com/juthing/)",
         "disclaimer": "Moddy n'est pas affilié à Discord Inc."
       },
       "buttons": {


### PR DESCRIPTION
- Use [@**Author** | Project Name](URL) format for attributions
- Add proper links to Google Fonts, discord.py, and Discord Userdoccers
- Fix developer mention to use @[**juthing**](https://github.com/juthing/) format