### PR TITLE
Improve permission error handling for announcement setup

### DIFF
--- a/staff/dev_commands.py
+++ b/staff/dev_commands.py
@@ -726,11 +726,17 @@ class DeveloperCommands(StaffCommandsCog):
                     footer=f"Executed by {message.author}"
                 )
             else:
-                view = create_error_message(
-                    "Setup Failed",
-                    f"Failed to setup announcements for **{guild.name}** (`{guild.id}`).",
-                    fields=[{'name': 'Error', 'value': f"```{result_message}```"}]
-                )
+                # Check if it's a permission error
+                if "permission" in result_message.lower():
+                    view = create_error_message(
+                        "Missing Permissions",
+                        f"Cannot setup announcements for **{guild.name}** (`{guild.id}`).\n\n**Reason:** {result_message}\n\n-# The bot needs **Manage Webhooks** and **Manage Channels** permissions in this server."
+                    )
+                else:
+                    view = create_error_message(
+                        "Setup Failed",
+                        f"Failed to setup announcements for **{guild.name}** (`{guild.id}`).\n\n**Reason:** {result_message}"
+                    )
 
             await msg.edit(view=view)
 


### PR DESCRIPTION
- Added detailed permission error detection in announcement_setup.py
- Handle 403 (Forbidden) and 400 (Bad Request) API responses
- Detect and report permission issues clearly
- Added specific error messages for missing Manage Webhooks/Channels permissions
- Improved error display in d.setup-announcements command
- Command now always responds, even when permissions are missing
- Added discord.Forbidden and discord.HTTPException handling

This ensures developers always get clear feedback about why setup failed.