### PR TITLE
Fix: invalid remove emoji crashes adaptive slowmode config

### DIFF
--- a/modules/configs/adaptive_slowmode_config.py
+++ b/modules/configs/adaptive_slowmode_config.py
@@ -13,7 +13,7 @@ import logging
 
 from utils.i18n import t
 from cogs.error_handler import BaseView, BaseModal
-from utils.emojis import TIME, REQUIRED_FIELDS, EDIT, BACK, SAVE, UNDONE, DELETE, ADD, REMOVE
+from utils.emojis import TIME, REQUIRED_FIELDS, EDIT, BACK, SAVE, UNDONE, DELETE, ADD
 
 logger = logging.getLogger('moddy.modules.adaptive_slowmode_config')
 
@@ -451,7 +451,7 @@ class AdaptiveSlowmodeConfigView(BaseView):
                 remove_btn = ui.Button(
                     label=t("modules.adaptive_slowmode.config.channel_list.remove_button", locale=self.locale),
                     style=discord.ButtonStyle.danger,
-                    emoji=discord.PartialEmoji.from_str(REMOVE),
+                    emoji=discord.PartialEmoji.from_str(DELETE),
                 )
                 remove_btn.callback = self._make_remove_cb(ch_id_str)
                 row.add_item(remove_btn)

--- a/utils/emojis.py
+++ b/utils/emojis.py
@@ -23,7 +23,6 @@ RED_STATUS = "<:red_status:1450929038758772940>"
 
 # Actions
 ADD = "<:add:1439697866049323090>"
-REMOVE = "<:remove:1398729478435393598>"
 EDIT = "<:edit:1401600709824086169>"
 DELETE = "<:delete:1401600770431909939>"
 SAVE = "<:save:1444101502154182778>"
@@ -138,7 +137,6 @@ EMOJIS = {
     "error": ERROR,
     # Actions
     "add": ADD,
-    "remove": REMOVE,
     "edit": EDIT,
     # Bot
     "moddy": MODDY,


### PR DESCRIPTION
## Problem

Opening the **Adaptive Slowmode** config panel threw `400 Bad Request (50035): Invalid Form Body / Invalid emoji` — but only on guilds where the module already had channels configured (e.g. set up via the dashboard).

## Root cause

In `AdaptiveSlowmodeConfigView`, each configured channel renders a row with an `edit` button (index 0) and a `remove` button (index 1). The error pointed precisely at `components.X.components.1.emoji.id` for every channel row → the **`REMOVE`** emoji (`<:remove:1398729478435393598>`) had an invalid ID (deleted from the emoji server).

This explains why:
- Other guilds worked → module not configured → no channel rows → `REMOVE` never rendered.
- Other modules worked → none of them render `REMOVE`; it was only used in the adaptive slowmode channel list.

## Fix

- Use the existing `DELETE` emoji for the remove button.
- Drop the dead `REMOVE` constant (and its `EMOJIS["remove"]` entry) from the emoji registry so it can't break anything else later.

## Test plan

- [ ] Open `/config` → Adaptive Slowmode on a guild with channels already configured → panel renders without error
- [ ] Remove button still works

https://claude.ai/code/session_01W7gAM13SoQtJdd1bh7WBN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7gAM13SoQtJdd1bh7WBN9)_