### PR TITLE
Fix automod NameError: import i18n `t` in the module

### DIFF
--- a/modules/automod.py
+++ b/modules/automod.py
@@ -48,6 +48,7 @@ from automod import (
     get_engine, Decision, TargetMessage, ContextMessage, AuthorHistory,
 )
 from automod import constants as ac
+from utils.i18n import t
 from utils.moderation_cases import IssuerType, SanctionAction, EventType, AuthorType
 
 logger = logging.getLogger("moddy.modules.automod")


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by the automod appeals/cases redesign (#282).

`modules/automod.py` started calling `t(...)` (the i18n helper) in
`_notify_channel` and the localized label helpers, but the module never
imported it. Every `apply_decision` therefore crashed with:

```
moddy.modules.automod - ERROR - automod apply_decision failed: name 't' is not defined
  File "/app/modules/automod.py", line 727, in _notify_channel
    actions_txt = ", ".join(_label(a) for a in applied) ...
NameError: name 't' is not defined
```

## Fix

Add `from utils.i18n import t` to `modules/automod.py`.

One-line change; `python -m py_compile modules/automod.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRmV8KpxgF7N7CtjiZ3nMC)_