### PR TITLE
fix(automod): config panel fails to open — replace inaccessible emoji on activations select

### DIFF
--- a/modules/configs/automod_config.py
+++ b/modules/configs/automod_config.py
@@ -27,7 +27,7 @@ from utils.i18n import t, i18n
 from cogs.error_handler import BaseView, BaseModal
 from utils.emojis import (
     FILTER, BOOK, BACK, DELETE, MESSAGE, GROUPS, SETTINGS, WARNING, SAVE,
-    UNDONE, REQUIRED_FIELDS, STAFF, GREEN_STATUS, RED_STATUS,
+    UNDONE, REQUIRED_FIELDS, MANAGE_USER, GREEN_STATUS, RED_STATUS,
 )
 from automod.rules_check import validate_rules, MAX_RULES_LENGTH
 from automod import constants as ac
@@ -236,7 +236,7 @@ class AutomodConfigView(BaseView):
                     label=t("modules.automod.config.ignore_mods.label", locale=self.locale),
                     value="ignore",
                     description=t("modules.automod.config.ignore_mods.desc", locale=self.locale)[:100],
-                    emoji=discord.PartialEmoji.from_str(STAFF),
+                    emoji=discord.PartialEmoji.from_str(MANAGE_USER),
                     default=ignore_on,
                 ),
             ],


### PR DESCRIPTION
## Problem

Opening `/config` → **Automod** throws `400 Bad Request (error code: 50035): Invalid Form Body … options.2.emoji.id: Invalid emoji` and the panel never renders.

The "Ignore moderators" option of the new activations multi-select used the `STAFF` emoji (id `1398729432759476245`), which the bot cannot use in a select option (it belongs to a guild the bot isn't in). Discord rejects the whole payload, so the config view fails to open.

This is a follow-up to #280 (the only piece of that work that wasn't included in the squash merge).

## Fix

Swap the option emoji for `manageuser` (id `1519798563880698066`), in the same accessible range as the other working emojis (`filter`, `message`). The other interactive components (severity select, appeal buttons, transform select) were audited and already use emojis from the accessible `1517/1519` ranges.

## Changes

- `modules/configs/automod_config.py`: `STAFF` → `MANAGE_USER` on the activations select option (2 lines).

## Verification

- `py_compile` clean; the panel builds without the rejected emoji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDwWYaRLaxEASoVRKaxKsa)_