### PR TITLE
Add centralised OpenAI client service with hook system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 ### Infrastructure
 | Document | When to Read |
 |---|---|
+| [docs/OPENAI.md](docs/OPENAI.md) | OpenAI API integration — `bot.openai`, hooks, quota extension points |
 | [docs/BACKEND-INTEGRATION.md](docs/BACKEND-INTEGRATION.md) | Bot ↔ Backend integration (Redis, Pub/Sub, Streams, `/status`) |
 | [docs/SOCIAL_NOTIFICATIONS.md](docs/SOCIAL_NOTIFICATIONS.md) | Social Notifications module + `moddy-feeds` Redis contract (what the backend must mirror) |
 | [docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md](docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md) | Backend/dashboard change spec: customizable message columns, quota, error codes, task fields |

--- a/bot.py
+++ b/bot.py
@@ -85,6 +85,8 @@ class ModdyBot(commands.Bot):
         self.db = None  # ModdyDatabase instance
         from services.case_service import CaseService
         self.cases = CaseService(self)  # scalable sanction -> case entry point
+        from services.openai_client import OpenAIClient
+        self.openai = OpenAIClient(self)
         self.redis = None  # Redis client (shared with backend)
         self._dev_team_ids: Set[int] = set()
         self.maintenance_mode = False
@@ -649,6 +651,9 @@ class ModdyBot(commands.Bot):
         # Set start time for /status uptime metric
         import time as _time
         self._start_time = _time.time()
+
+        # Initialize OpenAI client
+        await self.openai.start()
 
         # Connect to Redis
         if REDIS_URL:
@@ -1596,6 +1601,9 @@ class ModdyBot(commands.Bot):
 
         # Wait a bit for tasks to finish
         await asyncio.sleep(0.1)
+
+        # Close OpenAI client
+        await self.openai.stop()
 
         # Close Redis connection
         if self.redis:

--- a/config.py
+++ b/config.py
@@ -53,6 +53,9 @@ REDIS_PASSWORD: Optional[str] = os.environ.get("REDIS_PASSWORD") or None
 # DeepL API pour les traductions - Variable Railway: DEEPL_API_KEY
 DEEPL_API_KEY: str = os.environ.get("DEEPL_API_KEY", "")
 
+# OpenAI API - Variable Railway: OPENAI_API_KEY
+OPENAI_API_KEY: str = os.environ.get("OPENAI_API_KEY", "")
+
 # Fernet key for token_detector in-memory cache encryption - Variable Railway: TOKEN_DETECTOR_KEY
 # Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 TOKEN_DETECTOR_KEY: str = os.environ.get("TOKEN_DETECTOR_KEY", "")
@@ -200,6 +203,9 @@ def validate_config():
 
     if not DEEPL_API_KEY:
         print("[WARN] DEEPL_API_KEY not configured - translate command disabled")
+
+    if not OPENAI_API_KEY:
+        print("[WARN] OPENAI_API_KEY not configured - OpenAI features disabled")
 
     if DEBUG:
         print("Debug mode enabled")

--- a/docs/OPENAI.md
+++ b/docs/OPENAI.md
@@ -1,0 +1,140 @@
+# OpenAI Integration
+
+Moddy uses a centralised `OpenAIClient` service (attached to the bot as `bot.openai`) for all calls to the OpenAI API.  Every call goes through the same client so hooks, quotas, and usage tracking can be added in one place without touching individual call sites.
+
+---
+
+## Quick start
+
+```python
+from services.openai_client import OpenAIContext
+
+# Full response object
+response = await bot.openai.complete(
+    messages=[{"role": "user", "content": "Summarise this: ..."}],
+    context=OpenAIContext(guild_id=interaction.guild_id, user_id=interaction.user.id),
+)
+text = response.choices[0].message.content
+
+# Convenience wrapper — returns the text directly
+text = await bot.openai.complete_text(
+    messages=[{"role": "user", "content": "..."}],
+    context=OpenAIContext(guild_id=interaction.guild_id, user_id=interaction.user.id),
+)
+```
+
+Always pass a `context` with `guild_id` and `user_id` — they are optional today but will be required once quota enforcement is added.
+
+---
+
+## Configuration
+
+| Env var | Required | Description |
+|---|---|---|
+| `OPENAI_API_KEY` | Yes (for AI features) | Standard OpenAI API key |
+
+If the key is absent the client starts in disabled mode — `bot.openai.available` returns `False` and every call raises `RuntimeError`.  A warning is printed at startup; the bot itself keeps running.
+
+---
+
+## API reference — `OpenAIClient`
+
+### `bot.openai.available → bool`
+`True` when the client is ready to accept requests.
+
+### `bot.openai.complete(messages, *, model, context, **kwargs) → ChatCompletion`
+Low-level wrapper.  Returns the raw OpenAI `ChatCompletion` object so callers can inspect choices, finish reason, usage, etc.
+
+| Arg | Default | Description |
+|---|---|---|
+| `messages` | — | OpenAI-format message list |
+| `model` | `"gpt-4o-mini"` | Model name |
+| `context` | `OpenAIContext()` | Caller metadata (guild / user IDs) |
+| `**kwargs` | — | Forwarded to `client.chat.completions.create()` (e.g. `temperature`, `max_tokens`) |
+
+### `bot.openai.complete_text(messages, *, model, context, **kwargs) → str`
+Same as `complete()` but returns `response.choices[0].message.content` directly.
+
+---
+
+## `OpenAIContext`
+
+```python
+@dataclass
+class OpenAIContext:
+    guild_id: Optional[int] = None
+    user_id:  Optional[int] = None
+    extra:    dict = field(default_factory=dict)  # arbitrary tags
+```
+
+`extra` is a free-form dict for feature tags, cog names, or any metadata hooks may need:
+
+```python
+OpenAIContext(guild_id=guild.id, user_id=user.id, extra={"feature": "moderation"})
+```
+
+---
+
+## Hook system
+
+Hooks let you intercept every OpenAI request without modifying call sites.  Register them once (e.g. in `setup_hook` or a cog's `cog_load`) and they run automatically.
+
+### Pre-hooks — run before the API call
+
+```python
+from services.openai_client import OpenAIContext, OpenAIQuotaExceeded
+
+async def my_quota_checker(ctx: OpenAIContext, params: dict) -> None:
+    if await is_over_limit(ctx.guild_id):
+        raise OpenAIQuotaExceeded("Monthly quota reached for this server")
+
+bot.openai.add_pre_hook(my_quota_checker)
+```
+
+- `ctx` — the `OpenAIContext` passed by the caller
+- `params` — the dict that will be sent to the API (`model`, `messages`, …); you can mutate it
+- Raising any exception aborts the request; the exception propagates to the caller
+- `OpenAIQuotaExceeded` is the semantic exception for quota errors
+
+### Post-hooks — run after the API call
+
+```python
+async def track_usage(ctx: OpenAIContext, response, usage: dict) -> None:
+    await db.record_openai_usage(
+        guild_id=ctx.guild_id,
+        user_id=ctx.user_id,
+        tokens=usage["total_tokens"],
+    )
+
+bot.openai.add_post_hook(track_usage)
+```
+
+- `response` — the raw `ChatCompletion` object
+- `usage` — `{"prompt_tokens": int, "completion_tokens": int, "total_tokens": int}`
+- Exceptions in post-hooks are caught and logged; they do **not** affect the response returned to the caller
+
+### Hook execution order
+Pre-hooks run in registration order; if one raises, subsequent pre-hooks and the API call are skipped.  Post-hooks always run in registration order regardless of each other's outcome.
+
+---
+
+## Planned extensions
+
+These are not implemented yet but the hook system is designed to support them without any changes to call sites:
+
+- **Per-guild token quotas** — pre-hook reads the guild's monthly allowance from DB/Redis
+- **Per-user rate limiting** — pre-hook checks a Redis counter per `(user_id, day)`
+- **Usage billing / analytics** — post-hook writes token counts to a DB table
+- **Request logging** — post-hook emits to the technical webhook log (see `docs/TECHNICAL_LOGS.md`)
+- **Model routing** — pre-hook can swap `params["model"]` based on guild subscription tier
+
+---
+
+## File locations
+
+| File | Role |
+|---|---|
+| `services/openai_client.py` | `OpenAIClient`, `OpenAIContext`, hook types, `OpenAIQuotaExceeded` |
+| `config.py` | `OPENAI_API_KEY` env var |
+| `bot.py` | `self.openai = OpenAIClient(self)`, `start()` / `stop()` wiring |
+| `requirements.txt` | `openai>=1.0.0` |

--- a/docs/sessions/2026-06-28_openai-integration.md
+++ b/docs/sessions/2026-06-28_openai-integration.md
@@ -1,0 +1,30 @@
+# Session — 2026-06-28 : OpenAI integration
+
+## What was done
+
+Added a centralised OpenAI client service so any part of the bot can make AI requests through a single, interceptable entry point.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `services/openai_client.py` | New — `OpenAIClient`, `OpenAIContext`, pre/post hook system, `OpenAIQuotaExceeded` |
+| `config.py` | Added `OPENAI_API_KEY` env var + non-blocking startup warning |
+| `bot.py` | `self.openai = OpenAIClient(self)` in `__init__`, `await self.openai.start()` in `setup_hook`, `await self.openai.stop()` in `close` |
+| `requirements.txt` | Added `openai>=1.0.0` |
+| `docs/OPENAI.md` | New — full integration doc |
+
+## Decisions made
+
+- **No quotas yet** — intentionally out of scope for this session; the hook system is the future extension point.
+- **Pre-hook raises to block** — any exception from a pre-hook aborts the request and propagates to the caller; `OpenAIQuotaExceeded` is the semantic type for quota errors.
+- **Post-hook errors are swallowed** — a broken usage tracker should never break the user-facing response.
+- **Default model `gpt-4o-mini`** — cheapest capable model; callers override per-call with `model=`.
+- **`complete_text()` convenience wrapper** — avoids boilerplate `response.choices[0].message.content` at every call site.
+- **`OpenAIContext.extra` dict** — free-form bag for feature tags so hooks can branch on metadata without changing the context dataclass.
+
+## Follow-ups
+
+- Implement per-guild / per-user quota pre-hook once the DB table is defined.
+- Add a post-hook that writes token usage to the technical webhook log.
+- Consider model routing pre-hook tied to subscription tier.

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,6 @@ sentry-sdk==2.18.0
 # Token encryption for token_detector cog
 cryptography>=42.0.0
 
+# OpenAI API
+openai>=1.0.0
+

--- a/services/openai_client.py
+++ b/services/openai_client.py
@@ -1,0 +1,198 @@
+"""
+OpenAI service client — thin async wrapper around the OpenAI SDK.
+
+Usage (from a cog or anywhere you have a bot reference):
+
+    response = await bot.openai.complete(
+        messages=[{"role": "user", "content": "..."}],
+        context=OpenAIContext(guild_id=ctx.guild.id, user_id=ctx.user.id),
+    )
+    text = response.choices[0].message.content
+
+The ``context`` parameter is optional today but is the hook point for future
+per-guild / per-user quota enforcement and request interception.  Pre- and
+post-hooks can be registered on the client to intercept every call:
+
+    bot.openai.add_pre_hook(my_quota_checker)   # runs before the API call
+    bot.openai.add_post_hook(my_usage_tracker)  # runs after (with usage info)
+
+A pre-hook that raises ``OpenAIQuotaExceeded`` (or any exception) aborts the
+request before it hits the API.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, List, Optional
+
+logger = logging.getLogger("moddy.services.openai")
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class OpenAIContext:
+    """Caller-supplied metadata attached to every request.
+
+    Passed to all pre- and post-hooks so they can enforce quotas, log usage,
+    or tag telemetry without touching the core client logic.
+    """
+    guild_id: Optional[int] = None
+    user_id: Optional[int] = None
+    # Arbitrary key/value bag for future extension (feature tag, cog name, …)
+    extra: dict = field(default_factory=dict)
+
+
+class OpenAIQuotaExceeded(Exception):
+    """Raised by a pre-hook to block a request before it hits the API."""
+
+
+# Hook type aliases
+PreHook = Callable[[OpenAIContext, dict], Awaitable[None]]
+PostHook = Callable[[OpenAIContext, Any, dict], Awaitable[None]]
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL = "gpt-4o-mini"
+
+
+class OpenAIClient:
+    """Async OpenAI client attached to the bot instance as ``bot.openai``."""
+
+    def __init__(self, bot) -> None:
+        self.bot = bot
+        self._client = None
+        self._started = False
+        self._pre_hooks: List[PreHook] = []
+        self._post_hooks: List[PostHook] = []
+
+    # ------------------------------------------------------------------ #
+    # Hook registration
+    # ------------------------------------------------------------------ #
+
+    def add_pre_hook(self, hook: PreHook) -> None:
+        """Register an async pre-request hook.
+
+        Signature: ``async def hook(ctx: OpenAIContext, params: dict) -> None``
+        Raise to abort the request (e.g. quota exceeded).
+        """
+        self._pre_hooks.append(hook)
+
+    def add_post_hook(self, hook: PostHook) -> None:
+        """Register an async post-request hook.
+
+        Signature: ``async def hook(ctx: OpenAIContext, response, usage: dict) -> None``
+        ``usage`` is a dict with ``prompt_tokens``, ``completion_tokens``, ``total_tokens``.
+        """
+        self._post_hooks.append(hook)
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    async def start(self) -> None:
+        if self._started:
+            return
+
+        from config import OPENAI_API_KEY
+        if not OPENAI_API_KEY:
+            logger.warning("[OpenAI] OPENAI_API_KEY not set — OpenAI client disabled")
+            return
+
+        try:
+            from openai import AsyncOpenAI
+            self._client = AsyncOpenAI(api_key=OPENAI_API_KEY)
+            self._started = True
+            logger.info("[OpenAI] Client ready")
+        except ImportError:
+            logger.error("[OpenAI] 'openai' package not installed — client disabled")
+
+    async def stop(self) -> None:
+        if self._client:
+            try:
+                await self._client.close()
+            except Exception:
+                pass
+        self._client = None
+        self._started = False
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    @property
+    def available(self) -> bool:
+        return self._started and self._client is not None
+
+    async def complete(
+        self,
+        messages: list[dict],
+        *,
+        model: str = DEFAULT_MODEL,
+        context: Optional[OpenAIContext] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Send a chat completion request.
+
+        Args:
+            messages: OpenAI-format message list.
+            model:    Model name (default: gpt-4o-mini).
+            context:  Caller metadata for hooks and future quota checks.
+            **kwargs: Forwarded verbatim to ``client.chat.completions.create()``.
+
+        Returns:
+            The raw ``ChatCompletion`` object from the OpenAI SDK.
+
+        Raises:
+            RuntimeError: If the client is not started / API key missing.
+            OpenAIQuotaExceeded: If a pre-hook blocks the request.
+        """
+        if not self.available:
+            raise RuntimeError("OpenAI client is not available (check OPENAI_API_KEY)")
+
+        if context is None:
+            context = OpenAIContext()
+
+        params = {"model": model, "messages": messages, **kwargs}
+
+        # Run pre-hooks (any exception propagates to the caller)
+        for hook in self._pre_hooks:
+            await hook(context, params)
+
+        response = await self._client.chat.completions.create(**params)
+
+        # Build usage dict for post-hooks
+        usage: dict = {}
+        if response.usage:
+            usage = {
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            }
+
+        # Run post-hooks (errors are caught so they don't kill the response)
+        for hook in self._post_hooks:
+            try:
+                await hook(context, response, usage)
+            except Exception as e:
+                logger.error(f"[OpenAI] Post-hook error: {e}", exc_info=True)
+
+        return response
+
+    async def complete_text(
+        self,
+        messages: list[dict],
+        *,
+        model: str = DEFAULT_MODEL,
+        context: Optional[OpenAIContext] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Convenience wrapper — returns the first choice's text directly."""
+        response = await self.complete(messages, model=model, context=context, **kwargs)
+        return response.choices[0].message.content or ""


### PR DESCRIPTION
## Summary

Adds a production-ready `OpenAIClient` service attached to the bot as `bot.openai`, providing a single interceptable entry point for all OpenAI API calls. Includes a pre/post-hook system designed to support future quota enforcement, usage tracking, and request interception without modifying call sites.

## Changes

- **`services/openai_client.py`** (new)
  - `OpenAIClient`: async wrapper around the OpenAI SDK with lifecycle management
  - `OpenAIContext`: dataclass for caller metadata (guild_id, user_id, extra dict)
  - `OpenAIQuotaExceeded`: semantic exception for quota pre-hook blocks
  - Pre-hook system: runs before API call, can raise to abort request
  - Post-hook system: runs after API call, errors are caught and logged
  - `complete()`: low-level method returning raw `ChatCompletion` object
  - `complete_text()`: convenience wrapper returning first choice's text directly
  - Default model: `gpt-4o-mini`

- **`bot.py`**
  - Initialize `self.openai = OpenAIClient(self)` in `__init__`
  - Call `await self.openai.start()` in `setup_hook()`
  - Call `await self.openai.stop()` in `close()`

- **`config.py`**
  - Add `OPENAI_API_KEY` env var with Railway integration
  - Non-blocking startup warning if key is missing

- **`requirements.txt`**
  - Add `openai>=1.0.0`

- **`docs/OPENAI.md`** (new)
  - Complete integration guide with quick start, API reference, hook examples
  - Lists planned extensions (per-guild quotas, rate limiting, usage billing, model routing)

- **`docs/sessions/2026-06-28_openai-integration.md`** (new)
  - Session notes documenting decisions and follow-ups

- **`CLAUDE.md`**
  - Add reference to `docs/OPENAI.md` in infrastructure docs

## Implementation Details

- **Graceful degradation**: If `OPENAI_API_KEY` is missing, client starts disabled; `bot.openai.available` returns `False` and calls raise `RuntimeError`
- **Hook execution**: Pre-hooks run in registration order; any exception aborts the request. Post-hooks always run regardless of each other's outcome; exceptions are logged but don't affect the response
- **Context design**: `OpenAIContext.extra` dict allows hooks to branch on metadata without changing the dataclass
- **No quotas yet**: Intentionally out of scope; hook system is the extension point for future quota enforcement

https://claude.ai/code/session_01CPZjLBFhEuz5eNHkoifjm2