### PR TITLE
Staff UX: help menu, role icons, single user picker, clearer command names

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1387,7 +1387,9 @@
           "mod": "Moderation",
           "sup": "Support",
           "com": "Communication"
-        }
+        },
+        "count": "{count} command(s)",
+        "placeholder": "Choose a department…"
       }
     },
     "mod": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1386,7 +1386,9 @@
           "mod": "Modération",
           "sup": "Support",
           "com": "Communication"
-        }
+        },
+        "count": "{count} commande(s)",
+        "placeholder": "Choisis un département…"
       }
     },
     "mod": {

--- a/staff/commands/dev/jsk.py
+++ b/staff/commands/dev/jsk.py
@@ -97,7 +97,8 @@ class JskModal(BaseModal):
 @staff_command
 class JskCommand(StaffCommand):
     command_type = CommandType.DEV
-    name = "jsk"
+    name = "eval"
+    aliases = ("jsk",)
     description = "Evaluate Python code in the bot runtime."
     sensitive = True
 

--- a/staff/commands/dev/serverlist.py
+++ b/staff/commands/dev/serverlist.py
@@ -85,7 +85,8 @@ class ServerListView(BaseView):
 @staff_command
 class ServerListCommand(StaffCommand):
     command_type = CommandType.DEV
-    name = "serverlist"
+    name = "servers"
+    aliases = ("serverlist",)
     description = "Paginated list of every server Moddy is in."
 
     async def execute(self, ctx):

--- a/staff/commands/manage/staff.py
+++ b/staff/commands/manage/staff.py
@@ -57,7 +57,7 @@ class StaffManagerPanel(BaseView):
         loc = self.locale
         container = design.make_container("primary")
         container.add_item(ui.TextDisplay(
-            f"{design.title_line(emojis.STAFF, t('staff.manage.staff.title', locale=loc))}\n"
+            f"{design.title_line(emojis.MODDYTEAM_BADGE, t('staff.manage.staff.title', locale=loc))}\n"
             f"{self.target.mention} (`{self.target.id}`)\n"
             f"-# {t('staff.manage.staff.subtitle', locale=loc)}"
         ))
@@ -250,8 +250,7 @@ class StaffPanelCommand(StaffCommand):
     aliases = ("rank", "setstaff")
     description = "Manage a member's staff roles and permissions."
     options = [
-        SlashOption("user", "user", "Member to manage.", required=False),
-        SlashOption("user_id", "string", "Member id (optional).", required=False),
+        SlashOption("user", "user", "Member to manage.", required=True),
     ]
 
     def parse_message(self, raw: str) -> dict:

--- a/staff/commands/manage/staffinfo.py
+++ b/staff/commands/manage/staffinfo.py
@@ -16,8 +16,7 @@ class StaffInfoCommand(StaffCommand):
     name = "staffinfo"
     description = "Show information about a staff member (defaults to you)."
     options = [
-        SlashOption("user", "user", "Staff member (optional).", required=False),
-        SlashOption("user_id", "string", "Staff member id (optional).", required=False),
+        SlashOption("user", "user", "Staff member (defaults to you).", required=False),
     ]
 
     def parse_message(self, raw: str) -> dict:
@@ -61,7 +60,7 @@ class StaffInfoCommand(StaffCommand):
             role_lines.append(f"{badges.role_badge(role.value)} {get_role_display_name(role.value)}")
 
         fields = [{
-            "name": f"{emojis.STAFF} {t('staff.manage.info.roles', locale=locale)}",
+            "name": f"{emojis.MODDYTEAM_BADGE} {t('staff.manage.info.roles', locale=locale)}",
             "value": "\n".join(role_lines) if role_lines else f"-# {t('staff.manage.info.no_roles', locale=locale)}",
         }]
 
@@ -86,6 +85,6 @@ class StaffInfoCommand(StaffCommand):
             t("staff.manage.info.title", locale=locale),
             f"{rendered} (`{user.id}`)",
             fields=fields,
-            emoji=emojis.STAFF,
+            emoji=emojis.MODDYTEAM_BADGE,
             accent="primary",
         ))

--- a/staff/commands/manage/stafflist.py
+++ b/staff/commands/manage/stafflist.py
@@ -46,6 +46,6 @@ class StaffListCommand(StaffCommand):
             t("staff.manage.list.title", locale=locale),
             f"**{t('staff.manage.list.total', locale=locale, count=len(members))}**",
             fields=fields,
-            emoji=emojis.STAFF,
+            emoji=emojis.MODDYTEAM_BADGE,
             accent="primary",
         ))

--- a/staff/commands/manage/subrefresh.py
+++ b/staff/commands/manage/subrefresh.py
@@ -11,13 +11,12 @@ from utils.i18n import t
 @staff_command
 class SubRefreshCommand(StaffCommand):
     command_type = CommandType.MANAGEMENT
-    name = "subrefresh"
-    aliases = ("sub-refresh", "sub_refresh")
+    name = "refresh_subscription"
+    aliases = ("subrefresh", "sub-refresh", "sub_refresh")
     permission = "stripe_manage"
     description = "Invalidate a user's subscription cache (forces a fresh DB read)."
     options = [
-        SlashOption("user", "user", "Target user.", required=False),
-        SlashOption("user_id", "string", "Target user id.", required=False),
+        SlashOption("user", "user", "Target user.", required=True),
     ]
 
     def parse_message(self, raw: str) -> dict:

--- a/staff/commands/manage/unrank.py
+++ b/staff/commands/manage/unrank.py
@@ -18,8 +18,7 @@ class UnrankCommand(StaffCommand):
     name = "unrank"
     description = "Remove a member from the staff team."
     options = [
-        SlashOption("user", "user", "Member to remove.", required=False),
-        SlashOption("user_id", "string", "Member id (optional).", required=False),
+        SlashOption("user", "user", "Member to remove.", required=True),
     ]
 
     def parse_message(self, raw: str) -> dict:

--- a/staff/commands/team/flex.py
+++ b/staff/commands/team/flex.py
@@ -6,6 +6,7 @@ import discord
 from discord import ui
 
 from staff.framework import StaffCommand, staff_command, design, CommandType
+from staff.framework import badges
 from utils import emojis
 from utils.i18n import t
 from utils.staff_permissions import staff_permissions
@@ -43,12 +44,13 @@ class FlexCommand(StaffCommand):
 
         role_key = ROLE_KEY.get(roles[0].value, "member")
         role_display = t(f"staff.team.flex.roles.{role_key}", locale=locale)
+        badge = badges.role_badge(roles[0].value)
 
         view = BaseView()
         container = design.make_container("success")
         container.add_item(ui.TextDisplay(
             f"{emojis.VERIFIED} {ctx.author.mention} "
-            f"{t('staff.team.flex.message', locale=locale, role=role_display)}"
+            f"{t('staff.team.flex.message', locale=locale, role=role_display)} {badge}".rstrip()
         ))
         container.add_item(ui.TextDisplay(
             f"-# {t('staff.team.flex.disclaimer', locale=locale)}\n"

--- a/staff/commands/team/help.py
+++ b/staff/commands/team/help.py
@@ -1,45 +1,120 @@
-"""`/team help` — list the staff commands you can use, across all groups.
+"""`/team help` — interactive staff command menu.
 
-Framework-aware: introspects the router's registry and shows only the commands
-the caller is allowed to run, grouped by department, with both the slash and the
-message form.
+Shows a department picker (Select) using the staff role badges; choosing a
+department lists the commands you can run there, with both the slash and message
+forms. Framework-aware: introspects the router registry and filters by the
+caller's permissions.
 """
+
+import discord
+from discord import ui
 
 from staff.framework import StaffCommand, staff_command, design, CommandType
 from staff.framework.registry import SLASH_GROUPS
 from utils import emojis
 from utils.i18n import t
+from cogs.error_handler import BaseView
 
-# Display order + a representative emoji per command type.
+# Department display order + the staff badge used to represent it (same icons as
+# the /manage staff role selector).
 TYPE_ORDER = [
-    (CommandType.DEV, emojis.DEV),
-    (CommandType.TEAM, emojis.STAFF),
-    (CommandType.MANAGEMENT, emojis.SETTINGS),
-    (CommandType.MODERATOR, emojis.BLACKLIST),
-    (CommandType.SUPPORT, emojis.SUPPORT),
-    (CommandType.COMMUNICATION, emojis.MESSAGE),
+    CommandType.DEV, CommandType.TEAM, CommandType.MANAGEMENT,
+    CommandType.MODERATOR, CommandType.SUPPORT, CommandType.COMMUNICATION,
 ]
+DEPT_BADGE = {
+    "d": emojis.DEV_BADGE,
+    "t": emojis.MODDYTEAM_BADGE,
+    "m": emojis.MANAGER_BADGE,
+    "mod": emojis.MODERATOR_BADGE,
+    "sup": emojis.SUPPORTAGENT_BADGE,
+    "com": emojis.COMMUNICATION_BADGE,
+}
+
+
+class HelpView(BaseView):
+    """Department picker + command list. Author-checked, short-lived."""
+
+    def __init__(self, *, bot, author_id: int, locale: str, data: dict):
+        super().__init__(timeout=300)
+        self.bot = bot
+        self.author_id = author_id
+        self.locale = locale
+        self.data = data  # type_value -> [(label, description), ...]
+        # Departments available to this user, in display order.
+        self.available = [ct for ct in TYPE_ORDER if data.get(ct.value)]
+        self.selected = self.available[0].value if self.available else None
+        self._build()
+
+    def _build(self):
+        self.clear_items()
+        loc = self.locale
+        container = design.make_container("primary")
+        container.add_item(ui.TextDisplay(
+            f"{design.title_line(emojis.COMMANDS, t('staff.team.help.title', locale=loc))}\n"
+            f"-# {t('staff.team.help.subtitle', locale=loc)}"
+        ))
+
+        # Department select.
+        options = []
+        for ct in self.available:
+            entries = self.data.get(ct.value, [])
+            options.append(discord.SelectOption(
+                label=t(f"staff.team.help.groups.{ct.value}", locale=loc),
+                value=ct.value,
+                emoji=discord.PartialEmoji.from_str(DEPT_BADGE.get(ct.value)) if DEPT_BADGE.get(ct.value) else None,
+                description=t("staff.team.help.count", locale=loc, count=len(entries)),
+                default=ct.value == self.selected,
+            ))
+        row = ui.ActionRow()
+        select = ui.Select(placeholder=t("staff.team.help.placeholder", locale=loc),
+                           min_values=1, max_values=1, options=options, custom_id="help_dept")
+        select.callback = self._on_select
+        row.add_item(select)
+        self.add_item(row)
+
+        # Selected department's commands.
+        if self.selected:
+            ct = CommandType(self.selected)
+            slash = SLASH_GROUPS[ct][0]
+            badge = DEPT_BADGE.get(self.selected, "")
+            dept_name = t(f"staff.team.help.groups.{self.selected}", locale=loc)
+            entries = sorted(self.data.get(self.selected, []), key=lambda e: e[0])
+            lines = "\n".join(f"`/{slash} {label}` · `{self.selected}.{label}`\n-# {desc}"
+                              for label, desc in entries)
+            container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+            container.add_item(ui.TextDisplay(f"{badge} **{dept_name}**\n{lines}"))
+
+        self.add_item(container)
+
+    async def _on_select(self, interaction: discord.Interaction):
+        if interaction.user.id != self.author_id:
+            await interaction.response.send_message(t("staff.common.not_your_menu", locale=self.locale), ephemeral=True)
+            return
+        values = interaction.data.get("values", [])
+        if values:
+            self.selected = values[0]
+            self._build()
+            await interaction.response.edit_message(view=self)
+        else:
+            await interaction.response.defer()
 
 
 @staff_command
 class HelpCommand(StaffCommand):
     command_type = CommandType.TEAM
     name = "help"
-    description = "List the staff commands you can use."
+    description = "Browse the staff commands you can use."
 
     async def execute(self, ctx):
-        bot = ctx.bot
-        locale = ctx.locale
-        router = bot.get_cog("StaffCommandsRouter")
+        router = ctx.bot.get_cog("StaffCommandsRouter")
         if not router:
             await ctx.send(view=design.error(
-                t("staff.common.error.title", locale=locale),
-                t("staff.common.error.description", locale=locale),
+                t("staff.common.error.title", locale=ctx.locale),
+                t("staff.common.error.description", locale=ctx.locale),
             ))
             return
 
-        # type_value -> list of (label, description)
-        commands_by_type: dict = {}
+        data: dict = {}
         seen = set()
 
         async def _allowed(cmd) -> bool:
@@ -51,7 +126,7 @@ class HelpCommand(StaffCommand):
                 continue
             seen.add(id(cmd))
             if await _allowed(cmd):
-                commands_by_type.setdefault(tv, []).append((cmd.name, cmd.description))
+                data.setdefault(tv, []).append((cmd.name, cmd.description))
 
         for (tv, group), bucket in router.subgroup_index.items():
             local_seen = set()
@@ -60,33 +135,13 @@ class HelpCommand(StaffCommand):
                     continue
                 local_seen.add(id(cmd))
                 if await _allowed(cmd):
-                    commands_by_type.setdefault(tv, []).append((f"{group} {cmd.name}", cmd.description))
+                    data.setdefault(tv, []).append((f"{group} {cmd.name}", cmd.description))
 
-        fields = []
-        for ctype, emoji in TYPE_ORDER:
-            entries = commands_by_type.get(ctype.value)
-            if not entries:
-                continue
-            slash_name = SLASH_GROUPS[ctype][0]
-            entries.sort(key=lambda e: e[0])
-            lines = "\n".join(f"`{label}` — {desc}" for label, desc in entries)
-            fields.append({
-                "name": f"{emoji} {t(f'staff.team.help.groups.{ctype.value}', locale=locale)} — `/{slash_name}` · `{ctype.value}.`",
-                "value": lines,
-            })
-
-        if not fields:
+        if not data:
             await ctx.send(view=design.info(
-                t("staff.team.help.title", locale=locale),
-                t("staff.team.help.empty", locale=locale),
+                t("staff.team.help.title", locale=ctx.locale),
+                t("staff.team.help.empty", locale=ctx.locale),
             ))
             return
 
-        await ctx.send(view=design.panel(
-            "info",
-            t("staff.team.help.title", locale=locale),
-            t("staff.team.help.subtitle", locale=locale),
-            fields=fields,
-            emoji=emojis.COMMANDS,
-            accent="primary",
-        ))
+        await ctx.send(view=HelpView(bot=ctx.bot, author_id=ctx.author.id, locale=ctx.locale, data=data))

--- a/staff/commands/team/mutualserver.py
+++ b/staff/commands/team/mutualserver.py
@@ -31,11 +31,11 @@ def _key_perms(member: discord.Member, locale: str) -> str:
 @staff_command
 class MutualServerCommand(StaffCommand):
     command_type = CommandType.TEAM
-    name = "mutualserver"
+    name = "mutual_servers"
+    aliases = ("mutualserver",)
     description = "List servers shared between Moddy and a user."
     options = [
-        SlashOption("user", "user", "Target user.", required=False),
-        SlashOption("user_id", "string", "Target user id.", required=False),
+        SlashOption("user", "user", "Target user.", required=True),
     ]
 
     def parse_message(self, raw: str) -> dict:

--- a/staff/commands/team/subscription.py
+++ b/staff/commands/team/subscription.py
@@ -24,8 +24,7 @@ class SubscriptionCommand(StaffCommand):
     name = "subscription"
     description = "View a user's subscription details."
     options = [
-        SlashOption("user", "user", "Target user.", required=False),
-        SlashOption("user_id", "string", "Target user id.", required=False),
+        SlashOption("user", "user", "Target user.", required=True),
     ]
 
     def parse_message(self, raw: str) -> dict:

--- a/staff/commands/team/user.py
+++ b/staff/commands/team/user.py
@@ -14,8 +14,7 @@ class UserCommand(StaffCommand):
     name = "user"
     description = "Detailed info about a user (Discord + Moddy data)."
     options = [
-        SlashOption("user", "user", "Target user.", required=False),
-        SlashOption("user_id", "string", "Target user id (if not using the picker).", required=False),
+        SlashOption("user", "user", "Target user.", required=True),
     ]
 
     def parse_message(self, raw: str) -> dict:


### PR DESCRIPTION
Follow-up UX pass on the staff commands (requested):

**1. `/team help` is now an interactive menu** — a department picker (Select)
using the staff role badges; choosing a department lists the commands you can
run there (slash **and** message form), filtered by your permissions. Works on
both transports.

**2. Role icons everywhere** — `flex` now shows the staff role badge; the help
department menu uses the same badges as the `/manage staff` role selector.

**3. Slash: a single `user` picker** — removed the redundant `user_id` string
option from every command that had both; the Discord user picker already accepts
a raw ID. Marked `user` **required** where the target is required (`user`,
`mutual_servers`, `subscription`, `staff`, `unrank`, `refresh_subscription`);
`staffinfo` stays optional (defaults to you).

**4. Clearer command names** (old names kept as message aliases for muscle
memory): `jsk → eval`, `serverlist → servers`, `mutualserver → mutual_servers`,
`subrefresh → refresh_subscription`.

**5. Fixed the non-existent `:staff:` emoji** — replaced with the Moddy team badge.

Validated: all groups build & serialize; the new options are single + required;
`HelpView` builds and switches departments; i18n keys (FR + EN) audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxtVftAGM2mcs6jrjNx7ox

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxtVftAGM2mcs6jrjNx7ox)_