### PR TITLE
Handle discord.Forbidden when clearing commands on guild remove

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1230,6 +1230,9 @@ class ModdyBot(commands.Bot):
             self.tree.clear_commands(guild=guild)
             await self.tree.sync(guild=guild)
             logger.info(f"Commands cleared for guild {guild.name} ({guild.id})")
+        except discord.Forbidden:
+            # Bot was kicked — no longer has access to sync commands, this is expected
+            logger.debug(f"[SKIP] Cannot clear commands for guild {guild.id}: bot no longer has access (kicked)")
         except Exception as e:
             logger.error(f"[FAIL] Error clearing commands for guild {guild.id}: {e}")
 


### PR DESCRIPTION
## Summary
Add graceful handling for `discord.Forbidden` exceptions when the bot attempts to clear slash commands after being removed from a guild.

## Changes
- Added `discord.Forbidden` exception handler in `on_guild_remove()` to catch cases where the bot no longer has access to sync commands
- Logs a debug message indicating the bot was kicked and cannot clear commands (expected behavior)
- Prevents error logging for this expected scenario while maintaining error logging for other unexpected failures

## Details
When a bot is kicked from a guild, it loses access to that guild's resources. The existing code attempted to clear commands without handling the `Forbidden` exception that occurs in this case. This change adds a specific exception handler that:
1. Catches the `discord.Forbidden` exception before the generic `Exception` handler
2. Logs it as a debug message (not an error) since this is expected behavior
3. Allows the generic exception handler to catch other unexpected errors

This improves error logging clarity by distinguishing between expected failures (bot kicked) and actual errors that need investigation.

https://claude.ai/code/session_01W7gAM13SoQtJdd1bh7WBN9