### PR TITLE
Add Tally forms/submissions/answers tables and repository

### DIFF
--- a/db/base.py
+++ b/db/base.py
@@ -25,6 +25,7 @@ from db.repositories.token_secrets import TokenSecretRepository
 from db.repositories.subscription import SubscriptionRepository
 from db.repositories.redirects import RedirectRepository
 from db.repositories.banners import BannerRepository
+from db.repositories.forms import FormsRepository
 
 logger = logging.getLogger('moddy.database')
 
@@ -50,6 +51,7 @@ class ModdyDatabase(
     SubscriptionRepository,
     RedirectRepository,
     BannerRepository,
+    FormsRepository,
 ):
     """Gestionnaire principal de la base de données"""
 
@@ -711,6 +713,55 @@ class ModdyDatabase(
                         ALTER TABLE users ADD COLUMN subscription_interval TEXT;
                     END IF;
                 END $$;
+            """)
+
+            # --- Tally forms ---
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS forms (
+                    form_id        TEXT        PRIMARY KEY,
+                    title          TEXT        NOT NULL,
+                    signing_secret TEXT        NOT NULL,
+                    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+            """)
+
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS submissions (
+                    submission_id  TEXT        PRIMARY KEY,
+                    form_id        TEXT        NOT NULL REFERENCES forms(form_id) ON DELETE CASCADE,
+                    discord_id     BIGINT      NOT NULL,
+                    status         TEXT        NOT NULL DEFAULT 'pending'
+                                               CHECK (status IN ('pending', 'done', 'rejected')),
+                    note           TEXT,
+                    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+            """)
+
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_submissions_form_id
+                ON submissions(form_id)
+            """)
+
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_submissions_discord_id
+                ON submissions(discord_id)
+            """)
+
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS answers (
+                    id             SERIAL      PRIMARY KEY,
+                    submission_id  TEXT        NOT NULL REFERENCES submissions(submission_id) ON DELETE CASCADE,
+                    form_id        TEXT        NOT NULL,
+                    key            TEXT        NOT NULL,
+                    type           TEXT        NOT NULL,
+                    label          TEXT        NOT NULL,
+                    value          TEXT
+                )
+            """)
+
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_answers_submission_id
+                ON answers(submission_id)
             """)
 
             logger.info("[OK] Tables initialisées")

--- a/db/repositories/forms.py
+++ b/db/repositories/forms.py
@@ -1,0 +1,141 @@
+import logging
+from typing import Dict, Any, Optional, List
+
+logger = logging.getLogger('moddy.database')
+
+
+class FormsRepository:
+    """Tally form, submission, and answer database operations"""
+
+    # --- Forms ---
+
+    async def create_form(self, form_id: str, title: str, signing_secret: str) -> Dict[str, Any]:
+        """Creates a new Tally form entry, returns the created row"""
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                INSERT INTO forms (form_id, title, signing_secret)
+                VALUES ($1, $2, $3)
+                ON CONFLICT (form_id) DO UPDATE
+                    SET title = EXCLUDED.title,
+                        signing_secret = EXCLUDED.signing_secret
+                RETURNING *
+            """, form_id, title, signing_secret)
+            return dict(row)
+
+    async def get_form(self, form_id: str) -> Optional[Dict[str, Any]]:
+        """Fetches a form by its ID"""
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT * FROM forms WHERE form_id = $1", form_id)
+            return dict(row) if row else None
+
+    async def list_forms(self) -> List[Dict[str, Any]]:
+        """Lists all registered forms ordered by creation date"""
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch("SELECT * FROM forms ORDER BY created_at DESC")
+            return [dict(r) for r in rows]
+
+    async def delete_form(self, form_id: str) -> bool:
+        """Deletes a form and its cascaded submissions/answers"""
+        async with self.pool.acquire() as conn:
+            result = await conn.execute("DELETE FROM forms WHERE form_id = $1", form_id)
+            return result == "DELETE 1"
+
+    # --- Submissions ---
+
+    async def create_submission(self, submission_id: str, form_id: str,
+                                discord_id: int) -> Dict[str, Any]:
+        """Creates a new submission with status=pending, returns the created row"""
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                INSERT INTO submissions (submission_id, form_id, discord_id)
+                VALUES ($1, $2, $3)
+                RETURNING *
+            """, submission_id, form_id, discord_id)
+            return dict(row)
+
+    async def get_submission(self, submission_id: str) -> Optional[Dict[str, Any]]:
+        """Fetches a submission by its ID"""
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT * FROM submissions WHERE submission_id = $1", submission_id
+            )
+            return dict(row) if row else None
+
+    async def get_submissions_by_form(self, form_id: str,
+                                      status: str = None) -> List[Dict[str, Any]]:
+        """Lists submissions for a given form, optionally filtered by status"""
+        async with self.pool.acquire() as conn:
+            if status:
+                rows = await conn.fetch("""
+                    SELECT * FROM submissions
+                    WHERE form_id = $1 AND status = $2
+                    ORDER BY created_at DESC
+                """, form_id, status)
+            else:
+                rows = await conn.fetch("""
+                    SELECT * FROM submissions
+                    WHERE form_id = $1
+                    ORDER BY created_at DESC
+                """, form_id)
+            return [dict(r) for r in rows]
+
+    async def get_submissions_by_user(self, discord_id: int,
+                                      form_id: str = None) -> List[Dict[str, Any]]:
+        """Lists submissions for a given Discord user, optionally filtered by form"""
+        async with self.pool.acquire() as conn:
+            if form_id:
+                rows = await conn.fetch("""
+                    SELECT * FROM submissions
+                    WHERE discord_id = $1 AND form_id = $2
+                    ORDER BY created_at DESC
+                """, discord_id, form_id)
+            else:
+                rows = await conn.fetch("""
+                    SELECT * FROM submissions
+                    WHERE discord_id = $1
+                    ORDER BY created_at DESC
+                """, discord_id)
+            return [dict(r) for r in rows]
+
+    async def update_submission_status(self, submission_id: str,
+                                       status: str, note: str = None) -> bool:
+        """Updates the status (and optionally the note) of a submission"""
+        async with self.pool.acquire() as conn:
+            result = await conn.execute("""
+                UPDATE submissions
+                SET status = $2, note = COALESCE($3, note)
+                WHERE submission_id = $1
+            """, submission_id, status, note)
+            return result == "UPDATE 1"
+
+    # --- Answers ---
+
+    async def create_answers(self, submission_id: str, form_id: str,
+                             answers: List[Dict[str, Any]]) -> int:
+        """
+        Bulk-inserts answers for a submission.
+        Each answer dict must have: key, type, label, value (optional).
+        Returns the number of rows inserted.
+        """
+        if not answers:
+            return 0
+        async with self.pool.acquire() as conn:
+            rows = [
+                (submission_id, form_id, a['key'], a['type'], a['label'], a.get('value'))
+                for a in answers
+            ]
+            await conn.executemany("""
+                INSERT INTO answers (submission_id, form_id, key, type, label, value)
+                VALUES ($1, $2, $3, $4, $5, $6)
+            """, rows)
+            return len(rows)
+
+    async def get_answers(self, submission_id: str) -> List[Dict[str, Any]]:
+        """Fetches all answers for a given submission"""
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch("""
+                SELECT * FROM answers
+                WHERE submission_id = $1
+                ORDER BY id ASC
+            """, submission_id)
+            return [dict(r) for r in rows]


### PR DESCRIPTION
## Summary

- Adds three new tables (`forms`, `submissions`, `answers`) with indexes, créées automatiquement au démarrage via `_init_tables()`
- Ajoute `FormsRepository` mixin avec des méthodes CRUD complètes pour les trois entités
- Intègre le repository dans `ModdyDatabase` via héritage

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5XNu9CyZQRkv9dXF2U3bN)_