### PR TITLE
refactor(adaptive-slowmode): per-channel independent config

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -887,37 +887,49 @@
       "description": "Automatically adjusts slowmode based on channel activity",
       "config": {
         "title": "Adaptive Slowmode Configuration",
-        "description": "Monitor channels and let Moddy automatically adjust their slowmode based on real-time activity.",
-        "channels": {
+        "description": "Monitor channels and let Moddy automatically adjust their slowmode based on real-time activity. Each channel has its own settings.",
+        "channel_list": {
           "section_title": "Monitored channels",
-          "section_description": "Channels whose slowmode will be managed automatically by Moddy",
-          "placeholder": "Select text channels"
+          "empty": "No channels configured yet. Add one with the button below.",
+          "add_button": "Add a channel",
+          "edit_button": "Edit",
+          "remove_button": "Remove"
         },
-        "min_delay": {
-          "section_title": "Minimum delay",
-          "section_description": "Slowmode applied during normal activity (0 = no slowmode)",
-          "edit_button": "Edit"
-        },
-        "max_delay": {
-          "section_title": "Maximum delay",
-          "section_description": "Maximum slowmode applied during activity peaks (in seconds)",
-          "edit_button": "Edit"
-        },
-        "sensitivity": {
-          "section_title": "Sensitivity",
-          "section_description": "Determines how much activity is needed to trigger a slowmode increase",
-          "placeholder": "Select a sensitivity level",
-          "low": {
-            "label": "Low",
-            "description": "Only triggers during significant activity peaks"
+        "channel_settings": {
+          "title_add": "New channel",
+          "title_edit": "Edit channel",
+          "already_configured": "This channel is already configured. Use the Edit button to modify it.",
+          "channel": {
+            "section_title": "Channel",
+            "section_description": "Text channel whose slowmode will be automatically managed",
+            "placeholder": "Select a text channel"
           },
-          "medium": {
-            "label": "Normal",
-            "description": "Balanced between reactivity and stability (recommended)"
+          "min_delay": {
+            "section_title": "Minimum delay",
+            "section_description": "Slowmode applied during normal activity (0 = no slowmode)",
+            "edit_button": "Edit"
           },
-          "high": {
-            "label": "High",
-            "description": "Very reactive, adapts as soon as activity starts rising"
+          "max_delay": {
+            "section_title": "Maximum delay",
+            "section_description": "Maximum slowmode applied during activity peaks (in seconds)",
+            "edit_button": "Edit"
+          },
+          "sensitivity": {
+            "section_title": "Sensitivity",
+            "section_description": "Determines how much activity is needed to trigger a slowmode increase",
+            "placeholder": "Select a sensitivity level",
+            "low": {
+              "label": "Low",
+              "description": "Only triggers during significant activity peaks"
+            },
+            "medium": {
+              "label": "Normal",
+              "description": "Balanced between reactivity and stability (recommended)"
+            },
+            "high": {
+              "label": "High",
+              "description": "Very reactive, adapts as soon as activity starts rising"
+            }
           }
         },
         "delay_modal": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -886,37 +886,49 @@
       "description": "Ajuste automatiquement le slowmode selon l'activité",
       "config": {
         "title": "Configuration du Adaptive Slowmode",
-        "description": "Surveillez des salons et laissez Moddy ajuster leur slowmode automatiquement selon l'activité en temps réel.",
-        "channels": {
+        "description": "Surveillez des salons et laissez Moddy ajuster leur slowmode automatiquement selon l'activité en temps réel. Chaque salon a ses propres paramètres.",
+        "channel_list": {
           "section_title": "Salons surveillés",
-          "section_description": "Salons dont le slowmode sera géré automatiquement par Moddy",
-          "placeholder": "Sélectionnez des salons textuels"
+          "empty": "Aucun salon configuré. Ajoutez-en un avec le bouton ci-dessous.",
+          "add_button": "Ajouter un salon",
+          "edit_button": "Modifier",
+          "remove_button": "Retirer"
         },
-        "min_delay": {
-          "section_title": "Délai minimum",
-          "section_description": "Slowmode appliqué quand l'activité est normale (0 = aucun slowmode)",
-          "edit_button": "Modifier"
-        },
-        "max_delay": {
-          "section_title": "Délai maximum",
-          "section_description": "Slowmode maximal applicable lors des pics d'activité (en secondes)",
-          "edit_button": "Modifier"
-        },
-        "sensitivity": {
-          "section_title": "Sensibilité",
-          "section_description": "Détermine le seuil d'activité nécessaire pour déclencher une hausse du slowmode",
-          "placeholder": "Sélectionnez une sensibilité",
-          "low": {
-            "label": "Faible",
-            "description": "Se déclenche uniquement lors de pics d'activité importants"
+        "channel_settings": {
+          "title_add": "Nouveau salon",
+          "title_edit": "Modifier le salon",
+          "already_configured": "Ce salon est déjà configuré. Utilisez le bouton Modifier pour l'éditer.",
+          "channel": {
+            "section_title": "Salon",
+            "section_description": "Salon textuel dont le slowmode sera géré automatiquement",
+            "placeholder": "Sélectionnez un salon textuel"
           },
-          "medium": {
-            "label": "Normale",
-            "description": "Équilibre entre réactivité et stabilité (recommandé)"
+          "min_delay": {
+            "section_title": "Délai minimum",
+            "section_description": "Slowmode appliqué lors d'une activité normale (0 = aucun slowmode)",
+            "edit_button": "Modifier"
           },
-          "high": {
-            "label": "Haute",
-            "description": "Très réactif, s'adapte dès les premières hausses d'activité"
+          "max_delay": {
+            "section_title": "Délai maximum",
+            "section_description": "Slowmode maximal applicable lors des pics d'activité (en secondes)",
+            "edit_button": "Modifier"
+          },
+          "sensitivity": {
+            "section_title": "Sensibilité",
+            "section_description": "Détermine le seuil d'activité nécessaire pour déclencher une hausse du slowmode",
+            "placeholder": "Sélectionnez une sensibilité",
+            "low": {
+              "label": "Faible",
+              "description": "Se déclenche uniquement lors de pics d'activité importants"
+            },
+            "medium": {
+              "label": "Normale",
+              "description": "Équilibre entre réactivité et stabilité (recommandé)"
+            },
+            "high": {
+              "label": "Haute",
+              "description": "Très réactif, s'adapte dès les premières hausses d'activité"
+            }
           }
         },
         "delay_modal": {

--- a/modules/adaptive_slowmode.py
+++ b/modules/adaptive_slowmode.py
@@ -1,10 +1,11 @@
 """
 Module Adaptive Slowmode
-Adjusts channel slowmode automatically based on message activity using
-EWMA baselines and hysteresis to prevent oscillation.
+Adjusts per-channel slowmode automatically based on message activity.
+Each monitored channel has its own min/max delay and sensitivity settings.
 """
 
 import asyncio
+import copy
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -63,15 +64,28 @@ class ChannelState:
 class AdaptiveSlowmodeModule(ModuleBase):
     """
     Automatically adjusts per-channel slowmode based on real-time activity.
+    Each monitored channel has independent min/max delay and sensitivity settings.
 
     Algorithm:
       1. Count messages in a 60-second rolling window, weighted by unique authors.
       2. Maintain a per-channel EWMA baseline representing "normal" activity.
       3. Compute ratio = current_activity / baseline.
-      4. Map ratio to a slowmode level (0–5) using configurable sensitivity thresholds,
+      4. Map ratio to a slowmode level (0–5) using per-channel sensitivity thresholds,
          with hysteresis to prevent threshold oscillation.
       5. Apply level changes: fast rise (30 s cooldown), slow descent
          (one step every 5 min).
+
+    Config structure (stored in guilds.data.modules.adaptive_slowmode):
+      {
+        "channels": {
+          "<channel_id>": {
+            "min_delay":  0,
+            "max_delay":  120,
+            "sensitivity": "medium"
+          },
+          ...
+        }
+      }
     """
 
     MODULE_ID = "adaptive_slowmode"
@@ -82,10 +96,8 @@ class AdaptiveSlowmodeModule(ModuleBase):
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)
 
-        self.channel_ids: List[int] = []
-        self.min_delay: int = 0
-        self.max_delay: int = 120
-        self.sensitivity: str = "medium"
+        # channel_id (int) → {"min_delay", "max_delay", "sensitivity"}
+        self.channels_config: Dict[int, Dict[str, Any]] = {}
 
         self._channel_states: Dict[int, ChannelState] = {}
         self._task: Optional[asyncio.Task] = None
@@ -97,47 +109,39 @@ class AdaptiveSlowmodeModule(ModuleBase):
     async def load_config(self, config_data: Dict[str, Any]) -> bool:
         try:
             self.config = config_data
-            self.channel_ids = list(config_data.get("channel_ids", []))
-            self.min_delay = int(config_data.get("min_delay", 0))
-            self.max_delay = int(config_data.get("max_delay", 120))
-            self.sensitivity = config_data.get("sensitivity", "medium")
 
-            # Create state entries for new channels, remove stale ones.
-            for ch_id in self.channel_ids:
-                self._channel_states.setdefault(ch_id, ChannelState())
+            raw_channels = config_data.get("channels", {})
+            # JSON keys are always strings — normalise to int keys.
+            self.channels_config = {int(k): v for k, v in raw_channels.items()}
+
+            # Sync channel states: remove stale, add missing.
             for ch_id in list(self._channel_states):
-                if ch_id not in self.channel_ids:
+                if ch_id not in self.channels_config:
                     del self._channel_states[ch_id]
+            for ch_id in self.channels_config:
+                self._channel_states.setdefault(ch_id, ChannelState())
 
-            self.enabled = bool(self.channel_ids)
+            self.enabled = bool(self.channels_config)
             return True
         except Exception as e:
             logger.error(f"Error loading adaptive_slowmode config: {e}")
             return False
 
     async def validate_config(self, config_data: Dict[str, Any]) -> tuple[bool, Optional[str]]:
-        channel_ids = config_data.get("channel_ids", [])
-        if not channel_ids:
+        channels = config_data.get("channels", {})
+        if not channels:
             return False, "Au moins un salon est requis"
-
-        min_delay = config_data.get("min_delay", 0)
-        max_delay = config_data.get("max_delay", 120)
-
-        if not isinstance(min_delay, int) or not (0 <= min_delay <= 21600):
-            return False, "Le délai minimum doit être entre 0 et 21600 secondes"
-        if not isinstance(max_delay, int) or not (1 <= max_delay <= 21600):
-            return False, "Le délai maximum doit être entre 1 et 21600 secondes"
-        if min_delay >= max_delay:
-            return False, "Le délai maximum doit être supérieur au délai minimum"
-
-        if config_data.get("sensitivity", "medium") not in SENSITIVITY_THRESHOLDS:
-            return False, "Sensibilité invalide"
 
         guild = self.bot.get_guild(self.guild_id)
         if not guild:
             return False, "Serveur introuvable"
 
-        for ch_id in channel_ids:
+        for ch_id_str, ch_cfg in channels.items():
+            try:
+                ch_id = int(ch_id_str)
+            except (ValueError, TypeError):
+                return False, f"ID de salon invalide : `{ch_id_str}`"
+
             channel = guild.get_channel(ch_id)
             if not channel:
                 return False, f"Salon `{ch_id}` introuvable"
@@ -146,15 +150,22 @@ class AdaptiveSlowmodeModule(ModuleBase):
             if not channel.permissions_for(guild.me).manage_channels:
                 return False, f"Permission **Gérer les salons** manquante sur {channel.mention}"
 
+            min_delay = ch_cfg.get("min_delay", 0)
+            max_delay = ch_cfg.get("max_delay", 120)
+
+            if not isinstance(min_delay, int) or not (0 <= min_delay <= 21600):
+                return False, f"Délai minimum invalide pour {channel.mention}"
+            if not isinstance(max_delay, int) or not (1 <= max_delay <= 21600):
+                return False, f"Délai maximum invalide pour {channel.mention}"
+            if min_delay >= max_delay:
+                return False, f"Le délai maximum doit être supérieur au minimum pour {channel.mention}"
+            if ch_cfg.get("sensitivity", "medium") not in SENSITIVITY_THRESHOLDS:
+                return False, f"Sensibilité invalide pour {channel.mention}"
+
         return True, None
 
     def get_default_config(self) -> Dict[str, Any]:
-        return {
-            "channel_ids": [],
-            "min_delay": 0,
-            "max_delay": 120,
-            "sensitivity": "medium",
-        }
+        return {"channels": {}}
 
     # -------------------------------------------------------------------------
     # Lifecycle hooks
@@ -172,7 +183,7 @@ class AdaptiveSlowmodeModule(ModuleBase):
 
     async def on_message(self, message: discord.Message):
         """Record a message in the rolling window for its channel."""
-        if message.channel.id not in self.channel_ids:
+        if message.channel.id not in self.channels_config:
             return
         state = self._channel_states.setdefault(message.channel.id, ChannelState())
         state.message_log.append((time.monotonic(), message.author.id))
@@ -217,9 +228,12 @@ class AdaptiveSlowmodeModule(ModuleBase):
         if not guild:
             return
 
-        thresholds = SENSITIVITY_THRESHOLDS.get(self.sensitivity, SENSITIVITY_THRESHOLDS["medium"])
+        for ch_id, ch_cfg in self.channels_config.items():
+            min_delay  = ch_cfg.get("min_delay", 0)
+            max_delay  = ch_cfg.get("max_delay", 120)
+            sensitivity = ch_cfg.get("sensitivity", "medium")
+            thresholds = SENSITIVITY_THRESHOLDS.get(sensitivity, SENSITIVITY_THRESHOLDS["medium"])
 
-        for ch_id in self.channel_ids:
             state = self._channel_states.setdefault(ch_id, ChannelState())
 
             channel = guild.get_channel(ch_id)
@@ -255,48 +269,42 @@ class AdaptiveSlowmodeModule(ModuleBase):
             going_up = target > state.current_level
 
             if going_up:
-                # Jump directly to the target level on the way up.
                 apply_level = target
-                cooldown = INCREASE_COOLDOWN
-                last_edit = state.last_increase_time
+                cooldown   = INCREASE_COOLDOWN
+                last_edit  = state.last_increase_time
             else:
-                # Step down one level at a time on the way down.
                 apply_level = state.current_level - 1
-                cooldown = DECREASE_COOLDOWN
-                last_edit = state.last_decrease_time
+                cooldown   = DECREASE_COOLDOWN
+                last_edit  = state.last_decrease_time
 
             if now - last_edit >= cooldown:
-                new_delay = self._level_to_delay(apply_level)
+                new_delay = self._level_to_delay(apply_level, min_delay, max_delay)
                 await self._apply_slowmode(channel, new_delay, state, apply_level, going_up, now)
 
     @staticmethod
     def _compute_target_level(ratio: float, current_level: int, thresholds: List[float]) -> int:
         """Return the target level for a given ratio, applying hysteresis on the way down."""
-        # Natural level: the highest threshold the ratio satisfies.
         natural = sum(1 for thr in thresholds if ratio >= thr)
 
-        # Hysteresis guard: only step down if ratio is well below the current up-threshold.
         if natural < current_level and current_level > 0:
             down_threshold = thresholds[current_level - 1] * HYSTERESIS_FACTOR
             if ratio >= down_threshold:
-                return current_level  # Not low enough yet — hold position.
+                return current_level
 
         return natural
 
-    def _level_to_delay(self, level: int) -> int:
+    @staticmethod
+    def _level_to_delay(level: int, min_delay: int, max_delay: int) -> int:
         """Map a level (0–5) to a valid Discord slowmode delay within [min_delay, max_delay]."""
         if level <= 0:
-            return self.min_delay
+            return min_delay
         if level >= 5:
-            return self.max_delay
+            return max_delay
 
-        # Build a sorted list of valid Discord values strictly between min and max.
-        candidates = [v for v in VALID_SLOWMODE if self.min_delay < v < self.max_delay]
-
+        candidates = [v for v in VALID_SLOWMODE if min_delay < v < max_delay]
         if not candidates:
-            return self.max_delay
+            return max_delay
 
-        # Distribute levels 1–4 across the candidate list.
         step = len(candidates) / 4.0
         idx = min(int((level - 1) * step), len(candidates) - 1)
         return candidates[idx]
@@ -330,8 +338,8 @@ class AdaptiveSlowmodeModule(ModuleBase):
 
             arrow = "↑" if going_up else "↓"
             logger.info(
-                f"[Guild {self.guild_id}] #{channel.name}: slowmode → {delay}s "
-                f"(level {new_level} {arrow})"
+                f"[Guild {self.guild_id}] #{channel.name}: "
+                f"slowmode → {delay}s (level {new_level} {arrow})"
             )
 
         except discord.Forbidden:

--- a/modules/configs/adaptive_slowmode_config.py
+++ b/modules/configs/adaptive_slowmode_config.py
@@ -1,8 +1,11 @@
 """
 Configuration UI for the Adaptive Slowmode module.
-Allows admins to select monitored channels, set min/max delays and sensitivity.
+Two views:
+  - AdaptiveSlowmodeConfigView       : main list of monitored channels
+  - AdaptiveSlowmodeChannelConfigView : add / edit a single channel entry
 """
 
+import copy
 import discord
 from discord import ui
 from typing import Any, Callable, Dict, Optional
@@ -10,18 +13,22 @@ import logging
 
 from utils.i18n import t
 from cogs.error_handler import BaseView, BaseModal
-from utils.emojis import TIME, REQUIRED_FIELDS, EDIT, BACK, SAVE, UNDONE, DELETE
+from utils.emojis import TIME, REQUIRED_FIELDS, EDIT, BACK, SAVE, UNDONE, DELETE, ADD, REMOVE
 
 logger = logging.getLogger('moddy.modules.adaptive_slowmode_config')
 
+_SENSITIVITY_KEYS = ("low", "medium", "high")
+
+
+# ---------------------------------------------------------------------------
+# Shared modal for numeric delay input
+# ---------------------------------------------------------------------------
 
 class DelayModal(BaseModal, title="Délai (secondes)"):
-    """Generic modal for editing a numeric slowmode delay value."""
-
     def __init__(self, locale: str, label: str, placeholder: str,
                  current_value: int, callback: Callable):
         super().__init__(timeout=300)
-        self.locale = locale
+        self.locale   = locale
         self._callback = callback
 
         self.delay_input = ui.TextInput(
@@ -52,209 +59,205 @@ class DelayModal(BaseModal, title="Délai (secondes)"):
         await self._callback(interaction, value)
 
 
-class AdaptiveSlowmodeConfigView(BaseView):
-    """Configuration panel for the Adaptive Slowmode module."""
+# ---------------------------------------------------------------------------
+# Per-channel add / edit view
+# ---------------------------------------------------------------------------
+
+class AdaptiveSlowmodeChannelConfigView(BaseView):
+    """
+    Add or edit the settings for a single monitored channel.
+
+    add  mode: channel_id=None  — user must select a channel via the select
+    edit mode: channel_id=int   — channel is fixed, only settings change
+    """
 
     def __init__(
         self,
         bot,
         guild_id: int,
-        user_id: int,
-        locale: str,
-        current_config: Optional[Dict[str, Any]] = None,
+        user_id:  int,
+        locale:   str,
+        parent_view: "AdaptiveSlowmodeConfigView",
+        channel_id:     Optional[int]       = None,
+        channel_config: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(timeout=300)
-        self.bot = bot
-        self.guild_id = guild_id
-        self.user_id = user_id
-        self.locale = locale
+        self.bot         = bot
+        self.guild_id    = guild_id
+        self.user_id     = user_id
+        self.locale      = locale
+        self.parent_view = parent_view
 
-        from modules.adaptive_slowmode import AdaptiveSlowmodeModule
-        default_config = AdaptiveSlowmodeModule(bot, guild_id).get_default_config()
+        self.edit_mode  = channel_id is not None
+        self.channel_id = channel_id   # set in add mode once channel is chosen
 
-        if current_config and current_config.get("channel_ids"):
-            self.current_config = {**default_config, **current_config}
-            self.has_existing_config = True
-        else:
-            self.current_config = default_config
-            self.has_existing_config = False
-
-        self.working_config: Dict[str, Any] = dict(self.current_config)
-        self.has_changes = False
+        self.config: Dict[str, Any] = dict(channel_config) if channel_config else {
+            "min_delay":   0,
+            "max_delay":   120,
+            "sensitivity": "medium",
+        }
 
         self._build_view()
 
-    # -------------------------------------------------------------------------
-    # View construction
-    # -------------------------------------------------------------------------
+    # ------------------------------------------------------------------
 
     def _build_view(self):
         self.clear_items()
-
         container = ui.Container()
 
-        # ── Header ────────────────────────────────────────────────────────────
+        # ── Header ────────────────────────────────────────────────────
+        title_key = (
+            "modules.adaptive_slowmode.config.channel_settings.title_edit"
+            if self.edit_mode else
+            "modules.adaptive_slowmode.config.channel_settings.title_add"
+        )
         container.add_item(ui.TextDisplay(
-            f"### {TIME} {t('modules.adaptive_slowmode.config.title', locale=self.locale)}"
-        ))
-        container.add_item(ui.TextDisplay(
-            t("modules.adaptive_slowmode.config.description", locale=self.locale)
+            f"### {TIME} {t(title_key, locale=self.locale)}"
         ))
 
         container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
 
-        # ── Channels (required) ───────────────────────────────────────────────
-        container.add_item(ui.TextDisplay(
-            f"**{t('modules.adaptive_slowmode.config.channels.section_title', locale=self.locale)}"
-            f"**{REQUIRED_FIELDS}\n"
-            f"-# {t('modules.adaptive_slowmode.config.channels.section_description', locale=self.locale)}"
-        ))
+        # ── Channel selector (add mode only) ──────────────────────────
+        if not self.edit_mode:
+            container.add_item(ui.TextDisplay(
+                f"**{t('modules.adaptive_slowmode.config.channel_settings.channel.section_title', locale=self.locale)}"
+                f"**{REQUIRED_FIELDS}\n"
+                f"-# {t('modules.adaptive_slowmode.config.channel_settings.channel.section_description', locale=self.locale)}"
+            ))
 
-        channel_row = ui.ActionRow()
-        channel_select = ui.ChannelSelect(
-            placeholder=t("modules.adaptive_slowmode.config.channels.placeholder", locale=self.locale),
-            channel_types=[discord.ChannelType.text],
-            min_values=0,
-            max_values=25,
-        )
-        if self.working_config.get("channel_ids"):
-            defaults = [
-                self.bot.get_channel(ch_id)
-                for ch_id in self.working_config["channel_ids"]
-            ]
-            defaults = [ch for ch in defaults if ch is not None]
-            if defaults:
-                channel_select.default_values = defaults
-        channel_select.callback = self.on_channels_select
-        channel_row.add_item(channel_select)
-        container.add_item(channel_row)
+            ch_row = ui.ActionRow()
+            ch_select = ui.ChannelSelect(
+                placeholder=t("modules.adaptive_slowmode.config.channel_settings.channel.placeholder", locale=self.locale),
+                channel_types=[discord.ChannelType.text],
+                min_values=0,
+                max_values=1,
+            )
+            if self.channel_id:
+                ch = self.bot.get_channel(self.channel_id)
+                if ch:
+                    ch_select.default_values = [ch]
+            ch_select.callback = self.on_channel_select
+            ch_row.add_item(ch_select)
+            container.add_item(ch_row)
+        else:
+            guild   = self.bot.get_guild(self.guild_id)
+            channel = guild.get_channel(self.channel_id) if guild else None
+            mention = channel.mention if channel else f"`{self.channel_id}`"
+            container.add_item(ui.TextDisplay(
+                f"**{t('modules.adaptive_slowmode.config.channel_settings.channel.section_title', locale=self.locale)}**\n"
+                f"-# {mention}"
+            ))
 
-        # ── Minimum delay ─────────────────────────────────────────────────────
-        current_min = self.working_config.get("min_delay", 0)
+        # ── Min delay ─────────────────────────────────────────────────
+        current_min = self.config.get("min_delay", 0)
         container.add_item(ui.TextDisplay(
-            f"**{t('modules.adaptive_slowmode.config.min_delay.section_title', locale=self.locale)}**\n"
-            f"-# {t('modules.adaptive_slowmode.config.min_delay.section_description', locale=self.locale)}\n"
+            f"**{t('modules.adaptive_slowmode.config.channel_settings.min_delay.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.adaptive_slowmode.config.channel_settings.min_delay.section_description', locale=self.locale)}\n"
             f"-# {t('modules.config.current_value', locale=self.locale)} **{current_min}s**"
         ))
-
         min_row = ui.ActionRow()
-        edit_min_btn = ui.Button(
-            label=t("modules.adaptive_slowmode.config.min_delay.edit_button", locale=self.locale),
+        min_btn = ui.Button(
+            label=t("modules.adaptive_slowmode.config.channel_settings.min_delay.edit_button", locale=self.locale),
             style=discord.ButtonStyle.secondary,
             emoji=discord.PartialEmoji.from_str(EDIT),
         )
-        edit_min_btn.callback = self.on_edit_min_delay
-        min_row.add_item(edit_min_btn)
+        min_btn.callback = self.on_edit_min_delay
+        min_row.add_item(min_btn)
         container.add_item(min_row)
 
-        # ── Maximum delay ─────────────────────────────────────────────────────
-        current_max = self.working_config.get("max_delay", 120)
+        # ── Max delay ─────────────────────────────────────────────────
+        current_max = self.config.get("max_delay", 120)
         container.add_item(ui.TextDisplay(
-            f"**{t('modules.adaptive_slowmode.config.max_delay.section_title', locale=self.locale)}**\n"
-            f"-# {t('modules.adaptive_slowmode.config.max_delay.section_description', locale=self.locale)}\n"
+            f"**{t('modules.adaptive_slowmode.config.channel_settings.max_delay.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.adaptive_slowmode.config.channel_settings.max_delay.section_description', locale=self.locale)}\n"
             f"-# {t('modules.config.current_value', locale=self.locale)} **{current_max}s**"
         ))
-
         max_row = ui.ActionRow()
-        edit_max_btn = ui.Button(
-            label=t("modules.adaptive_slowmode.config.max_delay.edit_button", locale=self.locale),
+        max_btn = ui.Button(
+            label=t("modules.adaptive_slowmode.config.channel_settings.max_delay.edit_button", locale=self.locale),
             style=discord.ButtonStyle.secondary,
             emoji=discord.PartialEmoji.from_str(EDIT),
         )
-        edit_max_btn.callback = self.on_edit_max_delay
-        max_row.add_item(edit_max_btn)
+        max_btn.callback = self.on_edit_max_delay
+        max_row.add_item(max_btn)
         container.add_item(max_row)
 
-        # ── Sensitivity ───────────────────────────────────────────────────────
+        # ── Sensitivity ───────────────────────────────────────────────
         container.add_item(ui.TextDisplay(
-            f"**{t('modules.adaptive_slowmode.config.sensitivity.section_title', locale=self.locale)}**\n"
-            f"-# {t('modules.adaptive_slowmode.config.sensitivity.section_description', locale=self.locale)}"
+            f"**{t('modules.adaptive_slowmode.config.channel_settings.sensitivity.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.adaptive_slowmode.config.channel_settings.sensitivity.section_description', locale=self.locale)}"
         ))
-
-        sensitivity_row = ui.ActionRow()
-        current_sensitivity = self.working_config.get("sensitivity", "medium")
-        sensitivity_select = ui.Select(
-            placeholder=t("modules.adaptive_slowmode.config.sensitivity.placeholder", locale=self.locale),
+        current_sens = self.config.get("sensitivity", "medium")
+        sens_row = ui.ActionRow()
+        sens_select = ui.Select(
+            placeholder=t("modules.adaptive_slowmode.config.channel_settings.sensitivity.placeholder", locale=self.locale),
             options=[
                 discord.SelectOption(
-                    label=t("modules.adaptive_slowmode.config.sensitivity.low.label", locale=self.locale),
-                    value="low",
-                    description=t("modules.adaptive_slowmode.config.sensitivity.low.description", locale=self.locale),
-                    default=(current_sensitivity == "low"),
-                ),
-                discord.SelectOption(
-                    label=t("modules.adaptive_slowmode.config.sensitivity.medium.label", locale=self.locale),
-                    value="medium",
-                    description=t("modules.adaptive_slowmode.config.sensitivity.medium.description", locale=self.locale),
-                    default=(current_sensitivity == "medium"),
-                ),
-                discord.SelectOption(
-                    label=t("modules.adaptive_slowmode.config.sensitivity.high.label", locale=self.locale),
-                    value="high",
-                    description=t("modules.adaptive_slowmode.config.sensitivity.high.description", locale=self.locale),
-                    default=(current_sensitivity == "high"),
-                ),
+                    label=t(f"modules.adaptive_slowmode.config.channel_settings.sensitivity.{k}.label", locale=self.locale),
+                    value=k,
+                    description=t(f"modules.adaptive_slowmode.config.channel_settings.sensitivity.{k}.description", locale=self.locale),
+                    default=(current_sens == k),
+                )
+                for k in _SENSITIVITY_KEYS
             ],
             min_values=1,
             max_values=1,
         )
-        sensitivity_select.callback = self.on_sensitivity_select
-        sensitivity_row.add_item(sensitivity_select)
-        container.add_item(sensitivity_row)
+        sens_select.callback = self.on_sensitivity_select
+        sens_row.add_item(sens_select)
+        container.add_item(sens_row)
 
         self.add_item(container)
-        self._add_action_buttons()
 
-    def _add_action_buttons(self):
-        button_row = ui.ActionRow()
+        # ── Action buttons ────────────────────────────────────────────
+        btn_row = ui.ActionRow()
 
         back_btn = ui.Button(
             emoji=discord.PartialEmoji.from_str(BACK),
             label=t("modules.config.buttons.back", locale=self.locale),
             style=discord.ButtonStyle.secondary,
-            disabled=self.has_changes,
         )
         back_btn.callback = self.on_back
-        button_row.add_item(back_btn)
+        btn_row.add_item(back_btn)
 
-        if self.has_changes:
-            save_btn = ui.Button(
-                emoji=discord.PartialEmoji.from_str(SAVE),
-                label=t("modules.config.buttons.save", locale=self.locale),
-                style=discord.ButtonStyle.success,
-            )
-            save_btn.callback = self.on_save
-            button_row.add_item(save_btn)
+        save_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str(SAVE),
+            label=t("modules.config.buttons.save", locale=self.locale),
+            style=discord.ButtonStyle.success,
+            disabled=(not self.edit_mode and self.channel_id is None),
+        )
+        save_btn.callback = self.on_save
+        btn_row.add_item(save_btn)
 
-            cancel_btn = ui.Button(
-                emoji=discord.PartialEmoji.from_str(UNDONE),
-                label=t("modules.config.buttons.cancel", locale=self.locale),
-                style=discord.ButtonStyle.danger,
-            )
-            cancel_btn.callback = self.on_cancel
-            button_row.add_item(cancel_btn)
-        elif self.has_existing_config:
-            delete_btn = ui.Button(
-                emoji=discord.PartialEmoji.from_str(DELETE),
-                label=t("modules.config.buttons.delete", locale=self.locale),
-                style=discord.ButtonStyle.danger,
-            )
-            delete_btn.callback = self.on_delete
-            button_row.add_item(delete_btn)
+        self.add_item(btn_row)
 
-        self.add_item(button_row)
+    # ------------------------------------------------------------------
+    # Callbacks
+    # ------------------------------------------------------------------
 
-    # -------------------------------------------------------------------------
-    # Select / button callbacks
-    # -------------------------------------------------------------------------
-
-    async def on_channels_select(self, interaction: discord.Interaction):
+    async def on_channel_select(self, interaction: discord.Interaction):
         if not await self.check_user(interaction):
             return
-        self.working_config["channel_ids"] = [
-            int(v) for v in interaction.data.get("values", [])
-        ]
-        self.has_changes = True
+
+        values = interaction.data.get("values", [])
+        if not values:
+            self.channel_id = None
+            self._build_view()
+            await interaction.response.edit_message(view=self)
+            return
+
+        selected_id = int(values[0])
+
+        # Prevent selecting a channel that is already configured.
+        existing = self.parent_view.working_config.get("channels", {})
+        if str(selected_id) in existing and selected_id != self.channel_id:
+            await interaction.response.send_message(
+                t("modules.adaptive_slowmode.config.channel_settings.already_configured", locale=self.locale),
+                ephemeral=True,
+            )
+            return
+
+        self.channel_id = selected_id
         self._build_view()
         await interaction.response.edit_message(view=self)
 
@@ -265,22 +268,20 @@ class AdaptiveSlowmodeConfigView(BaseView):
             locale=self.locale,
             label=t("modules.adaptive_slowmode.config.delay_modal.min_label", locale=self.locale),
             placeholder="0",
-            current_value=self.working_config.get("min_delay", 0),
+            current_value=self.config.get("min_delay", 0),
             callback=self._on_min_delay_set,
         )
         modal.bot = self.bot
         await interaction.response.send_modal(modal)
 
     async def _on_min_delay_set(self, interaction: discord.Interaction, value: int):
-        current_max = self.working_config.get("max_delay", 120)
-        if value >= current_max:
+        if value >= self.config.get("max_delay", 120):
             await interaction.response.send_message(
                 t("modules.adaptive_slowmode.config.delay_modal.error_min_gte_max", locale=self.locale),
                 ephemeral=True,
             )
             return
-        self.working_config["min_delay"] = value
-        self.has_changes = True
+        self.config["min_delay"] = value
         self._build_view()
         await interaction.response.edit_message(view=self)
 
@@ -291,15 +292,14 @@ class AdaptiveSlowmodeConfigView(BaseView):
             locale=self.locale,
             label=t("modules.adaptive_slowmode.config.delay_modal.max_label", locale=self.locale),
             placeholder="120",
-            current_value=self.working_config.get("max_delay", 120),
+            current_value=self.config.get("max_delay", 120),
             callback=self._on_max_delay_set,
         )
         modal.bot = self.bot
         await interaction.response.send_modal(modal)
 
     async def _on_max_delay_set(self, interaction: discord.Interaction, value: int):
-        current_min = self.working_config.get("min_delay", 0)
-        if value <= current_min:
+        if value <= self.config.get("min_delay", 0):
             await interaction.response.send_message(
                 t("modules.adaptive_slowmode.config.delay_modal.error_max_lte_min", locale=self.locale),
                 ephemeral=True,
@@ -311,22 +311,255 @@ class AdaptiveSlowmodeConfigView(BaseView):
                 ephemeral=True,
             )
             return
-        self.working_config["max_delay"] = value
-        self.has_changes = True
+        self.config["max_delay"] = value
         self._build_view()
         await interaction.response.edit_message(view=self)
 
     async def on_sensitivity_select(self, interaction: discord.Interaction):
         if not await self.check_user(interaction):
             return
-        self.working_config["sensitivity"] = interaction.data["values"][0]
-        self.has_changes = True
+        self.config["sensitivity"] = interaction.data["values"][0]
         self._build_view()
         await interaction.response.edit_message(view=self)
 
-    # -------------------------------------------------------------------------
-    # Action button callbacks
-    # -------------------------------------------------------------------------
+    async def on_back(self, interaction: discord.Interaction):
+        if not await self.check_user(interaction):
+            return
+        self.parent_view._build_view()
+        await interaction.response.edit_message(view=self.parent_view)
+
+    async def on_save(self, interaction: discord.Interaction):
+        if not await self.check_user(interaction):
+            return
+        if self.channel_id is None:
+            await interaction.response.send_message(
+                t("modules.adaptive_slowmode.config.channel_settings.channel.placeholder", locale=self.locale),
+                ephemeral=True,
+            )
+            return
+
+        self.parent_view.working_config.setdefault("channels", {})[str(self.channel_id)] = dict(self.config)
+        self.parent_view.has_changes = True
+        self.parent_view._build_view()
+        await interaction.response.edit_message(view=self.parent_view)
+
+    # ------------------------------------------------------------------
+
+    async def check_user(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                t("modules.config.errors.wrong_user", locale=self.locale), ephemeral=True
+            )
+            return False
+        return True
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await self.check_user(interaction)
+
+
+# ---------------------------------------------------------------------------
+# Main config view — list of configured channels
+# ---------------------------------------------------------------------------
+
+class AdaptiveSlowmodeConfigView(BaseView):
+    """Main configuration panel showing the list of monitored channels."""
+
+    def __init__(
+        self,
+        bot,
+        guild_id: int,
+        user_id:  int,
+        locale:   str,
+        current_config: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(timeout=300)
+        self.bot      = bot
+        self.guild_id = guild_id
+        self.user_id  = user_id
+        self.locale   = locale
+
+        if current_config and current_config.get("channels"):
+            self.current_config    = {"channels": copy.deepcopy(current_config["channels"])}
+            self.has_existing_config = True
+        else:
+            self.current_config    = {"channels": {}}
+            self.has_existing_config = False
+
+        self.working_config: Dict[str, Any] = {
+            "channels": copy.deepcopy(self.current_config["channels"])
+        }
+        self.has_changes = False
+
+        self._build_view()
+
+    # ------------------------------------------------------------------
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container()
+
+        # ── Header ────────────────────────────────────────────────────
+        container.add_item(ui.TextDisplay(
+            f"### {TIME} {t('modules.adaptive_slowmode.config.title', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            t("modules.adaptive_slowmode.config.description", locale=self.locale)
+        ))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # ── Channel list ──────────────────────────────────────────────
+        channels = self.working_config.get("channels", {})
+
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.adaptive_slowmode.config.channel_list.section_title', locale=self.locale)}**"
+        ))
+
+        if not channels:
+            container.add_item(ui.TextDisplay(
+                f"-# {t('modules.adaptive_slowmode.config.channel_list.empty', locale=self.locale)}"
+            ))
+        else:
+            guild = self.bot.get_guild(self.guild_id)
+            for ch_id_str, ch_cfg in channels.items():
+                ch_id   = int(ch_id_str)
+                channel = guild.get_channel(ch_id) if guild else None
+                mention = channel.mention if channel else f"`{ch_id}`"
+
+                sensitivity_key = ch_cfg.get("sensitivity", "medium")
+                sensitivity_label = t(
+                    f"modules.adaptive_slowmode.config.channel_settings.sensitivity.{sensitivity_key}.label",
+                    locale=self.locale,
+                )
+
+                container.add_item(ui.TextDisplay(
+                    f"{mention}\n"
+                    f"-# `{ch_cfg.get('min_delay', 0)}s` → `{ch_cfg.get('max_delay', 120)}s`"
+                    f"  ·  {sensitivity_label}"
+                ))
+
+                row = ui.ActionRow()
+
+                edit_btn = ui.Button(
+                    label=t("modules.adaptive_slowmode.config.channel_list.edit_button", locale=self.locale),
+                    style=discord.ButtonStyle.secondary,
+                    emoji=discord.PartialEmoji.from_str(EDIT),
+                )
+                edit_btn.callback = self._make_edit_cb(ch_id, ch_cfg)
+                row.add_item(edit_btn)
+
+                remove_btn = ui.Button(
+                    label=t("modules.adaptive_slowmode.config.channel_list.remove_button", locale=self.locale),
+                    style=discord.ButtonStyle.danger,
+                    emoji=discord.PartialEmoji.from_str(REMOVE),
+                )
+                remove_btn.callback = self._make_remove_cb(ch_id_str)
+                row.add_item(remove_btn)
+
+                container.add_item(row)
+
+        # ── Add button ────────────────────────────────────────────────
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        add_row = ui.ActionRow()
+        add_btn = ui.Button(
+            label=t("modules.adaptive_slowmode.config.channel_list.add_button", locale=self.locale),
+            style=discord.ButtonStyle.primary,
+            emoji=discord.PartialEmoji.from_str(ADD),
+        )
+        add_btn.callback = self.on_add_channel
+        add_row.add_item(add_btn)
+        container.add_item(add_row)
+
+        self.add_item(container)
+
+        # ── Bottom action buttons ─────────────────────────────────────
+        self._add_action_buttons()
+
+    def _add_action_buttons(self):
+        btn_row = ui.ActionRow()
+
+        back_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str(BACK),
+            label=t("modules.config.buttons.back", locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            disabled=self.has_changes,
+        )
+        back_btn.callback = self.on_back
+        btn_row.add_item(back_btn)
+
+        if self.has_changes:
+            save_btn = ui.Button(
+                emoji=discord.PartialEmoji.from_str(SAVE),
+                label=t("modules.config.buttons.save", locale=self.locale),
+                style=discord.ButtonStyle.success,
+            )
+            save_btn.callback = self.on_save
+            btn_row.add_item(save_btn)
+
+            cancel_btn = ui.Button(
+                emoji=discord.PartialEmoji.from_str(UNDONE),
+                label=t("modules.config.buttons.cancel", locale=self.locale),
+                style=discord.ButtonStyle.danger,
+            )
+            cancel_btn.callback = self.on_cancel
+            btn_row.add_item(cancel_btn)
+        elif self.has_existing_config:
+            delete_btn = ui.Button(
+                emoji=discord.PartialEmoji.from_str(DELETE),
+                label=t("modules.config.buttons.delete", locale=self.locale),
+                style=discord.ButtonStyle.danger,
+            )
+            delete_btn.callback = self.on_delete
+            btn_row.add_item(delete_btn)
+
+        self.add_item(btn_row)
+
+    # ------------------------------------------------------------------
+    # Closure helpers for per-channel buttons
+    # ------------------------------------------------------------------
+
+    def _make_edit_cb(self, ch_id: int, ch_cfg: Dict[str, Any]):
+        async def callback(interaction: discord.Interaction):
+            if not await self.check_user(interaction):
+                return
+            channel_view = AdaptiveSlowmodeChannelConfigView(
+                bot=self.bot,
+                guild_id=self.guild_id,
+                user_id=self.user_id,
+                locale=self.locale,
+                parent_view=self,
+                channel_id=ch_id,
+                channel_config=dict(ch_cfg),
+            )
+            await interaction.response.edit_message(view=channel_view)
+        return callback
+
+    def _make_remove_cb(self, ch_id_str: str):
+        async def callback(interaction: discord.Interaction):
+            if not await self.check_user(interaction):
+                return
+            self.working_config.get("channels", {}).pop(ch_id_str, None)
+            self.has_changes = True
+            self._build_view()
+            await interaction.response.edit_message(view=self)
+        return callback
+
+    # ------------------------------------------------------------------
+    # Main callbacks
+    # ------------------------------------------------------------------
+
+    async def on_add_channel(self, interaction: discord.Interaction):
+        if not await self.check_user(interaction):
+            return
+        channel_view = AdaptiveSlowmodeChannelConfigView(
+            bot=self.bot,
+            guild_id=self.guild_id,
+            user_id=self.user_id,
+            locale=self.locale,
+            parent_view=self,
+        )
+        await interaction.response.edit_message(view=channel_view)
 
     async def on_back(self, interaction: discord.Interaction):
         if not await self.check_user(interaction):
@@ -346,9 +579,9 @@ class AdaptiveSlowmodeConfigView(BaseView):
         )
 
         if success:
-            self.current_config = dict(self.working_config)
-            self.has_changes = False
-            self.has_existing_config = True
+            self.current_config      = {"channels": copy.deepcopy(self.working_config["channels"])}
+            self.has_changes         = False
+            self.has_existing_config = bool(self.working_config.get("channels"))
             self._build_view()
             await interaction.followup.send(
                 t("modules.config.save.success", locale=self.locale), ephemeral=True
@@ -363,8 +596,8 @@ class AdaptiveSlowmodeConfigView(BaseView):
     async def on_cancel(self, interaction: discord.Interaction):
         if not await self.check_user(interaction):
             return
-        self.working_config = dict(self.current_config)
-        self.has_changes = False
+        self.working_config = {"channels": copy.deepcopy(self.current_config["channels"])}
+        self.has_changes    = False
         self._build_view()
         await interaction.response.edit_message(view=self)
 
@@ -373,15 +606,12 @@ class AdaptiveSlowmodeConfigView(BaseView):
             return
         await interaction.response.defer()
 
-        success = await self.bot.module_manager.delete_module_config(
-            self.guild_id, "adaptive_slowmode"
-        )
+        success = await self.bot.module_manager.delete_module_config(self.guild_id, "adaptive_slowmode")
 
         if success:
-            from modules.adaptive_slowmode import AdaptiveSlowmodeModule
-            self.current_config = AdaptiveSlowmodeModule(self.bot, self.guild_id).get_default_config()
-            self.working_config = dict(self.current_config)
-            self.has_changes = False
+            self.current_config      = {"channels": {}}
+            self.working_config      = {"channels": {}}
+            self.has_changes         = False
             self.has_existing_config = False
             self._build_view()
             await interaction.followup.send(
@@ -393,9 +623,7 @@ class AdaptiveSlowmodeConfigView(BaseView):
                 t("modules.config.delete.error", locale=self.locale), ephemeral=True
             )
 
-    # -------------------------------------------------------------------------
-    # User guard
-    # -------------------------------------------------------------------------
+    # ------------------------------------------------------------------
 
     async def check_user(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.user_id:


### PR DESCRIPTION
## Summary

- Refactors Adaptive Slowmode config from a single global config to per-channel independent settings
- Each channel now has its own `min_delay`, `max_delay`, and `sensitivity` stored under `channels.<channel_id>`
- Config UI redesigned: main list view (all configured channels) + per-channel settings sub-view (add/edit mode)
- JSON key normalization: channel IDs stored as strings in DB, normalized to `int` on load
- i18n updated (FR + EN) with new keys for the two-view config UI

## Config structure

```json
{
  "channels": {
    "123456789": { "min_delay": 0, "max_delay": 120, "sensitivity": "medium" },
    "987654321": { "min_delay": 5, "max_delay": 3600, "sensitivity": "high" }
  }
}
```

## Files changed

- `modules/adaptive_slowmode.py` — per-channel `channels_config` dict, int key normalization
- `modules/configs/adaptive_slowmode_config.py` — two-view UI with add/edit/remove per channel
- `locales/fr.json` + `locales/en-US.json` — new i18n keys for per-channel config UI

https://claude.ai/code/session_01PKuanrdvmqtJz82ktVFuFT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKuanrdvmqtJz82ktVFuFT)_