### PR TITLE
Add public health check endpoint for monitoring services

### DIFF
--- a/internal_api/server.py
+++ b/internal_api/server.py
@@ -67,6 +67,23 @@ async def ping():
     return {"ping": "pong"}
 
 
+@app.get("/health")
+async def health():
+    """
+    Endpoint de health check pour Railway et autres services de monitoring.
+
+    Retourne toujours un statut 200 quand le serveur est en ligne,
+    indépendamment de l'état du bot Discord.
+
+    Pour vérifier l'état du bot Discord, utilisez /internal/health (authentification requise).
+    """
+    return {
+        "status": "healthy",
+        "service": "moddy-bot-api",
+        "version": "1.0.0"
+    }
+
+
 def set_bot(bot):
     """
     Définit l'instance du bot Discord pour l'API interne.


### PR DESCRIPTION
## Summary
Added a new public `/health` endpoint to provide health check functionality for external monitoring services like Railway, without requiring authentication.

## Key Changes
- Added `/health` GET endpoint that returns a simple healthy status response
- Endpoint returns HTTP 200 with service name and version information
- Documented distinction between public `/health` and authenticated `/internal/health` endpoints
- Endpoint is always available when the server is running, independent of Discord bot state

## Implementation Details
- The new endpoint is placed alongside the existing `/ping` endpoint for consistency
- Returns a JSON response with `status`, `service`, and `version` fields
- Includes French documentation explaining its purpose for Railway and other monitoring services
- Does not require authentication, making it suitable for automated health checks by deployment platforms

https://claude.ai/code/session_015TRA261kSNfpYxW2XzrA4S