### PR TITLE
Create auto role assignment module for server

### DIFF
--- a/cogs/config.py
+++ b/cogs/config.py
@@ -158,6 +158,15 @@ class ConfigMainView(BaseView):
                 self.locale,
                 module_config
             )
+        elif module_id == 'auto_role':
+            from modules.configs.auto_role_config import AutoRoleConfigView
+            config_view = AutoRoleConfigView(
+                self.bot,
+                self.guild_id,
+                self.user_id,
+                self.locale,
+                module_config
+            )
         # Ajouter d'autres modules ici au fur et à mesure
         # elif module_id == 'ticket':
         #     from modules.configs.ticket_config import TicketConfigView

--- a/cogs/module_events.py
+++ b/cogs/module_events.py
@@ -55,6 +55,20 @@ class ModuleEvents(commands.Cog):
         except Exception as e:
             logger.error(f"Error in on_member_join (auto_restore_roles) for guild {member.guild.id}: {e}", exc_info=True)
 
+        try:
+            # Récupère l'instance du module Auto Role pour ce serveur
+            auto_role_module = await self.bot.module_manager.get_module_instance(
+                member.guild.id,
+                'auto_role'
+            )
+
+            # Si le module est actif, appelle sa méthode
+            if auto_role_module and auto_role_module.enabled:
+                await auto_role_module.on_member_join(member)
+
+        except Exception as e:
+            logger.error(f"Error in on_member_join (auto_role) for guild {member.guild.id}: {e}", exc_info=True)
+
     @commands.Cog.listener()
     async def on_member_remove(self, member: discord.Member):
         """

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -768,6 +768,24 @@
         }
       }
     },
+    "auto_role": {
+      "name": "Auto Role",
+      "description": "Automatically assigns roles to new members",
+      "config": {
+        "title": "Auto Role Configuration",
+        "description": "Configure automatic role assignment for new members and bots joining your server.",
+        "member_roles": {
+          "section_title": "Roles for users",
+          "section_description": "Roles that will be automatically assigned to users joining the server",
+          "placeholder": "Select roles for users"
+        },
+        "bot_roles": {
+          "section_title": "Roles for bots",
+          "section_description": "Roles that will be automatically assigned to bots joining the server",
+          "placeholder": "Select roles for bots"
+        }
+      }
+    },
     "auto_restore_roles": {
       "name": "Auto Restore Roles",
       "description": "Automatically restores roles for returning users",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -767,6 +767,24 @@
         }
       }
     },
+    "auto_role": {
+      "name": "Auto Role",
+      "description": "Attribue automatiquement des rôles aux nouveaux membres",
+      "config": {
+        "title": "Configuration de l'Auto Role",
+        "description": "Configurez l'attribution automatique de rôles pour les nouveaux membres et les bots qui rejoignent votre serveur.",
+        "member_roles": {
+          "section_title": "Rôles pour les utilisateurs",
+          "section_description": "Rôles qui seront attribués automatiquement aux utilisateurs qui rejoignent le serveur",
+          "placeholder": "Sélectionnez des rôles pour les utilisateurs"
+        },
+        "bot_roles": {
+          "section_title": "Rôles pour les bots",
+          "section_description": "Rôles qui seront attribués automatiquement aux bots qui rejoignent le serveur",
+          "placeholder": "Sélectionnez des rôles pour les bots"
+        }
+      }
+    },
     "auto_restore_roles": {
       "name": "Auto Restore Roles",
       "description": "Restaure automatiquement les rôles des utilisateurs qui reviennent",

--- a/modules/auto_role.py
+++ b/modules/auto_role.py
@@ -1,0 +1,161 @@
+"""
+Module Auto Role - Attribution automatique de rôles
+Attribue automatiquement des rôles aux nouveaux membres et aux bots qui rejoignent le serveur
+"""
+
+import discord
+from typing import Dict, Any, Optional, List
+import logging
+
+from modules.module_manager import ModuleBase
+
+logger = logging.getLogger('moddy.modules.auto_role')
+
+
+class AutoRoleModule(ModuleBase):
+    """
+    Module d'attribution automatique de rôles
+    Attribue des rôles automatiquement aux membres et bots qui rejoignent le serveur
+    """
+
+    MODULE_ID = "auto_role"
+    MODULE_NAME = "Auto Role"
+    MODULE_DESCRIPTION = "Attribue automatiquement des rôles aux nouveaux membres"
+    MODULE_EMOJI = "<:manageuser:1398729745293774919>"
+
+    def __init__(self, bot, guild_id: int):
+        super().__init__(bot, guild_id)
+
+        # Configuration
+        self.member_roles: List[int] = []  # Rôles pour les utilisateurs normaux
+        self.bot_roles: List[int] = []     # Rôles pour les bots
+
+    async def load_config(self, config_data: Dict[str, Any]) -> bool:
+        """Charge la configuration depuis la DB"""
+        try:
+            self.config = config_data
+
+            # Charge les rôles
+            self.member_roles = config_data.get('member_roles', [])
+            self.bot_roles = config_data.get('bot_roles', [])
+
+            # Le module est activé si au moins un rôle est configuré
+            self.enabled = len(self.member_roles) > 0 or len(self.bot_roles) > 0
+
+            return True
+        except Exception as e:
+            logger.error(f"Error loading auto_role config: {e}")
+            return False
+
+    async def validate_config(self, config_data: Dict[str, Any]) -> tuple[bool, Optional[str]]:
+        """Valide la configuration"""
+        member_roles = config_data.get('member_roles', [])
+        bot_roles = config_data.get('bot_roles', [])
+
+        # Au moins un rôle doit être configuré
+        if not member_roles and not bot_roles:
+            return False, "Vous devez configurer au moins un rôle (pour les membres ou pour les bots)"
+
+        # Vérifie que les rôles existent
+        guild = self.bot.get_guild(self.guild_id)
+        if not guild:
+            return False, "Serveur introuvable"
+
+        # Vérifie les rôles membres
+        for role_id in member_roles:
+            role = guild.get_role(role_id)
+            if not role:
+                return False, f"Rôle membre <@&{role_id}> introuvable"
+
+            # Vérifie que le bot peut attribuer ce rôle
+            if role >= guild.me.top_role:
+                return False, f"Je ne peux pas attribuer le rôle {role.mention} car il est au-dessus de mon rôle le plus élevé"
+
+            # Vérifie que le rôle n'est pas @everyone
+            if role.id == guild.id:
+                return False, "Vous ne pouvez pas utiliser @everyone comme rôle automatique"
+
+            # Vérifie que le rôle n'est pas managé (bot, intégration, etc.)
+            if role.managed:
+                return False, f"Le rôle {role.mention} est géré automatiquement et ne peut pas être attribué manuellement"
+
+        # Vérifie les rôles bots
+        for role_id in bot_roles:
+            role = guild.get_role(role_id)
+            if not role:
+                return False, f"Rôle bot <@&{role_id}> introuvable"
+
+            # Vérifie que le bot peut attribuer ce rôle
+            if role >= guild.me.top_role:
+                return False, f"Je ne peux pas attribuer le rôle {role.mention} car il est au-dessus de mon rôle le plus élevé"
+
+            # Vérifie que le rôle n'est pas @everyone
+            if role.id == guild.id:
+                return False, "Vous ne pouvez pas utiliser @everyone comme rôle automatique"
+
+            # Vérifie que le rôle n'est pas managé
+            if role.managed:
+                return False, f"Le rôle {role.mention} est géré automatiquement et ne peut pas être attribué manuellement"
+
+        # Vérifie que le bot a la permission de gérer les rôles
+        if not guild.me.guild_permissions.manage_roles:
+            return False, "Je n'ai pas la permission de gérer les rôles sur ce serveur"
+
+        return True, None
+
+    def get_default_config(self) -> Dict[str, Any]:
+        """Retourne la configuration par défaut"""
+        return {
+            'member_roles': [],
+            'bot_roles': []
+        }
+
+    async def on_member_join(self, member: discord.Member):
+        """
+        Appelé quand un membre rejoint le serveur
+        Attribue les rôles automatiques selon qu'il s'agit d'un bot ou d'un utilisateur
+        """
+        if not self.enabled:
+            return
+
+        try:
+            guild = self.bot.get_guild(self.guild_id)
+            if not guild:
+                return
+
+            # Détermine quels rôles attribuer selon le type de membre
+            roles_to_add = []
+
+            if member.bot:
+                # C'est un bot, on attribue les rôles bots
+                if self.bot_roles:
+                    for role_id in self.bot_roles:
+                        role = guild.get_role(role_id)
+                        if role and role < guild.me.top_role:
+                            roles_to_add.append(role)
+            else:
+                # C'est un utilisateur normal, on attribue les rôles membres
+                if self.member_roles:
+                    for role_id in self.member_roles:
+                        role = guild.get_role(role_id)
+                        if role and role < guild.me.top_role:
+                            roles_to_add.append(role)
+
+            # Attribue les rôles si il y en a
+            if roles_to_add:
+                await member.add_roles(*roles_to_add, reason="Auto Role")
+                role_names = ", ".join([role.name for role in roles_to_add])
+                logger.info(
+                    f"✅ Added {len(roles_to_add)} auto role(s) to {member.name} ({'bot' if member.bot else 'member'}) "
+                    f"in guild {self.guild_id}: {role_names}"
+                )
+
+        except discord.Forbidden:
+            logger.warning(
+                f"Missing permissions to add auto roles to {member.name} in guild {self.guild_id}"
+            )
+        except Exception as e:
+            logger.error(
+                f"Error adding auto roles to {member.name} in guild {self.guild_id}: {e}",
+                exc_info=True
+            )

--- a/modules/configs/auto_role_config.py
+++ b/modules/configs/auto_role_config.py
@@ -1,0 +1,319 @@
+"""
+Configuration UI pour le module Auto Role
+Interface pour configurer l'attribution automatique de rôles
+"""
+
+import discord
+from discord import ui
+from typing import Optional, Dict, Any
+import logging
+
+from utils.i18n import t
+from cogs.error_handler import BaseView
+
+logger = logging.getLogger('moddy.modules.auto_role_config')
+
+
+class AutoRoleConfigView(BaseView):
+    """
+    Interface de configuration du module Auto Role
+    """
+
+    def __init__(self, bot, guild_id: int, user_id: int, locale: str, current_config: Optional[Dict[str, Any]] = None):
+        super().__init__(timeout=300)
+        self.bot = bot
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.locale = locale
+
+        # Load default config
+        from modules.auto_role import AutoRoleModule
+        default_config = AutoRoleModule(bot, guild_id).get_default_config()
+
+        # Check if we have a real saved config (check for any configured roles)
+        if current_config and (
+            current_config.get('member_roles') or
+            current_config.get('bot_roles')
+        ):
+            # Merge with defaults to ensure all keys exist
+            self.current_config = default_config.copy()
+            self.current_config.update(current_config)
+            self.has_existing_config = True
+        else:
+            # Use default config
+            self.current_config = default_config
+            self.has_existing_config = False
+
+        # Working copy
+        self.working_config = self.current_config.copy()
+        self.has_changes = False
+
+        self._build_view()
+
+    def _build_view(self):
+        """Construit l'interface de configuration"""
+        self.clear_items()
+
+        container = ui.Container()
+
+        # Header
+        container.add_item(ui.TextDisplay(
+            f"### <:manageuser:1398729745293774919> {t('modules.auto_role.config.title', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            t('modules.auto_role.config.description', locale=self.locale)
+        ))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # Member roles selector
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.auto_role.config.member_roles.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.auto_role.config.member_roles.section_description', locale=self.locale)}"
+        ))
+
+        # Show current member roles if any
+        if self.working_config.get('member_roles'):
+            member_role_names = []
+            guild = self.bot.get_guild(self.guild_id)
+            if guild:
+                for role_id in self.working_config['member_roles']:
+                    role = guild.get_role(role_id)
+                    if role:
+                        member_role_names.append(role.mention)
+
+            if member_role_names:
+                container.add_item(ui.TextDisplay(
+                    f"-# {t('modules.config.current_value', locale=self.locale)} {', '.join(member_role_names)}"
+                ))
+
+        member_roles_row = ui.ActionRow()
+        member_roles_select = ui.RoleSelect(
+            placeholder=t('modules.auto_role.config.member_roles.placeholder', locale=self.locale),
+            min_values=0,
+            max_values=25
+        )
+
+        # Pre-select current member roles
+        if self.working_config.get('member_roles'):
+            guild = self.bot.get_guild(self.guild_id)
+            if guild:
+                default_roles = []
+                for role_id in self.working_config['member_roles']:
+                    role = guild.get_role(role_id)
+                    if role:
+                        default_roles.append(role)
+                if default_roles:
+                    member_roles_select.default_values = default_roles
+
+        member_roles_select.callback = self.on_member_roles_select
+        member_roles_row.add_item(member_roles_select)
+        container.add_item(member_roles_row)
+
+        # Bot roles selector
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.auto_role.config.bot_roles.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.auto_role.config.bot_roles.section_description', locale=self.locale)}"
+        ))
+
+        # Show current bot roles if any
+        if self.working_config.get('bot_roles'):
+            bot_role_names = []
+            guild = self.bot.get_guild(self.guild_id)
+            if guild:
+                for role_id in self.working_config['bot_roles']:
+                    role = guild.get_role(role_id)
+                    if role:
+                        bot_role_names.append(role.mention)
+
+            if bot_role_names:
+                container.add_item(ui.TextDisplay(
+                    f"-# {t('modules.config.current_value', locale=self.locale)} {', '.join(bot_role_names)}"
+                ))
+
+        bot_roles_row = ui.ActionRow()
+        bot_roles_select = ui.RoleSelect(
+            placeholder=t('modules.auto_role.config.bot_roles.placeholder', locale=self.locale),
+            min_values=0,
+            max_values=25
+        )
+
+        # Pre-select current bot roles
+        if self.working_config.get('bot_roles'):
+            guild = self.bot.get_guild(self.guild_id)
+            if guild:
+                default_roles = []
+                for role_id in self.working_config['bot_roles']:
+                    role = guild.get_role(role_id)
+                    if role:
+                        default_roles.append(role)
+                if default_roles:
+                    bot_roles_select.default_values = default_roles
+
+        bot_roles_select.callback = self.on_bot_roles_select
+        bot_roles_row.add_item(bot_roles_select)
+        container.add_item(bot_roles_row)
+
+        self.add_item(container)
+        self._add_action_buttons()
+
+    def _add_action_buttons(self):
+        """Ajoute les boutons Back/Save/Cancel/Delete"""
+        button_row = ui.ActionRow()
+
+        # Back button (disabled if changes pending)
+        back_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str("<:back:1401600847733067806>"),
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            disabled=self.has_changes
+        )
+        back_btn.callback = self.on_back
+        button_row.add_item(back_btn)
+
+        if self.has_changes:
+            # Save button
+            save_btn = ui.Button(
+                emoji=discord.PartialEmoji.from_str("<:save:1444101502154182778>"),
+                label=t('modules.config.buttons.save', locale=self.locale),
+                style=discord.ButtonStyle.success
+            )
+            save_btn.callback = self.on_save
+            button_row.add_item(save_btn)
+
+            # Cancel button
+            cancel_btn = ui.Button(
+                emoji=discord.PartialEmoji.from_str("<:undone:1398729502028333218>"),
+                label=t('modules.config.buttons.cancel', locale=self.locale),
+                style=discord.ButtonStyle.danger
+            )
+            cancel_btn.callback = self.on_cancel
+            button_row.add_item(cancel_btn)
+        else:
+            if self.has_existing_config:
+                # Delete button
+                delete_btn = ui.Button(
+                    emoji=discord.PartialEmoji.from_str("<:delete:1401600770431909939>"),
+                    label=t('modules.config.buttons.delete', locale=self.locale),
+                    style=discord.ButtonStyle.danger
+                )
+                delete_btn.callback = self.on_delete
+                button_row.add_item(delete_btn)
+
+        self.add_item(button_row)
+
+    async def on_member_roles_select(self, interaction: discord.Interaction):
+        """Callback quand les rôles membres sont sélectionnés"""
+        if not await self.check_user(interaction):
+            return
+
+        if interaction.data['values']:
+            role_ids = [int(role_id) for role_id in interaction.data['values']]
+            self.working_config['member_roles'] = role_ids
+        else:
+            self.working_config['member_roles'] = []
+
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    async def on_bot_roles_select(self, interaction: discord.Interaction):
+        """Callback quand les rôles bots sont sélectionnés"""
+        if not await self.check_user(interaction):
+            return
+
+        if interaction.data['values']:
+            role_ids = [int(role_id) for role_id in interaction.data['values']]
+            self.working_config['bot_roles'] = role_ids
+        else:
+            self.working_config['bot_roles'] = []
+
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    async def on_save(self, interaction: discord.Interaction):
+        """Sauvegarde la configuration"""
+        if not await self.check_user(interaction):
+            return
+
+        await interaction.response.defer()
+
+        module_manager = self.bot.module_manager
+        success, error_msg = await module_manager.save_module_config(
+            self.guild_id, 'auto_role', self.working_config
+        )
+
+        if success:
+            self.current_config = self.working_config.copy()
+            self.has_changes = False
+            self.has_existing_config = True
+            self._build_view()
+            await interaction.followup.send(
+                t('modules.config.save.success', locale=self.locale),
+                ephemeral=True
+            )
+            await interaction.edit_original_response(view=self)
+        else:
+            await interaction.followup.send(
+                t('modules.config.save.error', locale=self.locale, error=error_msg),
+                ephemeral=True
+            )
+
+    async def on_cancel(self, interaction: discord.Interaction):
+        """Annule les modifications"""
+        if not await self.check_user(interaction):
+            return
+
+        self.working_config = self.current_config.copy()
+        self.has_changes = False
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    async def on_delete(self, interaction: discord.Interaction):
+        """Supprime la configuration"""
+        if not await self.check_user(interaction):
+            return
+
+        await interaction.response.defer()
+
+        module_manager = self.bot.module_manager
+        success = await module_manager.delete_module_config(self.guild_id, 'auto_role')
+
+        if success:
+            from modules.auto_role import AutoRoleModule
+            default_config = AutoRoleModule(self.bot, self.guild_id).get_default_config()
+            self.current_config = default_config
+            self.working_config = default_config.copy()
+            self.has_changes = False
+            self.has_existing_config = False
+            self._build_view()
+            await interaction.followup.send(
+                t('modules.config.delete.success', locale=self.locale),
+                ephemeral=True
+            )
+            await interaction.edit_original_response(view=self)
+        else:
+            await interaction.followup.send(
+                t('modules.config.delete.error', locale=self.locale),
+                ephemeral=True
+            )
+
+    async def on_back(self, interaction: discord.Interaction):
+        """Retourne au menu principal"""
+        if not await self.check_user(interaction):
+            return
+
+        from cogs.config import ConfigMainView
+        main_view = ConfigMainView(self.bot, self.guild_id, self.user_id, self.locale)
+        await interaction.response.edit_message(view=main_view)
+
+    async def check_user(self, interaction: discord.Interaction) -> bool:
+        """Vérifie que c'est le bon utilisateur"""
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                t('modules.config.errors.wrong_user', locale=self.locale),
+                ephemeral=True
+            )
+            return False
+        return True


### PR DESCRIPTION
Features:
- Automatic role assignment for new members joining the server
- Separate role configuration for regular users and bots
- Full validation of role permissions and hierarchy
- Integration with existing module system
- Support for multiple roles per category

Implementation:
- Created AutoRoleModule with on_member_join event handler
- Built configuration UI using Components V2 with role selectors
- Added French and English translations
- Integrated with /config command and module_events system

Technical details:
- Uses RoleSelect components for intuitive role selection
- Validates bot can assign roles (hierarchy check)
- Prevents assignment of @everyone and managed roles
- Follows all design guidelines (BaseView, i18n, custom emojis)
- Proper error handling and logging