### PR TITLE
feat(moderation): AI-powered sanction reason pre-fill

### DIFF
--- a/cogs/moderation_commands.py
+++ b/cogs/moderation_commands.py
@@ -239,6 +239,15 @@ async def _fetch_recent_user_messages(
         collected.extend(chunk)
         if len(collected) >= max_messages:
             break
+
+    # Merge deleted messages from the in-memory cache (deduplicated by content)
+    deleted = _get_deleted_for_user(guild.id, user.id, cutoff)
+    existing = set(collected)
+    for msg in deleted:
+        if msg not in existing:
+            collected.append(msg)
+            existing.add(msg)
+
     return collected[:max_messages]
 
 
@@ -721,6 +730,45 @@ async def _resolve_incognito(bot, user_id: int, default: bool = True) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Deleted-message cache
+# ---------------------------------------------------------------------------
+# Stores (user_id, content, deleted_at) per guild for up to 24 h so the AI
+# can also consider messages the user deleted before the mod ran the command.
+# Keyed by guild_id; capped at 500 entries per guild to bound memory usage.
+
+_DELETED_CACHE: dict[int, list[tuple[int, str, datetime]]] = {}
+_DELETED_CACHE_MAX = 500
+
+
+def _cache_deleted(guild_id: int, user_id: int, content: str) -> None:
+    if not content.strip():
+        return
+    now = datetime.now(timezone.utc)
+    bucket = _DELETED_CACHE.setdefault(guild_id, [])
+    bucket.append((user_id, content[:500], now))
+    if len(bucket) > _DELETED_CACHE_MAX:
+        del bucket[: len(bucket) - _DELETED_CACHE_MAX]
+
+
+def _get_deleted_for_user(
+    guild_id: int, user_id: int, cutoff: datetime
+) -> List[str]:
+    bucket = _DELETED_CACHE.get(guild_id)
+    if not bucket:
+        return []
+    # Prune stale entries in-place while collecting
+    kept: list[tuple[int, str, datetime]] = []
+    found: List[str] = []
+    for entry in bucket:
+        if entry[2] >= cutoff:
+            kept.append(entry)
+            if entry[0] == user_id:
+                found.append(entry[1])
+    _DELETED_CACHE[guild_id] = kept
+    return found
+
+
+# ---------------------------------------------------------------------------
 # Cog
 # ---------------------------------------------------------------------------
 
@@ -729,6 +777,12 @@ class ModerationCommands(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_message_delete(self, message: discord.Message) -> None:
+        if message.guild is None or message.author.bot:
+            return
+        _cache_deleted(message.guild.id, message.author.id, message.content)
 
     # ── /ban ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Before opening the `/ban`, `/kick`, `/mute`, `/warn` modal, Moddy now fetches the target user's recent messages and asks `gpt-4.1-nano` to suggest a concise sanction reason, pre-filled (editable) in the reason field.

### How it works

1. **Message collection** — up to 20 messages from the last 24 h, gathered in parallel across up to 15 readable guild channels. Deleted messages are also included via an in-memory cache populated by `on_message_delete`.
2. **AI suggestion** — `gpt-4.1-nano` receives a strict system prompt and returns a 1–2 sentence reason in the guild's language (Community locale when enabled, English otherwise).
3. **Pre-fill** — the reason is set as the `default` of the `TextInput` in the modal. The moderator can edit or replace it freely before submitting.

### Safeguards

| Sentinel | Behaviour |
|---|---|
| `NO_REASON` | Model found no clear violation → modal opens with empty reason |
| `INJECTION_DETECTED` | Model spotted a prompt injection attempt in the messages → modal opens empty, warning logged |
| Timeout / error | Hard budget: 1.5 s for message fetch + 1.8 s for OpenAI API (2.5 s total wrapper) — always within the 3 s Discord interaction window |
| OpenAI unavailable | Modal opens normally without any pre-fill |

`incognito` DB lookup and the AI fetch run in parallel (`asyncio.gather`) to minimise latency.

### Deleted messages cache

- Module-level `_DELETED_CACHE: dict[guild_id, list]` capped at 500 entries per guild
- Populated by `on_message_delete` (bots and DMs excluded)
- Entries are pruned on read (TTL = 24 h)
- In-memory only — messages deleted before the last bot restart are not captured

## Files changed

- `cogs/moderation_commands.py` — all changes contained in this file

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAVp8u9mJa2xEUtNdqUs2n)_