### PR TITLE
fix(d.redirect): add missing target field for redirect destination

### DIFF
--- a/db/base.py
+++ b/db/base.py
@@ -652,6 +652,7 @@ class ModdyDatabase(
                     id SERIAL PRIMARY KEY,
                     domain TEXT NOT NULL,
                     path TEXT NOT NULL,
+                    target TEXT NOT NULL DEFAULT '',
                     description TEXT NOT NULL,
                     added_by BIGINT NOT NULL,
                     added_at TIMESTAMPTZ DEFAULT NOW(),

--- a/db/base.py
+++ b/db/base.py
@@ -664,6 +664,17 @@ class ModdyDatabase(
                 CREATE INDEX IF NOT EXISTS idx_redirect_links_domain ON redirect_links(domain)
             """)
 
+            await conn.execute("""
+                DO $$ BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'redirect_links' AND column_name = 'target'
+                    ) THEN
+                        ALTER TABLE redirect_links ADD COLUMN target TEXT NOT NULL DEFAULT '';
+                    END IF;
+                END $$;
+            """)
+
             # Banners table
             await conn.execute("""
                 CREATE TABLE IF NOT EXISTS banners (

--- a/db/repositories/redirects.py
+++ b/db/repositories/redirects.py
@@ -1,10 +1,9 @@
 """
 Redirect links repository.
-Manages short/vanity redirect links (domain + path → description).
+Manages short/vanity redirect links (domain + path → target URL).
 """
 
 import logging
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger('moddy.database.redirects')
@@ -17,6 +16,7 @@ class RedirectRepository:
         self,
         domain: str,
         path: str,
+        target: str,
         description: str,
         added_by: int,
     ) -> Dict[str, Any]:
@@ -25,25 +25,25 @@ class RedirectRepository:
         async with self.pool.acquire() as conn:
             row = await conn.fetchrow(
                 """
-                INSERT INTO redirect_links (domain, path, description, added_by, added_at)
-                VALUES ($1, $2, $3, $4, NOW())
-                RETURNING id, domain, path, description, added_by, added_at
+                INSERT INTO redirect_links (domain, path, target, description, added_by, added_at)
+                VALUES ($1, $2, $3, $4, $5, NOW())
+                RETURNING id, domain, path, target, description, added_by, added_at
                 """,
-                domain, path, description, added_by,
+                domain, path, target, description, added_by,
             )
         return dict(row)
 
     async def list_redirects(self) -> List[Dict[str, Any]]:
         async with self.pool.acquire() as conn:
             rows = await conn.fetch(
-                "SELECT id, domain, path, description, added_by, added_at FROM redirect_links ORDER BY added_at DESC"
+                "SELECT id, domain, path, target, description, added_by, added_at FROM redirect_links ORDER BY added_at DESC"
             )
         return [dict(r) for r in rows]
 
     async def get_redirect(self, redirect_id: int) -> Optional[Dict[str, Any]]:
         async with self.pool.acquire() as conn:
             row = await conn.fetchrow(
-                "SELECT id, domain, path, description, added_by, added_at FROM redirect_links WHERE id = $1",
+                "SELECT id, domain, path, target, description, added_by, added_at FROM redirect_links WHERE id = $1",
                 redirect_id,
             )
         return dict(row) if row else None

--- a/staff/dev_commands.py
+++ b/staff/dev_commands.py
@@ -1130,7 +1130,7 @@ class DeveloperCommands(StaffCommandsCog):
             view = create_error_message(
                 "Invalid Usage",
                 "**Subcommands:**\n"
-                "`d.redirect add <domain> <path> <description>`\n"
+                "`d.redirect add <domain> <path> <target> <description>`\n"
                 "`d.redirect list`\n"
                 "`d.redirect info <id>`\n"
                 "`d.redirect delete <id>`"
@@ -1148,23 +1148,22 @@ class DeveloperCommands(StaffCommandsCog):
             return
 
         if subcmd == "add":
-            sub_parts = sub_args.split(None, 2)
-            if len(sub_parts) < 3:
+            sub_parts = sub_args.split(None, 3)
+            if len(sub_parts) < 4:
                 view = create_error_message(
                     "Invalid Usage",
-                    "**Usage:** `d.redirect add <domain> <path> <description>`\n"
-                    "**Example:** `d.redirect add moddy.app /privacy Privacy policy page`"
+                    "**Usage:** `d.redirect add <domain> <path> <target> <description>`\n"
+                    "**Example:** `d.redirect add moddy.app /privacy https://docs.moddy.app/privacy Privacy policy page`"
                 )
                 await self.reply_with_tracking(message, view)
                 return
 
-            domain, path, description = sub_parts[0], sub_parts[1], sub_parts[2]
+            domain, path, target, description = sub_parts[0], sub_parts[1], sub_parts[2], sub_parts[3]
             try:
-                row = await bot_db.add_redirect(domain, path, description, message.author.id)
-                path_display = row['path']
+                row = await bot_db.add_redirect(domain, path, target, description, message.author.id)
                 view = create_success_message(
                     "Redirect Added",
-                    f"**ID:** `{row['id']}`\n**URL:** `{row['domain']}{path_display}`\n**Description:** {row['description']}",
+                    f"**ID:** `{row['id']}`\n**Source:** `{row['domain']}{row['path']}`\n**Target:** `{row['target']}`\n**Description:** {row['description']}",
                     footer=None,
                 )
             except Exception as e:
@@ -1185,7 +1184,7 @@ class DeveloperCommands(StaffCommandsCog):
             container = ui.Container()
             container.add_item(ui.TextDisplay(f"### {EMOJIS['web']} Redirect Links\n**Total:** `{len(rows)}`"))
             container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
-            lines = [f"`{r['id']}` **{r['domain']}{r['path']}**\n-# {r['description']}" for r in rows[:20]]
+            lines = [f"`{r['id']}` **{r['domain']}{r['path']}** → `{r['target']}`\n-# {r['description']}" for r in rows[:20]]
             container.add_item(ui.TextDisplay("\n\n".join(lines)))
             view = ui.LayoutView()
             view.add_item(container)
@@ -1213,7 +1212,8 @@ class DeveloperCommands(StaffCommandsCog):
             view = create_info_message(
                 "Redirect Info",
                 f"**ID:** `{row['id']}`\n"
-                f"**URL:** `{row['domain']}{row['path']}`\n"
+                f"**Source:** `{row['domain']}{row['path']}`\n"
+                f"**Target:** `{row['target']}`\n"
                 f"**Description:** {row['description']}\n"
                 f"**Added by:** <@{row['added_by']}>\n"
                 f"**Added:** <t:{ts}:R>",

--- a/utils/staff_help_view.py
+++ b/utils/staff_help_view.py
@@ -107,7 +107,7 @@ COMMAND_CATEGORIES = {
             ("d.presence [status] [text]", "Change the bot's presence/status"),
             ("d.setup-announcements [guild_id]", "Setup announcement channel following for a guild"),
             ("d.sub-refresh [user_id]", "Invalidate subscription Redis cache for a user"),
-            ("d.redirect add [domain] [path] [description]", "Add a redirect link"),
+            ("d.redirect add [domain] [path] [target] [description]", "Add a redirect link"),
             ("d.redirect list", "List all redirect links"),
             ("d.redirect info [id]", "Show details of a redirect link"),
             ("d.redirect delete [id]", "Delete a redirect link"),


### PR DESCRIPTION
## Summary

- The `redirect_links` table was missing a `target` column — il était impossible de stocker l'URL de destination d'une redirection
- Added `target TEXT NOT NULL DEFAULT ''` to the DB schema (`db/base.py`)
- Updated `db/repositories/redirects.py`: `add_redirect()` now takes a `target` param, all `SELECT` queries include `target`
- Updated `d.redirect add` syntax: `<domain> <path> <target> <description>` (was missing `<target>`)
- `d.redirect list` now shows `source → target` per entry
- `d.redirect info` now shows the **Target** field
- `t.help` developer section updated to reflect the new `add` syntax

## Migration required

```sql
ALTER TABLE redirect_links
ADD COLUMN IF NOT EXISTS target TEXT NOT NULL DEFAULT '';
```

---
_Generated by [Claude Code](https://claude.ai/code/session_014S7qqVrEF4qCrJaxFqVs72)_