### PR TITLE
Add subscription schema tables to database initialization

### DIFF
--- a/db/base.py
+++ b/db/base.py
@@ -591,6 +591,57 @@ class ModdyDatabase(
                 ON token_secrets(created_at)
             """)
 
+            # Migration: Add subscription columns to users if they don't exist
+            await conn.execute("""
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'users'
+                        AND column_name = 'subscription_tier'
+                    ) THEN
+                        ALTER TABLE users ADD COLUMN subscription_tier TEXT;
+                    END IF;
+
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'users'
+                        AND column_name = 'subscription_expires_at'
+                    ) THEN
+                        ALTER TABLE users ADD COLUMN subscription_expires_at TIMESTAMPTZ;
+                    END IF;
+                END $$;
+            """)
+
+            # Subscription plans catalogue
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS subscription_plans (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    is_active BOOLEAN DEFAULT TRUE
+                )
+            """)
+
+            await conn.execute("""
+                INSERT INTO subscription_plans (id, name) VALUES ('max', 'Moddy Max')
+                ON CONFLICT (id) DO NOTHING
+            """)
+
+            # Servers linked to a user's subscription
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS subscription_servers (
+                    user_id TEXT NOT NULL,
+                    server_id TEXT NOT NULL,
+                    added_at TIMESTAMPTZ DEFAULT NOW(),
+                    PRIMARY KEY (user_id, server_id)
+                )
+            """)
+
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_subscription_servers_user_id
+                ON subscription_servers(user_id)
+            """)
+
             logger.info("[OK] Tables initialisées")
 
     async def cleanup_old_errors(self, days: int = 30):

--- a/docs/sessions/2026-05-26_subscription-db-schema-fix.md
+++ b/docs/sessions/2026-05-26_subscription-db-schema-fix.md
@@ -1,0 +1,30 @@
+# Session: Subscription DB Schema Fix
+
+**Date:** 2026-05-26
+
+## What was done
+
+Fixed two production errors that occurred when a user invoked `/subscription`:
+
+1. `column "subscription_tier" does not exist` — the `users` table was missing the subscription columns.
+2. `relation "subscription_servers" does not exist` — the `subscription_servers` table had never been created.
+
+Root cause: `db/base.py::_init_tables()` contained `CREATE TABLE IF NOT EXISTS` statements for every table the bot uses, but the three subscription-related schema objects were never added there.
+
+## Files modified
+
+- `db/base.py` — added to `_init_tables()`:
+  - Migration block to `ALTER TABLE users ADD COLUMN subscription_tier TEXT` and `subscription_expires_at TIMESTAMPTZ` (idempotent via `information_schema` check)
+  - `CREATE TABLE IF NOT EXISTS subscription_plans (id TEXT PK, name TEXT, is_active BOOLEAN)`
+  - Seed row `INSERT INTO subscription_plans ... ON CONFLICT DO NOTHING` for the `'max'` plan
+  - `CREATE TABLE IF NOT EXISTS subscription_servers (user_id TEXT, server_id TEXT, added_at TIMESTAMPTZ, PK (user_id, server_id))`
+  - Index on `subscription_servers(user_id)`
+
+## Decisions
+
+- Used the same idempotent migration pattern already present in the codebase (DO $$ BEGIN IF NOT EXISTS … END $$) rather than touching the existing `CREATE TABLE IF NOT EXISTS users` block, to avoid any risk of column-order issues on fresh installs.
+- Tables match the schema specified in `docs/SUBSCRIPTION_SCHEMA.md` exactly.
+
+## Known issues / follow-ups
+
+None. The bot never writes subscription data; these are read-only tables managed by the backend.


### PR DESCRIPTION
## Summary
Fixed production errors when users invoke `/subscription` by adding missing subscription-related schema objects to the database initialization routine.

## Root Cause
The `db/base.py::_init_tables()` method contained `CREATE TABLE IF NOT EXISTS` statements for all tables the bot uses, but three subscription-related schema objects were never added:
- `subscription_tier` and `subscription_expires_at` columns on the `users` table
- `subscription_plans` table
- `subscription_servers` table

This caused runtime errors:
- `column "subscription_tier" does not exist`
- `relation "subscription_servers" does not exist`

## Key Changes
- **Added idempotent migration block** to `users` table to add `subscription_tier` (TEXT) and `subscription_expires_at` (TIMESTAMPTZ) columns using `information_schema` checks to avoid duplicate column errors
- **Created `subscription_plans` table** with columns: `id` (TEXT PK), `name` (TEXT), `is_active` (BOOLEAN)
- **Seeded `subscription_plans`** with the `'max'` plan (`'Moddy Max'`) using `ON CONFLICT DO NOTHING`
- **Created `subscription_servers` table** with columns: `user_id` (TEXT), `server_id` (TEXT), `added_at` (TIMESTAMPTZ), composite PK on `(user_id, server_id)`
- **Added index** on `subscription_servers(user_id)` for query performance
- **Added session documentation** in `docs/sessions/2026-05-26_subscription-db-schema-fix.md`

## Implementation Details
- Used the existing idempotent migration pattern (`DO $$ BEGIN IF NOT EXISTS … END $$`) already present in the codebase rather than modifying the existing `CREATE TABLE IF NOT EXISTS users` block, to avoid any risk of column-order issues on fresh installs
- Schema matches the specification in `docs/SUBSCRIPTION_SCHEMA.md` exactly
- All operations are idempotent and safe to run on existing databases

https://claude.ai/code/session_01H11Pf4W2cvxhQx2dDHMxG4