### PR TITLE
feat: foundation for persistent views + migrate /moddy, /roll, /banner, /avatar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,18 @@ moddy/
 - For "unexpected" errors in cogs/modules: let the global error handler manage them
 - For expected errors: use `create_error_message()` / `create_success_message()` from `utils/components_v2.py`
 
-### 8. Language
+### 8. Persistent Views
+- `BaseView` defaults to `timeout=None` — views never expire in memory
+- To make a view survive a **bot restart**:
+  1. Set `__persistent__ = True` on the class
+  2. Give every interactive child a stable, namespaced `custom_id` (`moddy:<cog>:<view>:<action>`)
+  3. Make `__init__` safely accept `bot=None` / default args so a "shell" can be instantiated
+  4. Implement `register_persistent(cls, bot)` (usually `bot.add_view(cls())`)
+  5. Add the class to `utils/persistent_views.py::_collect_persistent_view_classes()`
+- Callbacks on persistent views must re-derive state from `interaction` (not `self`) — after a restart, `self` is the shell
+- See → [docs/PERSISTENT_VIEWS.md](docs/PERSISTENT_VIEWS.md)
+
+### 9. Language
 - Code comments, commits, PRs: **English only**
 - User-facing strings: via i18n (French + English)
 
@@ -177,6 +188,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 |---|---|
 | [docs/DESIGN.md](docs/DESIGN.md) | Any UI/UX work, configuration panels, interactive components |
 | [docs/COMPONENTS_V2.md](docs/COMPONENTS_V2.md) | Any code that creates Discord UI elements |
+| [docs/PERSISTENT_VIEWS.md](docs/PERSISTENT_VIEWS.md) | Any view that should survive a bot restart (most views) |
 | [docs/ERROR_HANDLING.md](docs/ERROR_HANDLING.md) | Any code with Views, Modals, or error handling |
 | [docs/EMOJIS.md](docs/EMOJIS.md) | When you need to use an emoji/icon |
 

--- a/bot.py
+++ b/bot.py
@@ -279,6 +279,11 @@ class ModdyBot(commands.Bot):
         # Load extensions
         await self.load_extensions()
 
+        # Register persistent views (must run AFTER cogs are loaded so that
+        # every view class is importable). See docs/PERSISTENT_VIEWS.md.
+        from utils.persistent_views import register_all_persistent_views
+        register_all_persistent_views(self)
+
         # Start background tasks
         self.status_update.start()
 

--- a/cogs/avatar.py
+++ b/cogs/avatar.py
@@ -15,10 +15,13 @@ from utils.i18n import i18n
 
 
 class AvatarView(BaseView):
-    """View to display user avatar using Components V2"""
+    """View to display user avatar using Components V2.
+
+    Non-interactive (no buttons) — timeout=None is inherited from BaseView.
+    """
 
     def __init__(self, user_data: dict, locale: str):
-        super().__init__(timeout=180)
+        super().__init__()
         self.user_data = user_data
         self.locale = locale
 

--- a/cogs/banner.py
+++ b/cogs/banner.py
@@ -9,15 +9,20 @@ from discord.ext import commands
 from typing import Optional
 import aiohttp
 
+from cogs.error_handler import BaseView
 from utils.incognito import add_incognito_option, get_incognito_setting
 from utils.i18n import i18n
 
 
-class BannerView(ui.LayoutView):
-    """View to display user banner using Components V2"""
+class BannerView(BaseView):
+    """View to display user banner using Components V2.
+
+    Non-interactive (no buttons) — only needs BaseView inheritance for the
+    centralized error handler. ``timeout=None`` is inherited from BaseView.
+    """
 
     def __init__(self, user_data: dict, locale: str):
-        super().__init__(timeout=180)
+        super().__init__()
         self.user_data = user_data
         self.locale = locale
 

--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -171,11 +171,52 @@ class BaseView(ui.LayoutView):
     1. Errors are caught and logged with FULL traceback in ONE log line
     2. User ALWAYS receives an error embed
     3. Error handler processes ALL exceptions
+
+    Persistence
+    -----------
+    The default ``timeout`` is ``None`` — views never expire in memory.
+    Subclasses that still want a timeout can pass ``timeout=<seconds>`` to
+    ``super().__init__``; any numeric value overrides the default.
+
+    To make a view survive a bot restart, set the class attribute
+    ``__persistent__ = True`` and override :meth:`register_persistent`. The
+    registration runs once in :func:`bot.setup_hook` via
+    ``utils.persistent_views.register_all_persistent_views``. See
+    ``docs/PERSISTENT_VIEWS.md`` for the full pattern.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    # Override to True on subclasses that should be registered as persistent
+    # at bot startup. Subclasses that set this to True MUST also implement
+    # register_persistent(bot).
+    __persistent__: bool = False
+
+    def __init__(self, *, timeout: Optional[float] = None, **kwargs):
+        # Default timeout=None so views never expire in memory, regardless of
+        # whether they are registered as persistent. Subclasses can still
+        # override by passing timeout=<seconds>.
+        super().__init__(timeout=timeout, **kwargs)
         self.bot = None  # MUST be set by subclass
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """
+        Register this view for persistence across bot restarts.
+
+        Subclasses with ``__persistent__ = True`` MUST override this and
+        typically call one of:
+
+        - ``bot.add_view(cls())`` for a static shell instance
+          (all children have stable ``custom_id``s and callbacks re-derive
+          state from ``interaction``).
+        - ``bot.add_dynamic_items(...)`` for ``discord.ui.DynamicItem``
+          subclasses whose ``custom_id`` encodes state via a regex.
+
+        See ``docs/PERSISTENT_VIEWS.md`` for the cookbook.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__}.__persistent__ is True but register_persistent() "
+            f"is not implemented."
+        )
 
     async def on_error(self, interaction: discord.Interaction, error: Exception, item: discord.ui.Item) -> None:
         """
@@ -277,6 +318,14 @@ class BaseView(ui.LayoutView):
 class BaseModal(ui.Modal):
     """
     Base class for ALL UI Modals with centralized error handling.
+
+    Note
+    ----
+    Modals cannot be registered as persistent — Discord treats a modal
+    submission as a one-shot interaction that must be answered while the
+    owning message's component store is still in memory. ``discord.ui.Modal``
+    already defaults ``timeout`` to ``None``, so modals will not expire
+    mid-edit as long as the bot process stays up.
     """
 
     def __init__(self, *args, **kwargs):

--- a/cogs/moddy.py
+++ b/cogs/moddy.py
@@ -14,18 +14,31 @@ from utils.i18n import i18n, t
 from utils.emojis import EMOJIS
 
 
-class AttributionView(BaseView):
-    """View to display attributions"""
+# Namespaced custom_id constants for persistent dispatch.
+# Format: moddy:<cog>:<view>:<action>
+_CID_MAIN_ATTRIBUTION = "moddy:moddy:main:attribution"
+_CID_MAIN_WE_SUPPORT = "moddy:moddy:main:we_support"
+_CID_ATTRIBUTION_BACK = "moddy:moddy:attribution:back"
+_CID_WE_SUPPORT_BACK = "moddy:moddy:we_support:back"
 
-    def __init__(self, bot, locale: str, user_id: int):
-        super().__init__(timeout=600)
+
+class AttributionView(BaseView):
+    """View to display attributions.
+
+    Persistent: yes. Auth: public (informational command).
+    """
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, locale: str = "en-US", user_id: Optional[int] = None):
+        super().__init__()
         self.bot = bot
         self.locale = locale
         self.user_id = user_id
         self.build_view()
 
     def build_view(self):
-        """Build the attributions view"""
+        """Build the attributions view."""
         self.clear_items()
 
         container = ui.Container()
@@ -68,43 +81,48 @@ class AttributionView(BaseView):
 
         self.add_item(container)
 
-        # Back button
+        # Back button (persistent — stable custom_id)
         back_row = ui.ActionRow()
         back_btn = ui.Button(
             emoji=discord.PartialEmoji.from_str("<:back:1401600847733067806>"),
             label=t('commands.moddy.buttons.back', locale=self.locale),
-            style=discord.ButtonStyle.secondary
+            style=discord.ButtonStyle.secondary,
+            custom_id=_CID_ATTRIBUTION_BACK,
         )
         back_btn.callback = self.on_back
         back_row.add_item(back_btn)
         self.add_item(back_row)
 
     async def on_back(self, interaction: discord.Interaction):
-        """Handle back button click"""
-        if interaction.user.id != self.user_id:
-            await interaction.response.send_message(
-                t('commands.moddy.errors.wrong_user', locale=self.locale),
-                ephemeral=True
-            )
-            return
-
-        # Go back to main view
-        main_view = ModdyMainView(self.bot, self.locale, self.user_id)
+        """Handle back button click — re-derives state from interaction."""
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        main_view = ModdyMainView(bot, locale, interaction.user.id)
         await interaction.response.edit_message(view=main_view)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: public — anyone who can see the message can click."""
+        bot.add_view(cls())
 
 
 class WeSupportView(BaseView):
-    """View to display projects we support"""
+    """View to display projects we support.
 
-    def __init__(self, bot, locale: str, user_id: int):
-        super().__init__(timeout=600)
+    Persistent: yes. Auth: public (informational command).
+    """
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, locale: str = "en-US", user_id: Optional[int] = None):
+        super().__init__()
         self.bot = bot
         self.locale = locale
         self.user_id = user_id
         self.build_view()
 
     def build_view(self):
-        """Build the we support view"""
+        """Build the we support view."""
         self.clear_items()
 
         container = ui.Container()
@@ -128,43 +146,54 @@ class WeSupportView(BaseView):
 
         self.add_item(container)
 
-        # Back button
+        # Back button (persistent — stable custom_id)
         back_row = ui.ActionRow()
         back_btn = ui.Button(
             emoji=discord.PartialEmoji.from_str("<:back:1401600847733067806>"),
             label=t('commands.moddy.buttons.back', locale=self.locale),
-            style=discord.ButtonStyle.secondary
+            style=discord.ButtonStyle.secondary,
+            custom_id=_CID_WE_SUPPORT_BACK,
         )
         back_btn.callback = self.on_back
         back_row.add_item(back_btn)
         self.add_item(back_row)
 
     async def on_back(self, interaction: discord.Interaction):
-        """Handle back button click"""
-        if interaction.user.id != self.user_id:
-            await interaction.response.send_message(
-                t('commands.moddy.errors.wrong_user', locale=self.locale),
-                ephemeral=True
-            )
-            return
-
-        # Go back to main view
-        main_view = ModdyMainView(self.bot, self.locale, self.user_id)
+        """Handle back button click — re-derives state from interaction."""
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        main_view = ModdyMainView(bot, locale, interaction.user.id)
         await interaction.response.edit_message(view=main_view)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: public — anyone who can see the message can click."""
+        bot.add_view(cls())
 
 
 class ModdyMainView(BaseView):
-    """Main view for the /moddy command"""
+    """Main view for the /moddy command.
 
-    def __init__(self, bot, locale: str, user_id: int):
-        super().__init__(timeout=600)
+    Persistent: yes. Auth: public (informational command).
+
+    When ``bot`` is ``None`` the view is in "shell" mode — only the layout
+    structure needed for persistent dispatch is built, and any content that
+    requires runtime bot state (guild count, user count, version) is
+    skipped. The shell is what gets registered via ``bot.add_view`` and
+    never rendered to the user.
+    """
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, locale: str = "en-US", user_id: Optional[int] = None):
+        super().__init__()
         self.bot = bot
         self.locale = locale
         self.user_id = user_id
         self.build_view()
 
     def build_view(self):
-        """Build the main about view"""
+        """Build the main about view."""
         self.clear_items()
 
         container = ui.Container()
@@ -181,19 +210,22 @@ class ModdyMainView(BaseView):
 
         container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
 
-        # Bot Information section
-        version = self.bot.version or "Unknown"
-        server_count = len(self.bot.guilds)
-        user_count = len(self.bot.users)
+        # Bot Information section — only when we have a live bot reference.
+        # In shell mode (bot is None, used for persistent registration) we
+        # skip this since it requires runtime state.
+        if self.bot is not None:
+            version = self.bot.version or "Unknown"
+            server_count = len(self.bot.guilds)
+            user_count = len(self.bot.users)
 
-        container.add_item(ui.TextDisplay(
-            f"**{t('commands.moddy.bot_info.title', locale=self.locale)}**\n"
-            f"> **{t('commands.moddy.bot_info.version', locale=self.locale)}:** `{version}`\n"
-            f"> **{t('commands.moddy.bot_info.servers', locale=self.locale)}:** `{server_count:,}`\n"
-            f"> **{t('commands.moddy.bot_info.users', locale=self.locale)}:** `{user_count:,}`"
-        ))
+            container.add_item(ui.TextDisplay(
+                f"**{t('commands.moddy.bot_info.title', locale=self.locale)}**\n"
+                f"> **{t('commands.moddy.bot_info.version', locale=self.locale)}:** `{version}`\n"
+                f"> **{t('commands.moddy.bot_info.servers', locale=self.locale)}:** `{server_count:,}`\n"
+                f"> **{t('commands.moddy.bot_info.users', locale=self.locale)}:** `{user_count:,}`"
+            ))
 
-        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+            container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
 
         # Links section
         container.add_item(ui.TextDisplay(
@@ -218,13 +250,14 @@ class ModdyMainView(BaseView):
 
         self.add_item(container)
 
-        # Action buttons (Attribution and We Support)
+        # Action buttons (persistent — stable custom_ids)
         buttons_row = ui.ActionRow()
 
         attribution_btn = ui.Button(
             emoji=discord.PartialEmoji.from_str("<:attribution:1451293906175262871>"),
             label=t('commands.moddy.buttons.attribution', locale=self.locale),
-            style=discord.ButtonStyle.secondary
+            style=discord.ButtonStyle.secondary,
+            custom_id=_CID_MAIN_ATTRIBUTION,
         )
         attribution_btn.callback = self.on_attribution
         buttons_row.add_item(attribution_btn)
@@ -232,7 +265,8 @@ class ModdyMainView(BaseView):
         we_support_btn = ui.Button(
             emoji=discord.PartialEmoji.from_str("<:favorite:1451293904329769081>"),
             label=t('commands.moddy.buttons.we_support', locale=self.locale),
-            style=discord.ButtonStyle.secondary
+            style=discord.ButtonStyle.secondary,
+            custom_id=_CID_MAIN_WE_SUPPORT,
         )
         we_support_btn.callback = self.on_we_support
         buttons_row.add_item(we_support_btn)
@@ -240,30 +274,23 @@ class ModdyMainView(BaseView):
         self.add_item(buttons_row)
 
     async def on_attribution(self, interaction: discord.Interaction):
-        """Handle attribution button click"""
-        if interaction.user.id != self.user_id:
-            await interaction.response.send_message(
-                t('commands.moddy.errors.wrong_user', locale=self.locale),
-                ephemeral=True
-            )
-            return
-
-        # Show attribution view
-        attribution_view = AttributionView(self.bot, self.locale, self.user_id)
+        """Handle attribution button click — re-derives state from interaction."""
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        attribution_view = AttributionView(bot, locale, interaction.user.id)
         await interaction.response.edit_message(view=attribution_view)
 
     async def on_we_support(self, interaction: discord.Interaction):
-        """Handle we support button click"""
-        if interaction.user.id != self.user_id:
-            await interaction.response.send_message(
-                t('commands.moddy.errors.wrong_user', locale=self.locale),
-                ephemeral=True
-            )
-            return
-
-        # Show we support view
-        we_support_view = WeSupportView(self.bot, self.locale, self.user_id)
+        """Handle we support button click — re-derives state from interaction."""
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        we_support_view = WeSupportView(bot, locale, interaction.user.id)
         await interaction.response.edit_message(view=we_support_view)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: public — anyone who can see the message can click."""
+        bot.add_view(cls())
 
 
 class Moddy(commands.Cog):

--- a/cogs/roll.py
+++ b/cogs/roll.py
@@ -9,15 +9,20 @@ from discord.ext import commands
 from typing import Optional
 import random
 
+from cogs.error_handler import BaseView
 from utils.incognito import add_incognito_option, get_incognito_setting
 from utils.i18n import i18n
 
 
-class RollView(ui.LayoutView):
-    """View to display dice roll result using Components V2"""
+class RollView(BaseView):
+    """View to display dice roll result using Components V2.
+
+    Non-interactive (no buttons) — only needs BaseView inheritance for the
+    centralized error handler. ``timeout=None`` is inherited from BaseView.
+    """
 
     def __init__(self, result: int, max_value: int, locale: str):
-        super().__init__(timeout=180)
+        super().__init__()
         self.result = result
         self.max_value = max_value
         self.locale = locale

--- a/docs/COMPONENTS_V2.md
+++ b/docs/COMPONENTS_V2.md
@@ -27,6 +27,13 @@ class MyView(ui.LayoutView):
 
 Elle remplace `ui.View` quand tu veux utiliser des containers / textdisplay / separators.
 
+> ⚠️ **Dans Moddy, on n'hérite jamais directement de `ui.LayoutView`.** Toute
+> View doit hériter de `BaseView` (qui étend `ui.LayoutView`) pour bénéficier
+> du handler d'erreurs centralisé et du `timeout=None` par défaut.
+> Si la View doit survivre à un redémarrage du bot, voir
+> **[docs/PERSISTENT_VIEWS.md](PERSISTENT_VIEWS.md)** pour la convention
+> `custom_id` et le pattern `register_persistent`.
+
 ---
 
 ## 🧱 **2. Le `ui.Container`**

--- a/docs/PERSISTENT_VIEWS.md
+++ b/docs/PERSISTENT_VIEWS.md
@@ -1,0 +1,243 @@
+# Persistent Views
+
+> All interactive Discord views in Moddy should survive a bot restart. This
+> document explains how the persistence layer works, the conventions every
+> view must follow, and a cookbook for migrating existing views.
+
+---
+
+## Why
+
+Without persistence:
+- A view's buttons stop working after `timeout` seconds (default 180 s in
+  raw discord.py).
+- **Every** view in the bot dies on restart (Railway deploys, crashes,
+  manual `d.restart`). Users see "This interaction failed" on every click.
+
+With persistence:
+- `BaseView` defaults to `timeout=None` — views never expire in memory.
+- Registered views survive restarts: discord.py dispatches clicks back to a
+  registered "shell" instance that rebuilds fresh state from `interaction`.
+
+---
+
+## How discord.py persistence works (short version)
+
+A view is *persistent* when:
+1. `timeout=None`, AND
+2. every child item has a `custom_id` (URL buttons and non-interactive
+   components count as persistent automatically).
+
+You register persistent views **once** at startup with `bot.add_view(view)`.
+Discord dispatches incoming button clicks by looking up
+`(component_type, custom_id)`:
+- **Running bot**: the live in-memory view that was sent with the message
+  receives the click (full state available).
+- **After restart**: falls back to the registered persistent view (the
+  "shell"). `self` on the shell has no per-message state.
+
+> **Rule**: callbacks must never rely on `self.locale`, `self.user_id`, etc.
+> They must re-derive everything from `interaction`.
+
+---
+
+## The Moddy contract
+
+Every persistent view in Moddy follows the same shape:
+
+```python
+from cogs.error_handler import BaseView
+from utils.i18n import i18n, t
+import discord
+from discord import ui
+
+
+_CID_DO_THING = "moddy:<cog>:<view>:do_thing"  # custom_id constant
+
+
+class MyView(BaseView):
+    """One-line description. Persistent: yes. Auth: <who can click>."""
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, locale: str = "en-US", <other state>=None):
+        super().__init__()  # timeout=None by default
+        self.bot = bot
+        self.locale = locale
+        # ...
+        self.build_view()
+
+    def build_view(self):
+        self.clear_items()
+        container = ui.Container()
+        # Any TextDisplay that needs live bot state goes inside
+        #   `if self.bot is not None:` so the shell can build without crashing.
+        if self.bot is not None:
+            container.add_item(ui.TextDisplay(f"Servers: {len(self.bot.guilds)}"))
+        self.add_item(container)
+
+        # Interactive children — ALWAYS present, with stable custom_ids.
+        row = ui.ActionRow()
+        btn = ui.Button(
+            label=t("...", locale=self.locale),
+            style=discord.ButtonStyle.primary,
+            custom_id=_CID_DO_THING,
+        )
+        btn.callback = self.on_do_thing
+        row.add_item(btn)
+        self.add_item(row)
+
+    async def on_do_thing(self, interaction: discord.Interaction):
+        # Re-derive EVERYTHING from interaction — self state may be empty.
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        # ... fetch data, rebuild view, edit message ...
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: <describe>."""
+        bot.add_view(cls())  # shell instance: bot=None, defaults everywhere
+```
+
+Then add the class to
+[`utils/persistent_views.py`](../utils/persistent_views.py) in
+`_collect_persistent_view_classes()`. That's it.
+
+---
+
+## Custom ID convention
+
+Format: `moddy:<cog>:<view>:<action>[:<param>...]`
+
+Define them as **module-level constants** (e.g. `_CID_MAIN_BACK`) so they
+show up in a single grep and typos can't silently break dispatch.
+
+| Scope | Example | Comment |
+|---|---|---|
+| Stateless | `moddy:moddy:main:attribution` | No state encoded — callback derives from interaction |
+| User-scoped | `moddy:reminder:delete:<user_id>` | Only the owner can click |
+| Guild-scoped | `moddy:config:welcome:<guild_id>` | Re-check permission on click |
+| Entity-scoped | `moddy:cases:view:<case_id>` | ID identifies a DB row |
+| Paginated | `moddy:saved:page:<user_id>:<page>` | Page is small int |
+
+### Never put in a `custom_id`
+- `locale` → fetch from interaction via `i18n.get_user_locale(interaction)`
+- Secrets, tokens, webhook URLs
+- Anything the user should not be able to see (custom_ids are exposed to the
+  Discord client)
+
+---
+
+## Authorization
+
+**No single rule fits every view.** Pick the simplest model that preserves
+today's UX, and document it in a comment above `register_persistent`.
+
+| View type | Auth model | How |
+|---|---|---|
+| Public informational (`/moddy`, `/invite`, `/user`, `/avatar`, `/banner`, `/roll`) | **Public** | No check. Anyone who can see the message can click. |
+| Personal data (reminders, preferences, saved messages, user cases) | **Owner only** | Encode `user_id` in custom_id, compare to `interaction.user.id` on click. Reject mismatches with an ephemeral error. |
+| Guild config panels (`/config`, `modules/configs/*`) | **Guild permission** | Encode `guild_id` in custom_id. On click, verify `interaction.guild_id` matches and the user has the required permission (usually `manage_guild`). |
+| Staff tools (`staff/*`) | **Staff rank** | On click, re-run `utils/staff_permissions.py` check — no user_id in custom_id. |
+
+When the auth check fails, respond with an ephemeral
+`utils/components_v2.create_error_message(...)` — never silently swallow.
+
+---
+
+## State reconstruction
+
+Persistent views cannot remember anything between clicks. That is actually
+*the* feature — it forces a clean flow:
+
+1. **Click arrives** → `on_foo(interaction)` runs on either the live view or
+   the registered shell.
+2. **Re-derive context** from `interaction`:
+   ```python
+   bot = interaction.client
+   locale = i18n.get_user_locale(interaction)
+   user_id = interaction.user.id
+   guild_id = interaction.guild_id
+   ```
+3. **Fetch fresh data** from the database / Discord API — don't trust any
+   cached list stored on `self`.
+4. **Build a new view** with the fresh state and `edit_message(view=...)`.
+
+### Working-copy / pending edits
+Some current views (e.g. `InterServerConfigView`) hold a
+`working_config` with unsaved changes in memory. After a restart those are
+lost. **Accepted UX**: the view rebuilds from the DB-saved config on the
+next click; the user re-applies their unsaved edits. No drafts table.
+
+---
+
+## Registration flow
+
+1. `bot.setup_hook()` runs once on startup
+2. Cogs are loaded via `await self.load_extensions()`
+3. Immediately after, `register_all_persistent_views(self)` is called
+4. That function walks `_collect_persistent_view_classes()` and calls
+   `cls.register_persistent(bot)` on each class
+5. Each class typically calls `bot.add_view(cls())` with a shell instance
+
+If a single view fails to register, the error is logged and the bot
+continues — persistence is best-effort, it should never prevent startup.
+
+---
+
+## Cookbook: migrating an existing view
+
+Given an existing `BaseView` subclass like `OldView(bot, guild_id, user_id, locale)`:
+
+1. **Pick an auth model** (see table above) and write it in a 1-line comment.
+2. **Make every constructor arg optional** with safe defaults so
+   `OldView()` works.
+3. **Guard any `self.bot.something` access** inside `_build_view` with
+   `if self.bot is not None:` so the shell can build without a live bot.
+4. **Add `custom_id` to every button / select** using module-level
+   constants. Namespaced: `moddy:<cog>:<view>:<action>`.
+5. **Rewrite callbacks** to re-derive `bot`, `locale`, `user_id`,
+   `guild_id` from `interaction` instead of `self`.
+6. **For user-scoped views**: parse the `user_id` out of the custom_id and
+   reject mismatches. (Use a `DynamicItem` subclass when the id is encoded
+   with a regex.)
+7. **Set `__persistent__ = True`**.
+8. **Implement `register_persistent`**: `bot.add_view(cls())`.
+9. **Add the class** to `utils/persistent_views.py::_collect_persistent_view_classes()`.
+10. **Smoke test**: instantiate a shell in an asyncio context and assert
+    `view.is_persistent() is True`.
+
+---
+
+## Verifying a view is persistent
+
+```python
+# In an async context (event loop required):
+v = MyView()  # shell, default args
+assert v.timeout is None
+assert v.is_persistent()
+for item in v.walk_children():
+    cid = getattr(item, "custom_id", None)
+    if cid:
+        print(cid)  # should match the namespaced constants
+```
+
+`bot.add_view(v)` will silently accept a non-persistent view on the None
+key, but clicks will never dispatch. Always assert `is_persistent()` in
+tests or at the top of `register_persistent`.
+
+---
+
+## Deliberate exclusions
+
+- **Modals (`BaseModal`)** — Discord treats modal submission as a one-shot
+  interaction tied to the owning message's in-memory component store.
+  `discord.ui.Modal` already defaults to `timeout=None`, so modals will
+  not expire mid-edit as long as the bot stays up. On restart, any open
+  modal is effectively lost — the user re-opens it.
+- **`ErrorView`** ([cogs/error_handler.py](../cogs/error_handler.py)) —
+  error-recovery UI with only URL buttons. Already `timeout=None`. No
+  dispatchable items to register.
+- **`cogs/webhook.py::WebhookView`** — displays webhook tokens / URLs which
+  are secret and should not be re-rendered after a restart. Keep as-is;
+  users re-run the command.

--- a/docs/sessions/2026-04-09_persistent-views-foundation.md
+++ b/docs/sessions/2026-04-09_persistent-views-foundation.md
@@ -1,0 +1,252 @@
+# Session: Persistent Views — Foundation + Group 1
+
+**Date:** 2026-04-09
+**Agent:** Claude Code (Opus 4.6)
+**Branch:** `feature/persistent-views-foundation`
+**Plan file:** `/home/codespace/.claude/plans/iterative-purring-quill.md`
+
+---
+
+## Context
+
+User request (FR): *"tu vas rendre tous les boutons et autre trucs d'interaction persistant c'est à dire sans timeout et même si on redémarre le bot ça recharge les boutons et il redeviennent dispo"*.
+
+Before this session, every View in Moddy had a timeout (180–300 s) and **no** views were registered with `bot.add_view()`. Result: buttons died after a few minutes and every bot restart killed every open interaction.
+
+User decisions made during planning:
+1. **Auth model**: per-view, judged by context — cannot generalize. Public informational commands get no check; personal data gets owner-only; guild config gets permission-based; staff tools use existing staff permission system.
+2. **Rollout**: foundation-first PR, then migrate Groups 2–5 in follow-up PRs. This session ships only the foundation and Group 1.
+
+---
+
+## Summary
+
+Shipped the persistence infrastructure plus the 4 trivial views (Group 1). Groups 2–5 (29 remaining view classes) are **deferred to follow-up PRs**, but every convention, helper, and doc needed to execute them is in place.
+
+What now works:
+- `BaseView` defaults to `timeout=None` — every existing view that didn't explicitly set a timeout will no longer expire in memory.
+- `/moddy`, `/moddy → Attribution`, `/moddy → We Support`, and the back buttons on both sub-views **survive a bot restart**.
+- Every custom_id follows the `moddy:<cog>:<view>:<action>` convention.
+- A single audit point (`utils/persistent_views.py::_collect_persistent_view_classes`) lists every persistent view class.
+- A full developer doc (`docs/PERSISTENT_VIEWS.md`) explains the pattern, custom_id convention, auth table, and a per-view migration cookbook.
+
+---
+
+## Changes Made
+
+### Foundation
+
+- **`cogs/error_handler.py`**
+  - `BaseView.__init__` signature changed from `(*args, **kwargs)` to `(*, timeout: Optional[float] = None, **kwargs)`. Default `timeout=None`. Backward compatible: any subclass still passing `timeout=180`/`300` overrides the default.
+  - Added `__persistent__: bool = False` class attribute.
+  - Added `register_persistent(cls, bot)` classmethod that raises `NotImplementedError` by default; subclasses with `__persistent__ = True` must override.
+  - Added docstring block explaining the persistence contract.
+  - `BaseModal`: no signature change (discord.py `ui.Modal` already defaults `timeout=None`). Added docstring note explaining modals cannot be persistent.
+  - `ErrorView` untouched (already `timeout=None`, contains only URL buttons).
+
+- **`utils/persistent_views.py`** *(new file)*
+  - `_collect_persistent_view_classes()` — explicit hand-maintained list of persistent view classes. No auto-discovery (intentional: diff-auditable).
+  - `register_all_persistent_views(bot)` — iterates the list, calls `cls.register_persistent(bot)` on each. Catches exceptions per-class so a broken view never aborts bot startup. Logs one `INFO` line with `registered/total` at the end.
+
+- **`bot.py`**
+  - In `setup_hook()`, added a call to `register_all_persistent_views(self)` immediately after `await self.load_extensions()`. Ordering is critical: cogs must be loaded so view classes are importable.
+
+### Group 1 — Views migrated
+
+- **`cogs/moddy.py`** — full refactor. All 3 views (`ModdyMainView`, `AttributionView`, `WeSupportView`) are now persistent. Changes:
+  - Module-level custom_id constants `_CID_MAIN_ATTRIBUTION`, `_CID_MAIN_WE_SUPPORT`, `_CID_ATTRIBUTION_BACK`, `_CID_WE_SUPPORT_BACK`.
+  - Every constructor arg is optional with safe defaults (`bot=None, locale="en-US", user_id=None`) so `cls()` works for shell registration.
+  - `ModdyMainView.build_view` guards `self.bot`-dependent stats with `if self.bot is not None:` — the shell builds a minimal content-less version without crashing.
+  - All button callbacks re-derive `bot`, `locale`, `user_id` from `interaction.client` / `i18n.get_user_locale(interaction)` / `interaction.user.id`. **Removed** the `interaction.user.id != self.user_id` check per the user's decision for informational commands.
+  - Each class has a `register_persistent(cls, bot)` that calls `bot.add_view(cls())` with a 1-line auth comment.
+  - `__persistent__ = True` on all three.
+
+- **`cogs/roll.py`** — `RollView` migrated from `ui.LayoutView` to `BaseView`. No buttons → not persistent. Explicit `timeout=180` dropped → inherits `None`. (This View was previously violating the CLAUDE.md rule that all Views must inherit `BaseView`.)
+
+- **`cogs/banner.py`** — Same as `roll.py`: `BannerView` migrated from `ui.LayoutView` → `BaseView`, `timeout=180` dropped.
+
+- **`cogs/avatar.py`** — `AvatarView` already inherited `BaseView`, just dropped the explicit `timeout=180`.
+
+### Documentation
+
+- **`CLAUDE.md`**
+  - Added new mandatory rule **8. Persistent Views** with a 5-step quick checklist.
+  - Bumped the old "Language" rule to #9.
+  - Added `docs/PERSISTENT_VIEWS.md` to the Core References table.
+
+- **`docs/PERSISTENT_VIEWS.md`** *(new file)* — ~230 lines covering:
+  - Why persistence, and how discord.py dispatch works.
+  - The Moddy contract (full code template).
+  - Custom ID convention + what never to encode.
+  - Authorization table (public / owner / guild permission / staff rank) with guidance per view type.
+  - State reconstruction pattern and the "lost in-flight config edits" UX decision.
+  - Registration flow diagram (setup_hook → load_extensions → register_all_persistent_views).
+  - **Cookbook: migrating an existing view** — 10-step recipe for Groups 2–5.
+  - How to verify a view is persistent (snippet).
+  - Deliberate exclusions (Modals, ErrorView, WebhookView).
+
+- **`docs/COMPONENTS_V2.md`** — added a callout below the LayoutView section warning never to inherit `ui.LayoutView` directly, and pointing to `PERSISTENT_VIEWS.md`.
+
+---
+
+## Decisions & Rationale
+
+1. **Default `timeout=None` on `BaseView`** instead of leaving it explicit per-view.
+   - Backward compatible (views passing `timeout=X` keep X).
+   - Eliminates the "view dies after 5 min" UX regardless of whether a view is registered persistent.
+   - No view in the repo needed a timeout > 0 for safety reasons — timeouts existed as discord.py defaults, not deliberate choices.
+
+2. **Explicit hand-maintained registry** in `_collect_persistent_view_classes()` instead of auto-discovering all `BaseView` subclasses with `__persistent__ = True`.
+   - One place to read/audit what survives a restart.
+   - No surprise registrations from future cogs accidentally flipping the flag.
+
+3. **Shell instances with `bot=None` + guarded `build_view`** instead of `DynamicItem` for Group 1.
+   - Simpler for views with no state or fully public state.
+   - `DynamicItem` is still the right answer for Groups 3–5 when `user_id` must be encoded in the custom_id. Documented in the cookbook.
+
+4. **Remove `interaction.user.id != self.user_id` check in `/moddy`** rather than encoding user_id in the custom_id.
+   - `/moddy` is an informational, mostly-ephemeral command. The current check was mostly cosmetic (ephemeral messages are only visible to invoker anyway).
+   - Per user's guidance: auth is per-context, and informational public commands get no check.
+   - If the user runs `/moddy incognito:False` (public message), other users can now click the buttons. This is a trivial behavior change, not a security issue — the only outcome is switching tabs in a public embed-like view.
+
+5. **Registration runs after `load_extensions` but before `status_update.start`** in `setup_hook`.
+   - Cogs must be loaded so `from cogs.moddy import ...` works.
+   - Must run before `on_ready` so the bot is ready to dispatch clicks the instant it comes online.
+
+6. **Failures are logged, not fatal.** A broken persistent view should never prevent startup — it just means clicks on that view's buttons will fall through until the next deploy.
+
+---
+
+## Verification
+
+All Foundation + Group 1 verification steps from the plan were executed:
+
+### Static
+- `grep custom_id= cogs/moddy.py` → 4 unique namespaced custom_ids, all matching the module-level constants.
+- `grep timeout= cogs/error_handler.py` → `BaseView.__init__` now `timeout: Optional[float] = None`.
+- `grep "add_view\|register_persistent\|register_all_persistent_views" bot.py utils/persistent_views.py` → registration wired in both places.
+
+### Runtime (offline smoke test, no live Discord)
+- Instantiated `ModdyMainView()`, `AttributionView()`, `WeSupportView()` as shells inside an event loop.
+- All three returned `is_persistent() == True` with `timeout=None`.
+- `walk_children()` enumeration found all 4 custom_ids registered correctly.
+- `register_all_persistent_views(FakeBot())` logged `Persistent views registered (3/3)` and the `ViewStore` contained all 4 `(type, custom_id)` keys under `None`.
+- `BaseView(timeout=300)` → `300` (backward compat).
+- `BaseView()` → `None` (new default).
+- `RollView`, `BannerView`, `AvatarView` all inherit `timeout=None`.
+
+### Not yet verified (requires live bot — do this after merge)
+- Click `/moddy` buttons → restart bot → click the same buttons → should still work.
+- Click `/moddy → Attribution → Back` flow end-to-end.
+- No `CommandInvokeError: Unknown interaction` on restart.
+- Expected log line: `INFO:moddy.persistent_views:Persistent views registered (3/3)`.
+
+---
+
+## ⚠️ Follow-up work — Groups 2–5
+
+The foundation is ready. Each group below is **self-contained** and can be shipped as its own PR. Follow `docs/PERSISTENT_VIEWS.md` cookbook for each view. The list is ordered by effort (easiest first).
+
+### Group 2 — External lookup (re-fetch by identifier)
+
+Views whose state is a snapshot fetched from an external API. Encode the identifier in the custom_id and re-fetch on each click.
+
+| View | File | State to encode | Auth | Notes |
+|---|---|---|---|---|
+| `InviteView` | `cogs/invite.py:20` | invite `code` (string) | Public | `custom_id`s to add: `moddy:invite:server_info:<code>`, `moddy:invite:raw:<code>`. Currently has **no custom_ids at all** (lines 65, 74, 87). Re-fetch invite via Discord API on click. |
+| `ServerInfoView` | `cogs/invite.py:375` | invite `code` | Public | Same pattern. |
+| `UserInfoView` | `cogs/user.py:24` | target `user_id` | Public | Encode target user id; re-fetch `discord.User` on click. |
+| `EmojiView` | `cogs/emoji.py:20` | emoji id | Public | — |
+| `EmojiNavigationView` | `cogs/emoji.py:87` | `(guild_id, page)` for pagination | Public | Re-query emoji list from guild on click. |
+| `TranslateView` | `cogs/translate.py:22` | **SKIP persistence** | — | Translation results are transient; cost of re-calling DeepL on every click is not worth it. Just set `timeout=None` (inherited) and stop. |
+
+**Estimated effort:** 1 PR, ~3–4 hours.
+
+### Group 3 — User-scoped DB lookup
+
+Views whose state is entirely reconstructable from `user_id` + DB. Use `DynamicItem` subclasses to encode `user_id` in the custom_id regex; verify `interaction.user.id == parsed_user_id` on click.
+
+| View | File | Refactor notes |
+|---|---|---|
+| `PreferencesView` | `cogs/preferences.py:110` | Fetch prefs from `bot.db.users.get_preferences(user_id)` per click. Custom_id: `moddy:preferences:<action>:<user_id>`. |
+| `RemindersManageView` | `cogs/reminder.py:478` | Biggest in this group. State: `user_id`, `show_history` flag, pagination. Buttons: `add`, `edit`, `delete`, `back`, `history`. Drop `self.reminders` / `self.past_reminders` — re-query via `bot.db.reminders.get_active_by_user(user_id)` / `get_history_by_user(user_id)` on every click. Existing non-namespaced custom_ids (`back_btn`, `add_btn`, `edit_btn`) **must be renamed** to `moddy:reminder:<action>:<user_id>` to avoid collisions. |
+| `SavedMessagesLibraryView` | `cogs/saved_messages.py:222` | State: `user_id`, `page`, `show_detail`, `detail_msg_id`. Drop `self.messages` entirely — re-query `bot.db.saved_messages.list_for_user(user_id, offset, limit)` per click. Custom_id: `moddy:saved:<action>:<user_id>:<page>`. Note there are associated `BaseModal` subclasses (`AddNoteModal`, `EditNoteModal` at lines 92, 151) — leave them alone, modals can't be persistent. |
+| `CaseDetailView` | `cogs/cases_user.py:24` | Encode `case_id`. Fetch case from DB. Owner check: load `case.user_id`, compare to `interaction.user.id`. |
+| `SubscriptionView` | `cogs/subscription.py:20` | Subscription status is per-user. Encode `user_id`. Re-fetch Stripe status from DB per click. |
+
+**Estimated effort:** 2 PRs (one for `reminder.py` alone, one for the rest), ~6–8 hours total.
+
+**Gotcha:** `RemindersManageView` uses `AddReminderModal` / `EditReminderModal` which are `BaseModal` subclasses. Modals can still be opened from persistent callbacks — they just can't themselves be persistent. The modal submit handler runs while the bot has in-memory state, so no refactor needed there.
+
+### Group 4 — Guild config panels (biggest refactor)
+
+Views holding a `working_config` with pending unsaved edits. Accepted UX: on restart, the view rebuilds from the DB-saved config and pending edits are lost (documented in `docs/PERSISTENT_VIEWS.md`).
+
+Pattern for all of them:
+- Custom_id root: `moddy:config:<module>:<action>:<guild_id>`
+- Auth: on click, verify `interaction.guild_id` matches the encoded `guild_id` **and** `interaction.user.guild_permissions.manage_guild` (or the module-specific permission).
+- Rebuild: on every click, re-fetch module config from `bot.db.guilds.get_module_config(guild_id, module_name)` and rebuild a fresh view.
+- **Drop** `self.working_config`, `self.has_changes` — save directly on each interaction (auto-save) OR accept that pending edits are lost on restart.
+
+| View | File |
+|---|---|
+| `ConfigMainView` | `cogs/config.py:19` |
+| `AutoRestoreRolesConfigView` | `modules/configs/auto_restore_roles_config.py:18` |
+| `AutoRoleConfigView` | `modules/configs/auto_role_config.py:18` |
+| `InterServerConfigView` | `modules/configs/interserver_config.py:18` |
+| `StarboardConfigView` | `modules/configs/starboard_config.py:53` |
+| `WelcomeChannelConfigView` | `modules/configs/welcome_channel_config.py:119` |
+| `WelcomeDmConfigView` | `modules/configs/welcome_dm_config.py:119` |
+| `EditSubscriptionView` | `modules/configs/youtube_notifications_config.py:124` |
+| `YoutubeNotificationsConfigView` | `modules/configs/youtube_notifications_config.py:388` |
+
+**Decision needed** before starting Group 4: do we want **auto-save on every interaction** (no working copy at all) or keep the current "edit → save" UX and accept lost edits on restart? I'd recommend **auto-save** — simpler code, matches web dashboards, and pending edits being lost on restart feels buggier than "whoops, I saved too early".
+
+**Estimated effort:** 2–3 PRs (one for `config.py` + `auto_role` / `auto_restore_roles` as warm-up, one for the complex `interserver` + `starboard`, one for `welcome_*` + `youtube_*`), ~8–12 hours total.
+
+### Group 5 — Staff / utility views
+
+| View | File | Notes |
+|---|---|---|
+| `ServerListView` | `staff/dev_commands.py:28` | Pagination over the bot's guild list. Encode `(user_id, page)`. Staff-only. Fetch guild list from `bot.guilds` on click. |
+| `RoleSelectView` | `staff/staff_manager.py:41` | Select menu for staff rank management. Currently `ui.View` — must migrate to `BaseView`. Owner-scoped. |
+| `StaffPermissionsManagementView` | `staff/staff_manager.py:212` | Biggest staff view. Encode target staff member `user_id`. Re-check caller's rank on click via `utils/staff_permissions.py`. |
+| `CaseSelectionView` | `utils/case_management_views.py:334` | Encode pagination + filter. Staff-only. |
+| `StaffHelpView` | `utils/staff_help_view.py:103` | Pagination over staff command list. Staff-only. |
+
+**Estimated effort:** 1 PR, ~4 hours. Use `utils/staff_permissions.py::check_permission(user, permission)` inside every callback to re-auth.
+
+### Explicitly NOT migrating
+
+- **All `BaseModal` subclasses** (~18 of them). Discord doesn't support persistent modals. They already default to `timeout=None` via `discord.ui.Modal`.
+- **`cogs/webhook.py::WebhookView`** — shows webhook tokens/URLs which are secret. Not safe to re-render after restart. Keep as-is.
+- **`cogs/error_handler.py::ErrorView`** — URL buttons only, already `timeout=None`.
+
+---
+
+## Known Issues
+
+- **None observed during smoke test.** But the full verification plan still requires a live bot restart test (step 2 of the Verification section above), which was not executed in this session because it requires deploying to the dev Railway environment.
+
+- **Potential: custom_id collisions in unmigrated views.** Some Group 2–5 views have existing non-namespaced custom_ids like `"back_btn"`, `"add_btn"`, `"edit_btn"` (see `cogs/reminder.py:536, 581, 590`). These are currently fine because they are not registered as persistent, but the moment their parent views get migrated, **they will collide with each other**. The Group 3 PR that migrates `RemindersManageView` must rename them to `moddy:reminder:<action>:<user_id>`.
+
+- **`staff_manager.py::RoleSelectView` inherits `ui.View`** (not `ui.LayoutView` / `BaseView`). This is a pre-existing CLAUDE.md rule violation. Can be fixed as part of the Group 5 PR.
+
+---
+
+## Files Touched (final list)
+
+Created:
+- `utils/persistent_views.py`
+- `docs/PERSISTENT_VIEWS.md`
+- `docs/sessions/2026-04-09_persistent-views-foundation.md` (this file)
+
+Modified:
+- `cogs/error_handler.py` — BaseView signature + persistence hooks + BaseModal docstring
+- `bot.py` — register_all_persistent_views call in setup_hook
+- `cogs/moddy.py` — full persistence refactor (3 view classes)
+- `cogs/roll.py` — migrated to BaseView, dropped explicit timeout
+- `cogs/banner.py` — migrated to BaseView, dropped explicit timeout
+- `cogs/avatar.py` — dropped explicit timeout (was already BaseView)
+- `CLAUDE.md` — new "Persistent Views" mandatory rule + doc pointer
+- `docs/COMPONENTS_V2.md` — callout pointing to PERSISTENT_VIEWS.md

--- a/utils/persistent_views.py
+++ b/utils/persistent_views.py
@@ -1,0 +1,76 @@
+"""
+Persistent view registry for Moddy.
+
+This module is the single place where every ``BaseView`` subclass that must
+survive a bot restart is registered. It is called once in
+``bot.setup_hook`` after all cogs have been loaded.
+
+See ``docs/PERSISTENT_VIEWS.md`` for the full pattern, custom_id convention,
+and a cookbook for adding a new persistent view.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, List, Type
+
+if TYPE_CHECKING:
+    from cogs.error_handler import BaseView
+    from bot import ModdyBot
+
+logger = logging.getLogger('moddy.persistent_views')
+
+
+def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
+    """
+    Explicit registry of persistent view classes.
+
+    New persistent views are added here by hand (no auto-discovery) so the
+    full list of what survives a restart is always visible in one place and
+    trivially auditable in a PR diff.
+    """
+    # Imported lazily so this module can be imported before cogs are loaded.
+    from cogs.moddy import ModdyMainView, AttributionView, WeSupportView
+
+    return [
+        # Group 1 — /moddy (public informational, no user auth)
+        ModdyMainView,
+        AttributionView,
+        WeSupportView,
+    ]
+
+
+def register_all_persistent_views(bot: "ModdyBot") -> None:
+    """
+    Instantiate and register every persistent view class.
+
+    Each class is expected to:
+    - Have ``__persistent__ = True``
+    - Implement ``register_persistent(bot)`` which calls
+      ``bot.add_view(cls())`` and/or ``bot.add_dynamic_items(...)``.
+
+    Failures are logged but do not abort bot startup — a broken persistent
+    view should never take the entire bot down.
+    """
+    classes = _collect_persistent_view_classes()
+    logger.info(f"Registering {len(classes)} persistent view classes...")
+
+    registered = 0
+    for cls in classes:
+        if not getattr(cls, '__persistent__', False):
+            logger.warning(
+                f"{cls.__name__} is in the persistent view registry but its "
+                f"__persistent__ attribute is False — skipping."
+            )
+            continue
+        try:
+            cls.register_persistent(bot)
+            registered += 1
+            logger.debug(f"Registered persistent view: {cls.__name__}")
+        except Exception as e:
+            logger.error(
+                f"Failed to register persistent view {cls.__name__}: {e}",
+                exc_info=True,
+            )
+
+    logger.info(f"Persistent views registered ({registered}/{len(classes)})")


### PR DESCRIPTION
Buttons now default to timeout=None via BaseView and can be registered as persistent so they survive bot restarts. This commit ships the foundation (BaseView hook, registry, docs) plus the 4 Group 1 views that were safe to migrate without DB refactoring. Groups 2-5 (29 remaining views) are documented in docs/sessions/2026-04-09_persistent-views-foundation.md as scoped follow-up PRs and are intentionally left untouched — they still pass explicit timeouts so their runtime behavior is unchanged.

Foundation:
- BaseView.__init__ defaults to timeout=None (backward compatible: any subclass still passing timeout=X keeps X)
- New __persistent__ class flag + register_persistent classmethod hook
- utils/persistent_views.py: explicit hand-maintained registry + register_all_persistent_views(bot), called in bot.setup_hook after load_extensions
- docs/PERSISTENT_VIEWS.md: full pattern, custom_id convention, auth table, and per-view migration cookbook
- CLAUDE.md: new mandatory "Persistent Views" rule

Group 1 (persistent):
- cogs/moddy.py: ModdyMainView, AttributionView, WeSupportView — all three now register via bot.add_view(cls()) with namespaced custom_ids (moddy:moddy:<view>:<action>). Callbacks re-derive state from interaction; auth model is public (informational command).

Group 1 (BaseView migration only, no interactive elements):
- cogs/roll.py: RollView ui.LayoutView -> BaseView
- cogs/banner.py: BannerView ui.LayoutView -> BaseView
- cogs/avatar.py: AvatarView drop explicit timeout

Verification:
- All 28 view-containing modules import cleanly
- Shell instances of Group 1 views return is_persistent() == True
- register_all_persistent_views logs "Persistent views registered (3/3)"
- BaseView(timeout=300) still returns 300 (backward compat)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>