### PR TITLE
Add /dev emoji_replace and /dev emoji_preview + update staff docs

### DIFF
--- a/staff/commands/dev/emoji_preview.py
+++ b/staff/commands/dev/emoji_preview.py
@@ -35,7 +35,7 @@ async def _resolve_emoji(bot, raw: str):
         return pe, f"<:{name}:{emoji_id}>"
 
     # Name or ID only — need to look up the application emoji list.
-    for e in await bot.application.fetch_emojis():
+    for e in await bot.fetch_application_emojis():
         if emoji_id and e.id == emoji_id:
             pe = discord.PartialEmoji(name=e.name, id=e.id)
             return pe, f"<:{e.name}:{e.id}>"

--- a/staff/commands/dev/emoji_replace.py
+++ b/staff/commands/dev/emoji_replace.py
@@ -28,7 +28,7 @@ def _parse_input(raw: str):
 
 
 async def _find_app_emoji(bot, name, emoji_id):
-    for e in await bot.application.fetch_emojis():
+    for e in await bot.fetch_application_emojis():
         if emoji_id and e.id == emoji_id:
             return e
         if name and e.name.lower() == name.lower():
@@ -88,7 +88,7 @@ class EmojiReplaceCommand(StaffCommand):
             return
 
         try:
-            new = await ctx.bot.application.create_emoji(name=old_name, image=image_bytes)
+            new = await ctx.bot.create_application_emoji(name=old_name, image=image_bytes)
         except Exception as exc:
             await ctx.send(view=_plain(
                 f"Old emoji deleted but failed to create new one: `{exc}`\n"


### PR DESCRIPTION
## Summary

- `/dev emoji_replace` (slash-only): remplace un emoji applicatif par une nouvelle image. Accepte nom / ID / syntaxe complète `<:name:id>`. Supprime l'ancien, crée le nouveau avec le même nom, log `<old> -> <new>` dans le salon de tracking.
- `/dev emoji_preview` (slash-only): prévisualise un emoji dans tous les contextes Discord — texte inline, titre `###`, caption `-#`, menu déroulant, et boutons dans les 4 styles (primary, secondary, success, danger) + lien.
- `registry.py`: ajout du type `attachment` → `discord.Attachment` pour `SlashOption`.
- `docs/STAFF_SYSTEM.md` + `docs/STAFF_COMMANDS_FRAMEWORK.md`: réécriture complète, suppression de tout le legacy, documentation du système actuel uniquement.

## Test plan

- [ ] `/dev emoji_replace` avec nom exact, ID, et syntaxe `<:name:id>`
- [ ] Vérifier le log dans le salon `1519754560208375838`
- [ ] `/dev emoji_preview` avec un emoji applicatif
- [ ] Vérifier que les boutons et le select s'affichent correctement

---
_Generated by [Claude Code](https://claude.ai/code/session_01HB1xmMi8ZhnGEdurSkeSdM)_