### PR TITLE
Send welcome message to new server members

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -737,12 +737,11 @@
           "description": "Messages sent in this channel will be visible to all connected servers. Make sure your members understand this."
         }
       },
-      "sticky_message": {
-        "english_title": "### <:groups:1446127489842806967> Inter-Server Channel",
-        "english_body": "<:web:1398729801061240883> This is an international inter-server channel connecting multiple Discord servers.\n<:book:1446557736350388364> Please follow the [Inter-Server Guidelines](https://moddy.app/interserver-guidelines) and Discord's Terms of Service.\n<:verified:1398729677601902635> This channel is moderated by Moddy's moderation team.\n<:flag:1446197210198048778> To report a message to our team, join our [support server](https://moddy.app/support/) or use /interserver report.",
-        "french_title": "### <:groups:1446127489842806967> Salon Inter-Serveur",
-        "french_body": "<:web:1398729801061240883> Ceci est un salon inter-serveur francophone connectant plusieurs serveurs Discord.\n<:book:1446557736350388364> Veuillez respecter les [Règles Inter-Serveur](https://moddy.app/interserver-guidelines) et les Conditions d'Utilisation de Discord.\n<:verified:1398729677601902635> Ce salon est modéré par l'équipe de modération de Moddy.\n<:flag:1446197210198048778> Pour signaler un message à notre équipe, rejoignez notre [serveur de support](https://moddy.app/support/) ou utilisez /interserver report."
-      }
+      "welcome_dm": {
+        "title": "### <:groups:1446127489842806967> Welcome to Inter-Server!",
+        "body": "<:web:1398729801061240883> This is an international inter-server channel connecting multiple Discord servers.\n\n<:book:1446557736350388364> **Please follow:**\n• The [Inter-Server Guidelines](https://moddy.app/interserver-guidelines)\n• Discord's Terms of Service\n\n<:verified:1398729677601902635> This channel is moderated by Moddy's moderation team.\n\n<:flag:1446197210198048778> **To report a message:**\nJoin our [support server](https://moddy.app/support/) or use `/interserver report`\n\n-# You're receiving this message because you sent your first message in an inter-server channel."
+      },
+      "channel_description": "🌐 Inter-Server Channel | Connect with users from multiple Discord servers | Follow the Inter-Server Guidelines (https://moddy.app/interserver-guidelines) | Moderated by Moddy Team | Report: /interserver report"
     },
     "starboard": {
       "name": "Starboard",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -736,12 +736,11 @@
           "description": "Les messages envoyés dans ce salon seront visibles par tous les serveurs connectés. Assurez-vous que vos membres comprennent cela."
         }
       },
-      "sticky_message": {
-        "english_title": "### <:groups:1446127489842806967> Inter-Server Channel",
-        "english_body": "<:web:1398729801061240883> This is an international inter-server channel connecting multiple Discord servers.\n<:book:1446557736350388364> Please follow the [Inter-Server Guidelines](https://moddy.app/interserver-guidelines) and Discord's Terms of Service.\n<:verified:1398729677601902635> This channel is moderated by Moddy's moderation team.\n<:flag:1446197210198048778> To report a message to our team, join our [support server](https://moddy.app/support/) or use /interserver report.",
-        "french_title": "### <:groups:1446127489842806967> Salon Inter-Serveur",
-        "french_body": "<:web:1398729801061240883> Ceci est un salon inter-serveur francophone connectant plusieurs serveurs Discord.\n<:book:1446557736350388364> Veuillez respecter les [Règles Inter-Serveur](https://moddy.app/interserver-guidelines) et les Conditions d'Utilisation de Discord.\n<:verified:1398729677601902635> Ce salon est modéré par l'équipe de modération de Moddy.\n<:flag:1446197210198048778> Pour signaler un message à notre équipe, rejoignez notre [serveur de support](https://moddy.app/support/) ou utilisez /interserver report."
-      }
+      "welcome_dm": {
+        "title": "### <:groups:1446127489842806967> Bienvenue sur l'Inter-Serveur !",
+        "body": "<:web:1398729801061240883> Ceci est un salon inter-serveur francophone connectant plusieurs serveurs Discord.\n\n<:book:1446557736350388364> **Veuillez respecter :**\n• Les [Règles Inter-Serveur](https://moddy.app/interserver-guidelines)\n• Les Conditions d'Utilisation de Discord\n\n<:verified:1398729677601902635> Ce salon est modéré par l'équipe de modération de Moddy.\n\n<:flag:1446197210198048778> **Pour signaler un message :**\nRejoignez notre [serveur de support](https://moddy.app/support/) ou utilisez `/interserver report`\n\n-# Vous recevez ce message car vous avez envoyé votre premier message dans un salon inter-serveur."
+      },
+      "channel_description": "🌐 Salon Inter-Serveur | Connectez-vous avec des utilisateurs de plusieurs serveurs Discord | Respectez les Règles Inter-Serveur (https://moddy.app/interserver-guidelines) | Modéré par l'équipe Moddy | Signalement : /interserver report"
     },
     "starboard": {
       "name": "Starboard",

--- a/modules/configs/interserver_config.py
+++ b/modules/configs/interserver_config.py
@@ -130,46 +130,6 @@ class InterServerConfigView(BaseView):
         type_row.add_item(type_select)
         container.add_item(type_row)
 
-        # Section : Options d'affichage
-        container.add_item(ui.TextDisplay(
-            f"**{t('modules.interserver.config.options.section_title', locale=self.locale)}**\n"
-            f"-# {t('modules.interserver.config.options.section_description', locale=self.locale)}"
-        ))
-
-        # Sélecteur pour les options
-        options_row = ui.ActionRow()
-        options_select = ui.Select(
-            placeholder=t('modules.interserver.config.options.placeholder', locale=self.locale),
-            options=[
-                discord.SelectOption(
-                    label=t('modules.interserver.config.options.show_server_name', locale=self.locale),
-                    value="show_server_name",
-                    description=t('modules.interserver.config.options.show_server_name_desc', locale=self.locale),
-                    emoji=discord.PartialEmoji.from_str("<:label:1398729473649676440>"),
-                    default=self.working_config.get('show_server_name', True)
-                ),
-                discord.SelectOption(
-                    label=t('modules.interserver.config.options.show_avatar', locale=self.locale),
-                    value="show_avatar",
-                    description=t('modules.interserver.config.options.show_avatar_desc', locale=self.locale),
-                    emoji=discord.PartialEmoji.from_str("<:user:1398729712204779571>"),
-                    default=self.working_config.get('show_avatar', True)
-                ),
-                discord.SelectOption(
-                    label=t('modules.interserver.config.options.allowed_mentions', locale=self.locale),
-                    value="allowed_mentions",
-                    description=t('modules.interserver.config.options.allowed_mentions_desc', locale=self.locale),
-                    emoji=discord.PartialEmoji.from_str("<:notifications:1402261437493022775>"),
-                    default=self.working_config.get('allowed_mentions', False)
-                )
-            ],
-            min_values=0,
-            max_values=3
-        )
-        options_select.callback = self.on_options_select
-        options_row.add_item(options_select)
-        container.add_item(options_row)
-
         container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
 
         # Avertissement de sécurité
@@ -243,28 +203,6 @@ class InterServerConfigView(BaseView):
             self.working_config['channel_id'] = channel_id
         else:
             self.working_config['channel_id'] = None
-
-        # Marque comme modifié
-        self.has_changes = True
-
-        # Reconstruit la vue
-        self._build_view()
-
-        # Met à jour le message
-        await interaction.response.edit_message(view=self)
-
-    async def on_options_select(self, interaction: discord.Interaction):
-        """Callback quand des options sont sélectionnées"""
-        if not await self.check_user(interaction):
-            return
-
-        # Récupère les options sélectionnées
-        selected_options = interaction.data['values']
-
-        # Met à jour les options
-        self.working_config['show_server_name'] = 'show_server_name' in selected_options
-        self.working_config['show_avatar'] = 'show_avatar' in selected_options
-        self.working_config['allowed_mentions'] = 'allowed_mentions' in selected_options
 
         # Marque comme modifié
         self.has_changes = True


### PR DESCRIPTION
Major changes:
- Replace sticky messages with welcome DMs sent on first use
- Auto-update channel descriptions with inter-server rules
- Remove action buttons from internal log messages (simplified)
- Make :done: reactions temporary (disappear after 5 seconds)
- Accept both Moddy ID (F6ZEU3VS) and Discord snowflake in /interserver report and info
- Remove display options section from /config (simplified UI)

Technical details:
- Added _send_welcome_dm() to track and send first-time user messages
- Added _setup_channel_description() to auto-configure channel topics
- Simplified StaffLogView to display-only (no interactive buttons)
- Added async task to auto-remove success reactions
- Created _get_message_by_id() helper to support dual ID formats
- Updated translations with welcome_dm and channel_description keys

Fixes #issue-number