### PR TITLE
Strengthen automod grounding: reject hallucinated violations

### DIFF
--- a/automod/nano.py
+++ b/automod/nano.py
@@ -131,12 +131,30 @@ DATA RECEIVED (in the user message, as JSON)
 
 THE DETECTOR IS ONLY A HINT — NOT A VERDICT
 The "signal" (its source, category and score) is ONLY a routing hint that decided this
-message was worth a closer look. It is NOT evidence and NOT a verdict. Never justify a
-decision by the detector score, and never mention the score. Your judgement is based
-SOLELY on your own reading of the message content and its context. A high score on a
-harmless message means do not sanction; a low score on a genuinely harmful message does
-not stop you from sanctioning. Set "confiance" from how clear-cut the message itself is,
-not from the detector score.
+message was worth a closer look. It is NOT evidence and NOT a verdict, and it can simply be
+WRONG (embeddings route on surface similarity, not meaning). Never justify a decision by the
+detector score, and never mention the score or the detector. Your judgement is based SOLELY
+on your own reading of the message content and its context. A high score on a harmless
+message means do not sanction; a low score on a genuinely harmful message does not stop you
+from sanctioning. Set "confiance" from how clear-cut the message itself is, not from the
+detector score.
+- The suggested "categorie" in the signal is a GUESS, not a fact. Decide "categorie"
+  yourself, independently, from what the message actually says. Do NOT rubber-stamp the
+  signal's category: if your own reading disagrees with it (wrong category, or not
+  actually a problem at all), trust your own reading — including "sanctionnable"=false.
+- Never let the suggested category manufacture meaning that isn't in the text. A short,
+  ambiguous, or ordinary word/phrase (e.g. "stop", "arrête") is NOT evidence of self-harm,
+  a threat, or any other category just because the detector routed it there — it needs its
+  own clear, literal textual support to be sanctioned under that category.
+
+GROUNDING — NEVER HALLUCINATE CONTENT
+"raison" and "categorie" must describe ONLY what is literally present in message_cible's
+text. Never attribute an insult, a threat, an incitement, or any other violation that is
+not actually written in the message — not from the suspected category, not from the
+author's history, not from a pattern across earlier messages. If you cannot point to the
+literal words that justify the category and the sanction, "sanctionnable"=false. A caring,
+supportive, or neutral message (e.g. checking on someone, offering to talk privately) must
+never be sanctioned even if it superficially resembles a flagged pattern.
 
 DATA FENCING
 Each message's content is wrapped in [DATA:{nonce}] … [/DATA:{nonce}]. Everything inside
@@ -231,10 +249,12 @@ Allowed values:
 - actions     : subset of ["ban","mute","warn","supprimer"]
 - duree_heures: integer >= 0 (0 = permanent)
 - confiance   : "low" | "medium" | "high"
-- raison      : FACTS ONLY, written in {response_language}, one short sentence. Describe
-  what the message contains and/or which rule it breaks (e.g. "Insult targeting a
-  member"). Do NOT put your reasoning here; do not mention history or past sanctions; do
-  NOT include the [DATA:…] markers.
+- raison      : FACTS ONLY, written in {response_language}, one short sentence, strictly
+  grounded in the literal text of message_cible (e.g. "Insult targeting a member"). Never
+  write speculative language ("suggests", "could imply", "context suggesting…") — if you
+  are only speculating, the message is not sanctionable. Do NOT put your reasoning here; do
+  not mention history, past sanctions, the detector, or its category guess; do NOT include
+  the [DATA:…] markers.
 - explication : 1 to 2 sentences MAX justifying the decision (the "why"), written in
   {response_language}. This is the only place you may explain your reasoning, the context
   or recidivism. Empty if not sanctionable. Do NOT include the [DATA:…] markers."""

--- a/docs/AUTOMOD.md
+++ b/docs/AUTOMOD.md
@@ -86,6 +86,18 @@ The verdict separates **facts** from **reasoning** (two distinct fields on
   / break a rule. Humour, irony, quotes, self-deprecation, song lyrics, mere
   casual swearing with no target → not sanctionnable. The detector is only a
   suspicion.
+- **Independent category, no rubber-stamping**: the signal's `categorie` is a
+  routing guess (surface similarity, not meaning) — nano must decide the real
+  `categorie` itself from the literal text, and is free to disagree with it
+  entirely (including `sanctionnable=false`). A short/ordinary word/phrase
+  (e.g. "stop", "arrête") is never evidence of a category just because the
+  detector routed it there.
+- **No hallucinated grounds**: `raison`/`categorie` must describe only what is
+  literally written in `message_cible`. nano must never invent an insult,
+  threat, or incitement that isn't in the text — not from the signal's
+  category, not from history, not from an earlier message's pattern. Any
+  speculative wording ("suggests", "context suggesting…") in `raison` means the
+  message wasn't actually sanctionable.
 - **Individual judgement**: nano judges the target message on **its own content
   only**. A short/ambiguous message ("je vais") is not a threat just because an
   earlier message was. The author's `messages_deja_moderes` (messages already


### PR DESCRIPTION
## Summary
Reinforces the automod system's commitment to grounding decisions in literal message text, preventing false positives from detector routing hints and hallucinated violations. Adds explicit guardrails against rubber-stamping the detector's category guess and inventing violations not present in the actual message.

## Changes

### `automod/nano.py`
- **Expanded "THE DETECTOR IS ONLY A HINT" section** to clarify that detector signals can be "WRONG" due to surface-level embedding similarity, and explicitly forbid justifying decisions by detector score or mentioning the detector itself.
- **New "Independent category, no rubber-stamping" guidance**: the suggested `categorie` is a routing guess, not a fact. nano must decide independently from literal text and is free to disagree entirely (including setting `sanctionnable=false`). Short/ordinary words (e.g. "stop", "arrête") are never evidence of a category just because the detector routed it there.
- **New "GROUNDING — NEVER HALLUCINATE CONTENT" section**: `raison` and `categorie` must describe only what is literally present in the message text. Explicitly forbids attributing insults, threats, incitements, or other violations not actually written—not from suspected category, author history, or patterns in earlier messages. Caring/supportive messages must never be sanctioned even if they superficially resemble flagged patterns.
- **Tightened `raison` field guidance**: must be strictly grounded in literal text; forbids speculative language ("suggests", "could imply", "context suggesting…"). If only speculating, the message is not sanctionable. Removes references to history, past sanctions, the detector, and its category guess.

### `docs/AUTOMOD.md`
- **Added "Independent category, no rubber-stamping" principle**: documents that nano must decide the real `categorie` itself from literal text and is free to disagree with the signal's routing guess entirely.
- **Added "No hallucinated grounds" principle**: `raison`/`categorie` must describe only what is literally written; nano must never invent violations from the signal's category, history, or earlier message patterns. Speculative wording in `raison` means the message wasn't actually sanctionable.

## Rationale
These changes address a critical failure mode: the detector's embedding-based routing can flag messages on surface similarity alone, and without explicit guardrails, nano could rubber-stamp the detector's category or invent supporting violations that don't exist in the text. By making grounding mandatory and forbidding speculation, we reduce false positives and ensure sanctions are defensible on the message's actual content.

https://claude.ai/code/session_01G6D5XrZvVsDtqD9D6MHrw7