### PR TITLE
Improve cases browser UX: context preview, comments privacy, button styling

### DIFF
--- a/cogs/moderation_commands.py
+++ b/cogs/moderation_commands.py
@@ -40,6 +40,20 @@ _CONFIRM_ACCENT = 0x38B04B
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _build_discord_reason(
+    case_ref: str,
+    mod: discord.abc.User,
+    expires_at: Optional[datetime],
+    reason: str,
+) -> str:
+    """Build the formatted reason string for Discord audit logs."""
+    expiry = (
+        expires_at.strftime("%Y-%m-%d %H:%M UTC") if expires_at else "Permanent"
+    )
+    formatted = f"[{case_ref}] @{mod.name} ({expiry}) : {reason}"
+    return formatted[:512]
+
+
 def _parse_duration(raw: str) -> Optional[timedelta]:
     """Parse strings like '7d', '24h', '30m', '1w' into a timedelta.
 
@@ -550,7 +564,13 @@ class SanctionModal(BaseModal):
         except Exception as exc:
             logger.error("Failed to record case for %s in guild %s: %s", user.id, self.guild.id, exc)
 
-        discord_ok = await self._discord_action(user, reason, duration)
+        discord_reason = _build_discord_reason(
+            case_result["reference"] if case_result else "?",
+            self.mod,
+            expires_at,
+            reason,
+        )
+        discord_ok = await self._discord_action(user, discord_reason, duration)
 
         if notify_dm and case_result:
             guild_locale = _guild_locale(self.guild)

--- a/docs/MODERATION_CASES.md
+++ b/docs/MODERATION_CASES.md
@@ -204,12 +204,13 @@ button opens a modal to set: status (open/closed), sanction type, period
 (24h / 7d / 30d / 90d), and a context filter (a server in `/mycases`, a user in
 `/cases`). A select opens any listed case ("zoom").
 
-**Detail screen** — the full folder (fields, reason, sanctions, public
-comments). Internal Moddy-staff notes (`event_type = note`) are **never** shown
-here. In `/cases` the moderator gets every case action — add sanction,
-revoke sanction, comment, edit reason, close/reopen — recorded with
+**Detail screen** — the full folder (fields, reason, sanctions). In `/cases`
+the moderator additionally sees public comments and gets every case action — add
+sanction, revoke sanction, comment, edit reason, close/reopen — recorded with
 `author/issuer = discord_user` (the moderator), never `moddy_staff`. `/mycases`
-shows no action buttons.
+shows **no comments and no action buttons**: comments (`event_type = comment`)
+are private and only visible to guild moderators via `/cases`; internal
+Moddy-staff notes (`event_type = note`) are **never** shown in either command.
 
 **Permissions** — `/cases` is guild-only, gated by Discord's
 `default_permissions(manage_messages=True)` plus a bot-side check: viewing /

--- a/utils/cases_views.py
+++ b/utils/cases_views.py
@@ -449,7 +449,25 @@ class CasesBrowserView(BaseView):
             open_row = ui.ActionRow()
             open_opts = []
             for row in self.rows:
-                desc = (row.get("reason") or "").replace("\n", " ")[:90] or None
+                reason_preview = (row.get("reason") or "").replace("\n", " ")
+                if self.mode == "server":
+                    subject_id = row.get("subject_id")
+                    if subject_id and row.get("subject_type") == "discord_user":
+                        cached = self.bot.get_user(int(subject_id)) if self.bot else None
+                        subject_str = f"@{cached.name}" if cached else f"@{subject_id}"
+                    else:
+                        subject_str = str(subject_id) if subject_id else "?"
+                    context_str = subject_str
+                else:
+                    scope_type = row.get("scope_type")
+                    scope_id = row.get("scope_id")
+                    if scope_type == "discord_guild" and scope_id and self.bot:
+                        guild = self.bot.get_guild(int(scope_id)) if str(scope_id).isdigit() else None
+                        context_str = guild.name if guild else str(scope_id)
+                    else:
+                        context_str = str(scope_id) if scope_id else "?"
+                combined = f"{context_str} • {reason_preview}" if reason_preview else context_str
+                desc = combined[:100] or None
                 open_opts.append(discord.SelectOption(
                     label=row["reference"],
                     value=str(row["id"]),
@@ -543,6 +561,9 @@ class CasesBrowserView(BaseView):
         actions = row.get("actions") or []
         labels = " ".join(_action_emoji_safe(a) for a in actions)
 
+        # Prefix with type emoji only when non-empty (guild type has none).
+        type_prefix = f"{type_emoji} " if type_emoji else ""
+
         if self.mode == "server":
             who = f"<@{row['subject_id']}>" if row["subject_type"] == "discord_user" else f"`{row['subject_id']}`"
             context = f"{t('commands.cases.browser.subject_user', locale=self.locale)}: {who}"
@@ -554,18 +575,19 @@ class CasesBrowserView(BaseView):
             reason = reason[:77] + "…"
 
         line = (
-            f"{dot} {type_emoji} **`{ref}`** {labels}\n"
+            f"{dot} {type_prefix}**`{ref}`** {labels}\n"
             f"-# {context} • {_ts(row.get('created_at'))}"
         )
         if reason:
-            line += f"\n-# {reason}"
+            line += f"\n-# **{t('commands.cases.reason', locale=self.locale)}:** {reason}"
         return line
 
-    def _scope_label(self, scope_type: Optional[str], scope_id: Optional[str]) -> str:
+    def _scope_label(self, scope_type: Optional[str], scope_id: Optional[str], with_id: bool = False) -> str:
         if scope_type == "discord_guild" and scope_id:
             guild = self.bot.get_guild(int(scope_id)) if str(scope_id).isdigit() else None
             if guild:
-                return f"**{guild.name}**"
+                base = f"**{guild.name}**"
+                return f"{base} (`{scope_id}`)" if with_id else base
             return t("commands.cases.browser.unknown_server", locale=self.locale, id=scope_id)
         if scope_type:
             return f"`{t('commands.cases.browser.scope.' + scope_type, locale=self.locale)}`"
@@ -599,7 +621,7 @@ class CasesBrowserView(BaseView):
         if self.mode == "user":
             fields += (
                 f"**{t('commands.cases.browser.scope_field', locale=self.locale)}:** "
-                f"{self._scope_label(case.scope_type.value, case.scope_id)}\n"
+                f"{self._scope_label(case.scope_type.value, case.scope_id, with_id=True)}\n"
             )
         if self.mode == "server":
             subj = f"<@{case.subject_id}>" if case.subject_type.value == "discord_user" else f"`{case.subject_id}`"
@@ -628,27 +650,28 @@ class CasesBrowserView(BaseView):
                     line += f" • {emojis.TIME} {_ts(s.expires_at)}"
                 container.add_item(ui.TextDisplay(line))
 
-        # Public comments (never internal notes).
-        comments = [e for e in case.events if e.type == EventType.COMMENT]
-        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
-        container.add_item(ui.TextDisplay(f"**{t('commands.cases.comments', locale=self.locale)}**"))
-        if comments:
-            for e in comments[-5:]:
-                author = f"<@{e.author_id}> • " if e.author_id else ""
-                container.add_item(ui.TextDisplay(f"-# {author}{_ts(e.created_at)}\n{e.content or ''}"))
-        else:
-            container.add_item(ui.TextDisplay(f"-# {t('commands.cases.browser.no_comments', locale=self.locale)}"))
+        # Comments are private — only server moderators can see them.
+        if self.mode == "server":
+            comments = [e for e in case.events if e.type == EventType.COMMENT]
+            container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+            container.add_item(ui.TextDisplay(f"**{t('commands.cases.comments', locale=self.locale)}**"))
+            if comments:
+                for e in comments[-5:]:
+                    author = f"<@{e.author_id}> • " if e.author_id else ""
+                    container.add_item(ui.TextDisplay(f"-# {author}{_ts(e.created_at)}\n{e.content or ''}"))
+            else:
+                container.add_item(ui.TextDisplay(f"-# {t('commands.cases.browser.no_comments', locale=self.locale)}"))
 
-        self.add_item(container)
+        has_evidence = any(e.type == EventType.EVIDENCE for e in case.events)
 
-        # Action buttons sit OUTSIDE the container.
+        # Server-mode action rows go INSIDE the container.
         if self.can_manage:
-            # Row 1 — destructive / state-changing actions.
+            # Row 1 — state-changing actions (no grey buttons).
             row1 = ui.ActionRow()
 
             add_btn = ui.Button(
                 custom_id=_CID_DETAIL_ADD.format(mode=self.mode),
-                style=discord.ButtonStyle.secondary,
+                style=discord.ButtonStyle.primary,
                 label=t("commands.cases.browser.action_add_sanction", locale=self.locale),
                 emoji=discord.PartialEmoji.from_str(emojis.ADD),
             )
@@ -657,7 +680,7 @@ class CasesBrowserView(BaseView):
 
             revoke_btn = ui.Button(
                 custom_id=_CID_DETAIL_REVOKE.format(mode=self.mode),
-                style=discord.ButtonStyle.success,
+                style=discord.ButtonStyle.danger,
                 label=t("commands.cases.browser.action_revoke", locale=self.locale),
                 emoji=discord.PartialEmoji.from_str(emojis.UNDONE),
             )
@@ -674,7 +697,7 @@ class CasesBrowserView(BaseView):
             toggle_btn.callback = self._on_toggle_status
             row1.add_item(toggle_btn)
 
-            self.add_item(row1)
+            container.add_item(row1)
 
             # Row 2 — non-destructive case-content actions.
             row2 = ui.ActionRow()
@@ -690,7 +713,7 @@ class CasesBrowserView(BaseView):
 
             edit_btn = ui.Button(
                 custom_id=_CID_DETAIL_EDIT.format(mode=self.mode),
-                style=discord.ButtonStyle.secondary,
+                style=discord.ButtonStyle.primary,
                 label=t("commands.cases.browser.action_edit", locale=self.locale),
                 emoji=discord.PartialEmoji.from_str(emojis.EDIT),
             )
@@ -699,16 +722,19 @@ class CasesBrowserView(BaseView):
 
             evidence_btn = ui.Button(
                 custom_id=_CID_DETAIL_EVIDENCE.format(mode=self.mode),
-                style=discord.ButtonStyle.secondary,
+                style=discord.ButtonStyle.primary,
                 label=t("commands.cases.browser.action_evidence", locale=self.locale),
                 emoji=discord.PartialEmoji.from_str(emojis.IMAGE),
+                disabled=not has_evidence,
             )
             evidence_btn.callback = self._on_evidence
             row2.add_item(evidence_btn)
 
-            self.add_item(row2)
+            container.add_item(row2)
 
-        # Nav row — Back to list (both modes).
+        self.add_item(container)
+
+        # Nav row — Back to list only (outside the container).
         nav_row = ui.ActionRow()
         back_btn = ui.Button(
             custom_id=_CID_DETAIL_BACK.format(mode=self.mode),
@@ -719,13 +745,14 @@ class CasesBrowserView(BaseView):
         back_btn.callback = self._on_back
         nav_row.add_item(back_btn)
 
-        # In user mode, the evidence button still has a place (read-only view).
+        # In user mode, evidence button is in the nav row (read-only view).
         if not self.can_manage:
             evidence_btn = ui.Button(
                 custom_id=_CID_DETAIL_EVIDENCE.format(mode=self.mode),
                 style=discord.ButtonStyle.secondary,
                 label=t("commands.cases.browser.action_evidence", locale=self.locale),
                 emoji=discord.PartialEmoji.from_str(emojis.IMAGE),
+                disabled=not has_evidence,
             )
             evidence_btn.callback = self._on_evidence
             nav_row.add_item(evidence_btn)

--- a/utils/emojis.py
+++ b/utils/emojis.py
@@ -311,7 +311,7 @@ CASE_TYPE_EMOJIS = {
     "global": MODDY,
     "platform": MODDY,
     "network": WEB,
-    "guild": GROUPS,
+    "guild": "",
     "external": WEB,
 }
 CASE_TYPE_EMOJI_DEFAULT = INFO


### PR DESCRIPTION
## Summary
Enhances the moderation cases browser (`/cases` and `/mycases`) with better context previews in list view, enforces comment privacy (server-only), improves button styling consistency, and refines the detail view layout.

## Key Changes

### Cases Browser List View
- **Context preview in dropdown**: Added subject/scope context to case selection dropdown descriptions (e.g., "@username • reason preview" or "guild name • reason preview")
- **Smart context display**: Resolves Discord user/guild IDs to names when available via bot cache; falls back to IDs gracefully
- **Truncation**: Combined context + reason preview truncated to 100 characters

### Comments Privacy & Detail View
- **Comments now server-only**: Comments section only visible in `/cases` (server moderators); hidden from `/mycases` (user view)
- **Reason formatting**: Added "**Reason:**" label prefix in detail view for clarity
- **Evidence button state**: Disabled evidence button when no evidence exists in the case
- **Container restructuring**: Action buttons now placed inside the main container for better layout cohesion; navigation row remains outside

### Button Styling & UX
- **Primary buttons**: Changed "Add Sanction" and "Edit" buttons from secondary to primary style
- **Danger for revoke**: Changed "Revoke Sanction" button from success (green) to danger (red) to better reflect destructive action
- **Type emoji handling**: Guild scope type no longer displays emoji (changed from `GROUPS` to empty string); conditional emoji prefix only shown when non-empty

### Scope Label Enhancement
- **Optional ID display**: Added `with_id` parameter to `_scope_label()` method
- **Detail view**: Server scope now displays as "**Guild Name** (`guild_id`)" for better context in user mode

### Audit Log Formatting
- **Discord reason builder**: New `_build_discord_reason()` helper formats case reference, moderator name, expiry, and reason into a single audit log string (max 512 chars)
- **Structured format**: `[CASE_REF] @moderator (YYYY-MM-DD HH:MM UTC) : reason`

## Documentation Updates
- Updated `MODERATION_CASES.md` to clarify comment privacy: comments are private to guild moderators only; internal notes are never shown in either command

https://claude.ai/code/session_0151sYxDUE5VQf4hWFdAyEXB