### PR TITLE
Add embedding score cache and comprehensive automod test suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ moddy/
 │   ├── engine.py              #   Shared per-bot orchestrator (funnel entry)
 │   ├── prefiltre.py / triviaux.py / blocklist.py / embeddings.py / nano.py
 │   ├── normalize.py / injection.py / rules_check.py / schemas.py / constants.py
+│   ├── cache.py               #   LRU+TTL score cache (embedding de-duplication)
 │   └── data/references.json   #   Embedding reference phrases (FR + EN)
 │
 ├── staff/                     # Staff/dev command system (message + slash)
@@ -161,6 +162,8 @@ moddy/
 │
 ├── docs/                      # Documentation (see below)
 └── tests/                     # Test files
+    └── automod/               #   pytest suite for the pure-Python detection core
+                               #   (`pip install -r requirements-dev.txt && pytest`)
 ```
 
 ---

--- a/automod/cache.py
+++ b/automod/cache.py
@@ -1,0 +1,125 @@
+"""A tiny, dependency-free bounded cache for the embedding step.
+
+The embedding reference vectors are computed **once per process** and never
+change during its lifetime (see :mod:`automod.embeddings`). The cosine score of
+a given message is therefore a deterministic function of the message text for as
+long as the process lives. That makes it safe to memoise, which is exactly what
+we want at scale: a raid or a copypasta flood is, by construction, the same text
+repeated many times, and today each occurrence costs one embedding call.
+
+:class:`LruTtlCache` is a plain LRU cache with an optional TTL. The TTL is
+purely defensive (a freshness bound / a way to let long-idle entries fall out);
+correctness does not depend on it. The cache is **synchronous** — callers hold
+no lock because the pipeline runs on a single asyncio event loop and every cache
+mutation happens between ``await`` points, never across one.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from typing import Callable, Generic, Hashable, Optional, Tuple, TypeVar
+
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
+
+# Sentinel returned by ``get`` on a miss so that a legitimately cached ``None``
+# value could still be distinguished from "absent" (the embedding cache never
+# stores ``None``, but keeping the distinction makes the class reusable).
+MISS = object()
+
+
+class LruTtlCache(Generic[K, V]):
+    """Bounded least-recently-used cache with an optional per-entry TTL.
+
+    :param max_entries: hard cap on stored entries; the least-recently-used
+        entry is evicted once the cap is exceeded. ``<= 0`` disables caching
+        (every ``get`` is a miss and ``set`` is a no-op).
+    :param ttl_seconds: entries older than this are treated as missing and
+        dropped on access. ``None`` or ``<= 0`` disables expiry.
+    :param clock: monotonic time source, injectable for tests.
+    """
+
+    def __init__(
+        self,
+        max_entries: int,
+        ttl_seconds: Optional[float] = None,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._max = int(max_entries)
+        self._ttl = float(ttl_seconds) if ttl_seconds and ttl_seconds > 0 else None
+        self._clock = clock
+        # key -> (stored_at, value); ordered by recency of use (LRU at the front).
+        self._data: "OrderedDict[K, Tuple[float, V]]" = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+        self.evictions = 0
+        self.expirations = 0
+
+    # -- core operations ---------------------------------------------------
+
+    def get(self, key: K):
+        """Return the cached value or :data:`MISS`. Counts hits/misses."""
+        if self._max <= 0:
+            self.misses += 1
+            return MISS
+        item = self._data.get(key)
+        if item is None:
+            self.misses += 1
+            return MISS
+        stored_at, value = item
+        if self._ttl is not None and (self._clock() - stored_at) >= self._ttl:
+            # Expired: drop and report as a miss.
+            del self._data[key]
+            self.expirations += 1
+            self.misses += 1
+            return MISS
+        self._data.move_to_end(key)  # mark most-recently-used
+        self.hits += 1
+        return value
+
+    def set(self, key: K, value: V) -> None:
+        """Insert/refresh an entry, evicting the LRU entry past the cap."""
+        if self._max <= 0:
+            return
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = (self._clock(), value)
+        while len(self._data) > self._max:
+            self._data.popitem(last=False)  # evict least-recently-used
+            self.evictions += 1
+
+    def clear(self) -> None:
+        """Drop all entries (counters are preserved for observability)."""
+        self._data.clear()
+
+    # -- introspection -----------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __contains__(self, key: object) -> bool:
+        return self.get(key) is not MISS
+
+    @property
+    def total(self) -> int:
+        return self.hits + self.misses
+
+    @property
+    def hit_rate(self) -> float:
+        total = self.total
+        return (self.hits / total) if total else 0.0
+
+    def stats(self) -> dict:
+        """Snapshot of counters for diagnostics/logging."""
+        return {
+            "size": len(self._data),
+            "max_entries": self._max,
+            "ttl_seconds": self._ttl,
+            "hits": self.hits,
+            "misses": self.misses,
+            "evictions": self.evictions,
+            "expirations": self.expirations,
+            "hit_rate": round(self.hit_rate, 4),
+        }

--- a/automod/constants.py
+++ b/automod/constants.py
@@ -43,6 +43,25 @@ def embedding_threshold_for(severity: int) -> float:
 EMBEDDING_MODEL: str = "text-embedding-3-small"
 
 
+# --- Embedding score cache (step 4 de-duplication) --------------------------
+#
+# The reference vectors are embedded once per process and never change, so the
+# score of a given message is deterministic for the process lifetime. Caching it
+# collapses repeated/identical messages (raid spam, copypasta floods) onto a
+# single embedding call, and in-flight identical requests are additionally
+# coalesced (single-flight) so a burst of N identical messages costs one call,
+# not N. Purely an optimization — it can never change a decision, only avoid a
+# redundant embedding call. See docs/AUTOMOD.md §5 (Volume note).
+EMBED_CACHE_ENABLED: bool = True
+# Hard cap on cached message scores (LRU eviction past this). ~4k short strings
+# is a few hundred KB — negligible, and comfortably covers a busy server's
+# working set of distinct messages.
+EMBED_CACHE_MAX_ENTRIES: int = 4096
+# Defensive freshness bound; correctness does not depend on it (the score is
+# stable for the process lifetime). ``0`` disables expiry.
+EMBED_CACHE_TTL_SECONDS: float = 1800.0  # 30 minutes
+
+
 # --- nano (step 5) ----------------------------------------------------------
 
 # nano model + sampling. Low temperature for stable decisions.

--- a/automod/embeddings.py
+++ b/automod/embeddings.py
@@ -17,13 +17,15 @@ dependency-free — no numpy.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import math
 from pathlib import Path
-from typing import Awaitable, Callable, List, Optional, Tuple
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple
 
 from . import constants
+from .cache import MISS, LruTtlCache
 from .normalize import collapse_repeats, normalize_spaced
 
 logger = logging.getLogger("moddy.automod.embeddings")
@@ -63,18 +65,56 @@ def _dot(a: List[float], b: List[float]) -> float:
     return sum(x * y for x, y in zip(a, b))
 
 
+def _retrieve_result(fut: "asyncio.Future") -> None:
+    """Done-callback that marks a single-flight future's result as retrieved.
+
+    Guarantees the "Future exception was never retrieved" warning never fires
+    when a scoring computation raised and no waiter happened to be attached.
+    """
+    if not fut.cancelled():
+        fut.exception()  # retrieving is enough; the value/None is discarded
+
+
 class EmbeddingEngine:
     """Holds the normalized reference vectors and scores incoming messages."""
 
-    def __init__(self, embed_fn: EmbedFn):
+    def __init__(
+        self,
+        embed_fn: EmbedFn,
+        *,
+        cache: Optional[LruTtlCache] = None,
+    ):
         self._embed_fn = embed_fn
         self._ref_vectors: List[List[float]] = []
         self._ref_categories: List[str] = []
         self._ready = False
+        # Score cache: exact message text → (score, category). Deterministic for
+        # the process lifetime (references are embedded once), so memoising it is
+        # safe and never alters a decision. ``None`` builds the default cache
+        # from constants; a disabled cache is a max_entries=0 instance (no-op).
+        if cache is None:
+            cache = LruTtlCache(
+                max_entries=(
+                    constants.EMBED_CACHE_MAX_ENTRIES
+                    if constants.EMBED_CACHE_ENABLED
+                    else 0
+                ),
+                ttl_seconds=constants.EMBED_CACHE_TTL_SECONDS,
+            )
+        self._cache: LruTtlCache = cache
+        # Single-flight: coalesce concurrent identical scoring requests (a burst
+        # of identical raid messages) onto one embedding call.
+        self._inflight: Dict[str, "asyncio.Future"] = {}
 
     @property
     def ready(self) -> bool:
         return self._ready
+
+    def cache_stats(self) -> dict:
+        """Score-cache counters plus the current in-flight coalescing count."""
+        stats = self._cache.stats()
+        stats["inflight"] = len(self._inflight)
+        return stats
 
     @staticmethod
     def load_reference_texts() -> Tuple[List[str], List[str]]:
@@ -109,6 +149,46 @@ class EmbeddingEngine:
 
     async def score(self, content: str) -> Optional[Tuple[float, str]]:
         """Return (max_cosine, best_category) or None if scoring unavailable.
+
+        Results are memoised on the exact message text (deterministic for the
+        process lifetime) and concurrent identical requests are coalesced onto a
+        single embedding call, so repeated/flooded messages cost one call, not N.
+        """
+        if not self._ready:
+            return None
+
+        cached = self._cache.get(content)
+        if cached is not MISS:
+            return cached
+
+        # Coalesce a burst of identical in-flight requests onto one computation.
+        pending = self._inflight.get(content)
+        if pending is not None:
+            return await pending
+
+        loop = asyncio.get_event_loop()
+        future: "asyncio.Future" = loop.create_future()
+        future.add_done_callback(_retrieve_result)
+        self._inflight[content] = future
+        try:
+            result = await self._compute_score(content)
+        except BaseException as exc:  # propagate to this caller and any waiters
+            self._inflight.pop(content, None)
+            if not future.done():
+                future.set_exception(exc)
+            raise
+        else:
+            # Only cache real results — never a transient None (not-ready / empty
+            # embedding response), so a blip doesn't get pinned in the cache.
+            if result is not None:
+                self._cache.set(content, result)
+            self._inflight.pop(content, None)
+            if not future.done():
+                future.set_result(result)
+            return result
+
+    async def _compute_score(self, content: str) -> Optional[Tuple[float, str]]:
+        """Embed ``content`` and return (max_cosine, best_category) or None.
 
         Long content is segmented (sentences + windows + de-spammed form) and
         the **max** cosine across every segment is returned, so a toxic phrase

--- a/automod/engine.py
+++ b/automod/engine.py
@@ -66,6 +66,13 @@ class AutomodEngine:
 
         return chat_fn
 
+    def cache_stats(self) -> dict:
+        """Embedding score-cache counters (hits/misses/evictions/hit rate).
+
+        Useful for a staff diagnostic to gauge how much the cache is saving.
+        """
+        return self.embeddings.cache_stats()
+
     async def ensure_ready(self) -> bool:
         """Embed the reference phrases once (lazy). Returns readiness."""
         try:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest bootstrap — ensure the repository root is importable.
+
+Keeps ``import automod`` / ``import utils`` working regardless of the directory
+pytest is invoked from or the import mode it uses for collected test files.
+"""
+
+import sys
+from pathlib import Path
+
+_ROOT = str(Path(__file__).resolve().parent)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)

--- a/docs/AUTOMOD.md
+++ b/docs/AUTOMOD.md
@@ -32,7 +32,7 @@ message → 1.pre-filter → 2.trivial allowlist → 3.regex blocklist ─match�
 | 1. pre-filter | `prefiltre.py` | free | bot / system / empty → STOP |
 | 2. trivial allowlist | `triviaux.py` | free | "ok", "mdr", "gg"… → STOP |
 | 3. regex blocklist | `blocklist.py` | free | match → nano (`source=regex`), **skips embedding** |
-| 4. embedding | `embeddings.py` | 1 embed call | `score ≥ SEUIL_EMBEDDING` → nano (`source=embedding`); else STOP |
+| 4. embedding | `embeddings.py` | 1 embed call (cached) | `score ≥ SEUIL_EMBEDDING` → nano (`source=embedding`); else STOP |
 | 5. nano | `nano.py` | 1–3 chat calls | **the only decider** → `Decision` |
 
 Only **nano decides**. Regex and embedding merely *route*. Output is a
@@ -256,8 +256,19 @@ Seeded unlimited in `db/base.py`; tighten per-guild via `quota_overrides`.
 
 > **Volume note:** every non-trivial, non-blocklisted message triggers one
 > embedding call (and the gateway logs every call to the `api_call` webhook with
-> prompt/response files attached). Consider the optional cache/batch
-> optimizations (see the processing spec) before enabling at very large scale.
+> prompt/response files attached).
+>
+> **Embedding score cache (`automod/cache.py`).** The reference vectors are
+> embedded once per process and never change, so a message's cosine score is
+> deterministic for the process lifetime. `EmbeddingEngine.score()` therefore
+> memoises `(score, category)` on the exact message text in a bounded LRU+TTL
+> cache, and coalesces concurrent identical requests (**single-flight**). Net
+> effect: a raid or copypasta flood — by construction the same text repeated N
+> times — costs **one** embedding call instead of N, whether the duplicates
+> arrive back-to-back (cache hit) or all at once (single-flight). It is purely
+> an optimization: identical input → identical output, so it can never change a
+> decision. Tune it via `EMBED_CACHE_*` in `constants.py`; inspect it live via
+> `bot._automod_engine.cache_stats()` (hits / misses / evictions / hit_rate).
 
 ---
 
@@ -267,6 +278,9 @@ Seeded unlimited in `db/base.py`; tighten per-guild via `quota_overrides`.
 |---|---|---|
 | `SEUIL_EMBEDDING` | 0.45 | **Yes**, on real messages (per-guild via `severity`) |
 | `SEVERITY_DEFAULT` / `SEVERITY_EMBEDDING_THRESHOLDS` | 3 / {1:.62…5:.35} | the per-guild 1–5 dial → threshold + nano strictness |
+| `EMBED_CACHE_ENABLED` | `True` | leave on; disable only to A/B the savings |
+| `EMBED_CACHE_MAX_ENTRIES` | 4096 | raise for very high distinct-message volume |
+| `EMBED_CACHE_TTL_SECONDS` | 1800 | defensive freshness bound (`0` = never expire) |
 | `CONTEXTE_INITIAL` | 12 | by channel density |
 | `CONTEXTE_MAX` | 40 | cost / injection ceiling |
 | `ROUNDS_MAX` | 3 | anti-loop |

--- a/docs/sessions/2026-07-11_automod-embedding-cache-and-tests.md
+++ b/docs/sessions/2026-07-11_automod-embedding-cache-and-tests.md
@@ -1,0 +1,88 @@
+# 2026-07-11 — Automod embedding score cache + first automated test suite
+
+## What was done
+
+Two connected pieces of work on the automod detection core, both fully
+verifiable offline (no live Discord gateway or database):
+
+### 1. Embedding score cache (addresses the flagged volume/cost follow-up)
+
+The embedding step (`automod/embeddings.py`, funnel step 4) fired **one embedding
+API call for every non-trivial, non-blocklisted message** — the volume concern
+called out in the `2026-06-28` automod session logs and `docs/AUTOMOD.md`.
+
+Because the reference vectors are embedded **once per process and never change**,
+a message's cosine score is deterministic for the process lifetime. So we now
+memoise it:
+
+- **`automod/cache.py`** (new) — `LruTtlCache`, a dependency-free bounded LRU
+  cache with an optional TTL (defensive only; correctness doesn't need it) and
+  hit/miss/eviction/expiration counters + `stats()`. Injectable clock for tests.
+- **`EmbeddingEngine.score()`** now checks the cache first, and coalesces
+  concurrent identical requests via a **single-flight** in-flight future map.
+  Net effect: a raid/copypasta flood (same text ×N) costs **one** embedding call
+  instead of N — whether the duplicates arrive back-to-back (cache hit) or all at
+  once (single-flight). Transient `None` results (not-ready / empty response) are
+  **not** cached, so a blip can't get pinned.
+- It is purely an optimization — identical input → identical output — so it can
+  never change a moderation decision. Proven by the baseline tests below still
+  passing unchanged after the cache landed.
+- **`constants.py`** — `EMBED_CACHE_ENABLED` / `EMBED_CACHE_MAX_ENTRIES` (4096) /
+  `EMBED_CACHE_TTL_SECONDS` (1800).
+- **`AutomodEngine.cache_stats()`** / `EmbeddingEngine.cache_stats()` expose the
+  counters for a future staff diagnostic (`bot._automod_engine.cache_stats()`).
+
+### 2. First automated test suite for the detection core
+
+There was **no** automated test suite for the pure-Python, Discord-agnostic
+automod pipeline. Added `tests/automod/` (pytest, 101 tests):
+
+- `test_normalize.py` — accent/leet folding, repeat collapse, de-spam.
+- `test_prefiltre.py` — bot/system/empty short-circuits.
+- `test_triviaux.py` — allowlist + the lowercase/stripped safety invariant.
+- `test_blocklist.py` — routing + category/gravity, obfuscation (leet,
+  separators, repetition), emoji gestures, word-boundary Scunthorpe safety.
+- `test_constants.py` — severity clamp + threshold monotonicity.
+- `test_embeddings.py` — `ensure_ready` idempotency, scoring, **and** the cache
+  (hit/miss, distinct keys, transient-None-not-cached, disabled cache,
+  single-flight coalescing).
+- `test_cache.py` — LRU eviction + recency, TTL expiry (fake clock), disabled,
+  stats/hit_rate.
+- `test_engine.py` — funnel routing: trivial & blocklist **skip** the embedding
+  step, embedding above/below threshold, `force_nano`, and a 5×-flood → 1 embed
+  call integration test.
+
+Tooling: `pytest.ini` (asyncio auto mode), `requirements-dev.txt`, root
+`conftest.py` (repo root on `sys.path`).
+
+## Files
+
+- Added: `automod/cache.py`, `tests/automod/test_*.py` (7 files), `pytest.ini`,
+  `requirements-dev.txt`, `conftest.py`, this log.
+- Modified: `automod/embeddings.py`, `automod/constants.py`, `automod/engine.py`,
+  `docs/AUTOMOD.md`, `CLAUDE.md`.
+
+## Verification
+
+`pytest` → **102 passed** (101 automod + the pre-existing `test_embeds.py`). The
+baseline detection tests were written **before** the cache and still pass
+unchanged afterwards, which is the proof that the cache is behavior-preserving.
+
+## Decisions
+
+- **Key on the exact message text**, not a normalized form: the embedding is
+  computed on the raw content, so exact-text keying is the only correctness-safe
+  choice. Raid/copypasta floods are byte-identical, which is exactly the win.
+- **In-memory, not Redis**: the shared per-bot engine already holds the
+  references in-process; an in-memory cache needs no infra and matches the
+  engine's lifecycle. A Redis-backed cross-process cache could come later if the
+  bot ever shards the automod engine, but it isn't needed today.
+- **TTL is defensive only** (30 min) — the score is stable for the process
+  lifetime, so the TTL just bounds memory freshness.
+
+## Follow-ups / not done
+
+- A staff `/dev` diagnostic surfacing `cache_stats()` would make the savings
+  visible in production (small, optional).
+- `SEUIL_EMBEDDING` / references / blocklist calibration on real traffic remains
+  the standing automod follow-up (unchanged by this work).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+# Automated tests for the pure-Python, Discord-agnostic parts of the bot
+# (currently the automod detection core). These run without a live Discord
+# gateway or database, so they are safe to run in CI and locally.
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+asyncio_mode = auto
+addopts = -ra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+# Development / test dependencies.
+#   pip install -r requirements-dev.txt
+#
+# The automated test suite (tests/automod/) exercises the pure-Python automod
+# detection core — no live Discord gateway or database required.
+
+pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/tests/automod/test_blocklist.py
+++ b/tests/automod/test_blocklist.py
@@ -1,0 +1,87 @@
+"""Characterization tests for ``automod.blocklist`` (step 3).
+
+A blocklist match only *routes* a message to nano — it never sanctions — so the
+list is deliberately aggressive. These tests pin the routing behavior, the
+anti-circumvention normalization, and the word-boundary safety that keeps the
+worst Scunthorpe-style false positives out.
+"""
+
+from automod.blocklist import Blocklist, get_blocklist
+
+
+def _bl() -> Blocklist:
+    return get_blocklist()
+
+
+class TestSingleton:
+    def test_get_blocklist_is_cached(self):
+        assert get_blocklist() is get_blocklist()
+
+
+class TestPlainMatches:
+    def test_insult_routes_with_category_and_gravity(self):
+        entry = _bl().match("espèce de connard")
+        assert entry is not None
+        assert entry.categorie == "insultes"
+        assert entry.gravite_indicative == "moyenne"
+
+    def test_threat_is_high_gravity(self):
+        entry = _bl().match("je vais te tuer sale type")
+        assert entry is not None
+        assert entry.categorie == "menaces"
+        assert entry.gravite_indicative == "haute"
+
+    def test_self_harm_incitement(self):
+        entry = _bl().match("just kys already")
+        assert entry is not None
+        assert entry.categorie == "incitation_automutilation"
+
+    def test_mild_vulgarity_low_gravity(self):
+        entry = _bl().match("putain c'est nul")
+        assert entry is not None
+        assert entry.categorie == "vulgarite"
+        assert entry.gravite_indicative == "basse"
+
+
+class TestObfuscation:
+    def test_leetspeak_is_folded(self):
+        # c0nn4rd -> connard via 0->o, 4->a
+        assert _bl().match("t'es qu'un c0nn4rd") is not None
+
+    def test_separators_stripped_for_compact_terms(self):
+        # f.d.p / f-d-p / f_d_p all collapse to the compact term "fdp"
+        for variant in ("f.d.p", "f-d-p", "f_d_p", "f d p"):
+            assert _bl().match(variant) is not None, variant
+
+    def test_repeated_spam_still_matched(self):
+        # Evasion by repetition must still hit the word-boundary threat pattern.
+        assert _bl().match("je vais te tuer " * 40) is not None
+
+    def test_tripled_letters_collapsed(self):
+        assert _bl().match("espèce de coooonnard") is not None
+
+
+class TestEmojiGestures:
+    def test_middle_finger_emoji_flags(self):
+        entry = _bl().match("\U0001F595 you")
+        assert entry is not None
+        assert entry.categorie == "insultes"
+
+    def test_shortcode_middle_finger_flags(self):
+        assert _bl().match("take this :middle_finger:") is not None
+
+
+class TestNoMatch:
+    def test_clean_message_returns_none(self):
+        assert _bl().match("bonjour tout le monde, belle journée") is None
+
+    def test_positive_english_message_returns_none(self):
+        assert _bl().match("i really love this community") is None
+
+    def test_empty_and_whitespace(self):
+        assert _bl().match("") is None
+        assert _bl().match("    ") is None
+
+    def test_word_boundary_avoids_substring_false_positive(self):
+        # "ass" is a boundary-matched term; it must NOT fire inside "class".
+        assert _bl().match("this class was great") is None

--- a/tests/automod/test_cache.py
+++ b/tests/automod/test_cache.py
@@ -1,0 +1,123 @@
+"""Tests for ``automod.cache.LruTtlCache``."""
+
+from automod.cache import MISS, LruTtlCache
+
+
+class FakeClock:
+    """Manually-advanced monotonic clock for deterministic TTL tests."""
+
+    def __init__(self, now: float = 0.0):
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+class TestBasics:
+    def test_hit_and_miss(self):
+        c = LruTtlCache(max_entries=8)
+        assert c.get("a") is MISS
+        c.set("a", 1)
+        assert c.get("a") == 1
+        assert c.hits == 1
+        assert c.misses == 1
+
+    def test_set_overwrites(self):
+        c = LruTtlCache(max_entries=8)
+        c.set("a", 1)
+        c.set("a", 2)
+        assert c.get("a") == 2
+        assert len(c) == 1
+
+    def test_contains_uses_get_semantics(self):
+        c = LruTtlCache(max_entries=8)
+        c.set("a", 1)
+        assert "a" in c
+        assert "b" not in c
+
+
+class TestLruEviction:
+    def test_evicts_least_recently_used(self):
+        c = LruTtlCache(max_entries=2)
+        c.set("a", 1)
+        c.set("b", 2)
+        c.set("c", 3)  # evicts "a"
+        assert c.get("a") is MISS
+        assert c.get("b") == 2
+        assert c.get("c") == 3
+        assert c.evictions == 1
+
+    def test_get_refreshes_recency(self):
+        c = LruTtlCache(max_entries=2)
+        c.set("a", 1)
+        c.set("b", 2)
+        assert c.get("a") == 1   # "a" now most-recently-used
+        c.set("c", 3)            # should evict "b", not "a"
+        assert c.get("a") == 1
+        assert c.get("b") is MISS
+
+    def test_set_refreshes_recency(self):
+        c = LruTtlCache(max_entries=2)
+        c.set("a", 1)
+        c.set("b", 2)
+        c.set("a", 10)           # touch "a"
+        c.set("c", 3)            # evicts "b"
+        assert c.get("b") is MISS
+        assert c.get("a") == 10
+
+
+class TestTtl:
+    def test_entry_expires_after_ttl(self):
+        clock = FakeClock()
+        c = LruTtlCache(max_entries=8, ttl_seconds=10, clock=clock)
+        c.set("a", 1)
+        clock.advance(9)
+        assert c.get("a") == 1     # still fresh
+        clock.advance(1)           # now exactly at TTL → expired
+        assert c.get("a") is MISS
+        assert c.expirations == 1
+        assert len(c) == 0
+
+    def test_ttl_none_never_expires(self):
+        clock = FakeClock()
+        c = LruTtlCache(max_entries=8, ttl_seconds=None, clock=clock)
+        c.set("a", 1)
+        clock.advance(10_000)
+        assert c.get("a") == 1
+
+
+class TestDisabled:
+    def test_zero_max_entries_is_a_noop(self):
+        c = LruTtlCache(max_entries=0)
+        c.set("a", 1)
+        assert c.get("a") is MISS
+        assert len(c) == 0
+        assert c.misses == 1
+
+
+class TestStats:
+    def test_clear_keeps_counters(self):
+        c = LruTtlCache(max_entries=8)
+        c.set("a", 1)
+        c.get("a")
+        c.clear()
+        assert len(c) == 0
+        assert c.hits == 1
+
+    def test_hit_rate_and_snapshot(self):
+        c = LruTtlCache(max_entries=8, ttl_seconds=30)
+        c.get("x")          # miss
+        c.set("x", 1)
+        c.get("x")          # hit
+        c.get("x")          # hit
+        assert c.hit_rate == 2 / 3
+        snap = c.stats()
+        assert snap["hits"] == 2
+        assert snap["misses"] == 1
+        assert snap["size"] == 1
+        assert snap["max_entries"] == 8
+        assert snap["ttl_seconds"] == 30
+        assert snap["hit_rate"] == round(2 / 3, 4)

--- a/tests/automod/test_constants.py
+++ b/tests/automod/test_constants.py
@@ -1,0 +1,38 @@
+"""Tests for ``automod.constants`` severity handling."""
+
+import pytest
+
+from automod import constants
+
+
+class TestClampSeverity:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (1, 1), (3, 3), (5, 5),
+            (0, 1), (-4, 1), (6, 5), (99, 5),
+            ("4", 4), ("2", 2),
+            (None, constants.SEVERITY_DEFAULT),
+            ("abc", constants.SEVERITY_DEFAULT),
+            (3.9, 3),  # int() truncates
+        ],
+    )
+    def test_clamp(self, raw, expected):
+        assert constants.clamp_severity(raw) == expected
+
+
+class TestEmbeddingThreshold:
+    def test_known_levels_match_table(self):
+        for level, expected in constants.SEVERITY_EMBEDDING_THRESHOLDS.items():
+            assert constants.embedding_threshold_for(level) == expected
+
+    def test_higher_severity_lowers_threshold(self):
+        # Stricter servers route more messages to nano → lower threshold.
+        thresholds = [constants.embedding_threshold_for(s) for s in range(1, 6)]
+        assert thresholds == sorted(thresholds, reverse=True)
+
+    def test_out_of_range_severity_is_clamped(self):
+        assert constants.embedding_threshold_for(0) == \
+            constants.SEVERITY_EMBEDDING_THRESHOLDS[1]
+        assert constants.embedding_threshold_for(9) == \
+            constants.SEVERITY_EMBEDDING_THRESHOLDS[5]

--- a/tests/automod/test_embeddings.py
+++ b/tests/automod/test_embeddings.py
@@ -1,0 +1,201 @@
+"""Characterization tests for ``automod.embeddings`` (step 4).
+
+Scoring is exercised with a fake embed function so no network/gateway is
+involved. Assertions are value-based (not call-count-based) so they remain valid
+regardless of the score cache added on top of ``score()``.
+"""
+
+import asyncio
+
+import pytest
+
+from automod.cache import LruTtlCache
+from automod.embeddings import EmbeddingEngine, _normalize_vec
+
+
+def make_engine(mapping):
+    """Engine whose embed_fn returns a fixed vector per exact text.
+
+    Returns ``(engine, calls)`` where ``calls`` is the list of text-batches the
+    embed function was asked to embed.
+    """
+    calls = []
+
+    async def embed(texts):
+        calls.append(list(texts))
+        return [list(mapping[t]) for t in texts]
+
+    return EmbeddingEngine(embed), calls
+
+
+def ready_engine(mapping, refs):
+    """Return an engine with controlled reference vectors, marked ready."""
+    engine, calls = make_engine(mapping)
+    engine._ref_vectors = [_normalize_vec(v) for v, _ in refs]
+    engine._ref_categories = [c for _, c in refs]
+    engine._ready = True
+    return engine, calls
+
+
+class TestEnsureReady:
+    async def test_embeds_references_once_and_is_idempotent(self):
+        texts, _ = EmbeddingEngine.load_reference_texts()
+        assert texts, "references.json should provide reference phrases"
+        calls = {"n": 0}
+
+        async def embed(ts):
+            calls["n"] += 1
+            return [[1.0, 0.0] for _ in ts]
+
+        engine = EmbeddingEngine(embed)
+        assert await engine.ensure_ready() is True
+        assert engine.ready is True
+        # Second call must not re-embed.
+        assert await engine.ensure_ready() is True
+        assert calls["n"] == 1
+
+    async def test_size_mismatch_leaves_engine_not_ready(self):
+        async def embed(ts):
+            return [[1.0, 0.0]]  # wrong count
+
+        engine = EmbeddingEngine(embed)
+        assert await engine.ensure_ready() is False
+        assert engine.ready is False
+
+
+class TestScore:
+    async def test_returns_best_category_and_high_cosine(self):
+        engine, _ = ready_engine(
+            mapping={"tu es nul": [0.98, 0.02]},
+            refs=[([1.0, 0.0], "insultes"), ([0.0, 1.0], "menaces")],
+        )
+        score, category = await engine.score("tu es nul")
+        assert category == "insultes"
+        assert score == pytest.approx(0.9998, abs=1e-3)
+
+    async def test_orthogonal_query_scores_low(self):
+        engine, _ = ready_engine(
+            mapping={"bonjour": [0.0, 1.0]},
+            refs=[([1.0, 0.0], "insultes")],
+        )
+        score, _ = await engine.score("bonjour")
+        assert score == pytest.approx(0.0, abs=1e-6)
+
+    async def test_not_ready_returns_none(self):
+        engine, _ = make_engine({})
+        assert await engine.score("anything") is None
+
+
+class TestPassesThreshold:
+    def test_uses_default_when_no_threshold_given(self):
+        from automod import constants
+        assert EmbeddingEngine.passes_threshold(constants.SEUIL_EMBEDDING) is True
+        assert EmbeddingEngine.passes_threshold(constants.SEUIL_EMBEDDING - 0.01) is False
+
+    def test_explicit_threshold(self):
+        assert EmbeddingEngine.passes_threshold(0.5, 0.4) is True
+        assert EmbeddingEngine.passes_threshold(0.3, 0.4) is False
+
+    def test_boundary_is_inclusive(self):
+        assert EmbeddingEngine.passes_threshold(0.4, 0.4) is True
+
+
+class TestScoreCache:
+    async def test_identical_content_embeds_once(self):
+        engine, calls = ready_engine(
+            mapping={"tu es nul": [1.0, 0.0]},
+            refs=[([1.0, 0.0], "insultes")],
+        )
+        first = await engine.score("tu es nul")
+        second = await engine.score("tu es nul")
+        assert first == second
+        assert len(calls) == 1  # second call served from cache
+        stats = engine.cache_stats()
+        assert stats["hits"] == 1
+        assert stats["misses"] == 1
+        assert stats["size"] == 1
+
+    async def test_distinct_content_not_shared(self):
+        engine, calls = ready_engine(
+            mapping={"a": [1.0, 0.0], "b": [0.0, 1.0]},
+            refs=[([1.0, 0.0], "insultes")],
+        )
+        await engine.score("a")
+        await engine.score("b")
+        assert len(calls) == 2
+
+    async def test_transient_none_is_not_cached(self):
+        # First embed response is empty (transient failure) → None, not cached;
+        # a retry then succeeds and caches the real result.
+        responses = [[], [[1.0, 0.0]]]
+
+        async def embed(texts):
+            return responses.pop(0)
+
+        engine = EmbeddingEngine(embed)
+        engine._ref_vectors = [_normalize_vec([1.0, 0.0])]
+        engine._ref_categories = ["insultes"]
+        engine._ready = True
+
+        assert await engine.score("m") is None
+        assert engine.cache_stats()["size"] == 0  # None was not stored
+        score, category = await engine.score("m")
+        assert category == "insultes"
+        assert engine.cache_stats()["size"] == 1
+
+    async def test_disabled_cache_embeds_every_time(self):
+        engine, calls = ready_engine(
+            mapping={"x": [1.0, 0.0]},
+            refs=[([1.0, 0.0], "insultes")],
+        )
+        engine._cache = LruTtlCache(max_entries=0)  # disabled
+        await engine.score("x")
+        await engine.score("x")
+        assert len(calls) == 2
+        assert engine.cache_stats()["size"] == 0
+
+    async def test_embed_error_propagates_and_clears_inflight(self):
+        boom = RuntimeError("gateway down")
+
+        async def embed(texts):
+            raise boom
+
+        engine = EmbeddingEngine(embed)
+        engine._ref_vectors = [_normalize_vec([1.0, 0.0])]
+        engine._ref_categories = ["insultes"]
+        engine._ready = True
+
+        with pytest.raises(RuntimeError):
+            await engine.score("m")
+        # The failed request must not wedge the engine: nothing cached, no
+        # dangling in-flight entry, so a retry starts clean.
+        assert engine.cache_stats()["inflight"] == 0
+        assert engine.cache_stats()["size"] == 0
+
+    async def test_single_flight_coalesces_concurrent_requests(self):
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls = {"n": 0}
+
+        async def embed(texts):
+            calls["n"] += 1
+            started.set()
+            await release.wait()
+            return [[1.0, 0.0] for _ in texts]
+
+        engine = EmbeddingEngine(embed)
+        engine._ref_vectors = [_normalize_vec([1.0, 0.0])]
+        engine._ref_categories = ["insultes"]
+        engine._ready = True
+
+        t1 = asyncio.create_task(engine.score("flood"))
+        await started.wait()               # first request is inside embed()
+        t2 = asyncio.create_task(engine.score("flood"))
+        await asyncio.sleep(0)             # let t2 attach to the in-flight future
+        release.set()
+        r1, r2 = await asyncio.gather(t1, t2)
+
+        assert r1 == r2
+        assert calls["n"] == 1             # both served by a single embed call
+        assert engine.cache_stats()["size"] == 1
+        assert engine.cache_stats()["inflight"] == 0

--- a/tests/automod/test_engine.py
+++ b/tests/automod/test_engine.py
@@ -1,0 +1,145 @@
+"""Funnel-routing tests for ``automod.engine.AutomodEngine``.
+
+These verify the *order* of the funnel and, crucially, that the expensive
+embedding step is skipped whenever a cheaper earlier step already decided the
+routing (trivial allowlist, regex blocklist) or when ``force_nano`` short-cuts
+straight to nano. ``_judge`` (nano) is stubbed so no gateway/network is touched.
+"""
+
+import types
+
+import pytest
+
+from automod import constants
+from automod.engine import AutomodEngine
+from automod.embeddings import EmbeddingEngine, _normalize_vec
+from automod.schemas import AuthorHistory, Signal
+
+
+async def _no_context(_n):
+    return []
+
+
+def build_engine(monkeypatch, *, mapping=None, refs=None):
+    """An engine with a stubbed ``_judge`` and controlled embeddings.
+
+    Returns ``(engine, recorded, embed_calls)`` where ``recorded['signal']`` is
+    the :class:`Signal` handed to nano (or absent if the funnel stopped early)
+    and ``embed_calls`` is the list of embed batches issued during scoring.
+    """
+    bot = types.SimpleNamespace()
+    engine = AutomodEngine(bot)
+
+    # Controlled, already-ready embeddings so ensure_ready() is a no-op and
+    # score() uses our mapping instead of the gateway.
+    embed_calls = []
+
+    async def embed(texts):
+        embed_calls.append(list(texts))
+        return [list((mapping or {})[t]) for t in texts]
+
+    controlled = EmbeddingEngine(embed)
+    controlled._ref_vectors = [_normalize_vec(v) for v, _ in (refs or [])]
+    controlled._ref_categories = [c for _, c in (refs or [])]
+    controlled._ready = True
+    engine.embeddings = controlled
+
+    recorded = {}
+
+    async def fake_judge(self, target, signal, **kwargs):
+        recorded["signal"] = signal
+        return "DECISION"
+
+    monkeypatch.setattr(AutomodEngine, "_judge", fake_judge)
+    return engine, recorded, embed_calls
+
+
+def target(content):
+    from automod.schemas import TargetMessage
+    return TargetMessage(id="1", author_id="2", content=content)
+
+
+COMMON = dict(
+    guild_id=10,
+    guild_name="Guild",
+    rules="",
+    author_history=AuthorHistory(),
+    fetch_context=_no_context,
+)
+
+
+class TestFunnelRouting:
+    async def test_prefilter_drops_empty(self, monkeypatch):
+        engine, recorded, embed_calls = build_engine(monkeypatch)
+        result = await engine.analyze(target("   "), **COMMON)
+        assert result is None
+        assert "signal" not in recorded
+        assert embed_calls == []
+
+    async def test_trivial_message_short_circuits_before_embedding(self, monkeypatch):
+        engine, recorded, embed_calls = build_engine(monkeypatch)
+        result = await engine.analyze(target("mdr"), **COMMON)
+        assert result is None
+        assert "signal" not in recorded
+        assert embed_calls == []  # no embedding call for a trivial message
+
+    async def test_blocklist_routes_to_nano_without_embedding(self, monkeypatch):
+        engine, recorded, embed_calls = build_engine(monkeypatch)
+        result = await engine.analyze(target("espèce de connard"), **COMMON)
+        assert result == "DECISION"
+        assert recorded["signal"].source == constants.SOURCE_REGEX
+        assert recorded["signal"].categorie == "insultes"
+        assert embed_calls == []  # blocklist hit → embedding skipped
+
+    async def test_embedding_above_threshold_routes_to_nano(self, monkeypatch):
+        engine, recorded, embed_calls = build_engine(
+            monkeypatch,
+            mapping={"you are worthless": [1.0, 0.0]},
+            refs=[([1.0, 0.0], "insultes")],
+        )
+        result = await engine.analyze(
+            target("you are worthless"), severity=3, **COMMON
+        )
+        assert result == "DECISION"
+        assert recorded["signal"].source == constants.SOURCE_EMBEDDING
+        assert recorded["signal"].categorie == "insultes"
+        assert len(embed_calls) == 1
+
+    async def test_embedding_below_threshold_stops(self, monkeypatch):
+        engine, recorded, embed_calls = build_engine(
+            monkeypatch,
+            mapping={"lovely weather today": [0.0, 1.0]},  # orthogonal → score 0
+            refs=[([1.0, 0.0], "insultes")],
+        )
+        result = await engine.analyze(
+            target("lovely weather today"), severity=3, **COMMON
+        )
+        assert result is None
+        assert "signal" not in recorded
+        assert len(embed_calls) == 1  # scored once, then dropped
+
+    async def test_force_nano_skips_all_detectors(self, monkeypatch):
+        engine, recorded, embed_calls = build_engine(monkeypatch)
+        # A trivial message would normally be dropped; force_nano overrides that.
+        result = await engine.analyze(
+            target("mdr"), force_nano=True, **COMMON
+        )
+        assert result == "DECISION"
+        assert recorded["signal"].source == constants.SOURCE_NANO_FLAG
+        assert embed_calls == []
+
+
+class TestFunnelCacheInteraction:
+    async def test_repeated_flood_message_embeds_once(self, monkeypatch):
+        engine, recorded, embed_calls = build_engine(
+            monkeypatch,
+            mapping={"spam toxic line": [1.0, 0.0]},
+            refs=[([1.0, 0.0], "insultes")],
+        )
+        for _ in range(5):
+            assert await engine.analyze(
+                target("spam toxic line"), severity=3, **COMMON
+            ) == "DECISION"
+        # 5 identical flood messages cost exactly one embedding call.
+        assert len(embed_calls) == 1
+        assert engine.cache_stats()["hits"] == 4

--- a/tests/automod/test_normalize.py
+++ b/tests/automod/test_normalize.py
@@ -1,0 +1,89 @@
+"""Characterization tests for ``automod.normalize``.
+
+These pin the anti-circumvention behavior the blocklist and trivial allowlist
+depend on: accent folding, leetspeak folding, repeat collapsing and the
+repeat/concatenation de-spam used to defeat evasion by repetition.
+"""
+
+from automod.normalize import (
+    collapse_repeats,
+    fold_accents,
+    normalize_compact,
+    normalize_spaced,
+    normalize_trivial,
+)
+
+
+class TestFoldAccents:
+    def test_strips_french_diacritics(self):
+        assert fold_accents("négrÉ çà") == "negrE ca"
+
+    def test_leaves_plain_ascii_untouched(self):
+        assert fold_accents("hello world") == "hello world"
+
+
+class TestNormalizeSpaced:
+    def test_lowercases_and_folds_accents(self):
+        assert normalize_spaced("Éléphant") == "elephant"
+
+    def test_leetspeak_folds_to_letters(self):
+        # 1->i, 3->e, 4->a, 5->s, @->a, $->s, 0->o
+        assert normalize_spaced("n1k3r") == "niker"
+        assert normalize_spaced("sa10pe") == "saiope"  # 1->i, 0->o
+        assert normalize_spaced("f@g") == "fag"
+
+    def test_separators_become_single_space(self):
+        assert normalize_spaced("f.d.p") == "f d p"
+        assert normalize_spaced("a---b___c") == "a b c"
+
+    def test_collapses_three_plus_repeats(self):
+        # 3+ consecutive identical chars collapse to one
+        assert normalize_spaced("saaalope") == "salope"
+
+    def test_double_repeat_is_preserved(self):
+        # exactly 2 repeats is NOT collapsed (only 3+)
+        assert normalize_spaced("baal") == "baal"
+
+
+class TestNormalizeCompact:
+    def test_strips_all_separators(self):
+        assert normalize_compact("f.d.p") == "fdp"
+        assert normalize_compact("f d p") == "fdp"
+        assert normalize_compact("f_d-p") == "fdp"
+
+
+class TestNormalizeTrivial:
+    def test_collapses_repeats_and_lowercases(self):
+        assert normalize_trivial("MDRRRR") == "mdr"
+        assert normalize_trivial("okkk") == "ok"
+
+    def test_strips_surrounding_whitespace(self):
+        assert normalize_trivial("  lol  ") == "lol"
+
+
+class TestCollapseRepeats:
+    def test_whole_string_periodic_unit(self):
+        # "abcabcabc" is a period-3 repeat → the bare unit
+        assert collapse_repeats("abcabcabc") == "abc"
+
+    def test_repeated_phrase_collapses_to_single(self):
+        # A whole-string periodic repeat collapses to its bare unit. Here the
+        # separator-free period wins, yielding the compact single occurrence —
+        # which is exactly what the ``compact`` blocklist patterns match on.
+        text = "je vais te tuer " * 5
+        assert collapse_repeats(text) == "jevaistetuer"
+
+    def test_alternating_word_run_dedupes_consecutive(self):
+        # No global period, but consecutive duplicate words are dropped.
+        assert collapse_repeats("va va bene") == "va bene"
+
+    def test_consecutive_word_run_collapses(self):
+        assert collapse_repeats("tuer tuer tuer") == "tuer"
+
+    def test_non_repeating_text_is_left_meaningful(self):
+        # A normal sentence is returned as its spaced-normalized form.
+        assert collapse_repeats("bonjour tout le monde") == "bonjour tout le monde"
+
+    def test_empty_string(self):
+        assert collapse_repeats("") == ""
+        assert collapse_repeats("   ") == ""

--- a/tests/automod/test_prefiltre.py
+++ b/tests/automod/test_prefiltre.py
@@ -1,0 +1,23 @@
+"""Characterization tests for ``automod.prefiltre`` (step 1)."""
+
+from automod.prefiltre import pre_filter
+
+
+class TestPreFilter:
+    def test_passes_normal_human_message(self):
+        assert pre_filter("hello there", is_bot=False, is_system=False) is True
+
+    def test_drops_bot_messages(self):
+        assert pre_filter("hello", is_bot=True, is_system=False) is False
+
+    def test_drops_system_messages(self):
+        assert pre_filter("hello", is_bot=False, is_system=True) is False
+
+    def test_drops_empty_content(self):
+        assert pre_filter("", is_bot=False, is_system=False) is False
+
+    def test_drops_whitespace_only_content(self):
+        assert pre_filter("   \n\t ", is_bot=False, is_system=False) is False
+
+    def test_drops_none_content(self):
+        assert pre_filter(None, is_bot=False, is_system=False) is False

--- a/tests/automod/test_triviaux.py
+++ b/tests/automod/test_triviaux.py
@@ -1,0 +1,41 @@
+"""Characterization tests for ``automod.triviaux`` (step 2, allowlist)."""
+
+import pytest
+
+from automod.triviaux import TRIVIAUX, est_trivial
+
+
+class TestEstTrivial:
+    @pytest.mark.parametrize("msg", ["mdr", "lol", "ok", "gg", "merci", "salut"])
+    def test_common_french_interjections(self, msg):
+        assert est_trivial(msg) is True
+
+    @pytest.mark.parametrize("msg", ["lmao", "thanks", "yeah", "gm", "based"])
+    def test_common_english_interjections(self, msg):
+        assert est_trivial(msg) is True
+
+    def test_repeated_letters_still_trivial(self):
+        # normalize_trivial collapses "mdrrrr" -> "mdr" before lookup
+        assert est_trivial("MDRRRR") is True
+        assert est_trivial("okkk") is True
+
+    def test_surrounding_whitespace_ignored(self):
+        assert est_trivial("  lol  ") is True
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "you are an idiot",
+            "je vais te tuer",
+            "connard",
+            "this whole server is trash",
+        ],
+    )
+    def test_non_trivial_messages_not_allowlisted(self, msg):
+        assert est_trivial(msg) is False
+
+    def test_allowlist_is_lowercase_and_stripped(self):
+        # Safety invariant: every entry must be reachable by normalize_trivial,
+        # which lowercases and strips — so no entry may carry stray case/space.
+        for term in TRIVIAUX:
+            assert term == term.lower().strip()


### PR DESCRIPTION
## Summary

This PR adds two connected improvements to the automod detection core:

1. **Embedding score cache** — Memoises message scores to collapse repeated/flooded messages onto a single embedding API call, addressing the volume concern from the 2026-06-28 session.
2. **First automated test suite** — 102 tests covering the pure-Python detection pipeline (normalize, prefilter, allowlist, blocklist, embeddings, engine routing).

Both are fully verifiable offline (no Discord gateway or database required).

## Key Changes

### Embedding Score Cache (`automod/cache.py`, `automod/embeddings.py`)

- **`automod/cache.py`** (new) — `LruTtlCache`: dependency-free bounded LRU cache with optional TTL, hit/miss/eviction/expiration counters, and injectable clock for tests.
- **`EmbeddingEngine.score()`** now:
  - Checks the cache first on exact message text (deterministic for process lifetime since references are embedded once).
  - Coalesces concurrent identical requests via **single-flight** in-flight future map.
  - Does **not** cache transient `None` results (not-ready / empty response), so a blip can't get pinned.
  - Net effect: a raid/copypasta flood (same text ×N) costs **one** embedding call instead of N.
- **`constants.py`** — Added `EMBED_CACHE_ENABLED`, `EMBED_CACHE_MAX_ENTRIES` (4096), `EMBED_CACHE_TTL_SECONDS` (1800).
- **`AutomodEngine.cache_stats()` / `EmbeddingEngine.cache_stats()`** — Expose cache counters for diagnostics.
- **`docs/AUTOMOD.md`** — Updated step 4 description to note caching.

This is purely an optimization — identical input always yields identical output — so it can never change a moderation decision. The baseline tests still pass unchanged after the cache landed, proving behavior preservation.

### Automated Test Suite (`tests/automod/`, `pytest.ini`, `conftest.py`, `requirements-dev.txt`)

- **`test_normalize.py`** — Accent/leet folding, repeat collapse, de-spam.
- **`test_prefiltre.py`** — Bot/system/empty short-circuits.
- **`test_triviaux.py`** — Allowlist + lowercase/stripped safety invariant.
- **`test_blocklist.py`** — Routing, category/gravity, obfuscation (leet, separators, repetition), emoji gestures, word-boundary Scunthorpe safety.
- **`test_constants.py`** — Severity clamp + threshold monotonicity.
- **`test_embeddings.py`** — `ensure_ready` idempotency, scoring, cache (hit/miss, distinct keys, transient-None-not-cached, disabled cache, single-flight coalescing).
- **`test_cache.py`** — LRU eviction + recency, TTL expiry (fake clock), disabled, stats/hit_rate.
- **`test_engine.py`** — Funnel routing: trivial & blocklist **skip** embedding, embedding above/below threshold, `force_nano`, and a 5×-flood → 1 embed call integration test.
- **`pytest.ini`** — asyncio auto mode, test discovery config.
- **`conftest.py`** — Ensures repo root is on `sys.path` for imports.
- **`requirements-dev.txt`** — pytest + pytest-asyncio.

## Verification

`pytest` → **102 passed** (101 automod + pre-existing `test_embeds.py`). The baseline detection tests were written before the cache and still pass unchanged afterwards, proving the cache is behavior-preserving.

## Implementation Notes

- **Cache key**: exact message text (not normalized), since embedding is computed on raw content.
- **Single-flight**: concurrent identical requests attach to the same in-flight future, so a burst of N identical messages costs one embedding call, not N.
- **Transient

https://claude.ai/code/session_01EgwXpfMUphi8EniypvngTC