### PR TITLE
Add Linear issue tracker for team guild

### DIFF
--- a/cogs/linear_tracker.py
+++ b/cogs/linear_tracker.py
@@ -13,7 +13,7 @@ logger = logging.getLogger('moddy.cogs.linear_tracker')
 
 TEAM_GUILD_ID = 1394001780148535387
 LINEAR_BASE_URL = "https://linear.app/moddyapp/issue/"
-MDY_PATTERN = re.compile(r'\bMDY-(\d+)\b', re.IGNORECASE)
+MDY_PATTERN = re.compile(r'\bMDY-(\d{1,7})\b', re.IGNORECASE)
 MAX_BUTTONS_PER_ROW = 5
 
 


### PR DESCRIPTION
## Summary

- Adds `cogs/linear_tracker.py` — a new cog that listens to messages on the team guild (`1394001780148535387`)
- Detects `MDY-{number}` references via regex and replies with link buttons pointing to the corresponding Linear issues
- Only responds to team members (users with the `TEAM` attribute or developers)
- Reply is sent without ping (`mention_author=False`)
- Handles multiple references in a single message (one button per ticket, up to 25)
- Caps the number to 7 digits in the regex to prevent Discord's 80-char button label limit from being hit

## Test plan

- [ ] Message containing `MDY-123` from a team member → reply with one button labeled `MDY-123` linking to `https://linear.app/moddyapp/issue/MDY-123`
- [ ] Message with multiple references → multiple buttons in a single reply
- [ ] Reply does not ping the author
- [ ] Message from a non-team member → no reply
- [ ] Message in a different guild → no reply
- [ ] Abnormally long number (e.g. `MDY-12345678`) → no match, no reply

https://claude.ai/code/session_01RZeSZMktmvCbMCfCUVhwd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZeSZMktmvCbMCfCUVhwd8)_