### PR TITLE
feat: /ban, /mute, /warn — moderation commands with V2 modal and case system

### DIFF
--- a/cogs/moderation_commands.py
+++ b/cogs/moderation_commands.py
@@ -324,7 +324,7 @@ class SanctionModal(BaseModal):
 
             guild_name = self.guild.name
             guild_id = self.guild.id
-            guild_url = f"https://discord.com/channels/{guild_id}/"
+            guild_url = f"https://discord.com/channels/{guild_id}"
 
             text = (
                 f"### {sanction_emoji} {title}\n"

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -592,6 +592,52 @@
       "empty_title": "No Cases",
       "empty": "You have no moderation cases on record.\n-# This is a good thing!",
       "error": "An error occurred while fetching your cases. Please try again later."
+    },
+    "moderation": {
+      "modal": {
+        "title_ban": "Ban",
+        "title_mute": "Timeout",
+        "title_warn": "Warn",
+        "users_label": "Target users",
+        "users_description": "Select users to sanction",
+        "reason_label": "Reason",
+        "reason_placeholder": "Enter the reason for this sanction...",
+        "duration_label": "Duration",
+        "duration_placeholder": "e.g. 7d, 24h, 30m — leave empty for permanent",
+        "duration_description": "Leave empty or write \"permanent\" for no expiry",
+        "evidence_label": "Evidence",
+        "evidence_description": "Files will be accessible to the sanctioned user",
+        "notify_dm_label": "Notify user(s) by DM"
+      },
+      "confirm": {
+        "action_ban": "banned",
+        "action_mute": "timed out",
+        "action_warn": "warned",
+        "reason": "Reason",
+        "duration": "Duration",
+        "case_id": "Case ID",
+        "permanent": "Permanent",
+        "users_sanctioned": "users"
+      },
+      "dm": {
+        "ban_title": "You got banned :(",
+        "mute_title": "You have been timed out :(",
+        "warn_title": "You got warned :(",
+        "reason": "Reason",
+        "responsible": "Responsible",
+        "expires": "Automatically expires",
+        "permanent": "Never (permanent)",
+        "case_id": "Case ID",
+        "sent_by": "Sent by [**{guild}**]({guild_url}) (`{guild_id}`)"
+      },
+      "errors": {
+        "invalid_duration_title": "Invalid Duration",
+        "invalid_duration": "Use formats like `7d`, `24h`, `30m`, or leave empty for permanent.",
+        "no_users_title": "No Users Selected",
+        "no_users": "Please select at least one user to sanction.",
+        "all_failed_title": "Action Failed",
+        "all_failed": "The sanction could not be applied. Check the bot's permissions."
+      }
     }
   },
   "errors": {
@@ -1653,52 +1699,6 @@
         "deleted": "Banner {id} has been deleted.",
         "confirm_title": "Delete Banner?",
         "confirm": "Permanently delete banner {id}?"
-      }
-    },
-    "moderation": {
-      "modal": {
-        "title_ban": "Ban",
-        "title_mute": "Timeout",
-        "title_warn": "Warn",
-        "users_label": "Target users",
-        "users_description": "Select users to sanction",
-        "reason_label": "Reason",
-        "reason_placeholder": "Enter the reason for this sanction...",
-        "duration_label": "Duration",
-        "duration_placeholder": "e.g. 7d, 24h, 30m — leave empty for permanent",
-        "duration_description": "Leave empty or write \"permanent\" for no expiry",
-        "evidence_label": "Evidence",
-        "evidence_description": "Files will be accessible to the sanctioned user",
-        "notify_dm_label": "Notify user(s) by DM"
-      },
-      "confirm": {
-        "action_ban": "banned",
-        "action_mute": "timed out",
-        "action_warn": "warned",
-        "reason": "Reason",
-        "duration": "Duration",
-        "case_id": "Case ID",
-        "permanent": "Permanent",
-        "users_sanctioned": "users"
-      },
-      "dm": {
-        "ban_title": "You got banned :(",
-        "mute_title": "You have been timed out :(",
-        "warn_title": "You got warned :(",
-        "reason": "Reason",
-        "responsible": "Responsible",
-        "expires": "Automatically expires",
-        "permanent": "Never (permanent)",
-        "case_id": "Case ID",
-        "sent_by": "Sent by [**{guild}**]({guild_url}) (`{guild_id}`)"
-      },
-      "errors": {
-        "invalid_duration_title": "Invalid Duration",
-        "invalid_duration": "Use formats like `7d`, `24h`, `30m`, or leave empty for permanent.",
-        "no_users_title": "No Users Selected",
-        "no_users": "Please select at least one user to sanction.",
-        "all_failed_title": "Action Failed",
-        "all_failed": "The sanction could not be applied. Check the bot's permissions."
       }
     }
   }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -591,6 +591,52 @@
       "empty_title": "Aucun dossier",
       "empty": "Tu n'as aucun dossier de modération enregistré.\n-# C'est une bonne nouvelle !",
       "error": "Une erreur est survenue lors de la récupération de tes dossiers. Réessaie plus tard."
+    },
+    "moderation": {
+      "modal": {
+        "title_ban": "Bannissement",
+        "title_mute": "Expiration du droit de parole",
+        "title_warn": "Avertissement",
+        "users_label": "Utilisateurs ciblés",
+        "users_description": "Sélectionne les utilisateurs à sanctionner",
+        "reason_label": "Raison",
+        "reason_placeholder": "Entre la raison de cette sanction...",
+        "duration_label": "Durée",
+        "duration_placeholder": "ex. 7d, 24h, 30m — vide = permanent",
+        "duration_description": "Laisse vide ou écris \"permanent\" pour aucune expiration",
+        "evidence_label": "Preuves",
+        "evidence_description": "Les fichiers seront accessibles à l'utilisateur sanctionné",
+        "notify_dm_label": "Notifier les utilisateur(s) par MP"
+      },
+      "confirm": {
+        "action_ban": "banni",
+        "action_mute": "mis en sourdine",
+        "action_warn": "averti",
+        "reason": "Raison",
+        "duration": "Durée",
+        "case_id": "ID du cas",
+        "permanent": "Permanent",
+        "users_sanctioned": "utilisateurs"
+      },
+      "dm": {
+        "ban_title": "Tu as été banni :(",
+        "mute_title": "Tu as été mis en sourdine :(",
+        "warn_title": "Tu as reçu un avertissement :(",
+        "reason": "Raison",
+        "responsible": "Responsable",
+        "expires": "Expire automatiquement",
+        "permanent": "Jamais (permanent)",
+        "case_id": "ID du cas",
+        "sent_by": "Envoyé par [**{guild}**]({guild_url}) (`{guild_id}`)"
+      },
+      "errors": {
+        "invalid_duration_title": "Durée invalide",
+        "invalid_duration": "Utilise des formats comme `7d`, `24h`, `30m`, ou laisse vide pour permanent.",
+        "no_users_title": "Aucun utilisateur sélectionné",
+        "no_users": "Sélectionne au moins un utilisateur à sanctionner.",
+        "all_failed_title": "Échec de l'action",
+        "all_failed": "La sanction n'a pas pu être appliquée. Vérifie les permissions du bot."
+      }
     }
   },
   "errors": {
@@ -1652,52 +1698,6 @@
         "deleted": "La bannière {id} a été supprimée.",
         "confirm_title": "Supprimer la bannière ?",
         "confirm": "Supprimer définitivement la bannière {id} ?"
-      }
-    },
-    "moderation": {
-      "modal": {
-        "title_ban": "Bannissement",
-        "title_mute": "Expiration du droit de parole",
-        "title_warn": "Avertissement",
-        "users_label": "Utilisateurs ciblés",
-        "users_description": "Sélectionne les utilisateurs à sanctionner",
-        "reason_label": "Raison",
-        "reason_placeholder": "Entre la raison de cette sanction...",
-        "duration_label": "Durée",
-        "duration_placeholder": "ex. 7d, 24h, 30m — vide = permanent",
-        "duration_description": "Laisse vide ou écris \"permanent\" pour aucune expiration",
-        "evidence_label": "Preuves",
-        "evidence_description": "Les fichiers seront accessibles à l'utilisateur sanctionné",
-        "notify_dm_label": "Notifier les utilisateur(s) par MP"
-      },
-      "confirm": {
-        "action_ban": "banni",
-        "action_mute": "mis en sourdine",
-        "action_warn": "averti",
-        "reason": "Raison",
-        "duration": "Durée",
-        "case_id": "ID du cas",
-        "permanent": "Permanent",
-        "users_sanctioned": "utilisateurs"
-      },
-      "dm": {
-        "ban_title": "Tu as été banni :(",
-        "mute_title": "Tu as été mis en sourdine :(",
-        "warn_title": "Tu as reçu un avertissement :(",
-        "reason": "Raison",
-        "responsible": "Responsable",
-        "expires": "Expire automatiquement",
-        "permanent": "Jamais (permanent)",
-        "case_id": "ID du cas",
-        "sent_by": "Envoyé par [**{guild}**]({guild_url}) (`{guild_id}`)"
-      },
-      "errors": {
-        "invalid_duration_title": "Durée invalide",
-        "invalid_duration": "Utilise des formats comme `7d`, `24h`, `30m`, ou laisse vide pour permanent.",
-        "no_users_title": "Aucun utilisateur sélectionné",
-        "no_users": "Sélectionne au moins un utilisateur à sanctionner.",
-        "all_failed_title": "Échec de l'action",
-        "all_failed": "La sanction n'a pas pu être appliquée. Vérifie les permissions du bot."
       }
     }
   }


### PR DESCRIPTION
## Summary

- Add three guild-only slash commands (`/ban`, `/mute`, `/warn`) backed by a V2 Modal
- Full integration with the case system — each sanction records a case via `CaseService`
- Multi-user support: up to 10 users per batch, linked via a shared `group_id`
- Deduplication guard in `case_sync` prevents double-recording when Moddy itself triggers the audit log event

## Changes

### `cogs/moderation_commands.py` (new)
- `SanctionModal` (V2 Modal, 5 labels): UserSelect, reason TextInput, duration TextInput (ban/mute only), FileUpload for evidence, Checkbox for DM notification
- `_apply_sanction()` — marks action as Moddy-initiated, records case, executes Discord action, sends DM
- `_discord_action()` — `guild.ban()` / `member.timeout()` (capped at 28 days) / no-op for warn
- `_send_dm()` — Components V2 container with coloured accent + `ui.MediaGallery` for evidence files; language follows `guild.preferred_locale`
- `_send_confirmation()` — green accent panel for the moderator; adapts to single vs. multi-user
- `/ban`, `/mute`, `/warn` commands with optional `user` pre-fill and `incognito` flag

### `cogs/case_sync.py`
- Added `_is_moddy_initiated()` — checks `bot._moddy_initiated_sanctions[(guild_id, user_id, action)]` within a 10-second window to skip audit-log-triggered duplicate recording

### `services/case_service.py`
- `record_sanction()` now accepts an optional `group_id` parameter passed through to `create_case()`

### `utils/emojis.py`
- Added `LEGAL`, `MIC_OFF`, `CHECK` emoji constants

### `locales/en-US.json` / `locales/fr.json`
- Added `commands.moderation.*` keys: `modal.*`, `dm.*`, `confirm.*`, `errors.*`

### `docs/sessions/2026-06-27_moderation-commands.md` (new)
- Session log for this feature

## Known limitations

- Discord timeout is capped at 28 days for `/mute`; the case records the full requested duration
- `/warn` creates no Discord action — case record + optional DM only
- Evidence in DMs uses `ui.MediaGallery` — raw files (PDFs, ZIPs) may not render in Discord

---
_Generated by [Claude Code](https://claude.ai/code/session_0123nEyV3kKKbvDoS2wre3ZY)_