### PR TITLE
Flex: match the exact requested design (icon, accent, disclaimer)

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1374,7 +1374,9 @@
           "member": "member",
           "support": "support agent",
           "moderator": "moderator"
-        }
+        },
+        "authorized": "Moddy team are authorized to take action on your server.",
+        "prevent": "This message was sent to prevent identity theft."
       },
       "help": {
         "title": "Staff Commands",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1373,7 +1373,9 @@
           "member": "membre",
           "support": "agent de support",
           "moderator": "modérateur"
-        }
+        },
+        "authorized": "L'équipe Moddy est autorisée à agir sur ton serveur.",
+        "prevent": "Ce message a été envoyé pour prévenir l'usurpation d'identité."
       },
       "help": {
         "title": "Commandes staff",

--- a/staff/commands/team/flex.py
+++ b/staff/commands/team/flex.py
@@ -6,13 +6,15 @@ import discord
 from discord import ui
 
 from staff.framework import StaffCommand, staff_command, design, CommandType
-from staff.framework import badges
-from utils import emojis
 from utils.i18n import t
 from utils.staff_permissions import staff_permissions
 from cogs.error_handler import BaseView
 
 logger = logging.getLogger("moddy.staff.team.flex")
+
+# Exact flex design (see request): Moddy square icon + accent colour 27391.
+MODDY_ICON = "<:ModdyIconCarre:1517239121322578090>"
+FLEX_ACCENT = 27391
 
 ROLE_KEY = {
     "Dev": "developer",
@@ -44,18 +46,18 @@ class FlexCommand(StaffCommand):
 
         role_key = ROLE_KEY.get(roles[0].value, "member")
         role_display = t(f"staff.team.flex.roles.{role_key}", locale=locale)
-        badge = badges.role_badge(roles[0].value)
 
         view = BaseView()
-        container = design.make_container("success")
+        container = design.make_container(FLEX_ACCENT)
         container.add_item(ui.TextDisplay(
-            f"{emojis.VERIFIED} {ctx.author.mention} "
-            f"{t('staff.team.flex.message', locale=locale, role=role_display)} {badge}".rstrip()
+            f"### **{MODDY_ICON} {ctx.author.mention} "
+            f"{t('staff.team.flex.message', locale=locale, role=role_display)}**"
         ))
         container.add_item(ui.TextDisplay(
-            f"-# {t('staff.team.flex.disclaimer', locale=locale)}\n"
+            f"-# {t('staff.team.flex.authorized', locale=locale)}\n"
+            f"-# {t('staff.team.flex.prevent', locale=locale)}\n"
             "-# [Report Staff](https://moddy.app/report-staff) • "
-            "[Support](https://moddy.app/support) • [Documentation](https://docs.moddy.app/)"
+            "[Support](https://moddy.app/support) • [Documentation](https://moddy.app/docs-flex)"
         ))
         view.add_item(container)
 


### PR DESCRIPTION
Aligns the `/team flex` output with the exact requested design:

- Container **accent colour `27391`**.
- Title: `### **<:ModdyIconCarre:1517239121322578090> @user is a {role} of the Moddy Team**`
  (Moddy square icon, no role badge).
- Disclaimer as two separate `-#` lines (authorized / identity-theft) plus the
  links line, with **Documentation → `https://moddy.app/docs-flex`**.

Text stays localized (FR/EN) via i18n; structure matches the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxtVftAGM2mcs6jrjNx7ox

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxtVftAGM2mcs6jrjNx7ox)_