### PR TITLE
Social Notifications: fix premium detection, normalize URLs, richer /subscription list

### DIFF
--- a/cogs/social_notifications.py
+++ b/cogs/social_notifications.py
@@ -24,6 +24,7 @@ from modules.social_notifications import (
     build_notification_view,
     desired_poll_interval,
     platform_subscription_limit,
+    normalize_identifier,
 )
 
 logger = logging.getLogger('moddy.cogs.social_notifications')
@@ -74,9 +75,12 @@ class SocialNotifications(commands.Cog):
         Returns ``(ok, reply)`` where ``reply`` is the service response dict
         (on success it carries ``target_id``/``display_name``/``avatar_url``).
         """
+        # Normalize a pasted profile URL into a clean handle (idempotent).
+        identifier = normalize_identifier(platform, identifier)
+
         is_premium = False
         try:
-            is_premium = await self.bot.db.has_attribute('guild', guild.id, 'PREMIUM')
+            is_premium = await self.bot.db.is_guild_premium(guild.id)
         except Exception:
             pass
 

--- a/cogs/subscription.py
+++ b/cogs/subscription.py
@@ -77,8 +77,13 @@ class SubscriptionView(BaseView):
             container.add_item(ui.TextDisplay(f"**Linked servers:** `{count}/5`"))
 
             if self.servers:
-                lines_srv = "\n".join(f"- `{s['server_id']}`" for s in self.servers)
-                container.add_item(ui.TextDisplay(lines_srv))
+                lines = []
+                for s in self.servers:
+                    sid = s['server_id']
+                    guild = self.bot.get_guild(int(sid)) if str(sid).isdigit() else None
+                    name = guild.name if guild else "Unknown server"
+                    lines.append(f"- **{discord.utils.escape_markdown(name)}** (`{sid}`)")
+                container.add_item(ui.TextDisplay("\n".join(lines)))
             else:
                 container.add_item(ui.TextDisplay(
                     "-# No servers are linked to your subscription."

--- a/db/repositories/subscription.py
+++ b/db/repositories/subscription.py
@@ -69,3 +69,31 @@ class SubscriptionRepository:
                 str(user_id),
             )
         return [{'server_id': r['server_id'], 'added_at': r['added_at']} for r in rows]
+
+    async def is_guild_premium(self, guild_id: int) -> bool:
+        """Whether a guild is linked to an active subscription (premium).
+
+        A guild is premium when it appears in ``subscription_servers`` for a user
+        whose subscription is active (has a tier and is not expired). This is the
+        source of truth for premium — there is no per-guild ``PREMIUM`` attribute.
+        """
+        try:
+            async with self.pool.acquire() as conn:
+                val = await conn.fetchval(
+                    """
+                    SELECT EXISTS (
+                        SELECT 1
+                        FROM subscription_servers ss
+                        JOIN users u ON u.user_id = ss.user_id::bigint
+                        WHERE ss.server_id = $1
+                          AND u.subscription_tier IS NOT NULL
+                          AND (u.subscription_expires_at IS NULL
+                               OR u.subscription_expires_at > NOW())
+                    )
+                    """,
+                    str(guild_id),
+                )
+            return bool(val)
+        except Exception as e:
+            logger.error(f"[ERROR] is_guild_premium failed: {e}", exc_info=True)
+            return False

--- a/docs/SOCIAL_NOTIFICATIONS.md
+++ b/docs/SOCIAL_NOTIFICATIONS.md
@@ -91,7 +91,9 @@ one for free guilds.
 | instagram (future) | **600 s** | **1800 s** | 600 / 86400 / 1800 |
 | bluesky | realtime | realtime | interval ignored |
 
-- Premium status = guild attribute `PREMIUM`.
+- **Premium status** = the guild is linked to an **active subscription**
+  (`subscription_servers` joined with `users`, via `db.is_guild_premium`). There
+  is **no** per-guild `PREMIUM` attribute — do not use one.
 - **Per-platform quota:** a guild may follow **1 account per platform** (free) or
   **5 per platform** (premium) — `modules/social_notifications.py::platform_subscription_limit`.
   Enforced in `cogs/social_notifications.py::add_subscription` (re-adding an

--- a/docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md
+++ b/docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md
@@ -90,6 +90,11 @@ A guild may follow a limited number of **distinct accounts per platform**:
 Source of truth: `modules/social_notifications.py::platform_subscription_limit`
 (`FREE_PER_PLATFORM_LIMIT = 1`, `PREMIUM_PER_PLATFORM_LIMIT = 5`).
 
+**Premium detection** = the guild is linked to an active subscription, i.e. it
+appears in `subscription_servers` for a user whose `users.subscription_tier` is
+set and not expired (`db.is_guild_premium`). There is **no** per-guild `PREMIUM`
+attribute — the dashboard/backend must use the same subscription-link definition.
+
 Enforcement (bot, in `add_subscription` — also covers backend Option A tasks):
 1. Count existing rows for `(guild_id, platform)`.
 2. Resolve the target via the service.
@@ -157,6 +162,22 @@ Platform brand colours (defaults): youtube `#FF0000`, twitch `#9146FF`,
 bluesky `#1185FE`, rss `#EE802F`, instagram `#E1306C`.
 
 ---
+
+## 6b. Identifier normalization (NEW)
+
+`add_subscription` now runs `modules/social_notifications.py::normalize_identifier`
+on the raw input so a pasted profile URL becomes the handle before resolution:
+
+| Platform | Input | Stored `identifier` |
+|---|---|---|
+| youtube | `https://www.youtube.com/@juthing_jm` | `@juthing_jm` |
+| youtube | `youtube.com/channel/UC…` | `UC…` |
+| twitch | `https://twitch.tv/name` | `name` |
+| bluesky | `https://bsky.app/profile/h.bsky.social` | `h.bsky.social` |
+| rss | (any feed URL) | kept verbatim |
+
+Bare handles are left untouched; the function is idempotent. The dashboard should
+apply the same normalization so the displayed handle matches the bot.
 
 ## 7. Dependency
 

--- a/docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md
+++ b/docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md
@@ -85,7 +85,7 @@ A guild may follow a limited number of **distinct accounts per platform**:
 | Tier | Accounts per platform |
 |---|---|
 | Free | **1** |
-| Premium (`PREMIUM` guild attribute) | **5** |
+| Premium (active linked subscription) | **5** |
 
 Source of truth: `modules/social_notifications.py::platform_subscription_limit`
 (`FREE_PER_PLATFORM_LIMIT = 1`, `PREMIUM_PER_PLATFORM_LIMIT = 5`).

--- a/docs/sessions/2026-06-14_social-notifications-customization.md
+++ b/docs/sessions/2026-06-14_social-notifications-customization.md
@@ -63,6 +63,19 @@ and `NULL` means the **platform default template** (no longer a localized
 caption). Backend Option A (`moddy:tasks`) passthrough fields added:
 `embed_color`, `show_avatar`, `show_media` on `social_subscribe` / `social_update`.
 
+## Addendum — fixes (same session)
+- **Premium detection fixed:** the quota used `has_attribute('guild', …, 'PREMIUM')`
+  which is never set. Premium is subscription-based — added
+  `db.is_guild_premium(guild_id)` (`subscription_servers` JOIN `users` on
+  `user_id`, active tier check) and used it everywhere (cog + config). Doc
+  corrected (no per-guild `PREMIUM` attribute).
+- **Identifier normalization:** `normalize_identifier(platform, raw)` turns a
+  pasted profile URL into a clean handle (`youtube.com/@x` → `@x`, `twitch.tv/x`
+  → `x`, `bsky.app/profile/x` → `x`; RSS kept verbatim). Applied in the account
+  modal and in `add_subscription` (idempotent, covers backend tasks).
+- **/subscription:** linked servers now show **name + (`id`)** instead of just
+  the id (`cogs/subscription.py`).
+
 ## Known follow-ups
 - Could not runtime-test the discord UI here (discord.py not installed in the
   session env); Modals V2 / Checkbox usage follows `docs/MODALS_V2.md`.

--- a/modules/configs/social_notifications_config.py
+++ b/modules/configs/social_notifications_config.py
@@ -34,6 +34,7 @@ from modules.social_notifications import (
     SUPPORTED_PLATFORMS,
     MAX_MESSAGE_LENGTH,
     is_platform_disabled,
+    normalize_identifier,
     platform_subscription_limit,
     supports_avatar,
     supports_media,
@@ -314,7 +315,7 @@ class SocialNotificationsConfigView(BaseView):
         try:
             if getattr(bot, "feeds_client", None):
                 service_alive = await bot.feeds_client.is_service_alive()
-            is_premium = await bot.db.has_attribute('guild', guild_id, 'PREMIUM')
+            is_premium = await bot.db.is_guild_premium(guild_id)
         except Exception:
             pass
         return cls(bot, guild_id, user_id, locale, subscriptions, service_alive, is_premium)
@@ -435,7 +436,7 @@ class SocialNotificationsConfigView(BaseView):
         locale = i18n.get_user_locale(interaction)
         is_premium = False
         try:
-            is_premium = await bot.db.has_attribute('guild', interaction.guild_id, 'PREMIUM')
+            is_premium = await bot.db.is_guild_premium(interaction.guild_id)
         except Exception:
             pass
         add_view = AddSubscriptionView(bot, interaction.guild_id, locale, is_premium)
@@ -686,7 +687,8 @@ class AddSubscriptionView(BaseView):
         await interaction.response.send_modal(modal)
 
     async def _on_account_set(self, interaction: discord.Interaction, identifier: str):
-        self.identifier = identifier or None
+        # Turn a pasted profile URL into a clean handle right away.
+        self.identifier = normalize_identifier(self.platform or "", identifier) or None
         self._build_view()
         await interaction.response.edit_message(view=self)
 

--- a/modules/social_notifications.py
+++ b/modules/social_notifications.py
@@ -28,6 +28,7 @@ backend so both sides agree — see docs/SOCIAL_NOTIFICATIONS.md.
 import logging
 import time
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 import discord
 from discord import ui
@@ -184,6 +185,59 @@ def get_default_message(platform: str) -> str:
 def platform_placeholders(platform: str) -> List[str]:
     """Placeholders advertised in the customization modal for a platform."""
     return PLATFORM_PLACEHOLDERS.get(platform, ["{title}", "{url}", "{platform}", "{timestamp}"])
+
+
+def normalize_identifier(platform: str, raw: str) -> str:
+    """Extract a clean handle/identifier from a pasted profile URL.
+
+    The user can paste a full URL (e.g. ``https://www.youtube.com/@juthing_jm``)
+    and we turn it into the canonical-ish handle (``@juthing_jm``) per platform.
+    Bare handles are returned untouched. RSS feeds are kept **verbatim** (the
+    identifier *is* the feed URL). Idempotent — safe to call more than once.
+    """
+    s = (raw or "").strip()
+    if not s or platform == "rss":
+        return s
+
+    # Parse as a URL only when it looks like one.
+    host, segments = "", []
+    if s.startswith("http://") or s.startswith("https://") or "/" in s:
+        candidate = s if s.startswith(("http://", "https://")) else "https://" + s
+        try:
+            parsed = urlparse(candidate)
+            host = (parsed.netloc or "").lower()
+            segments = [seg for seg in (parsed.path or "").split("/") if seg]
+        except Exception:
+            host, segments = "", []
+
+    if platform == "youtube":
+        if "youtu" in host and segments:
+            first = segments[0]
+            if first.startswith("@"):
+                return first
+            if first.lower() in ("channel", "c", "user") and len(segments) >= 2:
+                return segments[1]
+            return first
+        return s
+
+    if platform == "twitch":
+        if "twitch.tv" in host and segments:
+            return segments[0]
+        return s.lstrip("@")
+
+    if platform == "bluesky":
+        if "bsky" in host and segments:
+            if segments[0].lower() == "profile" and len(segments) >= 2:
+                return segments[1]
+            return segments[-1]
+        return s.lstrip("@")
+
+    if platform == "instagram":
+        if "instagram.com" in host and segments:
+            return segments[0]
+        return s.lstrip("@")
+
+    return s
 
 
 def desired_poll_interval(platform: str, is_premium: bool) -> Optional[int]:


### PR DESCRIPTION
The squash-merge of #250 was taken **before** the commit with these fixes, so
they never landed on `main` (e.g. `/subscription` still shows only the server
id). This PR re-applies that missing commit cleanly on top of the current `main`.

## What's included
1. **Premium detection fixed** — the social quota/poll-interval used
   `has_attribute('guild', …, 'PREMIUM')`, which is never set. Premium is a
   per-user subscription with linked servers. Adds `db.is_guild_premium(guild_id)`
   (`subscription_servers` JOIN `users` on `user_id::bigint`, active tier) and
   uses it in the cog + config panel. → premium guilds now correctly get the
   5-per-platform cap instead of 1.
2. **Identifier normalization** — `normalize_identifier(platform, raw)` turns a
   pasted profile URL into a clean handle: `youtube.com/@x` → `@x`,
   `twitch.tv/x` → `x`, `bsky.app/profile/x` → `x`; RSS kept verbatim. Applied
   in the account modal and in `add_subscription` (idempotent, covers backend
   tasks).
3. **`/subscription`** — linked servers now show **name + (`id`)** instead of
   just the id (falls back to "Unknown server" when the bot isn't in the guild).
4. Docs corrected: premium = active linked subscription, not a guild attribute.

## Files
`db/repositories/subscription.py`, `cogs/social_notifications.py`,
`modules/social_notifications.py`, `modules/configs/social_notifications_config.py`,
`cogs/subscription.py`, `docs/SOCIAL_NOTIFICATIONS*.md`, session log.

No schema changes.

https://claude.ai/code/session_01828oMkJvRbigAyKhrCypBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01828oMkJvRbigAyKhrCypBG)_