### PR TITLE
Fix: message staff commands never dispatched (owned_types type mismatch)

### DIFF
--- a/staff/framework/cog.py
+++ b/staff/framework/cog.py
@@ -108,7 +108,7 @@ class StaffCommandsRouter(StaffCommandsCog):
         command_type, command_name, args = parsed
 
         # Only handle types owned by the new framework; legacy cogs handle others.
-        if command_type not in self.owned_types:
+        if command_type.value not in self.owned_types:
             return
 
         # Flat command, or a sub-group command (`mod.case create ...`).


### PR DESCRIPTION
## What

Follow-up to #254. The staff router's `owned_types` holds command-type **values**
(strings: `d`, `t`, `m`, `mod`), but `on_message` compared a `CommandType`
**enum** against it. The guard `command_type not in self.owned_types` was always
true, so **every message staff command was silently ignored** (`@Moddy t.help`,
`d.stats`, … never responded).

Fix: compare `command_type.value`. One-line change in `staff/framework/cog.py`.

## Why a fresh branch

`#254` was squash-merged, which left the original feature branch diverged from
`main` (PR #255 came up as `dirty`/conflicting). This branch is cut from current
`main` with only the fix, so it's a clean 1-file diff. **#255 can be closed.**

## Verified

Production logs confirm the framework loads fine
(`Staff router ready: 47 command(s), 4 slash group(s)`); only the dispatch guard
was wrong. Simulated parse → owned-check → lookup against the real registry:
`t.help` and `mod.case create` both route correctly. Slash commands were
unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxtVftAGM2mcs6jrjNx7ox

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxtVftAGM2mcs6jrjNx7ox)_