### PR TITLE
Fix stale emoji ids in technical logs + record who added the bot

### DIFF
--- a/utils/emojis.py
+++ b/utils/emojis.py
@@ -46,7 +46,8 @@ REQUIRED_FIELDS = "<:required_fields:1446549185385074769>"
 # Objects / Concepts
 USER = "<:user:1519798911517196511>"
 DEV = "<:dev:1398729645557285066>"
-MODDY = "<:moddy:1396880909117947924>"
+MODDY = "<:ModdyIcon:1517239367184285909>"
+MODDY_SQUARE = "<:ModdyIconCarre:1517239121322578090>"  # rounded-square variant
 MODDY_ALT = "<:moddy:1451280939412881508>"
 BLACKLIST = "<:blacklist:1519797375470669944>"
 TIME = "<:time:1519798202990330087>"
@@ -171,6 +172,7 @@ EMOJIS = {
     "edit": EDIT,
     # Bot
     "moddy": MODDY,
+    "moddy_square": MODDY_SQUARE,
     "developer": DEV,
     "staff": STAFF,
     "ping": SUPPORT,

--- a/utils/tech_logger.py
+++ b/utils/tech_logger.py
@@ -31,7 +31,7 @@ from discord import ui, SeparatorSpacing
 
 from config import LOG_WEBHOOKS, LOG_WEBHOOK_DEFAULT, ENV_MODE
 from utils.emojis import (
-    DONE, UNDONE, ADD, LOGOUT, MODDY, BUG, STAFF, SETTINGS, COMMANDS,
+    DONE, UNDONE, ADD, LOGOUT, MODDY, BUG, MODDYTEAM_BADGE, SETTINGS, COMMANDS,
     SAVE, MANAGE_USER, BLACKLIST, TIME, PAUSE,
 )
 
@@ -169,9 +169,26 @@ class TechLogger:
             bots = sum(1 for m in guild.members if m.bot) if guild.members else None
             members = guild.member_count or 0
             owner = f"`{guild.owner}`" if guild.owner else "unknown"
+
+            # Who added Moddy (requires View Audit Log permission).
+            added_by = None
+            try:
+                async for entry in guild.audit_logs(limit=8, action=discord.AuditLogAction.bot_add):
+                    if entry.target and self.bot.user and entry.target.id == self.bot.user.id:
+                        added_by = entry.user
+                        break
+            except (discord.Forbidden, discord.HTTPException):
+                pass
+
             lines = [
                 f"**Guild** `{guild.name}` `{guild.id}`",
                 f"**Owner** {owner} `{guild.owner_id}`",
+            ]
+            if added_by:
+                lines.append(f"**Added by** `{added_by}` `{added_by.id}`")
+            else:
+                lines.append("**Added by** `unknown` (no audit log access)")
+            lines += [
                 f"**Members** `{members}`"
                 + (f" • humans `{humans}` / bots `{bots}`" if humans is not None else ""),
                 f"**Created** <t:{int(guild.created_at.timestamp())}:R>",
@@ -322,7 +339,7 @@ class TechLogger:
             if args:
                 lines.append(f"**Args** `{_trunc(args, 200)}`")
             lines.append(f"{_b(success)} **Executed**")
-            view = self._card("staff_command", STAFF, "Staff Command", lines)
+            view = self._card("staff_command", MODDYTEAM_BADGE, "Staff Command", lines)
             await self._dispatch("staff_command", view)
         except Exception as exc:
             logger.warning("log_staff_command failed: %s", exc)


### PR DESCRIPTION
## Summary

Follow-up to #265 (webhook-based technical logging). Fixes the `400 Bad Request — Invalid emoji` caused by stale custom-emoji ids, and enriches the guild-join log.

## Changes

- **Fix invalid `:moddy:` emoji id**: `1396880909117947924` no longer exists and was replaced with `<:ModdyIcon:1517239367184285909>`. An invalid emoji id on a component is exactly what triggers Discord's `400 Invalid emoji`. Added `MODDY_SQUARE` (`<:ModdyIconCarre:1517239121322578090>`, rounded-square variant) to `utils/emojis.py`.
- **Stop using the non-existent `:staff:` emoji** in the technical logs; the staff-command card now uses the Moddy team badge.
- **Guild-join log now records who added Moddy** (via the audit log, when the bot has *View Audit Log*); falls back to `unknown (no audit log access)` otherwise.

## Notes

`Invalid emoji` errors always come from a dead custom-emoji id on a button/select. If another staff command still raises it, the offending id is on that command's component (e.g. a Save button or a role badge) and can be updated the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017A78J9Fook65zTVrcyhMUV

---
_Generated by [Claude Code](https://claude.ai/code/session_017A78J9Fook65zTVrcyhMUV)_