### PR TITLE
Social Notifications: platform-labelled link button under the notification

### DIFF
--- a/docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md
+++ b/docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md
@@ -148,7 +148,10 @@ When the bot posts a notification it builds (Components V2):
      `TextDisplay`;
    - a `MediaGallery` with the large media when `show_media` is on and media
      exists.
-3. **No other text.** No buttons.
+3. **No other text** inside the container.
+4. A single **link `Button` below the container** (when the event has a URL),
+   labelled per platform (youtube=Watch, twitch=Watch live, bluesky/instagram=
+   View post, rss=Read article — the `notify.open.*` i18n labels).
 
 Platform brand colours (defaults): youtube `#FF0000`, twitch `#9146FF`,
 bluesky `#1185FE`, rss `#EE802F`, instagram `#E1306C`.

--- a/modules/social_notifications.py
+++ b/modules/social_notifications.py
@@ -64,6 +64,16 @@ PLATFORMS: Dict[str, Dict[str, Any]] = {
 # Order shown in the platform picker.
 SUPPORTED_PLATFORMS: List[str] = ["youtube", "twitch", "bluesky", "rss", "instagram"]
 
+# Maps a platform to the i18n ``notify.open.<type>`` label used on the link
+# button under the notification (e.g. youtube -> "Watch", rss -> "Read article").
+PLATFORM_OPEN_TYPE: Dict[str, str] = {
+    "youtube": "video",
+    "twitch": "live",
+    "bluesky": "post",
+    "rss": "article",
+    "instagram": "post",
+}
+
 # Requested poll interval (seconds) per platform, by tier.
 # premium = fastest the platform allows; free = slower but still reasonable.
 # Realtime platforms (bluesky) are omitted — interval is ignored by the service.
@@ -260,6 +270,7 @@ def build_notification_view(
     """
     platform = event.get("platform", "")
 
+    url = event.get("url")
     media = event.get("thumbnail")
     avatar = event.get("author_avatar") or subscription.get("avatar_url")
 
@@ -304,6 +315,17 @@ def build_notification_view(
         container.add_item(ui.MediaGallery(discord.MediaGalleryItem(media=media)))
 
     view.add_item(container)
+
+    # 4. Link button under the container — always present when we have a URL,
+    #    with a platform-adapted label (reuses the notify.open.* labels).
+    if url:
+        open_type = PLATFORM_OPEN_TYPE.get(platform, "default")
+        open_label = t(f"modules.social_notifications.notify.open.{open_type}", locale=locale)
+        if open_label.startswith("["):  # missing key -> fallback
+            open_label = t("modules.social_notifications.notify.open.default", locale=locale)
+        row = ui.ActionRow()
+        row.add_item(ui.Button(label=open_label, style=discord.ButtonStyle.link, url=url))
+        view.add_item(row)
 
     allowed = discord.AllowedMentions(everyone=False, users=False, roles=bool(role_ids))
     return view, allowed


### PR DESCRIPTION
Follow-up to #250.

## What
Always render a link `Button` **below the container** of a social notification
(when the event has a URL), with a **platform-adapted label**:

| Platform | Button label |
|---|---|
| YouTube | Watch |
| Twitch | Watch live |
| Bluesky / Instagram | View post |
| RSS | Read article |
| (fallback) | Open |

The labels reuse the existing `notify.open.*` i18n keys (fr + en), mapped per
platform via a new `PLATFORM_OPEN_TYPE` table. The button sits outside the
container, so the "container holds only the user's message" rule from #250 still
holds.

## Files
- `modules/social_notifications.py` — `PLATFORM_OPEN_TYPE` + link button in
  `build_notification_view`.
- `docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md` — rendering contract updated
  (§6) so the dashboard preview matches.

No schema or contract changes.

https://claude.ai/code/session_01828oMkJvRbigAyKhrCypBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01828oMkJvRbigAyKhrCypBG)_