### PR TITLE
Refactor invite view to separate invite info and server details

### DIFF
--- a/docs/claude.md
+++ b/docs/claude.md
@@ -1,13 +1,13 @@
 Instructions for Claude Code:
 
-* If the code you need to write is a server module, you must read `/documentation/Module_System.md`.
-* If the code you need to write contains slash commands, you must read `/documentation/COMMANDS.md`.
-* If the code you need to write concerns staff/dev commands or anything related to Moddy's staff, you must read `/documentation/STAFF_SYSTEM.md`.
-* **If the code you need to write contains discord.ui Views or Modals, you MUST read `/documentation/Error_Handling.md`** to ensure ALL errors are properly handled.
-* **If the code you need to write involves any user interface, configuration panels, or interactive components, you MUST read `/documentation/DESIGN.md`** for design guidelines and best practices.
+* If the code you need to write is a server module, you must read `/docs/Module_System.md`.
+* If the code you need to write contains slash commands, you must read `/docs/COMMANDS.md`.
+* If the code you need to write concerns staff/dev commands or anything related to Moddy's staff, you must read `/docs/STAFF_SYSTEM.md`.
+* **If the code you need to write contains discord.ui Views or Modals, you MUST read `/docs/Error_Handling.md`** to ensure ALL errors are properly handled.
+* **If the code you need to write involves any user interface, configuration panels, or interactive components, you MUST read `/docs/DESIGN.md`** for design guidelines and best practices.
 
-In all cases, you must read `/documentation/Components_V2.md` to know how to create V2 components. Also, all the text you write must use Moddy's i18n system (see `/utils/i18n.py`). Furthermore, unless explicitly stated otherwise, you must only use Moddy's "custom" emojis and not default emojis. The list of all custom emojis to use is available in `/documentation/emojis.md`. If you need an emoji, icon, or anything else, don't hesitate to ask.
+In all cases, you must read `/docs/Components_V2.md` to know how to create V2 components. Also, all the text you write must use Moddy's i18n system (see `/utils/i18n.py`). Furthermore, unless explicitly stated otherwise, you must only use Moddy's "custom" emojis and not default emojis. The list of all custom emojis to use is available in `/docs/emojis.md`. If you need an emoji, icon, or anything else, don't hesitate to ask.
 
-Additionally, **ALL UI components (Views, Modals) MUST inherit from `BaseView` or `BaseModal`** (see `/documentation/Error_Handling.md`). In cogs and modules concerning "unexpected" errors, you must let the bot's global error system handle them (`error_handler.py`). Also, embed/container titles must always start with `###` followed by the icon, then the title. Example:
+Additionally, **ALL UI components (Views, Modals) MUST inherit from `BaseView` or `BaseModal`** (see `/docs/Error_Handling.md`). In cogs and modules concerning "unexpected" errors, you must let the bot's global error system handle them (`error_handler.py`). Also, embed/container titles must always start with `###` followed by the icon, then the title. Example:
 `### [module or command icon/emoji] module or command name`.
 Additionally, commits, PRs, and code comments must be written in English.

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -121,7 +121,7 @@
       "loading": "<a:loading:1395047662092550194> **Fetching invite information...**",
       "view": {
         "guild": {
-          "title": "Server Invite Information",
+          "title": "Invite Information",
           "name": "Server Name",
           "id": "Server ID",
           "description": "Description",
@@ -135,7 +135,12 @@
           "features": "Server Features",
           "verification": "Verification Level",
           "nsfw": "NSFW Server",
-          "invite_code": "Invite Code"
+          "invite_code": "Invite Code",
+          "show_server_info": "View server info"
+        },
+        "server_info": {
+          "title": "Server Information",
+          "back": "Back"
         },
         "group_dm": {
           "title": "Group DM Invite",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -121,7 +121,7 @@
       "loading": "<a:loading:1395047662092550194> **Récupération des informations de l'invitation...**",
       "view": {
         "guild": {
-          "title": "Informations sur l'invitation du serveur",
+          "title": "Informations sur l'invitation",
           "name": "Nom du serveur",
           "id": "ID du serveur",
           "description": "Description",
@@ -135,7 +135,12 @@
           "features": "Fonctionnalités du serveur",
           "verification": "Niveau de vérification",
           "nsfw": "Serveur NSFW",
-          "invite_code": "Code d'invitation"
+          "invite_code": "Code d'invitation",
+          "show_server_info": "Voir les infos du serveur"
+        },
+        "server_info": {
+          "title": "Informations du serveur",
+          "back": "Retour"
         },
         "group_dm": {
           "title": "Invitation de groupe MP",


### PR DESCRIPTION
## Summary
Refactored the guild invite view to split functionality into two separate views: a lightweight invite information view and a detailed server information view. This improves UX by showing essential invite details upfront while keeping server metadata behind an optional button.

## Key Changes
- **Renamed method**: `_build_guild_invite()` → `_build_guild_invite_info()` to clarify its purpose
- **Simplified invite view**: Removed guild details (name, ID, description, member counts, features, verification level, NSFW status) from the main invite display
- **Created `ServerInfoView` class**: New view that displays comprehensive server information, accessible via a "View server info" button
- **Added navigation**: Implemented back button in server info view to return to invite details
- **Updated i18n**: 
  - Changed "Server Invite Information" → "Invite Information" for clarity
  - Added new translation keys for server info view and button labels
  - Updated French translations accordingly
- **Fixed documentation paths**: Updated `/documentation/` references to `/docs/` in `claude.md`

## Implementation Details
- Both views inherit from `BaseView` following project conventions
- Server info button uses custom emoji `<:groups:1446127489842806967>`
- Back button uses custom emoji `<:back:1401600847733067806>`
- Invite code display moved to top of invite info view for prominence
- Channel information remains in the main invite view as it's directly relevant to the invite destination