### PR TITLE
Add d.sub-refresh command to invalidate subscription cache

### DIFF
--- a/staff/dev_commands.py
+++ b/staff/dev_commands.py
@@ -207,6 +207,8 @@ class DeveloperCommands(StaffCommandsCog):
             await self.handle_cogs_command(message, args)
         elif command_name == "presence":
             await self.handle_presence_command(message, args)
+        elif command_name == "sub-refresh":
+            await self.handle_sub_refresh_command(message, args)
         else:
             view = create_error_message("Unknown Command", f"Developer command `{command_name}` not found.")
             await self.reply_with_tracking(message, view)
@@ -1074,6 +1076,40 @@ class DeveloperCommands(StaffCommandsCog):
             "Loaded Cogs",
             f"**{len(cog_names)}** cog(s) loaded:\n\n{listing}",
             footer=f"Requested by {message.author}"
+        )
+        await self.reply_with_tracking(message, view)
+
+
+    async def handle_sub_refresh_command(self, message: discord.Message, args: str):
+        """
+        Handle d.sub-refresh command - Invalidate subscription Redis cache for a user
+        Usage: <@bot> d.sub-refresh <user_id>
+        """
+        from utils.subscription import invalidate_cache
+
+        if staff_logger:
+            await staff_logger.log_command("d", "sub-refresh", message.author)
+
+        if not args:
+            view = create_error_message(
+                "Missing Argument",
+                "**Usage:** `d.sub-refresh <user_id>`",
+            )
+            await self.reply_with_tracking(message, view)
+            return
+
+        try:
+            user_id = int(args.strip())
+        except ValueError:
+            view = create_error_message("Invalid Argument", f"Invalid user ID: `{args.strip()}`")
+            await self.reply_with_tracking(message, view)
+            return
+
+        await invalidate_cache(self.bot, user_id)
+
+        view = create_success_message(
+            "Cache Invalidated",
+            f"Subscription Redis cache cleared for user `{user_id}`.\nNext `/subscription` call will fetch fresh data from the DB.",
         )
         await self.reply_with_tracking(message, view)
 

--- a/utils/subscription.py
+++ b/utils/subscription.py
@@ -66,7 +66,10 @@ async def get_subscription(bot, user_id: int) -> Optional[Dict[str, Any]]:
         logger.error(f"[Subscription] DB read error for {user_id}: {e}")
         return None
 
-    if data and bot.redis:
+    if data and data.get('is_active') and bot.redis:
+        # Only cache active subscriptions. Inactive results are never cached so that
+        # a newly-created subscription is always visible on the next read even if the
+        # Pub/Sub invalidation message was missed (fire-and-forget).
         try:
             payload = {
                 'tier': data['tier'],


### PR DESCRIPTION
## Summary
Adds a new developer command `d.sub-refresh` to manually invalidate the Redis subscription cache for a specific user, forcing a fresh database read on the next subscription check.

## Changes
- **staff/dev_commands.py**
  - Added `handle_sub_refresh_command()` method to process the `d.sub-refresh <user_id>` command
  - Validates user ID argument and calls `invalidate_cache()` from the subscription utility
  - Returns success/error messages via Components V2
  - Logs command execution via staff logger

- **utils/subscription.py**
  - Modified `get_subscription()` to only cache **active** subscriptions
  - Inactive subscription results are never cached, ensuring newly-created subscriptions are visible on the next read even if Pub/Sub invalidation is missed
  - Added explanatory comment about the fire-and-forget caching strategy

## Implementation Details
- The new command requires a valid user ID argument and returns appropriate error messages for missing or invalid input
- Cache invalidation is fire-and-forget; the next `/subscription` call will fetch fresh data from the database
- Only active subscriptions are cached to prevent stale data for newly-created subscriptions when Pub/Sub messages are missed

https://claude.ai/code/session_01Tm7pKCBtj3NqygcJSd2q3A