### PR TITLE
Implement subscription system with Redis cache and Pub/Sub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,9 @@ moddy/
 │   ├── cog_manager.py         #   Hot-reload / disable cogs
 │   ├── console_logger.py      #   Console logging
 │   ├── dev_logger.py          #   Dev logging
-│   └── dev_tools.py           #   Developer tools
+│   ├── dev_tools.py           #   Developer tools
+│   ├── subscription.py        #   /subscription command (user subscription status)
+│   └── staff_subscription.py  #   /staff subscription-info command (staff view)
 │
 ├── modules/                   # Server-level configurable features
 │   ├── module_manager.py      #   ModuleManager + ModuleBase class
@@ -82,6 +84,7 @@ moddy/
 │       ├── reminders.py, saved_messages.py, saved_roles.py
 │       ├── moderation.py, interserver.py, attributes.py
 │       ├── token_alerts.py, token_secrets.py
+│       ├── subscription.py    #   Subscription read-only queries
 │       └── _utils.py
 │
 ├── utils/                     # Utility modules
@@ -89,6 +92,7 @@ moddy/
 │   ├── emojis.py              #   Emoji constants
 │   ├── components_v2.py       #   V2 helper functions (create_error_message, etc.)
 │   ├── staff_permissions.py   #   Permission system
+│   ├── subscription.py        #   Subscription helper (is_subscribed, get_subscription)
 │   ├── staff_logger.py        #   Staff action logging
 │   ├── staff_role_permissions.py
 │   ├── staff_help_view.py
@@ -220,6 +224,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | Document | When to Read |
 |---|---|
 | [docs/BACKEND-INTEGRATION.md](docs/BACKEND-INTEGRATION.md) | Bot ↔ Backend integration (Redis, Pub/Sub, Streams, `/status`) |
+| [docs/SUBSCRIPTION_SCHEMA.md](docs/SUBSCRIPTION_SCHEMA.md) | Subscription DB schema, Redis cache contract, Pub/Sub events |
 | [docs/RAILWAY.md](docs/RAILWAY.md) | Environment variables, deployment, troubleshooting |
 
 ### Other

--- a/bot.py
+++ b/bot.py
@@ -212,24 +212,126 @@ class ModdyBot(commands.Bot):
             self.redis = None
 
     async def _listen_pubsub(self):
-        """Listen to Redis Pub/Sub channel moddy:bot (non-critical backend notifications)."""
+        """Listen to Redis Pub/Sub channels (non-critical backend notifications)."""
         import json
         while True:
             try:
                 pubsub = self.redis.pubsub()
-                await pubsub.subscribe("moddy:bot")
-                logger.info("Pub/Sub subscribed to moddy:bot")
+                await pubsub.subscribe("moddy:bot", "moddy:subscription:updates")
+                logger.info("Pub/Sub subscribed to moddy:bot and moddy:subscription:updates")
                 async for message in pubsub.listen():
                     if message["type"] != "message":
                         continue
                     try:
                         data = json.loads(message["data"])
-                        await self._handle_bot_event(data)
+                        channel = message.get("channel", "")
+                        if channel == "moddy:subscription:updates":
+                            await self._handle_subscription_event(data)
+                        else:
+                            await self._handle_bot_event(data)
                     except Exception as e:
                         logger.error(f"[PubSub] Error handling message: {e}")
             except Exception as e:
                 logger.error(f"[PubSub] Connection error: {e}")
                 await asyncio.sleep(5)
+
+    async def _handle_subscription_event(self, data: dict):
+        """Handle events from the moddy:subscription:updates channel."""
+        from utils.subscription import invalidate_cache
+        event_type = data.get("type")
+        user_id_raw = data.get("user_id")
+
+        if not user_id_raw:
+            logger.warning(f"[SubPubSub] Missing user_id in event: {data}")
+            return
+
+        try:
+            user_id = int(user_id_raw)
+        except (ValueError, TypeError):
+            logger.warning(f"[SubPubSub] Invalid user_id: {user_id_raw}")
+            return
+
+        if event_type == "refresh":
+            await invalidate_cache(self, user_id)
+            logger.info(f"[SubPubSub] Cache invalidated for user {user_id}")
+
+        elif event_type == "notify_payment_late":
+            await invalidate_cache(self, user_id)
+            await self._send_subscription_dm(user_id, "payment_late")
+
+        elif event_type == "notify_subscription_started":
+            tier = data.get("tier")
+            await invalidate_cache(self, user_id)
+            await self._send_subscription_dm(user_id, "subscription_started", tier=tier)
+
+        elif event_type == "notify_subscription_renewed":
+            tier = data.get("tier")
+            await invalidate_cache(self, user_id)
+            await self._send_subscription_dm(user_id, "subscription_renewed", tier=tier)
+
+        else:
+            logger.debug(f"[SubPubSub] Unknown subscription event type: {event_type}")
+
+    async def _send_subscription_dm(self, user_id: int, event: str, tier: str | None = None):
+        """Send a DM to a user for a subscription lifecycle event."""
+        import discord
+        from discord import ui
+        from utils.emojis import PREMIUM, WARNING, GREEN_STATUS
+
+        try:
+            user = await self.fetch_user(user_id)
+        except discord.NotFound:
+            logger.warning(f"[SubDM] User {user_id} not found, cannot send DM")
+            return
+        except Exception as e:
+            logger.error(f"[SubDM] Error fetching user {user_id}: {e}")
+            return
+
+        tier_label = tier or "Moddy Max"
+
+        if event == "subscription_started":
+            content = (
+                f"### {PREMIUM} Abonnement activé\n"
+                f"{GREEN_STATUS} Ton abonnement **{tier_label}** est maintenant actif. Merci pour ton soutien !\n\n"
+                "-# Gère ton abonnement sur [dashboard.moddy.app/billing](https://dashboard.moddy.app/billing)"
+            )
+        elif event == "subscription_renewed":
+            content = (
+                f"### {PREMIUM} Abonnement renouvelé\n"
+                f"{GREEN_STATUS} Ton abonnement **{tier_label}** a été renouvelé avec succès.\n\n"
+                "-# Gère ton abonnement sur [dashboard.moddy.app/billing](https://dashboard.moddy.app/billing)"
+            )
+        elif event == "payment_late":
+            content = (
+                f"### {WARNING} Problème de paiement\n"
+                "Un problème est survenu lors du renouvellement de ton abonnement.\n"
+                "Merci de mettre à jour tes informations de paiement pour maintenir l'accès.\n\n"
+                "-# Gère ton abonnement sur [dashboard.moddy.app/billing](https://dashboard.moddy.app/billing)"
+            )
+        else:
+            return
+
+        container = ui.Container()
+        container.add_item(ui.TextDisplay(content))
+
+        view = ui.LayoutView()
+        view.add_item(container)
+
+        row = ui.ActionRow()
+        row.add_item(ui.Button(
+            label="Gérer mon abonnement",
+            url="https://dashboard.moddy.app/billing",
+            style=discord.ButtonStyle.link,
+        ))
+        view.add_item(row)
+
+        try:
+            await user.send(view=view)
+            logger.info(f"[SubDM] Sent {event} DM to user {user_id}")
+        except discord.Forbidden:
+            logger.info(f"[SubDM] Cannot DM user {user_id} (DMs closed)")
+        except Exception as e:
+            logger.error(f"[SubDM] Error sending DM to user {user_id}: {e}")
 
     async def _handle_bot_event(self, data: dict):
         """Route Pub/Sub events from the backend."""

--- a/cogs/staff_subscription.py
+++ b/cogs/staff_subscription.py
@@ -1,0 +1,156 @@
+"""
+/staff subscription-info <user> — staff-only view of a user's subscription.
+Shows all subscription fields including stripe_customer_id and server linked timestamps.
+"""
+
+import logging
+from datetime import timezone
+
+import discord
+from discord import app_commands, ui
+from discord.ext import commands
+
+from cogs.error_handler import BaseView
+from utils.components_v2 import create_error_message
+from utils.emojis import GREEN_STATUS, RED_STATUS, STAFF
+from utils.subscription import get_subscription
+
+logger = logging.getLogger('moddy.cogs.staff_subscription')
+
+
+class StaffSubscriptionView(BaseView):
+    """Components V2 view for the staff subscription-info command."""
+
+    def __init__(self, bot, target: discord.User, sub: dict | None, servers: list):
+        super().__init__(timeout=300)
+        self.bot = bot
+        self.target = target
+        self.sub = sub
+        self.servers = servers
+        self._build()
+
+    def _build(self):
+        self.clear_items()
+        container = ui.Container()
+
+        container.add_item(ui.TextDisplay(
+            f"### {STAFF} Informations d'abonnement\n"
+            f"Utilisateur : **{self.target.display_name}** (`{self.target.id}`)"
+        ))
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        if self.sub and self.sub.get('is_active'):
+            tier = self.sub.get('tier') or 'Moddy Max'
+            container.add_item(ui.TextDisplay(
+                f"{GREEN_STATUS} **Abonnement actif** — tier : `{tier}`"
+            ))
+        else:
+            container.add_item(ui.TextDisplay(
+                f"{RED_STATUS} **Aucun abonnement actif**"
+            ))
+
+        expires_at = self.sub.get('expires_at') if self.sub else None
+        if expires_at:
+            ts = int(expires_at.astimezone(timezone.utc).timestamp())
+            container.add_item(ui.TextDisplay(
+                f"**Expire le :** `{expires_at.strftime('%Y-%m-%d %H:%M UTC')}` (<t:{ts}:R>)"
+            ))
+        else:
+            container.add_item(ui.TextDisplay("**Expire le :** `-`"))
+
+        stripe_id = self.sub.get('stripe_customer_id') if self.sub else None
+        if stripe_id:
+            container.add_item(ui.TextDisplay(
+                f"**Stripe customer ID :** `{stripe_id}`"
+            ))
+        else:
+            container.add_item(ui.TextDisplay("**Stripe customer ID :** `-`"))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        count = len(self.servers)
+        container.add_item(ui.TextDisplay(f"**Serveurs liés :** `{count}/5`"))
+
+        if self.servers:
+            lines = []
+            for s in self.servers:
+                added = s['added_at']
+                ts = int(added.astimezone(timezone.utc).timestamp()) if added else 0
+                lines.append(f"- `{s['server_id']}` — ajouté <t:{ts}:D>")
+            container.add_item(ui.TextDisplay("\n".join(lines)))
+        else:
+            container.add_item(ui.TextDisplay("-# Aucun serveur lié."))
+
+        self.add_item(container)
+
+
+class StaffSubscription(commands.Cog):
+    """Staff subscription-info slash command."""
+
+    staff_group = app_commands.Group(
+        name="staff",
+        description="Staff-only commands",
+    )
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    async def _is_staff(self, user_id: int) -> bool:
+        if self.bot.is_developer(user_id):
+            return True
+        if not self.bot.db:
+            return False
+        perms = await self.bot.db.get_staff_permissions(user_id)
+        return bool(perms and perms.get('roles'))
+
+    @staff_group.command(
+        name="subscription-info",
+        description="[Staff] Affiche les informations d'abonnement d'un utilisateur",
+    )
+    @app_commands.describe(user="L'utilisateur dont afficher l'abonnement")
+    @app_commands.allowed_installs(guilds=True, users=True)
+    @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
+    async def subscription_info(
+        self,
+        interaction: discord.Interaction,
+        user: discord.User,
+    ):
+        if not await self._is_staff(interaction.user.id):
+            await interaction.response.send_message(
+                view=create_error_message(
+                    "Accès refusé",
+                    "Cette commande est réservée au staff de Moddy.",
+                ),
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+
+        try:
+            sub = await get_subscription(self.bot, user.id)
+            servers = []
+            if self.bot.db:
+                servers = await self.bot.db.get_subscription_servers(user.id)
+        except Exception as e:
+            logger.error(
+                f"Staff subscription fetch error for {user.id} "
+                f"by {interaction.user.id}: {e}",
+                exc_info=True,
+            )
+            await interaction.followup.send(
+                view=create_error_message(
+                    "Erreur",
+                    "Impossible de récupérer les données d'abonnement.",
+                ),
+                ephemeral=True,
+            )
+            return
+
+        view = StaffSubscriptionView(self.bot, user, sub, servers)
+        await interaction.followup.send(view=view, ephemeral=True)
+
+
+async def setup(bot):
+    await bot.add_cog(StaffSubscription(bot))
+    logger.info("StaffSubscription cog loaded")

--- a/cogs/subscription.py
+++ b/cogs/subscription.py
@@ -1,112 +1,140 @@
 """
-Commande /subscription — affiche le statut Premium de l'utilisateur.
-Les données sont lues directement depuis la base de données partagée.
-Les détails complets (factures, période de renouvellement) sont sur le dashboard.
+/subscription command — displays the user's subscription status.
+Reads from Redis cache (sub:user:{id}) with DB fallback.
+The bot never modifies subscription data.
 """
+
+import logging
+from datetime import timezone
 
 import discord
 from discord import app_commands, ui
 from discord.ext import commands
-import logging
 
 from cogs.error_handler import BaseView
+from utils.components_v2 import create_error_message
+from utils.emojis import PREMIUM, GREEN_STATUS, RED_STATUS, DONE
 from utils.i18n import t
-from utils.emojis import PREMIUM, WARNING, GREEN_STATUS, RED_STATUS, INFO, ERROR
+from utils.subscription import get_subscription
 
 logger = logging.getLogger('moddy.cogs.subscription')
 
 
 class SubscriptionView(BaseView):
-    """Vue Components V2 pour le statut d'abonnement."""
+    """Components V2 view for the /subscription command."""
 
-    def __init__(self, bot, user_id: int, is_premium: bool, stripe_customer_id: str | None):
+    def __init__(self, bot, user_id: int, sub: dict | None, servers: list, locale: str):
         super().__init__(timeout=300)
         self.bot = bot
         self.user_id = user_id
-        self.is_premium = is_premium
-        self.stripe_customer_id = stripe_customer_id
-        self._build_view()
+        self.sub = sub
+        self.servers = servers
+        self.locale = locale
+        self._build()
 
-    def _build_view(self):
+    def _build(self):
         self.clear_items()
         container = ui.Container()
 
-        container.add_item(ui.TextDisplay(f"### {PREMIUM} Your Subscription"))
+        container.add_item(ui.TextDisplay(
+            t('commands.subscription.title', locale=self.locale,
+              premium=PREMIUM)
+        ))
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
 
-        if self.is_premium:
+        if self.sub and self.sub.get('is_active'):
+            tier = self.sub.get('tier') or 'Moddy Max'
             container.add_item(ui.TextDisplay(
-                f"{GREEN_STATUS} **Active Subscription**\n"
-                "-# Your account has an active Moddy Premium subscription."
+                t('commands.subscription.active', locale=self.locale,
+                  green=GREEN_STATUS, tier=tier)
             ))
-            container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
-            container.add_item(ui.TextDisplay(
-                "For billing details, invoices and renewal date, visit your dashboard."
-            ))
+
+            expires_at = self.sub.get('expires_at')
+            if expires_at:
+                ts = int(expires_at.astimezone(timezone.utc).timestamp())
+                container.add_item(ui.TextDisplay(
+                    t('commands.subscription.expires', locale=self.locale,
+                      date=f"<t:{ts}:D>")
+                ))
+
+            if self.sub.get('stripe_customer_id'):
+                container.add_item(ui.TextDisplay(
+                    t('commands.subscription.stripe_linked', locale=self.locale,
+                      done=DONE)
+                ))
         else:
             container.add_item(ui.TextDisplay(
-                f"{RED_STATUS} **No Active Subscription**\n"
-                "-# You don't have an active Moddy Premium subscription."
+                t('commands.subscription.inactive', locale=self.locale,
+                  red=RED_STATUS)
             ))
-            container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        count = len(self.servers)
+        container.add_item(ui.TextDisplay(
+            t('commands.subscription.servers_title', locale=self.locale,
+              count=count)
+        ))
+
+        if self.servers:
+            lines = "\n".join(
+                t('commands.subscription.server_entry', locale=self.locale,
+                  server_id=s['server_id'])
+                for s in self.servers
+            )
+            container.add_item(ui.TextDisplay(lines))
+        else:
             container.add_item(ui.TextDisplay(
-                "**Subscribe to Moddy Premium** to unlock exclusive features!\n"
-                "-# Visit our website to get started."
+                t('commands.subscription.servers_empty', locale=self.locale)
             ))
 
         self.add_item(container)
 
         row = ui.ActionRow()
         row.add_item(ui.Button(
-            label="Dashboard",
-            url="https://moddy.app/dashboard",
+            label=t('commands.subscription.manage_button', locale=self.locale),
+            url="https://dashboard.moddy.app/billing",
             style=discord.ButtonStyle.link,
         ))
         self.add_item(row)
 
 
 class Subscription(commands.Cog):
-    """Commandes liées aux abonnements Premium."""
+    """Subscription status command."""
 
     def __init__(self, bot):
         self.bot = bot
 
     @app_commands.command(
         name="subscription",
-        description="View your Moddy Premium subscription status"
+        description="View your Moddy subscription status",
     )
     @app_commands.allowed_installs(guilds=True, users=True)
     @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
     async def subscription(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
 
-        is_premium = False
-        stripe_customer_id = None
+        locale = str(interaction.locale)
+        user_id = interaction.user.id
 
-        if self.bot.db:
-            try:
-                is_premium = await self.bot.db.has_attribute('user', interaction.user.id, 'PREMIUM')
-                user_data = await self.bot.db.get_user(interaction.user.id)
-                stripe_customer_id = user_data.get('stripe_customer_id') if user_data else None
-            except Exception as e:
-                logger.error(f"DB error for user {interaction.user.id}: {e}", exc_info=True)
-                await interaction.followup.send(
-                    view=_error_view(),
-                    ephemeral=True,
-                )
-                return
+        try:
+            sub = await get_subscription(self.bot, user_id)
+            servers = []
+            if self.bot.db:
+                servers = await self.bot.db.get_subscription_servers(user_id)
+        except Exception as e:
+            logger.error(f"Subscription fetch error for {user_id}: {e}", exc_info=True)
+            await interaction.followup.send(
+                view=create_error_message(
+                    "Error",
+                    t('commands.subscription.error', locale=locale),
+                ),
+                ephemeral=True,
+            )
+            return
 
-        view = SubscriptionView(self.bot, interaction.user.id, is_premium, stripe_customer_id)
+        view = SubscriptionView(self.bot, user_id, sub, servers, locale)
         await interaction.followup.send(view=view, ephemeral=True)
-        logger.info(f"Subscription status shown for user {interaction.user.id} (premium={is_premium})")
-
-
-def _error_view():
-    """Vue d'erreur simple."""
-    from utils.components_v2 import create_error_message
-    return create_error_message(
-        "Error",
-        "Unable to retrieve your subscription status. Please try again later.",
-    )
 
 
 async def setup(bot):

--- a/db/base.py
+++ b/db/base.py
@@ -22,6 +22,7 @@ from db.repositories.moderation import ModerationRepository
 from db.repositories.saved_roles import SavedRolesRepository
 from db.repositories.token_alerts import TokenAlertRepository
 from db.repositories.token_secrets import TokenSecretRepository
+from db.repositories.subscription import SubscriptionRepository
 
 logger = logging.getLogger('moddy.database')
 
@@ -44,6 +45,7 @@ class ModdyDatabase(
     SavedRolesRepository,
     TokenAlertRepository,
     TokenSecretRepository,
+    SubscriptionRepository,
 ):
     """Gestionnaire principal de la base de données"""
 

--- a/db/migrations/subscription.sql
+++ b/db/migrations/subscription.sql
@@ -1,0 +1,26 @@
+-- Subscription system migration
+-- Run once against the railway DB.
+-- stripe_customer_id already exists on users — skip if present.
+
+-- 1. Add subscription columns to users (idempotent)
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS subscription_expires_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS subscription_tier       TEXT;
+
+-- 2. Subscription plans catalogue
+CREATE TABLE IF NOT EXISTS subscription_plans (
+    id        TEXT PRIMARY KEY,
+    name      TEXT        NOT NULL,
+    is_active BOOLEAN     NOT NULL DEFAULT true
+);
+
+INSERT INTO subscription_plans (id, name) VALUES ('max', 'Moddy Max')
+    ON CONFLICT (id) DO NOTHING;
+
+-- 3. Servers linked to a user subscription (max 5 per user)
+CREATE TABLE IF NOT EXISTS subscription_servers (
+    user_id   TEXT        NOT NULL REFERENCES users(id),
+    server_id TEXT        NOT NULL REFERENCES servers(id),
+    added_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, server_id)
+);

--- a/db/repositories/subscription.py
+++ b/db/repositories/subscription.py
@@ -1,0 +1,69 @@
+"""
+Subscription repository — read-only access to subscription data.
+The bot never writes subscription_* or stripe_customer_id columns.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger('moddy.database.subscription')
+
+
+class SubscriptionRepository:
+    """Read-only subscription queries."""
+
+    async def get_subscription(self, user_id: int) -> Optional[Dict[str, Any]]:
+        """
+        Return subscription info for a user, or None if no subscription row exists.
+
+        Returns dict with keys:
+            tier               (str | None)
+            expires_at         (datetime | None)
+            stripe_customer_id (str | None)
+            is_active          (bool)
+        """
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT subscription_tier,
+                       subscription_expires_at,
+                       stripe_customer_id
+                FROM users
+                WHERE user_id = $1
+                """,
+                user_id,
+            )
+
+        if not row:
+            return None
+
+        tier = row['subscription_tier']
+        expires_at = row['subscription_expires_at']
+        now = datetime.now(timezone.utc)
+
+        is_active = bool(
+            tier
+            and (expires_at is None or expires_at > now)
+        )
+
+        return {
+            'tier': tier,
+            'expires_at': expires_at,
+            'stripe_customer_id': row['stripe_customer_id'],
+            'is_active': is_active,
+        }
+
+    async def get_subscription_servers(self, user_id: int) -> List[Dict[str, Any]]:
+        """Return the list of servers linked to this user's subscription."""
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT server_id, added_at
+                FROM subscription_servers
+                WHERE user_id = $1
+                ORDER BY added_at ASC
+                """,
+                str(user_id),
+            )
+        return [{'server_id': r['server_id'], 'added_at': r['added_at']} for r in rows]

--- a/docs/SUBSCRIPTION_SCHEMA.md
+++ b/docs/SUBSCRIPTION_SCHEMA.md
@@ -1,0 +1,201 @@
+# Subscription System — Schema & Contracts
+
+> This document covers the DB schema, Redis contract, Pub/Sub contract,
+> and what the **backend** must do for each subscription lifecycle action.
+> The bot is **read-only** on all subscription data.
+
+---
+
+## 1. Database Schema
+
+### Table `users` — added columns
+
+| Column | Type | Nullable | Description |
+|---|---|---|---|
+| `subscription_expires_at` | `TIMESTAMPTZ` | YES | UTC timestamp when the subscription expires; `NULL` = no expiry (lifetime) |
+| `subscription_tier` | `TEXT` | YES | Plan identifier: `'free_trial'`, `'monthly'`, `'yearly'` (or `NULL` = no sub) |
+| `stripe_customer_id` | `VARCHAR(50)` | YES | Stripe customer ID, e.g. `cus_UAf6a2WKTw6yCI` (pre-existing column) |
+
+**Active subscription rule:**
+```
+is_active = subscription_tier IS NOT NULL
+        AND (subscription_expires_at IS NULL OR subscription_expires_at > NOW())
+```
+
+---
+
+### Table `subscription_plans`
+
+Catalogue of available plans. The bot reads this table for display names.
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `id` | `TEXT` | — | Plan identifier (PRIMARY KEY), e.g. `'max'` |
+| `name` | `TEXT` | — | Human-readable name, e.g. `'Moddy Max'` |
+| `is_active` | `BOOLEAN` | `true` | Whether new subscriptions can be created for this plan |
+
+**Seed row:** `INSERT INTO subscription_plans (id, name) VALUES ('max', 'Moddy Max');`
+
+---
+
+### Table `subscription_servers`
+
+Servers linked to a user's subscription (max 5 per user, enforced by the backend).
+
+| Column | Type | Default | Description |
+|---|---|---|---|
+| `user_id` | `TEXT` | — | Discord user ID (FK → `users.id`) |
+| `server_id` | `TEXT` | — | Discord guild ID (FK → `servers.id`) |
+| `added_at` | `TIMESTAMPTZ` | `NOW()` | When the server was linked |
+
+**Primary key:** `(user_id, server_id)`
+
+---
+
+## 2. Redis Cache Contract
+
+### Key format
+
+```
+sub:user:{user_id}
+```
+
+Example: `sub:user:123456789012345678`
+
+### Value format (JSON string)
+
+```json
+{
+  "tier": "monthly",
+  "expires_at": "2026-06-01T00:00:00+00:00",
+  "stripe_customer_id": "cus_UAf6a2WKTw6yCI"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `tier` | `string \| null` | Same as `users.subscription_tier` |
+| `expires_at` | ISO 8601 string `\| null` | Same as `users.subscription_expires_at`; `null` = no expiry |
+| `stripe_customer_id` | `string \| null` | Same as `users.stripe_customer_id` |
+
+### TTL policy
+
+- TTL = `(expires_at - now)` in seconds, rounded down to the nearest second.
+- If `expires_at` is `NULL` (no expiry), the key is set **without a TTL**.
+- On subscription cancellation / expiry, the backend must **delete** the key immediately.
+
+### Bot read strategy
+
+1. `GET sub:user:{user_id}` from Redis
+2. If hit → parse JSON, compute `is_active` from `tier` + `expires_at`
+3. If miss → query DB, write result to Redis with TTL, return
+
+### When to invalidate
+
+The **backend** must delete or update the Redis key on every mutation:
+- Subscription created / renewed / upgraded / cancelled / expired
+- `stripe_customer_id` updated
+- Server linked / unlinked
+
+---
+
+## 3. Pub/Sub Contract
+
+### Channel
+
+```
+moddy:subscription:updates
+```
+
+Direction: **backend → bot** (fire-and-forget; bot may miss messages if restarting).
+
+### Message format
+
+All messages are JSON strings published via `PUBLISH`.
+
+#### `refresh` — invalidate cache
+
+```json
+{ "type": "refresh", "user_id": "123456789012345678" }
+```
+
+Bot action: delete `sub:user:{user_id}` from Redis. Next read will hit DB.
+
+---
+
+#### `notify_payment_late` — payment failed / overdue
+
+```json
+{ "type": "notify_payment_late", "user_id": "123456789012345678" }
+```
+
+Bot action:
+1. Invalidate Redis cache.
+2. Send DM to user:
+
+> ### ⚠️ Problème de paiement
+> Un problème est survenu lors du renouvellement de ton abonnement.
+> Merci de mettre à jour tes informations de paiement pour maintenir l'accès.
+>
+> *[Gérer mon abonnement → https://dashboard.moddy.app/billing]*
+
+---
+
+#### `notify_subscription_started` — new subscription
+
+```json
+{ "type": "notify_subscription_started", "user_id": "123456789012345678", "tier": "monthly" }
+```
+
+Bot action:
+1. Invalidate Redis cache.
+2. Send DM to user:
+
+> ### ✨ Abonnement activé
+> Ton abonnement **Moddy Max** est maintenant actif. Merci pour ton soutien !
+>
+> *[Gérer mon abonnement → https://dashboard.moddy.app/billing]*
+
+---
+
+#### `notify_subscription_renewed` — renewal
+
+```json
+{ "type": "notify_subscription_renewed", "user_id": "123456789012345678", "tier": "yearly" }
+```
+
+Bot action:
+1. Invalidate Redis cache.
+2. Send DM to user:
+
+> ### ✨ Abonnement renouvelé
+> Ton abonnement **Moddy Max** a été renouvelé avec succès.
+>
+> *[Gérer mon abonnement → https://dashboard.moddy.app/billing]*
+
+---
+
+## 4. Backend Responsibilities
+
+The following table lists every subscription event and what the backend must do.
+
+| Event | DB writes | Redis | Pub/Sub |
+|---|---|---|---|
+| **Checkout completed / sub created** | Set `subscription_tier`, `subscription_expires_at`, `stripe_customer_id` on `users` | Write `sub:user:{id}` with TTL | Publish `notify_subscription_started` |
+| **Invoice paid / renewed** | Update `subscription_expires_at` | Update or re-write `sub:user:{id}` with new TTL | Publish `notify_subscription_renewed` |
+| **Payment failed (grace period)** | No change | No change | Publish `notify_payment_late` |
+| **Subscription cancelled / expired** | Set `subscription_tier = NULL`, optionally clear `subscription_expires_at` | DELETE `sub:user:{id}` | Publish `refresh` |
+| **Server linked** | INSERT into `subscription_servers` | Publish `refresh` (bot re-reads linked servers from DB on demand) | Publish `refresh` |
+| **Server unlinked** | DELETE from `subscription_servers` | — | Publish `refresh` |
+| **Stripe customer ID updated** | Update `stripe_customer_id` on `users` | Update `sub:user:{id}` | Publish `refresh` |
+
+> **Note:** The bot **never writes** `subscription_tier`, `subscription_expires_at`, `stripe_customer_id`, or `subscription_servers`. All mutations are the backend's responsibility.
+
+---
+
+## 5. Bot Read-Only Invariants
+
+- The bot's subscription helper (`utils/subscription.py`) only calls `GET`/`SETEX`/`SET`/`DELETE` on Redis keys prefixed with `sub:user:`.
+- The bot's DB repository (`db/repositories/subscription.py`) only executes `SELECT` queries.
+- If Redis is unavailable, the bot falls back to DB transparently.
+- There is **no polling** — subscription state is checked lazily per interaction.

--- a/docs/sessions/2026-05-26_subscription-system.md
+++ b/docs/sessions/2026-05-26_subscription-system.md
@@ -1,0 +1,37 @@
+# Session 2026-05-26 — Subscription System
+
+## What was done
+
+Implemented the full subscription system for Moddy, covering DB schema, Redis cache,
+Pub/Sub listener, user-facing command, staff command, and documentation.
+
+## Files modified / created
+
+| File | Change |
+|---|---|
+| `db/migrations/subscription.sql` | **New** — idempotent SQL migration: adds `subscription_expires_at` + `subscription_tier` to `users`; creates `subscription_plans` and `subscription_servers` tables |
+| `db/repositories/subscription.py` | **New** — read-only repository: `get_subscription(user_id)`, `get_subscription_servers(user_id)` |
+| `db/base.py` | **Updated** — inherits `SubscriptionRepository` |
+| `utils/subscription.py` | **New** — `get_subscription(bot, user_id)` and `is_subscribed(bot, user_id)` helpers; Redis-first, DB fallback, TTL aligned on `expires_at` |
+| `bot.py` | **Updated** — `_listen_pubsub` now subscribes to `moddy:subscription:updates`; added `_handle_subscription_event` and `_send_subscription_dm` |
+| `cogs/subscription.py` | **Rewritten** — full Components V2 view showing tier, expiry, Stripe link indicator, linked servers, and "Gérer mon abonnement" button |
+| `cogs/staff_subscription.py` | **New** — `/staff subscription-info <user>` slash command with full data including `stripe_customer_id` and server `added_at` |
+| `locales/fr.json` | **Updated** — added `commands.subscription.*` keys |
+| `locales/en-US.json` | **Updated** — added `commands.subscription.*` keys |
+| `docs/SUBSCRIPTION_SCHEMA.md` | **New** — DB schema, Redis contract, Pub/Sub contract, backend responsibilities |
+| `CLAUDE.md` | **Updated** — project structure, utils list, docs index |
+
+## Decisions made
+
+- **Bot is read-only on subscription data** — only the backend writes subscription columns and `subscription_servers`. This avoids race conditions with Stripe webhooks.
+- **Redis-first, lazy DB fallback** — no polling. The cache TTL is aligned to `expires_at` so it auto-expires when the subscription ends.
+- **`moddy:subscription:updates` is a separate Pub/Sub channel** from `moddy:bot`. This keeps subscription events isolated and easy to trace.
+- **DMs are Components V2** — follows the project-wide rule: no `discord.Embed()`.
+- **`/staff subscription-info`** is a slash command group (`/staff <subcommand>`) using `app_commands.Group` as a `Cog` class variable, which is the clean discord.py pattern.
+- **`stripe_customer_id` shown in staff view only** — the user command shows only a "linked" indicator, not the raw ID.
+
+## Known issues / follow-ups
+
+- The `db/migrations/subscription.sql` file references `servers(id)` as FK for `subscription_servers.server_id`. Verify the actual PK column name in the `servers` table before running the migration (it may be `guild_id`).
+- The migration should be run manually by the backend team against the Railway DB.
+- `is_subscribed()` / `get_subscription()` helpers take `bot` as first arg (not just the user_id). Callers must pass `self.bot`.

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1,5 +1,18 @@
 {
   "commands": {
+    "subscription": {
+      "description": "View your Moddy subscription status",
+      "title": "### {premium} Your Subscription",
+      "active": "{green} **Active Subscription**\n-# Your **{tier}** subscription is active.",
+      "inactive": "{red} **No Active Subscription**\n-# You don't have an active Moddy subscription.",
+      "expires": "**Expires:** `{date}`",
+      "stripe_linked": "{done} Stripe account linked",
+      "servers_title": "**Linked servers:** `{count}/5`",
+      "servers_empty": "-# No servers are linked to your subscription.",
+      "server_entry": "- `{server_id}`",
+      "manage_button": "Manage my subscription",
+      "error": "Unable to retrieve your subscription status. Please try again later."
+    },
     "ping": {
       "description": "Check the bot's latency and status",
       "response": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,5 +1,18 @@
 {
   "commands": {
+    "subscription": {
+      "description": "Affiche ton statut d'abonnement Moddy",
+      "title": "### {premium} Ton abonnement",
+      "active": "{green} **Abonnement actif**\n-# Ton abonnement **{tier}** est actif.",
+      "inactive": "{red} **Aucun abonnement actif**\n-# Tu n'as pas d'abonnement Moddy actif.",
+      "expires": "**Expire le :** `{date}`",
+      "stripe_linked": "{done} Compte Stripe lié",
+      "servers_title": "**Serveurs liés :** `{count}/5`",
+      "servers_empty": "-# Aucun serveur lié à ton abonnement.",
+      "server_entry": "- `{server_id}`",
+      "manage_button": "Gérer mon abonnement",
+      "error": "Impossible de récupérer ton statut d'abonnement. Réessaie plus tard."
+    },
     "ping": {
       "description": "Vérifie la latence et le statut du bot",
       "response": {

--- a/utils/subscription.py
+++ b/utils/subscription.py
@@ -1,0 +1,100 @@
+"""
+Subscription helper — gate commands/modules on active subscriptions.
+
+Read strategy: Redis cache first (key sub:user:{user_id}), DB fallback.
+The bot never writes subscription data; only the backend does.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger('moddy.subscription')
+
+_CACHE_KEY = "sub:user:{user_id}"
+
+
+def _cache_key(user_id: int) -> str:
+    return _CACHE_KEY.format(user_id=user_id)
+
+
+def _ttl_seconds(expires_at: Optional[datetime]) -> Optional[int]:
+    """Return seconds until expiry, or None if no expiry (no TTL set)."""
+    if expires_at is None:
+        return None
+    delta = int((expires_at - datetime.now(timezone.utc)).total_seconds())
+    return max(delta, 0)
+
+
+async def get_subscription(bot, user_id: int) -> Optional[Dict[str, Any]]:
+    """
+    Return subscription info dict or None.
+
+    Dict keys: tier, expires_at (datetime|None), stripe_customer_id, is_active.
+    Reads Redis first; falls back to DB and caches the result.
+    """
+    if bot.redis:
+        try:
+            raw = await bot.redis.get(_cache_key(user_id))
+            if raw:
+                cached = json.loads(raw)
+                expires_raw = cached.get('expires_at')
+                expires_at = (
+                    datetime.fromisoformat(expires_raw) if expires_raw else None
+                )
+                now = datetime.now(timezone.utc)
+                is_active = bool(
+                    cached.get('tier')
+                    and (expires_at is None or expires_at > now)
+                )
+                return {
+                    'tier': cached.get('tier'),
+                    'expires_at': expires_at,
+                    'stripe_customer_id': cached.get('stripe_customer_id'),
+                    'is_active': is_active,
+                }
+        except Exception as e:
+            logger.warning(f"[Subscription] Redis read error for {user_id}: {e}")
+
+    if not bot.db:
+        return None
+
+    try:
+        data = await bot.db.get_subscription(user_id)
+    except Exception as e:
+        logger.error(f"[Subscription] DB read error for {user_id}: {e}")
+        return None
+
+    if data and bot.redis:
+        try:
+            payload = {
+                'tier': data['tier'],
+                'expires_at': data['expires_at'].isoformat() if data['expires_at'] else None,
+                'stripe_customer_id': data['stripe_customer_id'],
+            }
+            ttl = _ttl_seconds(data['expires_at'])
+            if ttl is None or ttl > 0:
+                if ttl:
+                    await bot.redis.setex(_cache_key(user_id), ttl, json.dumps(payload))
+                else:
+                    await bot.redis.set(_cache_key(user_id), json.dumps(payload))
+        except Exception as e:
+            logger.warning(f"[Subscription] Redis write error for {user_id}: {e}")
+
+    return data
+
+
+async def is_subscribed(bot, user_id: int) -> bool:
+    """Return True if the user has an active subscription."""
+    sub = await get_subscription(bot, user_id)
+    return bool(sub and sub.get('is_active'))
+
+
+async def invalidate_cache(bot, user_id: int) -> None:
+    """Evict the Redis cache entry for this user."""
+    if bot.redis:
+        try:
+            await bot.redis.delete(_cache_key(user_id))
+        except Exception as e:
+            logger.warning(f"[Subscription] Cache invalidation error for {user_id}: {e}")


### PR DESCRIPTION
## Summary

Implements a complete subscription system for Moddy, enabling premium tier management with Redis caching, Pub/Sub notifications, and read-only bot access. The backend is responsible for all subscription mutations; the bot only reads and caches data.

## Key Changes

### Database & Schema
- **New migration** (`db/migrations/subscription.sql`): Adds `subscription_tier` and `subscription_expires_at` columns to `users` table; creates `subscription_plans` and `subscription_servers` tables
- **New repository** (`db/repositories/subscription.py`): Read-only queries for subscription data and linked servers
- **Updated base** (`db/base.py`): Inherits `SubscriptionRepository`

### Caching & Pub/Sub
- **New helper** (`utils/subscription.py`): 
  - `get_subscription(bot, user_id)` — Redis-first with DB fallback
  - `is_subscribed(bot, user_id)` — check active subscription
  - `invalidate_cache(bot, user_id)` — evict cache on backend mutations
  - TTL aligned to `subscription_expires_at` for automatic expiry
- **Updated bot** (`bot.py`):
  - `_listen_pubsub()` now subscribes to `moddy:subscription:updates` channel
  - `_handle_subscription_event()` routes refresh, payment, and notification events
  - `_send_subscription_dm()` sends localized DMs for lifecycle events (started, renewed, payment_late)

### User-Facing Commands
- **Rewritten** `/subscription` command (`cogs/subscription.py`):
  - Components V2 view showing tier, expiry date, Stripe link indicator, and linked servers
  - Displays server count (max 5 per user)
  - "Gérer mon abonnement" button linking to dashboard
  - Localized for French and English
- **New** `/staff subscription-info <user>` command (`cogs/staff_subscription.py`):
  - Staff-only view of full subscription data including `stripe_customer_id` and server `added_at` timestamps
  - Requires staff permissions or developer role

### Documentation & Localization
- **New schema doc** (`docs/SUBSCRIPTION_SCHEMA.md`): Complete specification of DB schema, Redis contract, Pub/Sub message formats, and backend responsibilities
- **Updated locales**: Added `commands.subscription.*` keys for French and English
- **Updated CLAUDE.md**: Added subscription files to project structure

## Implementation Details

- **Bot is read-only**: The bot never writes subscription columns or `subscription_servers`. All mutations are the backend's responsibility, preventing race conditions with Stripe webhooks.
- **Lazy caching**: No polling. Cache is checked on-demand per interaction and auto-expires when subscription ends.
- **Graceful fallback**: If Redis is unavailable, the bot transparently falls back to DB queries.
- **Pub/Sub fire-and-forget**: Messages are non-critical; the bot may miss them during restarts but will re-sync on next interaction.
- **Localized notifications**: DMs sent via Pub/Sub events use French by default with proper emoji and formatting.

https://claude.ai/code/session_01XuRTcSKMMTeVs4t9wWajff