### PR TITLE
Automod v2 (session 2): deterministic barème & recidivism engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ moddy/
 │   ├── engine.py              #   Shared per-bot orchestrator (funnel entry)
 │   ├── prefiltre.py / triviaux.py / blocklist.py / embeddings.py / nano.py
 │   ├── normalize.py / injection.py / rules_check.py / schemas.py / constants.py
+│   ├── bareme.py              #   Deterministic sanction scale (cran ladder + recidivism)
 │   ├── cache.py               #   LRU+TTL score cache (embedding de-duplication)
 │   └── data/references.json   #   Embedding reference phrases (FR + EN)
 │

--- a/automod/bareme.py
+++ b/automod/bareme.py
@@ -1,0 +1,349 @@
+"""
+Deterministic sanction scale (barème) — session 2.
+
+nano **qualifies** a message (category + gravity + confidence); this module
+**computes the sanction**. The result is 100 % reproducible, auditable and
+explainable: given the same verdict, the same recidivism history and the same
+guild config, the barème always returns the same *cran* (rung) on a single
+sanction ladder, together with a line-by-line breakdown of how it got there.
+
+The module is **pure**: no I/O, no Discord, no DB. The caller
+(``modules/automod.py``) gathers the inputs (the member's past sanctions, their
+age on the server, the guild severity/config) and translates the returned cran
+into Discord actions. This keeps the whole thing table-testable to a dry.
+
+See docs/AUTOMOD.md §2bis and docs/AUTOMOD_V2_PLAN.md (Session 2).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# 1. The ladder — every sanction is one rung on a single scale
+# ---------------------------------------------------------------------------
+#
+# ``supprimer`` is ALWAYS included: in the ``content`` feature the message is
+# always the problem, so it always goes. A cran maps to the Discord actions the
+# module applies and the timeout duration in hours (``None`` = no timed
+# component, ``0`` = permanent for ban).
+
+CRAN_MIN = 0
+CRAN_MAX = 7
+
+# cran -> (actions, duree_heures)
+LADDER: Dict[int, Tuple[List[str], Optional[int]]] = {
+    0: (["supprimer"], None),            # deletion only
+    1: (["warn", "supprimer"], 0),       # warn
+    2: (["mute", "supprimer"], 2),       # short mute
+    3: (["mute", "supprimer"], 12),      # medium mute
+    4: (["mute", "supprimer"], 48),      # long mute
+    5: (["mute", "supprimer"], 168),     # very long mute (7 d)
+    6: (["mute", "supprimer"], 672),     # maximal mute (28 d)
+    7: (["ban", "supprimer"], 0),        # ban (permanent)
+}
+
+
+def ladder_for(cran: int) -> Tuple[List[str], Optional[int]]:
+    """Return ``(actions, duree_heures)`` for a cran (clamped to 0..7)."""
+    cran = max(CRAN_MIN, min(CRAN_MAX, int(cran)))
+    actions, duree = LADDER[cran]
+    return list(actions), duree
+
+
+# ---------------------------------------------------------------------------
+# 2. Floor cran per (category × gravity) — the "cold" first-offence policy
+# ---------------------------------------------------------------------------
+
+PLANCHER: Dict[Tuple[str, str], int] = {
+    ("insulte", "basse"): 1,    ("insulte", "moyenne"): 1,
+    ("insulte", "haute"): 2,    ("insulte", "critique"): 3,
+
+    ("harcelement", "basse"): 1,    ("harcelement", "moyenne"): 2,
+    ("harcelement", "haute"): 3,    ("harcelement", "critique"): 5,
+
+    ("menace", "basse"): 2,     ("menace", "moyenne"): 3,
+    ("menace", "haute"): 6,     ("menace", "critique"): 7,
+
+    ("haine_discrimination", "basse"): 2,    ("haine_discrimination", "moyenne"): 4,
+    ("haine_discrimination", "haute"): 6,    ("haine_discrimination", "critique"): 7,
+
+    ("incitation_automutilation", "basse"): 3,    ("incitation_automutilation", "moyenne"): 5,
+    ("incitation_automutilation", "haute"): 7,    ("incitation_automutilation", "critique"): 7,
+
+    ("harcelement_sexuel", "basse"): 3,    ("harcelement_sexuel", "moyenne"): 5,
+    ("harcelement_sexuel", "haute"): 7,    ("harcelement_sexuel", "critique"): 7,
+
+    ("doxxing", "basse"): 4,    ("doxxing", "moyenne"): 6,
+    ("doxxing", "haute"): 7,    ("doxxing", "critique"): 7,
+
+    ("arnaque_scam", "basse"): 2,    ("arnaque_scam", "moyenne"): 4,
+    ("arnaque_scam", "haute"): 7,    ("arnaque_scam", "critique"): 7,
+
+    ("violation_indications", "basse"): 0,    ("violation_indications", "moyenne"): 1,
+    ("violation_indications", "haute"): 2,    ("violation_indications", "critique"): 4,
+}
+
+# Fallback floor when nano returns an unknown/empty (category, gravity) pair but
+# still flagged the message sanctionnable — deletion only, never a heavy action.
+PLANCHER_DEFAUT = 0
+
+# Categories that are never softened and always act: the veteran-clemency bonus
+# is refused for these at gravity haute+, and (deletion aside) they are the hard
+# floor of the policy.
+CATEGORIES_SENSIBLES = frozenset({
+    "incitation_automutilation", "doxxing", "harcelement_sexuel",
+})
+
+
+# ---------------------------------------------------------------------------
+# 3. Recidivism — weighted points with exponential (half-life) decay
+# ---------------------------------------------------------------------------
+
+POINTS_GRAVITE = {"basse": 1.0, "moyenne": 3.0, "haute": 7.0, "critique": 15.0}
+DEMI_VIE_JOURS = 45.0
+
+# Reliability of the sanction's source: a human weighs more than an automod, and
+# an appeal is the tie-breaker.
+POIDS_SOURCE = {
+    "manuel":                1.5,   # posted by a human moderator
+    "automod_confirme":      1.25,  # automod sanction whose appeal was REFUSED
+    "automod":               1.0,   # automod sanction, never contested
+    "automod_appel_accepte": 0.0,   # appeal ACCEPTED => false positive => 0 point
+}
+
+# Specialisation aggravates: re-offending in the same category counts for more.
+MULT_MEME_CATEGORIE = 1.5
+
+
+@dataclass
+class SanctionPassee:
+    """One past sanction, as consumed by the recidivism engine.
+
+    ``source_fiabilite`` is a key of :data:`POIDS_SOURCE` (an accepted appeal
+    yields ``automod_appel_accepte`` → weight 0, so a proven false positive never
+    counts). The caller derives it from the sanction issuer + the appeal state.
+    """
+    categorie: str
+    gravite: str
+    date: datetime
+    source_fiabilite: str = "automod"
+
+
+def points_actifs(
+    sanctions: List[SanctionPassee],
+    categorie_courante: str,
+    now: Optional[datetime] = None,
+) -> float:
+    """Sum of decayed, source-weighted recidivism points for a member."""
+    now = now or datetime.now(timezone.utc)
+    total = 0.0
+    for s in sanctions:
+        base = POINTS_GRAVITE.get(s.gravite, 0.0)
+        if base <= 0.0:
+            continue
+        age_jours = (now - _aware(s.date)).total_seconds() / 86400.0
+        if age_jours < 0:
+            age_jours = 0.0
+        decay = 0.5 ** (age_jours / DEMI_VIE_JOURS)
+        poids = POIDS_SOURCE.get(s.source_fiabilite, 1.0)
+        meme_cat = MULT_MEME_CATEGORIE if (s.categorie and s.categorie == categorie_courante) else 1.0
+        total += base * decay * poids * meme_cat
+    return total
+
+
+def crans_recidive(points: float) -> int:
+    """How many extra crans the active recidivism points add to the floor."""
+    if points >= 40:
+        return 3
+    if points >= 15:
+        return 2
+    if points >= 5:
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# 4. Guild config knobs
+# ---------------------------------------------------------------------------
+
+# Hard ceiling a guild can impose on what the automod is allowed to do.
+PLAFOND_CONFIG = {"warn": 1, "mute": 6, "ban": 7}
+MAX_ACTION_DEFAULT = "ban"
+
+# Severity (1–5) global shift.
+_SEVERITE_SHIFT = {1: -1, 2: 0, 3: 0, 4: 0, 5: 1}
+
+
+@dataclass
+class MembreInfo:
+    """The member facts the barème needs (all trivially available in the event)."""
+    anciennete_jours: float = 0.0
+
+
+@dataclass
+class ConfigBareme:
+    """Guild-level barème configuration."""
+    max_action: str = MAX_ACTION_DEFAULT
+    #: Categories the guild opted out of AI sanctioning (kill-switch, annexe 5):
+    #: a disabled category is capped to deletion only (cran 0).
+    categories_desactivees: Tuple[str, ...] = ()
+
+    @property
+    def plafond_cran(self) -> int:
+        return PLAFOND_CONFIG.get(self.max_action, CRAN_MAX)
+
+
+# ---------------------------------------------------------------------------
+# 5. The computation + its explainable breakdown
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Composante:
+    """One line of the sanction breakdown (a step in the computation)."""
+    code: str          # stable machine code (mapped to i18n by the caller)
+    delta: int         # signed change this step applied to the running cran
+    detail: str = ""   # short human hint (e.g. "insulte/moyenne", "8.2 pts")
+
+
+@dataclass
+class ResultatBareme:
+    """The barème's output: the final cran, its actions and how it was reached."""
+    cran: int
+    actions: List[str]
+    duree_heures: Optional[int]
+    categorie: str
+    gravite: str
+    points_recidive: float
+    composantes: List[Composante] = field(default_factory=list)
+    #: cran ≥ 6 (mute 672 h / ban) decided purely by automod → flag for review
+    #: (session-6 mini confirmation; today it only highlights the alert card).
+    needs_review: bool = False
+
+    @property
+    def sanction_reelle(self) -> bool:
+        """Whether a real sanction (beyond deletion) is applied."""
+        return any(a in ("warn", "mute", "ban") for a in self.actions)
+
+
+def calculer(
+    verdict,
+    sanctions_passees: List[SanctionPassee],
+    membre: MembreInfo,
+    *,
+    severite_guild: int = 3,
+    config: Optional[ConfigBareme] = None,
+    now: Optional[datetime] = None,
+) -> ResultatBareme:
+    """Compute the sanction cran for a qualified verdict.
+
+    ``verdict`` is any object carrying ``categorie`` / ``gravite`` / ``confiance``
+    (an :class:`automod.schemas.Decision` fits). ``sanctions_passees`` is the
+    member's recent history, ``membre`` their server tenure, ``severite_guild``
+    the 1–5 dial and ``config`` the guild ceiling / kill-switches.
+
+    Returns a :class:`ResultatBareme` whose ``composantes`` explain the cran
+    line by line — the whole point of the deterministic barème.
+    """
+    config = config or ConfigBareme()
+    now = now or datetime.now(timezone.utc)
+    categorie = getattr(verdict, "categorie", "") or ""
+    gravite = getattr(verdict, "gravite", "basse") or "basse"
+    confiance = getattr(verdict, "confiance", "low") or "low"
+
+    composantes: List[Composante] = []
+
+    # Kill-switch: a disabled category never earns more than deletion.
+    if categorie in set(config.categories_desactivees):
+        composantes.append(Composante("categorie_desactivee", 0, categorie))
+        actions, duree = ladder_for(0)
+        return ResultatBareme(
+            cran=0, actions=actions, duree_heures=duree,
+            categorie=categorie, gravite=gravite, points_recidive=0.0,
+            composantes=composantes,
+        )
+
+    # -- Floor -----------------------------------------------------------
+    plancher = PLANCHER.get((categorie, gravite), PLANCHER_DEFAUT)
+    cran = plancher
+    composantes.append(Composante("plancher", plancher, f"{categorie or '?'}/{gravite}"))
+
+    # -- Recidivism ------------------------------------------------------
+    points = points_actifs(sanctions_passees, categorie, now)
+    add_recidive = crans_recidive(points)
+    cran += add_recidive
+    if add_recidive:
+        composantes.append(Composante("recidive", add_recidive, f"{points:.1f} pts"))
+
+    # -- a) Guild severity (global shift) --------------------------------
+    sev = _clamp_severite(severite_guild)
+    shift = _SEVERITE_SHIFT[sev]
+    cran += shift
+    if shift:
+        composantes.append(Composante("severite", shift, f"serveur {sev}"))
+
+    # -- b) nano confidence cap (never mute/ban on weak confidence) ------
+    #    low  => at worst a warn (cran 1); medium => never mute >48 h nor ban.
+    ceiling = {"low": 1, "medium": 4}.get(confiance)
+    if ceiling is not None and cran > ceiling:
+        composantes.append(Composante("confiance", ceiling - cran, confiance))
+        cran = ceiling
+
+    # -- c) Veteran clemency (never on sensitive categories / high gravity)
+    veteran = (
+        membre.anciennete_jours >= 90
+        and not sanctions_passees
+        and gravite in ("basse", "moyenne")
+        and categorie not in CATEGORIES_SENSIBLES
+    )
+    if veteran and cran > 0:
+        cran -= 1
+        composantes.append(Composante("veteran", -1, "≥90 j, casier vierge"))
+
+    # -- d) Fresh-account malus ------------------------------------------
+    if membre.anciennete_jours < 7:
+        cran += 1
+        composantes.append(Composante("compte_recent", 1, "<7 j"))
+
+    # -- e) Guild hard ceiling (max_action) ------------------------------
+    plafond = config.plafond_cran
+    if cran > plafond:
+        delta = plafond - cran
+        cran = plafond
+        composantes.append(Composante("plafond", delta, config.max_action))
+
+    # -- Clamp (keep the breakdown honest: record it if it bites) --------
+    borne = max(CRAN_MIN, min(CRAN_MAX, cran))
+    if borne != cran:
+        composantes.append(Composante("borne", borne - cran, ""))
+        cran = borne
+
+    actions, duree = ladder_for(cran)
+    return ResultatBareme(
+        cran=cran, actions=actions, duree_heures=duree,
+        categorie=categorie, gravite=gravite, points_recidive=points,
+        composantes=composantes, needs_review=cran >= 6,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _clamp_severite(value) -> int:
+    try:
+        v = int(value)
+    except (TypeError, ValueError):
+        return 3
+    return max(1, min(5, v))
+
+
+def _aware(dt: datetime) -> datetime:
+    """Coerce a naive datetime to UTC-aware so arithmetic never raises."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+

--- a/automod/nano.py
+++ b/automod/nano.py
@@ -46,14 +46,9 @@ ChatFn = Callable[[str, str], Awaitable[dict]]
 # A context loader: (n) -> the n messages preceding the target, oldest first.
 ContextFn = Callable[[int], Awaitable[List[ContextMessage]]]
 
-_ALLOWED_ACTIONS = {"ban", "mute", "warn", "supprimer"}  # TODO(session2): to the barème
 _ALLOWED_GRAVITE = {"basse", "moyenne", "haute", "critique"}
 _ALLOWED_CONFIANCE = {"low", "medium", "high"}
 _ALLOWED_CIBLE = {"membre", "auteur_lui_meme", "groupe", "aucune"}
-
-# Upper bound for a model-decided sanction duration (Discord timeout caps at 28
-# days; we apply the same ceiling to every temporary sanction).
-_MAX_DUREE_HEURES = 24 * 28
 
 # Canonical FR category set (v2 contract) + folding of the legacy detector /
 # stored values onto it. See docs/AUTOMOD.md §2. Anything unknown folds to "".
@@ -89,10 +84,9 @@ _DEFAULT_VERDICT = {
     "sanctionnable": False,
     "categorie": "",
     "gravite": "basse",
-    # TODO(session2): `actions` / `duree_heures` leave the nano contract for the
-    # deterministic barème. Kept for now so the module can still apply sanctions.
-    "actions": [],
-    "duree_heures": 0,
+    # v2 (session 2): nano no longer decides `actions` / `duree_heures`. It only
+    # QUALIFIES (categorie + gravite + confiance); the deterministic barème
+    # (automod/bareme.py) computes the sanction from that qualification.
     "citation": "",
     "cible": "aucune",
     "raison": "",
@@ -252,11 +246,15 @@ NEED MORE CONTEXT
 If context is insufficient, besoin_plus_contexte=true and nb_messages_supplementaires
 between 1 and {restant}; leave verdict fields at defaults.
 
+YOU DO NOT DECIDE THE SANCTION
+You only qualify the message (categorie + gravite + confiance). The punishment
+(warn / mute / ban / duration) is computed by a deterministic system from your
+qualification and the member's history. Do not mention or choose any punishment.
+
 STRICT OUTPUT FORMAT
 Respond ONLY with a valid JSON object with EXACTLY these keys:
 {{"besoin_plus_contexte": false, "nb_messages_supplementaires": 0,
  "sanctionnable": false, "categorie": "", "gravite": "basse",
- "actions": [], "duree_heures": 0,
  "citation": "", "cible": "aucune", "raison": "", "explication": "",
  "confiance": "low", "autres_messages_a_verifier": []}}
 Allowed values:
@@ -267,9 +265,6 @@ Allowed values:
 - cible     : "membre" | "auteur_lui_meme" | "groupe" | "aucune"
 - confiance : "low" | "medium" | "high"
 - citation  : exact verbatim substring of message_cible (no [DATA:…] markers)
-- actions   : subset of ["ban","mute","warn","supprimer"] (proportionate; always add
-              "supprimer" when you sanction the content)
-- duree_heures: integer >= 0 (0 = permanent), <= { _MAX_DUREE_HEURES }
 - raison    : FACTS ONLY, one short sentence, written in {response_language}, shown to the
               sanctioned member. No speculation ("suggests", "could imply"), no history,
               no reasoning. Do NOT include the [DATA:…] markers.
@@ -332,18 +327,6 @@ def parse_verdict(raw: dict) -> dict:
     gravite = raw.get("gravite", "basse")
     verdict["gravite"] = gravite if gravite in _ALLOWED_GRAVITE else "basse"
 
-    actions = raw.get("actions", [])
-    if isinstance(actions, list):
-        verdict["actions"] = [a for a in actions if a in _ALLOWED_ACTIONS]
-    else:
-        verdict["actions"] = []
-
-    try:
-        duree = int(raw.get("duree_heures", 0) or 0)
-    except (TypeError, ValueError):
-        duree = 0
-    verdict["duree_heures"] = max(0, min(duree, _MAX_DUREE_HEURES))
-
     # Category is coerced onto the canonical FR set (legacy values folded).
     verdict["categorie"] = normalize_categorie(raw.get("categorie", ""))
 
@@ -371,8 +354,6 @@ def parse_verdict(raw: dict) -> dict:
     # A verdict asking for more context carries no sanction.
     if verdict["besoin_plus_contexte"]:
         verdict["sanctionnable"] = False
-        verdict["actions"] = []
-        verdict["duree_heures"] = 0
 
     return verdict
 
@@ -385,8 +366,6 @@ def _reject(verdict: dict, motif: str) -> dict:
     this is free evaluation data on avoided false positives.
     """
     verdict["sanctionnable"] = False
-    verdict["actions"] = []
-    verdict["duree_heures"] = 0
     verdict["rejet_grounding"] = motif
     return verdict
 
@@ -474,11 +453,14 @@ async def juger(
             verdict["rejet_grounding"], verdict.get("categorie") or "-", target.id,
         )
 
+    # v2 (session 2): nano no longer decides `actions` / `duree_heures`. They are
+    # left empty here and filled by the deterministic barème in the module, from
+    # the qualification (categorie / gravite / confiance) below.
     return Decision(
         message_id=target.id,
         auteur_id=target.author_id,
         sanctionnable=verdict["sanctionnable"],
-        actions=verdict["actions"],
+        actions=[],
         categorie=verdict["categorie"] or normalize_categorie(signal.categorie),
         gravite=verdict["gravite"],
         raison=verdict["raison"],
@@ -487,7 +469,7 @@ async def juger(
         signal_source=signal.source,
         score_detecteur=signal.score_confiance,
         a_reverifier=verdict["autres_messages_a_verifier"],
-        duree_heures=verdict["duree_heures"],
+        duree_heures=0,
         citation=verdict["citation"],
         cible=verdict["cible"],
         rejet_grounding=verdict["rejet_grounding"],

--- a/automod/schemas.py
+++ b/automod/schemas.py
@@ -79,7 +79,10 @@ class Decision:
     message_id: str
     auteur_id: str
     sanctionnable: bool
-    actions: List[str]          # ⊆ {"ban", "mute", "warn", "supprimer"}  # TODO(session2): moves to the barème
+    # ⊆ {"ban", "mute", "warn", "supprimer"}. In v2 these are decided by the
+    # deterministic barème (automod/bareme.py), NOT by nano: the pipeline leaves
+    # them empty and the module fills them from the barème's cran.
+    actions: List[str]
     categorie: str              # canonical FR category (see nano.CATEGORIES)
     gravite: str                # basse | moyenne | haute | critique
     raison: str                 # FACTUAL only: what the message contains / which rule it breaks
@@ -88,7 +91,7 @@ class Decision:
     signal_source: str          # "regex" | "embedding" | "signalé_par_nano"
     score_detecteur: float      # detector input score
     a_reverifier: List[str] = field(default_factory=list)
-    duree_heures: int = 0       # temporary-sanction duration in hours (0 = permanent)  # TODO(session2)
+    duree_heures: int = 0       # sanction duration in hours (0 = permanent); barème-owned in v2
     # v2 grounding contract (docs/AUTOMOD.md §2).
     citation: str = ""          # verbatim substring of the target that justifies the category
     cible: str = "aucune"       # "membre" | "auteur_lui_meme" | "groupe" | "aucune"

--- a/db/repositories/moderation.py
+++ b/db/repositories/moderation.py
@@ -720,6 +720,13 @@ class ModerationRepository:
                   AND e.type = 'evidence'::event_type
                   AND e.payload ->> 'source' = 'automod'
                   AND e.payload ->> 'message_id' IS NOT NULL
+                  -- A sanction whose appeal was ACCEPTED was a false positive:
+                  -- drop its message so it never counts as "already moderated".
+                  AND NOT EXISTS (
+                      SELECT 1 FROM case_appeals ap
+                      JOIN case_sanctions s2 ON s2.id = ap.sanction_id
+                      WHERE s2.case_id = c.id AND ap.status = 'accepted'
+                  )
                 ORDER BY e.created_at DESC
                 LIMIT $3
                 """,
@@ -733,6 +740,90 @@ class ModerationRepository:
                 continue
             out.append({"id": str(mid), "extrait": (payload.get("extrait") or "")[:120]})
         return out
+
+    # Fallback gravity when a manual sanction carries no automod evidence to
+    # read a gravity from (the barème still needs one to weigh recidivism).
+    _GRAVITE_PAR_ACTION = {"warn": "basse", "mute": "moyenne", "ban": "haute"}
+
+    async def list_member_sanctions(
+        self,
+        guild_id: Union[str, int],
+        user_id: Union[str, int],
+        *,
+        since: Optional[datetime] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """Recidivism input for the automod barème (session 2).
+
+        Returns the member's guild sanctions since ``since`` as dicts
+        ``{action, categorie, gravite, date, source_fiabilite}``. ``categorie`` /
+        ``gravite`` come from the automod evidence event (else derived from the
+        action); ``source_fiabilite`` is derived from the issuer + the appeal
+        state so the barème can weight each past sanction:
+
+        * automod sanction, appeal **accepted** → ``automod_appel_accepte`` (a
+          proven false positive; the barème weights it 0).
+        * automod sanction, appeal **refused**  → ``automod_confirme`` (a human
+          confirmed it; weighted above a plain automod sanction).
+        * automod sanction, no ruling           → ``automod``.
+        * human-issued sanction                 → ``manuel``.
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT s.id, s.action::text AS action, s.created_at,
+                       s.issued_by_type::text AS issued_by_type,
+                       (SELECT e.payload FROM case_events e
+                          WHERE e.case_id = c.id AND e.type = 'evidence'::event_type
+                            AND e.payload ->> 'source' = 'automod'
+                          ORDER BY e.created_at ASC LIMIT 1) AS evidence,
+                       (SELECT a.status FROM case_appeals a
+                          WHERE a.sanction_id = s.id
+                          ORDER BY a.created_at DESC LIMIT 1) AS appeal_status
+                FROM case_sanctions s
+                JOIN cases c ON c.id = s.case_id
+                WHERE c.subject_type = 'discord_user'::subject_type
+                  AND c.subject_id = $1
+                  AND c.scope_type = 'discord_guild'::scope_type
+                  AND c.scope_id = $2
+                  AND c.type = 'guild'::case_type
+                  AND ($3::timestamptz IS NULL OR s.created_at >= $3)
+                ORDER BY s.created_at DESC
+                LIMIT $4
+                """,
+                str(user_id), str(guild_id), since, limit,
+            )
+
+        out: List[Dict[str, Any]] = []
+        for r in rows:
+            evidence = self._parse_jsonb(r["evidence"]) if r["evidence"] else {}
+            action = r["action"]
+            categorie = (evidence.get("categorie") or "") if evidence else ""
+            gravite = (evidence.get("gravite") if evidence else None) \
+                or self._GRAVITE_PAR_ACTION.get(action, "moyenne")
+            out.append({
+                "action": action,
+                "categorie": categorie,
+                "gravite": gravite,
+                "date": r["created_at"],
+                "source_fiabilite": self._derive_source_fiabilite(
+                    r["issued_by_type"], r["appeal_status"]),
+            })
+        return out
+
+    @staticmethod
+    def _derive_source_fiabilite(issued_by_type: Optional[str],
+                                 appeal_status: Optional[str]) -> str:
+        """Map (issuer, appeal state) onto a barème reliability weight key."""
+        if issued_by_type == "automod":
+            if appeal_status == "accepted":
+                return "automod_appel_accepte"
+            if appeal_status == "refused":
+                return "automod_confirme"
+            return "automod"
+        if issued_by_type in ("discord_user", "moddy_staff"):
+            return "manuel"
+        return "automod"
 
     async def get_active_subject_sanctions(
         self, subject_type: str, subject_id: Union[str, int],

--- a/docs/AUTOMOD.md
+++ b/docs/AUTOMOD.md
@@ -88,9 +88,10 @@ that is the deterministic barème's job (session 2). The key v2 fields:
 | `explication` | 1–2 sentences justifying the decision (the *why*). Stored on the evidence event + logs. |
 | `confiance` | `low` \| `medium` \| `high`. |
 
-> `actions` / `duree_heures` are **still emitted** by nano as a temporary bridge
-> (marked `# TODO(session2)` in the code) so sanctions keep applying until the
-> barème lands; session 2 removes them from this contract.
+> **`actions` / `duree_heures` are gone from the nano contract (v2, session 2).**
+> nano no longer decides *any* punishment — it only qualifies. The sanction is
+> computed by the deterministic **barème** (§2bis). The pipeline leaves
+> `Decision.actions` empty; the module fills it from the barème's cran.
 
 **Canonical categories** (`automod.constants.CATEGORIES`): `insulte`, `menace`,
 `harcelement`, `harcelement_sexuel`, `haine_discrimination`,
@@ -153,6 +154,75 @@ reduce surface and impact while the deterministic layers (regex) keep working.
 
 ---
 
+## 2bis. The barème — deterministic sanction scale (`automod/bareme.py`)
+
+nano **qualifies**; the **barème computes the sanction**. It is a pure module
+(no I/O, no Discord, no DB — fully table-testable): given the same verdict, the
+same recidivism history and the same guild config it always returns the same
+*cran* (rung) plus a line-by-line breakdown of how it got there. The module
+(`modules/automod.py`) gathers the inputs and translates the cran into Discord
+actions.
+
+### The ladder (`LADDER`)
+
+Every sanction is one rung on a single scale. `supprimer` is **always** included
+(in the `content` feature the message is always the problem).
+
+| Cran | Sanction | actions | duree_heures |
+|---|---|---|---|
+| 0 | deletion only | `["supprimer"]` | — |
+| 1 | warn | `["warn","supprimer"]` | 0 |
+| 2–6 | mute (2h→12h→48h→168h→672h) | `["mute","supprimer"]` | 2 … 672 |
+| 7 | ban | `["ban","supprimer"]` | 0 (permanent) |
+
+### How a cran is computed (`bareme.calculer`)
+
+1. **Floor** `PLANCHER[(categorie, gravite)]` — the "cold" first-offence policy.
+2. **Recidivism** `+ crans_recidive(points_actifs(...))` — past sanctions are
+   **weighted points** (`POINTS_GRAVITE`) that **decay exponentially** (half-life
+   45 days), scaled by source reliability (`POIDS_SOURCE`) and ×1.5 for a repeat
+   in the **same category**. Thresholds: ≥5 pts → +1, ≥15 → +2, ≥40 → +3.
+3. **Guild severity (1–5)** — global shift `{1:-1, 5:+1}`.
+4. **Confidence cap** — `low` ⇒ at most a warn (cran 1); `medium` ⇒ never a mute
+   >48h nor a ban (cran ≤ 4).
+5. **Veteran clemency** (−1) — ≥90 days on the server, clean record, gravity
+   `basse`/`moyenne` only; **never** for sensitive categories.
+6. **Fresh-account malus** (+1) — <7 days on the server.
+7. **Guild ceiling** — `max_action` (`warn`/`mute`/`ban`) caps the cran
+   (`PLAFOND_CONFIG`). Deletion always survives the ceiling.
+8. Clamp to 0–7.
+
+**Source reliability** (`POIDS_SOURCE`): `manuel` 1.5, `automod_confirme` 1.25
+(appeal **refused** — a human confirmed it), `automod` 1.0, `automod_appel_accepte`
+**0.0** (appeal **accepted** — a proven false positive never counts). The module
+derives it per past sanction from the issuer + the appeal state
+(`db.list_member_sanctions`).
+
+**Kill-switch** (`categories_desactivees`): a guild can opt a category out of AI
+sanctioning entirely — it is capped to deletion only (cran 0).
+
+### Explainability
+
+`ResultatBareme.composantes` lists every step (`plancher`, `recidive`,
+`severite`, `confiance`, `veteran`, `compte_recent`, `plafond`, …) with its
+signed delta; the deltas sum to the final cran. The module renders this as a
+breakdown on the alert card and stores it on the case evidence (`payload.bareme`
+/ `payload.cran`) so the timeline explains the sanction line by line — no other
+automod on the market does this. A cran ≥ 6 decided purely by automod sets
+`needs_review` (a "Réviser" highlight today; session-6 mini confirmation later).
+
+### Recidivism data (`db.list_member_sanctions`)
+
+`list_member_sanctions(guild_id, user_id, since=now-180d)` returns
+`{action, categorie, gravite, date, source_fiabilite}` per past guild sanction.
+`categorie`/`gravite` come from the automod evidence event (else derived from the
+action for manual sanctions). **No migration needed**: `source_fiabilite` is
+derived live from `case_sanctions.issued_by_type` + the latest `case_appeals`
+status. An **accepted appeal** additionally drops the message from
+`messages_deja_moderes` (it was not at fault).
+
+---
+
 ## 3. The module (`modules/automod.py`)
 
 `MODULE_ID = "automod"`. Config stored in `guilds.data.modules.automod`:
@@ -179,12 +249,23 @@ on **and** `notify_channel_id` is set — the **alert channel is mandatory**
 (automod never runs without it). Legacy keys `rules` / `log_channel_id` are
 still read transparently.
 
-- **`severity`** (1–5) scales **both** detection sensitivity (the embedding
-  threshold, see `constants.embedding_threshold_for`) and how strict nano is
-  told to be. Default 3.
+- **`severity`** (1–5) scales detection sensitivity (the embedding threshold,
+  see `constants.embedding_threshold_for`) and is the barème's global cran shift.
+  Default 3.
 - **`indications`** (ex-`rules`) is the guidance fed to nano's system prompt.
+- **`max_action`** (`warn`/`mute`/`ban`, default `ban`) is the barème's hard
+  ceiling — a server can forbid the automod from ever muting/banning.
+- **`langue_serveur`** (`auto`/`fr`/`en-US`, default `auto`) overrides the
+  language of the sanction reason / member DM (auto = derive from the guild).
+- **`categories_desactivees`** (list) kill-switches AI sanctioning per category.
 
 ### Applying a decision
+
+The module runs the **barème** first (`_compute_bareme`): it loads the member's
+recent guild sanctions (`list_member_sanctions`, 180 d), their server tenure and
+the guild config, computes the cran and **overwrites `decision.actions` /
+`decision.duree_heures`** from it. nano's qualification is the only thing read
+from the pipeline. Then:
 
 - `supprimer` → delete the message.
 - `ban` (precedence) / `mute` (Discord timeout, duration by gravity) → applied
@@ -225,7 +306,8 @@ removes the stored config, **Back** returns to the module list (disabled while
 there are unsaved changes). The view has a 300 s timeout and is opened fresh by
 `/config` (it is **not** a persistent view — consistent with the other module
 panels). Sections: **État**, **Salon d'alertes** (required), **Sévérité** (1–5),
-**Indications** (replaces "Règlement"), **Exemptions**, **Options**.
+**Limites & langue** (`max_action` + `langue_serveur`), **Indications**
+(replaces "Règlement"), **Exemptions**, **Options**.
 
 ### Indications safety check
 
@@ -316,3 +398,15 @@ Seeded unlimited in `db/base.py`; tighten per-guild via `quota_overrides`.
 | `ROUNDS_MAX` | 3 | anti-loop |
 | `NANO_TEMPERATURE` | 0.0 | classification → deterministic |
 | `NANO_MAX_TOKENS` | 300 | lean v2 contract |
+
+### Barème tunables (`automod/bareme.py`)
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `PLANCHER` | table | floor cran per (category, gravity) |
+| `POINTS_GRAVITE` | basse 1 / moyenne 3 / haute 7 / critique 15 | recidivism points per gravity |
+| `DEMI_VIE_JOURS` | 45 | points half-life (decay) |
+| `POIDS_SOURCE` | manuel 1.5 … appel accepté 0 | source-reliability weight |
+| `MULT_MEME_CATEGORIE` | 1.5 | same-category repeat multiplier |
+| `PLAFOND_CONFIG` | warn 1 / mute 6 / ban 7 | guild `max_action` cran ceiling |
+| `CATEGORIES_SENSIBLES` | self-harm/doxxing/sexual | no veteran clemency at haute+ |

--- a/docs/AUTOMOD_V2_PLAN.md
+++ b/docs/AUTOMOD_V2_PLAN.md
@@ -9,7 +9,7 @@
 | # | Session | État | Date | Commit / notes |
 |---|---|---|---|---|
 | 1 | Grounding & contrat de verdict v2 | ✅ Terminée | 2026-07-12 | Garde-fous grounding déterministes, prompt nano v2, contrat `citation`/`cible`, historique retiré du payload nano, temp 0.0. Tests : `tests/automod/test_nano_grounding.py`. |
-| 2 | Barème déterministe & moteur de récidive | ⬜ À faire | — | — |
+| 2 | Barème déterministe & moteur de récidive | ✅ Terminée | 2026-07-12 | `automod/bareme.py` pur (ladder + plancher + récidive à demi-vie + modulateurs + kill-switch), `db.list_member_sanctions` (fiabilité dérivée de l'issuer + appel, sans migration), module applique le cran (nano ne décide plus les actions), breakdown sur carte + timeline, config `max_action`/`langue_serveur`, appel accepté → poids 0 + purge `messages_deja_moderes`. Tests : `tests/automod/test_bareme.py` (36 cas). |
 | 3 | Harnais de régression & shadow mode | ⬜ À faire | — | — |
 | 4 | Coûts & anti-fragmentation | ⬜ À faire | — | — |
 | 5 | Graphe relationnel & réaction de la cible | ⬜ À faire | — | — |
@@ -43,6 +43,48 @@
 **Suites (pour S2) :** brancher le barème déterministe, réintroduire la sévérité comme modulateur
 de cran, retirer `actions`/`duree_heures` du contrat nano, consommer `history` dans le moteur de
 récidive.
+
+### Journal de session 2 (2026-07-12)
+
+**Livré :**
+- `automod/bareme.py` — module **pur** : `LADDER` (cran → actions/durée), `PLANCHER`
+  (catégorie×gravité), moteur de récidive à points pondérés + décroissance demi-vie 45 j
+  (`points_actifs`/`crans_recidive`, `POIDS_SOURCE`, `MULT_MEME_CATEGORIE`), modulateurs dans
+  l'ordre §2.4 (sévérité, plafond confiance, bonus vétéran, malus compte neuf, plafond
+  `max_action`), kill-switch `categories_desactivees`, sortie `ResultatBareme` avec
+  `composantes` (breakdown explicable, somme = cran) + flag `needs_review` (cran ≥ 6).
+- `db/repositories/moderation.py` — `list_member_sanctions(guild, user, since)` renvoyant
+  `{action, categorie, gravite, date, source_fiabilite}` ; `source_fiabilite` **dérivée** de
+  `issued_by_type` + dernier statut d'appel (`case_appeals`) — aucune migration. Exclusion des
+  cases à appel accepté dans `list_automod_evidence_message_ids` (purge `messages_deja_moderes`).
+- `automod/nano.py` + `schemas.py` — `actions`/`duree_heures` **retirés** du contrat nano
+  (prompt, `parse_verdict`, `_DEFAULT_VERDICT`, `_reject`, `juger`). `Decision.actions` reste
+  mais est désormais rempli par le barème côté module.
+- `modules/automod.py` — `_compute_bareme` (charge l'historique 180 j, l'ancienneté du membre,
+  la config), applique le cran (écrase `decision.actions`/`duree_heures`), breakdown localisé sur
+  la carte d'alerte + payload d'evidence (`cran`, `points_recidive`, `bareme`). Config
+  `max_action`/`langue_serveur`/`categories_desactivees` chargée + validée ; `guild_locale`
+  honore `langue_serveur`.
+- `modules/configs/automod_config.py` — section **Limites & langue** (selects `max_action` +
+  `langue_serveur`).
+- i18n `modules.automod.bareme.*` + `modules.automod.config.{section_limits,max_action,language}`
+  (fr + en-US).
+- Tests : `tests/automod/test_bareme.py` (36 cas table-driven) ; S1 adaptés (nano ne porte plus
+  d'actions).
+
+**Décisions :**
+- **`source_fiabilite` dérivée, pas stockée.** Plutôt que muter la sanction sur décision d'appel
+  (schéma), on la dérive à la lecture depuis `issued_by_type` + `case_appeals.status`. Idem pour
+  la purge de `messages_deja_moderes` (exclusion des cases à appel accepté dans la requête).
+  Résultat identique au plan (§2.5) mais **sans migration** — `AppealService.decide` écrit déjà
+  le statut, donc rien à ajouter côté service.
+- **Gravité de secours** pour les sanctions manuelles sans evidence automod : `warn→basse`,
+  `mute→moyenne`, `ban→haute` (le barème a toujours besoin d'une gravité pour pondérer).
+- **`needs_review`** = cran ≥ 6 (préparation S6 : confirmation mini). Aujourd'hui c'est un simple
+  encart « Réviser » sur la carte.
+
+**Suites (pour S3) :** golden set + runner offline + shadow mode ; le breakdown et les composantes
+du barème sont déjà prêts à alimenter les annotations.
 
 <!-- ======================================================================= -->
 
@@ -498,12 +540,12 @@ refusé sur gravité haute, plafond guild, bornes 0–7. Le module ne doit plus 
 
 ## Critères de fin
 
-- [ ] `automod/bareme.py` pur et testé (≥15 cas verts).
-- [ ] `modules/automod.py` applique le cran, plus le verdict nano.
-- [ ] Appels acceptés purgent points + `messages_deja_moderes`.
-- [ ] Breakdown du calcul visible sur la carte d'alerte + timeline.
-- [ ] Config : `max_action` + `langue_serveur` dans l'UI `/config`.
-- [ ] `AUTOMOD.md` mis à jour.
+- [x] `automod/bareme.py` pur et testé (36 cas verts, ≥15 requis).
+- [x] `modules/automod.py` applique le cran, plus le verdict nano.
+- [x] Appels acceptés purgent points + `messages_deja_moderes` (dérivé, sans migration).
+- [x] Breakdown du calcul visible sur la carte d'alerte + timeline.
+- [x] Config : `max_action` + `langue_serveur` dans l'UI `/config`.
+- [x] `AUTOMOD.md` mis à jour.
 
 ---
 ---

--- a/docs/sessions/2026-07-12_automod-v2-session-2-bareme.md
+++ b/docs/sessions/2026-07-12_automod-v2-session-2-bareme.md
@@ -1,0 +1,105 @@
+# 2026-07-12 — Automod v2 (session 2): deterministic barème & recidivism engine
+
+Session 2 of the automod v2 track (see `docs/AUTOMOD_V2_PLAN.md`). nano now only
+**qualifies** a message; a new deterministic **barème** computes the sanction.
+Sanctions are 100 % reproducible, auditable and explainable line by line.
+
+## What was done
+
+### 1. `automod/bareme.py` (new — pure, no I/O)
+
+The core deliverable. Given a qualified verdict (`categorie` / `gravite` /
+`confiance`), the member's recidivism history and the guild config, it returns a
+`ResultatBareme`: a **cran** (0–7 rung on a single ladder), the Discord
+`actions` + `duree_heures`, and a `composantes` breakdown whose signed deltas sum
+to the cran.
+
+- **Ladder** (`LADDER`): 0 deletion-only → 1 warn → 2–6 mute (2h…672h) → 7 ban.
+  `supprimer` is always included.
+- **Floor** (`PLANCHER`): cran per (category × gravity), the cold first-offence
+  policy from the plan §2.2.
+- **Recidivism engine**: `points_actifs` = Σ `POINTS_GRAVITE` × exponential decay
+  (half-life 45 d) × `POIDS_SOURCE` (source reliability) × `MULT_MEME_CATEGORIE`
+  (1.5 for same-category repeats). `crans_recidive`: ≥5→+1, ≥15→+2, ≥40→+3.
+- **Modulators** (plan §2.4 order): guild severity shift, confidence cap
+  (`low`→≤1, `medium`→≤4), veteran clemency (−1, never on sensitive categories
+  or gravity haute+), fresh-account malus (+1), guild `max_action` ceiling.
+- **Kill-switch** (`categories_desactivees`): a category → deletion only.
+- `needs_review` when cran ≥ 6 (prep for session-6 mini confirmation).
+
+### 2. Recidivism data — `db.list_member_sanctions` (no migration)
+
+`db/repositories/moderation.py::list_member_sanctions(guild, user, since)`
+returns `{action, categorie, gravite, date, source_fiabilite}` per past guild
+sanction. `categorie`/`gravite` come from the automod evidence event (else
+derived from the action). **`source_fiabilite` is derived at read time** from
+`case_sanctions.issued_by_type` + the latest `case_appeals` status — an accepted
+appeal → `automod_appel_accepte` (weight 0), a refused one → `automod_confirme`.
+`list_automod_evidence_message_ids` now excludes cases with an accepted appeal
+(purges `messages_deja_moderes`). Both requirements from plan §2.5 are met
+without a schema change.
+
+### 3. nano contract cleanup
+
+`actions` / `duree_heures` are **removed** from the nano contract (system prompt,
+`parse_verdict`, `_DEFAULT_VERDICT`, `_reject`, `juger`). nano no longer decides
+any punishment. `Decision.actions` stays on the dataclass but is now filled by
+the barème in the module.
+
+### 4. Module application + explainability
+
+`modules/automod.py::_compute_bareme` loads the 180-day sanction history, the
+member's server tenure and the guild config, computes the cran and **overwrites
+`decision.actions` / `decision.duree_heures`**. The alert card shows a localized
+breakdown (`_bareme_breakdown`) and the case evidence payload stores `cran`,
+`points_recidive` and the `bareme` components for the timeline.
+
+### 5. Config + i18n
+
+`max_action` (warn/mute/ban), `langue_serveur` (auto/fr/en-US) and
+`categories_desactivees` added to the config, validation and defaults;
+`guild_locale` honours `langue_serveur`. New **Limites & langue** section in
+`modules/configs/automod_config.py` (two selects). i18n keys
+`modules.automod.bareme.*` and `modules.automod.config.{section_limits,max_action,language}`
+added to `fr.json` + `en-US.json`.
+
+### 6. Tests
+
+`tests/automod/test_bareme.py` — 36 table-driven cases: ladder bounds, floor per
+(cat, gravity), decay at half-life, accepted-appeal weight 0, same-category
+multiplier, source ordering, recidivism escalation, severity shift, confidence
+caps, veteran clemency (granted / refused on high gravity / refused with
+history / refused on sensitive category), fresh-account malus, `max_action`
+ceiling, kill-switch, 0–7 bounds, breakdown-sum invariant, `needs_review`.
+Session-1 nano tests adapted (nano no longer carries actions). **Full suite: 162
+passed.**
+
+## Files modified
+
+- `automod/bareme.py` (new), `automod/nano.py`, `automod/schemas.py`
+- `db/repositories/moderation.py`
+- `modules/automod.py`, `modules/configs/automod_config.py`
+- `locales/fr.json`, `locales/en-US.json`
+- `tests/automod/test_bareme.py` (new), `tests/automod/test_nano_grounding.py`
+- `docs/AUTOMOD.md`, `docs/AUTOMOD_V2_PLAN.md`
+
+## Decisions & rationale
+
+- **Derived, not stored, `source_fiabilite`.** Deriving from issuer + appeal
+  state at read time (and excluding accepted-appeal messages in SQL) matches the
+  plan's effect with **zero migration** and no new AppealService code — the
+  service already records the appeal status.
+- **Fallback gravity** for manual sanctions without automod evidence
+  (`warn→basse`, `mute→moyenne`, `ban→haute`) so the barème always has a gravity
+  to weigh.
+- **Breakdown honesty**: a `borne` component is recorded whenever the final 0–7
+  clamp bites, so the displayed deltas always sum to the cran.
+
+## Known follow-ups
+
+- Session 3 (regression harness + shadow mode) can feed on the barème's
+  breakdown / components already emitted here.
+- `needs_review` is only a card highlight today; session 6 wires the mini
+  confirmation for cran ≥ 6.
+- Transform-appealed sanctions currently keep weight `automod` (only
+  accept/refuse are special-cased) — revisit if it proves noisy.

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1393,6 +1393,21 @@
         "status_hint": "Check/uncheck in the menu below to enable or disable.",
         "activations": {
           "placeholder": "Enable / disable…"
+        },
+        "section_limits": "Limits & language",
+        "max_action": {
+          "desc": "The most severe action the automod is allowed to apply.",
+          "placeholder": "Maximum action…",
+          "option_warn": "Warn at most",
+          "option_mute": "Mute at most",
+          "option_ban": "Ban allowed"
+        },
+        "language": {
+          "desc": "Language of sanction messages (reason, member DM).",
+          "placeholder": "Sanction language…",
+          "auto": "Automatic (server language)",
+          "fr": "French",
+          "en": "English"
         }
       },
       "action": {
@@ -1535,6 +1550,20 @@
         "server_opened": "{user} appealed to the Moddy team (case {case}).",
         "server_decided_title": "Appeal handled",
         "server_decided": "{user}'s appeal ({route}) was handled: **{status}**."
+      },
+      "bareme": {
+        "title": "Scale: {sanction} (rung {cran})",
+        "cran": "rung {n}",
+        "floor": "Floor",
+        "recidivism": "Recidivism",
+        "severity": "Server severity",
+        "confidence": "Confidence cap",
+        "veteran": "Tenure (clean record)",
+        "fresh_account": "New account",
+        "ceiling": "Server ceiling",
+        "disabled_category": "Disabled category",
+        "review_hint": "Heavy AI-decided sanction — a moderator can review it.",
+        "bounds": "Bounds 0–7"
       }
     }
   },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1392,6 +1392,21 @@
         "status_hint": "Coche/décoche dans le menu ci-dessous pour activer ou désactiver.",
         "activations": {
           "placeholder": "Activer / désactiver…"
+        },
+        "section_limits": "Limites & langue",
+        "max_action": {
+          "desc": "Action la plus sévère que l'automod peut appliquer.",
+          "placeholder": "Action maximale…",
+          "option_warn": "Avertissement au maximum",
+          "option_mute": "Exclusion au maximum",
+          "option_ban": "Bannissement autorisé"
+        },
+        "language": {
+          "desc": "Langue des messages de sanction (raison, DM du membre).",
+          "placeholder": "Langue des sanctions…",
+          "auto": "Automatique (langue du serveur)",
+          "fr": "Français",
+          "en": "Anglais"
         }
       },
       "action": {
@@ -1534,6 +1549,20 @@
         "server_opened": "{user} a fait appel auprès de l'équipe Moddy (dossier {case}).",
         "server_decided_title": "Appel traité",
         "server_decided": "L'appel de {user} ({route}) a été traité : **{status}**."
+      },
+      "bareme": {
+        "title": "Barème : {sanction} (cran {cran})",
+        "cran": "cran {n}",
+        "floor": "Plancher",
+        "recidivism": "Récidive",
+        "severity": "Sévérité serveur",
+        "confidence": "Plafond de confiance",
+        "veteran": "Ancienneté (casier vierge)",
+        "fresh_account": "Compte récent",
+        "ceiling": "Plafond du serveur",
+        "disabled_category": "Catégorie désactivée",
+        "review_hint": "Sanction lourde décidée par l'IA — un modérateur peut la réviser.",
+        "bounds": "Bornes 0–7"
       }
     }
   },

--- a/modules/automod.py
+++ b/modules/automod.py
@@ -20,9 +20,13 @@ Config (stored in ``guilds.data.modules.automod``)::
 
     {
       "enabled": true,
-      "rules": "server rules text (AI-validated for prompt injection)",
-      "log_channel_id": 123 | null,
+      "indications": "server guidance (AI-validated for prompt injection)",
+      "notify_channel_id": 123 | null,
       "ignore_moderators": true,
+      "severity": 3,                     # 1–5 detection/severity dial
+      "max_action": "ban",              # barème hard ceiling: warn|mute|ban
+      "langue_serveur": "auto",         # sanction language: auto|fr|en-US
+      "categories_desactivees": [],      # kill-switched AI categories
       "features": {
         "content": {
           "enabled": true,
@@ -31,6 +35,12 @@ Config (stored in ``guilds.data.modules.automod``)::
         }
       }
     }
+
+The sanction itself is not decided by nano: the detection pipeline only
+*qualifies* the message (category + gravity + confidence) and the deterministic
+barème (``automod/bareme.py``) computes the sanction cran from that
+qualification, the member's recidivism history and the guild config. See
+``docs/AUTOMOD.md`` §2bis.
 """
 
 from __future__ import annotations
@@ -48,6 +58,7 @@ from automod import (
     get_engine, Decision, TargetMessage, ContextMessage, AuthorHistory,
 )
 from automod import constants as ac
+from automod import bareme as ab
 from utils.i18n import t
 from utils.moderation_cases import IssuerType, SanctionAction, EventType, AuthorType
 
@@ -221,6 +232,10 @@ class AutomodModule(ModuleBase):
         self.notify_channel_id: Optional[int] = None
         self.ignore_moderators: bool = True
         self.severity: int = ac.SEVERITY_DEFAULT
+        # v2 barème knobs (session 2).
+        self.max_action: str = "ban"          # "warn" | "mute" | "ban"
+        self.langue_serveur: str = "auto"      # "auto" | "fr" | "en-US"
+        self.categories_desactivees: List[str] = []
         self._features: Dict[str, AutomodFeature] = {}
         self._warmup_task: Optional[asyncio.Task] = None
 
@@ -235,6 +250,15 @@ class AutomodModule(ModuleBase):
             self.notify_channel_id = self.config.get("notify_channel_id", self.config.get("log_channel_id"))
             self.ignore_moderators = bool(self.config.get("ignore_moderators", True))
             self.severity = ac.clamp_severity(self.config.get("severity", ac.SEVERITY_DEFAULT))
+
+            # v2 barème config.
+            max_action = str(self.config.get("max_action", "ban") or "ban")
+            self.max_action = max_action if max_action in ("warn", "mute", "ban") else "ban"
+            lang = str(self.config.get("langue_serveur", "auto") or "auto")
+            self.langue_serveur = lang if lang in ("auto", "fr", "en-US") else "auto"
+            self.categories_desactivees = [
+                str(c) for c in (self.config.get("categories_desactivees", []) or [])
+            ]
 
             features_cfg = self.config.get("features", {}) or {}
             self._features = {}
@@ -271,6 +295,14 @@ class AutomodModule(ModuleBase):
         if severity is not None and ac.clamp_severity(severity) != int(severity):
             return False, "Niveau de sévérité invalide (1 à 5)"
 
+        max_action = config_data.get("max_action")
+        if max_action is not None and max_action not in ("warn", "mute", "ban"):
+            return False, "Action maximale invalide"
+
+        langue = config_data.get("langue_serveur")
+        if langue is not None and langue not in ("auto", "fr", "en-US"):
+            return False, "Langue invalide"
+
         features_cfg = config_data.get("features", {}) or {}
         for fid in features_cfg:
             if fid not in FEATURE_CLASSES:
@@ -284,6 +316,9 @@ class AutomodModule(ModuleBase):
             "notify_channel_id": None,
             "ignore_moderators": True,
             "severity": ac.SEVERITY_DEFAULT,
+            "max_action": "ban",
+            "langue_serveur": "auto",
+            "categories_desactivees": [],
             "features": {
                 "content": {
                     "enabled": False,
@@ -425,6 +460,89 @@ class AutomodModule(ModuleBase):
             logger.error("automod: failed to build author history: %s", e)
             return AuthorHistory()
 
+    # -- Barème (deterministic sanction scale) -----------------------------
+
+    async def _member_sanctions(self, user_id: int) -> List[ab.SanctionPassee]:
+        """Recidivism input for the barème: this member's recent guild sanctions.
+
+        180 days is enough — past that the half-life decay (0.5^4 ≈ 6 %) makes a
+        sanction negligible. The current message is NOT here yet (the case is
+        recorded *after* the barème runs), so it never inflates its own cran.
+        """
+        if not self.bot.db:
+            return []
+        try:
+            since = datetime.now(timezone.utc) - timedelta(days=180)
+            rows = await self.bot.db.list_member_sanctions(
+                self.guild_id, user_id, since=since,
+            )
+        except Exception as e:
+            logger.error("automod: failed to load member sanctions: %s", e)
+            return []
+        out: List[ab.SanctionPassee] = []
+        for r in rows:
+            out.append(ab.SanctionPassee(
+                categorie=r.get("categorie") or "",
+                gravite=r.get("gravite") or "moyenne",
+                date=r.get("date") or datetime.now(timezone.utc),
+                source_fiabilite=r.get("source_fiabilite") or "automod",
+            ))
+        return out
+
+    async def _compute_bareme(self, message: discord.Message,
+                              decision: Decision) -> ab.ResultatBareme:
+        """Compute the deterministic cran (sanction) for a qualified decision."""
+        sanctions = await self._member_sanctions(int(decision.auteur_id))
+
+        member = message.guild.get_member(int(decision.auteur_id)) if message.guild else None
+        anciennete = 0.0
+        joined = getattr(member, "joined_at", None) if member else None
+        if joined is not None:
+            anciennete = max(0.0, (datetime.now(timezone.utc) - joined).total_seconds() / 86400.0)
+
+        config = ab.ConfigBareme(
+            max_action=self.max_action,
+            categories_desactivees=tuple(self.categories_desactivees),
+        )
+        return ab.calculer(
+            decision, sanctions, ab.MembreInfo(anciennete_jours=anciennete),
+            severite_guild=self.severity, config=config,
+        )
+
+    # Component code → i18n key suffix for the sanction breakdown card.
+    _BAREME_LABELS = {
+        "plancher": "floor",
+        "recidive": "recidivism",
+        "severite": "severity",
+        "confiance": "confidence",
+        "veteran": "veteran",
+        "compte_recent": "fresh_account",
+        "plafond": "ceiling",
+        "categorie_desactivee": "disabled_category",
+        "borne": "bounds",
+    }
+
+    def _bareme_breakdown(self, bareme: ab.ResultatBareme, locale: str) -> str:
+        """A localized, line-by-line explanation of how the cran was reached."""
+        lines: List[str] = []
+        for c in bareme.composantes:
+            label = t(f"modules.automod.bareme.{self._BAREME_LABELS.get(c.code, c.code)}",
+                      locale=locale)
+            if c.code == "plancher":
+                amount = t("modules.automod.bareme.cran", locale=locale, n=c.delta)
+            else:
+                amount = f"{'+' if c.delta >= 0 else ''}{c.delta}"
+            detail = f" ({c.detail})" if c.detail else ""
+            lines.append(f"- {label}{detail} · {amount}")
+        return "\n".join(lines)
+
+    def _sanction_name(self, bareme: ab.ResultatBareme, locale: str) -> str:
+        """Human name of the applied sanction (most punitive action)."""
+        for a in ("ban", "mute", "warn"):
+            if a in bareme.actions:
+                return t(f"modules.automod.action.{a}", locale=locale)
+        return t("modules.automod.action.supprimer", locale=locale)
+
     # -- Decision application ----------------------------------------------
 
     def _mark_moddy_initiated(self, user_id: int, action: str):
@@ -436,7 +554,16 @@ class AutomodModule(ModuleBase):
         store[(self.guild_id, user_id, action)] = time.time()
 
     async def apply_decision(self, message: discord.Message, decision: Decision):
-        if not decision.sanctionnable or not decision.actions:
+        if not decision.sanctionnable:
+            return
+
+        # v2 (session 2): nano only QUALIFIED the message; the deterministic
+        # barème computes the sanction (cran → actions + duration) from the
+        # qualification, the member's recidivism history and the guild config.
+        bareme = await self._compute_bareme(message, decision)
+        decision.actions = list(bareme.actions)
+        decision.duree_heures = bareme.duree_heures or 0
+        if not decision.actions:
             return
 
         guild = message.guild
@@ -464,7 +591,7 @@ class AutomodModule(ModuleBase):
         # 2. Record the case FIRST so the Discord audit-log reason can carry the
         #    public case reference, exactly like a manual sanction.
         case_ref, case_id, primary_action, primary_sanction_id = \
-            await self._record_case(message, decision)
+            await self._record_case(message, decision, bareme)
 
         # 3. Apply the Discord-side sanction with the standardized reason.
         can_act = member is not None and me is not None and member != guild.owner \
@@ -498,7 +625,7 @@ class AutomodModule(ModuleBase):
 
         # 4. Notify the server in the mandatory alert channel, then remember the
         #    log message on the case so later appeal updates reply to it.
-        log_msg = await self._notify_channel(message, decision, applied, case_ref, primary_action)
+        log_msg = await self._notify_channel(message, decision, applied, case_ref, primary_action, bareme)
         if log_msg is not None and case_id is not None:
             try:
                 await self.bot.db.add_event(
@@ -553,7 +680,8 @@ class AutomodModule(ModuleBase):
         expiry = expires_at.strftime("%Y-%m-%d %H:%M UTC") if expires_at else "Permanent"
         return f"[{ref}] @{mod_name} ({expiry}) : {reason}"[:512]
 
-    async def _record_case(self, message: discord.Message, decision: Decision):
+    async def _record_case(self, message: discord.Message, decision: Decision,
+                           bareme: Optional[ab.ResultatBareme] = None):
         """Open ONE guild case for this incident, attach its sanctions + evidence.
 
         Each automod incident is its own case: the first sanction opens a fresh
@@ -657,6 +785,17 @@ class AutomodModule(ModuleBase):
                         "score_detecteur": round(decision.score_detecteur, 4),
                         "confiance": decision.confiance,
                         "actions": decision.actions,
+                        # Deterministic barème breakdown (session 2): the cran and
+                        # every component that produced it, so the timeline can
+                        # explain the sanction line by line.
+                        **({
+                            "cran": bareme.cran,
+                            "points_recidive": round(bareme.points_recidive, 2),
+                            "bareme": [
+                                {"code": c.code, "delta": c.delta, "detail": c.detail}
+                                for c in bareme.composantes
+                            ],
+                        } if bareme is not None else {}),
                     },
                 )
             except Exception as e:
@@ -667,10 +806,14 @@ class AutomodModule(ModuleBase):
     def guild_locale(self, guild: Optional[discord.Guild]) -> str:
         """The locale automod speaks in this guild.
 
-        Uses the guild's preferred locale **only when Community is enabled**
-        (that's when Discord lets the server pick a real language); otherwise we
-        have no reliable language signal, so we default to English.
+        An explicit ``langue_serveur`` config override (``fr`` / ``en-US``) wins;
+        otherwise (``auto``) we use the guild's preferred locale **only when
+        Community is enabled** (that's when Discord lets the server pick a real
+        language), and default to English when there is no reliable signal.
         """
+        override = getattr(self, "langue_serveur", "auto")
+        if override in ("fr", "en-US"):
+            return override
         try:
             features = set(getattr(guild, "features", []) or [])
             if "COMMUNITY" not in features:
@@ -722,7 +865,8 @@ class AutomodModule(ModuleBase):
 
     async def _notify_channel(self, message: discord.Message, decision: Decision,
                               applied: List[str], case_ref: Optional[str],
-                              primary_action: Optional[str] = None):
+                              primary_action: Optional[str] = None,
+                              bareme: Optional[ab.ResultatBareme] = None):
         """Post the decision to the mandatory server alert channel.
 
         Returns the sent message (or None) so the caller can link it to the
@@ -771,6 +915,18 @@ class AutomodModule(ModuleBase):
         if case_ref:
             body += f"\n- **{t('modules.automod.log.case', locale=locale)} :** `{case_ref}`"
         container.add_item(ui.TextDisplay(body))
+
+        # Deterministic barème breakdown: explain the sanction line by line.
+        if bareme is not None and bareme.composantes:
+            sanction_name = self._sanction_name(bareme, locale)
+            header = t("modules.automod.bareme.title", locale=locale,
+                       sanction=sanction_name, cran=bareme.cran)
+            container.add_item(ui.TextDisplay(
+                f"**{header}**\n{self._bareme_breakdown(bareme, locale)}"))
+            if bareme.needs_review:
+                container.add_item(ui.TextDisplay(
+                    f"-# {t('modules.automod.bareme.review_hint', locale=locale)}"))
+
         container.add_item(ui.TextDisplay(
             f"-# {t('modules.automod.log.appeal_hint', locale=locale)}"))
         view.add_item(container)

--- a/modules/configs/automod_config.py
+++ b/modules/configs/automod_config.py
@@ -41,6 +41,8 @@ _DEFAULT_CONFIG = {
     "notify_channel_id": None,
     "ignore_moderators": True,
     "severity": ac.SEVERITY_DEFAULT,
+    "max_action": "ban",
+    "langue_serveur": "auto",
     "features": {
         "content": {"enabled": False, "exempt_roles": [], "exempt_channels": []},
     },
@@ -58,6 +60,10 @@ def _deep_default(current: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     cfg["notify_channel_id"] = current.get("notify_channel_id", current.get("log_channel_id"))
     cfg["ignore_moderators"] = bool(current.get("ignore_moderators", True))
     cfg["severity"] = ac.clamp_severity(current.get("severity", ac.SEVERITY_DEFAULT))
+    max_action = str(current.get("max_action", "ban") or "ban")
+    cfg["max_action"] = max_action if max_action in ("warn", "mute", "ban") else "ban"
+    langue = str(current.get("langue_serveur", "auto") or "auto")
+    cfg["langue_serveur"] = langue if langue in ("auto", "fr", "en-US") else "auto"
     content = (current.get("features", {}) or {}).get("content", {}) or {}
     cfg["features"]["content"] = {
         "enabled": bool(content.get("enabled", False)),
@@ -285,6 +291,48 @@ class AutomodConfigView(BaseView):
         sev_row.add_item(sev_select)
         container.add_item(sev_row)
 
+        # ── Limits & language (max sanction the automod may apply + DM tongue) ─
+        container.add_item(ui.TextDisplay(
+            f"{SETTINGS} **{t('modules.automod.config.section_limits', locale=self.locale)}**\n"
+            f"-# {t('modules.automod.config.max_action.desc', locale=self.locale)}"
+        ))
+        max_action = cfg.get("max_action", "ban")
+        maxa_row = ui.ActionRow()
+        maxa_select = ui.Select(
+            placeholder=t("modules.automod.config.max_action.placeholder", locale=self.locale),
+            min_values=1, max_values=1,
+            options=[
+                discord.SelectOption(
+                    label=t(f"modules.automod.config.max_action.option_{v}", locale=self.locale),
+                    value=v, default=(v == max_action),
+                )
+                for v in ("warn", "mute", "ban")
+            ],
+        )
+        maxa_select.callback = self.on_max_action
+        maxa_row.add_item(maxa_select)
+        container.add_item(maxa_row)
+
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.automod.config.language.desc', locale=self.locale)}"
+        ))
+        langue = cfg.get("langue_serveur", "auto")
+        lang_row = ui.ActionRow()
+        lang_select = ui.Select(
+            placeholder=t("modules.automod.config.language.placeholder", locale=self.locale),
+            min_values=1, max_values=1,
+            options=[
+                discord.SelectOption(
+                    label=t(f"modules.automod.config.language.{key}", locale=self.locale),
+                    value=value, default=(value == langue),
+                )
+                for key, value in (("auto", "auto"), ("fr", "fr"), ("en", "en-US"))
+            ],
+        )
+        lang_select.callback = self.on_language
+        lang_row.add_item(lang_select)
+        container.add_item(lang_row)
+
         # ── Guidance (button+modal → keep a preview, can't show it inline) ─
         indications = cfg.get("indications", "")
         if indications:
@@ -431,6 +479,24 @@ class AutomodConfigView(BaseView):
         values = interaction.data.get("values", [])
         if values:
             self.working_config["severity"] = ac.clamp_severity(values[0])
+        self.has_changes = True
+        await self._rerender(interaction)
+
+    async def on_max_action(self, interaction: discord.Interaction):
+        if not await self._check_user(interaction):
+            return
+        values = interaction.data.get("values", [])
+        if values and values[0] in ("warn", "mute", "ban"):
+            self.working_config["max_action"] = values[0]
+        self.has_changes = True
+        await self._rerender(interaction)
+
+    async def on_language(self, interaction: discord.Interaction):
+        if not await self._check_user(interaction):
+            return
+        values = interaction.data.get("values", [])
+        if values and values[0] in ("auto", "fr", "en-US"):
+            self.working_config["langue_serveur"] = values[0]
         self.has_changes = True
         await self._rerender(interaction)
 

--- a/tests/automod/test_bareme.py
+++ b/tests/automod/test_bareme.py
@@ -1,0 +1,242 @@
+"""Tests for the deterministic sanction barème (``automod.bareme``).
+
+The barème is pure (no I/O), so everything here is a dry table-driven check:
+floor per (category, gravity), recidivism decay + weighting, confidence caps,
+veteran clemency, fresh-account malus, the guild ``max_action`` ceiling, the
+category kill-switch and the 0–7 bounds. Session 2 requires ≥15 cases.
+
+See docs/AUTOMOD.md §2bis and docs/AUTOMOD_V2_PLAN.md (Session 2, §2.7).
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from automod import bareme
+from automod.bareme import (
+    SanctionPassee, MembreInfo, ConfigBareme, calculer,
+    points_actifs, crans_recidive, ladder_for,
+)
+
+
+# --- Harness ---------------------------------------------------------------- #
+
+NOW = datetime(2026, 7, 12, tzinfo=timezone.utc)
+
+
+@dataclass
+class _Verdict:
+    """Minimal stand-in for a Decision (what the barème actually reads)."""
+    categorie: str
+    gravite: str
+    confiance: str = "high"
+
+
+def _veteran(days: float = 400.0) -> MembreInfo:
+    return MembreInfo(anciennete_jours=days)
+
+
+def _member(days: float = 30.0) -> MembreInfo:
+    # A plain member: old enough to escape the fresh-account malus (<7 d) but
+    # not a clean veteran (≥90 d), so neither modulator fires by default.
+    return MembreInfo(anciennete_jours=days)
+
+
+def _past(cat: str, grav: str, days_ago: float, source: str = "automod") -> SanctionPassee:
+    return SanctionPassee(
+        categorie=cat, gravite=grav,
+        date=NOW - timedelta(days=days_ago), source_fiabilite=source,
+    )
+
+
+def _cran(verdict, sanctions=None, membre=None, *, severity=3, config=None):
+    return calculer(
+        verdict, sanctions or [], membre or _member(),
+        severite_guild=severity, config=config, now=NOW,
+    ).cran
+
+
+# --- Ladder ----------------------------------------------------------------- #
+
+class TestLadder:
+    def test_deletion_always_present(self):
+        for c in range(0, 8):
+            actions, _ = ladder_for(c)
+            assert "supprimer" in actions
+
+    def test_ladder_bounds_are_clamped(self):
+        assert ladder_for(-3) == ladder_for(0)
+        assert ladder_for(99) == ladder_for(7)
+
+    def test_ban_is_top_rung(self):
+        actions, duree = ladder_for(7)
+        assert "ban" in actions and duree == 0
+
+    def test_mute_durations(self):
+        assert ladder_for(2)[1] == 2
+        assert ladder_for(6)[1] == 672
+
+
+# --- Floor (plancher) ------------------------------------------------------- #
+
+class TestPlancher:
+    @pytest.mark.parametrize("cat,grav,expected", [
+        ("insulte", "moyenne", 1),
+        ("insulte", "critique", 3),
+        ("menace", "haute", 6),
+        ("menace", "critique", 7),
+        ("haine_discrimination", "moyenne", 4),
+        ("doxxing", "basse", 4),
+        ("violation_indications", "basse", 0),
+    ])
+    def test_floor_first_offence_no_history(self, cat, grav, expected):
+        # A plain member, severity 3, no history → the cran is exactly the floor.
+        assert _cran(_Verdict(cat, grav)) == expected
+
+    def test_unknown_category_defaults_to_deletion(self):
+        assert _cran(_Verdict("", "moyenne")) == 0
+        assert _cran(_Verdict("banana", "haute")) == 0
+
+
+# --- Recidivism ------------------------------------------------------------- #
+
+class TestRecidive:
+    def test_points_thresholds(self):
+        assert crans_recidive(0) == 0
+        assert crans_recidive(4.9) == 0
+        assert crans_recidive(5) == 1
+        assert crans_recidive(15) == 2
+        assert crans_recidive(40) == 3
+
+    def test_decay_halves_points_at_half_life(self):
+        # A single "haute" sanction (7 pts) 45 days ago ≈ half its value.
+        recent = points_actifs([_past("insulte", "haute", 0)], "menace", NOW)
+        aged = points_actifs([_past("insulte", "haute", bareme.DEMI_VIE_JOURS)], "menace", NOW)
+        assert recent == pytest.approx(7.0, abs=1e-6)
+        assert aged == pytest.approx(3.5, rel=1e-3)
+
+    def test_accepted_appeal_weighs_zero(self):
+        pts = points_actifs(
+            [_past("insulte", "critique", 1, source="automod_appel_accepte")],
+            "insulte", NOW,
+        )
+        assert pts == 0.0
+
+    def test_same_category_multiplier(self):
+        same = points_actifs([_past("insulte", "moyenne", 0)], "insulte", NOW)
+        other = points_actifs([_past("insulte", "moyenne", 0)], "menace", NOW)
+        assert same == pytest.approx(other * bareme.MULT_MEME_CATEGORIE)
+
+    def test_manual_source_weighs_more_than_automod(self):
+        manual = points_actifs([_past("insulte", "moyenne", 0, source="manuel")], "x", NOW)
+        auto = points_actifs([_past("insulte", "moyenne", 0, source="automod")], "x", NOW)
+        assert manual > auto
+
+    def test_recidive_escalates_the_cran(self):
+        # Two recent same-category "moyenne" automod mutes: 3 * 1.5 * 2 = 9 pts → +1 cran.
+        history = [_past("insulte", "moyenne", 2), _past("insulte", "moyenne", 5)]
+        cran = _cran(_Verdict("insulte", "moyenne"), history)
+        assert cran == 2  # floor 1 + recidive 1
+
+    def test_old_isolated_warn_changes_nothing(self):
+        # A single "basse" sanction ~60 days ago is well under 5 pts → +0.
+        history = [_past("insulte", "basse", 60)]
+        assert _cran(_Verdict("insulte", "moyenne"), history) == 1
+
+
+# --- Modulators ------------------------------------------------------------- #
+
+class TestModulateurs:
+    def test_severity_1_softens_and_5_hardens(self):
+        base = _cran(_Verdict("insulte", "haute"))               # floor 2
+        assert _cran(_Verdict("insulte", "haute"), severity=1) == base - 1
+        assert _cran(_Verdict("insulte", "haute"), severity=5) == base + 1
+
+    def test_low_confidence_caps_at_warn(self):
+        v = _Verdict("menace", "haute", confiance="low")         # floor 6
+        assert _cran(v) == 1
+
+    def test_medium_confidence_caps_at_mute48(self):
+        v = _Verdict("menace", "critique", confiance="medium")   # floor 7
+        assert _cran(v) == 4
+
+    def test_veteran_bonus_on_low_gravity(self):
+        # Clean veteran, low gravity → one cran of clemency.
+        assert _cran(_Verdict("insulte", "moyenne"), membre=_veteran()) == 0
+
+    def test_veteran_bonus_refused_on_high_gravity(self):
+        # A veteran who makes a death threat is still banned — no clemency.
+        assert _cran(_Verdict("menace", "haute"), membre=_veteran()) == 6
+
+    def test_veteran_bonus_refused_with_history(self):
+        history = [_past("insulte", "moyenne", 3)]
+        assert _cran(_Verdict("insulte", "moyenne"), history, _veteran()) == 1
+
+    def test_fresh_account_malus(self):
+        assert _cran(_Verdict("insulte", "moyenne"), membre=_member(days=2)) == 2
+
+    def test_veteran_bonus_never_on_sensitive_category(self):
+        # harcelement_sexuel basse floor is 3; a veteran gets no discount here
+        # only because it is a sensitive category (gravity is low).
+        assert _cran(_Verdict("harcelement_sexuel", "basse"), membre=_veteran()) == 3
+
+
+# --- Guild ceiling + kill-switch ------------------------------------------- #
+
+class TestConfig:
+    def test_max_action_warn_caps_everything_to_warn(self):
+        cfg = ConfigBareme(max_action="warn")
+        assert _cran(_Verdict("menace", "critique"), config=cfg) == 1
+
+    def test_max_action_mute_forbids_ban(self):
+        cfg = ConfigBareme(max_action="mute")
+        assert _cran(_Verdict("menace", "critique"), config=cfg) == 6
+
+    def test_disabled_category_is_deletion_only(self):
+        cfg = ConfigBareme(categories_desactivees=("violation_indications",))
+        assert _cran(_Verdict("violation_indications", "critique"), config=cfg) == 0
+
+    def test_deletion_survives_the_ceiling(self):
+        # Even bridled to "warn", the offending message is still deleted.
+        cfg = ConfigBareme(max_action="warn")
+        result = calculer(_Verdict("doxxing", "critique"), [], _member(),
+                          config=cfg, now=NOW)
+        assert "supprimer" in result.actions
+
+
+# --- Bounds + breakdown ----------------------------------------------------- #
+
+class TestResultat:
+    def test_cran_never_below_zero(self):
+        cfg = ConfigBareme(max_action="warn")
+        result = calculer(_Verdict("violation_indications", "basse"), [], _veteran(),
+                          severite_guild=1, config=cfg, now=NOW)
+        assert result.cran == 0
+
+    def test_breakdown_sum_holds_even_when_clamped(self):
+        # floor 0 + severity(-1) would go to -1; the clamp brings it back to 0
+        # and records a "borne" component so the breakdown still sums to the cran.
+        result = calculer(_Verdict("violation_indications", "basse"), [], _member(),
+                          severite_guild=1, now=NOW)
+        assert result.cran == 0
+        assert sum(c.delta for c in result.composantes) == result.cran
+
+    def test_breakdown_sums_to_final_cran(self):
+        # floor 1 + recidive 1 + fresh malus 1 = cran 3.
+        history = [_past("insulte", "moyenne", 2), _past("insulte", "moyenne", 5)]
+        result = calculer(_Verdict("insulte", "moyenne"), history, _member(days=2),
+                          now=NOW)
+        total = sum(c.delta for c in result.composantes)
+        assert total == result.cran
+        codes = [c.code for c in result.composantes]
+        assert "plancher" in codes and "recidive" in codes and "compte_recent" in codes
+
+    def test_needs_review_flag_on_heavy_automod_sanction(self):
+        result = calculer(_Verdict("menace", "critique"), [], _member(), now=NOW)
+        assert result.cran == 7
+        assert result.needs_review is True
+
+    def test_no_review_flag_on_light_sanction(self):
+        result = calculer(_Verdict("insulte", "moyenne"), [], _member(), now=NOW)
+        assert result.needs_review is False

--- a/tests/automod/test_nano_grounding.py
+++ b/tests/automod/test_nano_grounding.py
@@ -36,8 +36,6 @@ def _raw(**overrides):
         "sanctionnable": True,
         "categorie": "insulte",
         "gravite": "moyenne",
-        "actions": ["warn", "supprimer"],
-        "duree_heures": 0,
         "citation": "",
         "cible": "membre",
         "raison": "Insulte visant un membre",
@@ -118,7 +116,9 @@ class TestGroundingRoundTrip:
         assert decision.rejet_grounding is None
         assert decision.categorie == "insulte"
         assert decision.cible == "membre"
-        assert "supprimer" in decision.actions
+        # v2: nano no longer decides actions — the barème owns them. The pipeline
+        # leaves them empty; the module fills them from the computed cran.
+        assert decision.actions == []
 
 
 # --- Unit-level guards ------------------------------------------------------ #
@@ -168,9 +168,13 @@ class TestParseVerdict:
         v = parse_verdict(_raw(categorie="banana"))
         assert v["categorie"] == ""
 
-    def test_actions_still_parsed_for_session2_bridge(self):
-        v = parse_verdict(_raw(actions=["ban", "nope", "supprimer"]))
-        assert v["actions"] == ["ban", "supprimer"]
+    def test_actions_and_duree_dropped_from_nano_contract(self):
+        # v2 (session 2): nano no longer decides the sanction. Even if a stray
+        # `actions` / `duree_heures` shows up in the raw output, parse_verdict
+        # ignores it — the barème is the only source of the sanction.
+        v = parse_verdict(_raw(actions=["ban", "supprimer"], duree_heures=48))
+        assert "actions" not in v
+        assert "duree_heures" not in v
 
 
 class TestNormalizeCategorie:


### PR DESCRIPTION
## Session 2 — Barème déterministe & moteur de récidive

Deuxième session du chantier **automod v2** (`docs/AUTOMOD_V2_PLAN.md`). nano ne
fait plus que **qualifier** un message (catégorie / gravité / confiance) ; un
nouveau **barème déterministe** calcule la sanction. Les sanctions sont désormais
100 % reproductibles, auditables et **expliquées ligne à ligne**.

### Ce qui change

- **`automod/bareme.py`** (nouveau, pur — sans I/O, entièrement testable à sec)
  - échelle de crans unique (0 suppression → 1 warn → 2–6 mute 2h…672h → 7 ban) ;
  - plancher par (catégorie × gravité) ;
  - moteur de récidive : points pondérés (`POINTS_GRAVITE`) à **décroissance
    exponentielle demi-vie 45 j**, × fiabilité de la source, × 1.5 même catégorie ;
  - modulateurs (§2.4) : sévérité serveur, plafond de confiance
    (`low`→≤warn, `medium`→≤mute48h), bonus vétéran (jamais sur catégories
    sensibles / gravité haute+), malus compte neuf, plafond `max_action` ;
  - kill-switch `categories_desactivees` ;
  - breakdown explicable (`composantes`, somme des deltas = cran) + `needs_review`
    (cran ≥ 6, préparation S6).
- **`db.list_member_sanctions`** — entrée de récidive ; `source_fiabilite`
  **dérivée** de l'issuer + dernier statut d'appel (`case_appeals`), **sans
  migration**. Appel accepté → poids 0 et retiré de `messages_deja_moderes`.
- **nano** — `actions` / `duree_heures` **retirés** du contrat (prompt, parse,
  `juger`). `Decision.actions` est désormais rempli par le barème côté module.
- **`modules/automod.py`** — applique le cran calculé, affiche le breakdown sur
  la carte d'alerte et le stocke sur l'evidence de la case ; config `max_action`
  / `langue_serveur` / `categories_desactivees` (+ `guild_locale` qui honore la
  langue).
- **UI `/config`** — nouvelle section **Limites & langue** (`max_action` +
  `langue_serveur`).
- **i18n** — `modules.automod.bareme.*` + config (fr + en-US).

### Décisions

- **`source_fiabilite` dérivée, pas stockée** : dérivation à la lecture depuis
  `issued_by_type` + `case_appeals.status` (et exclusion SQL des cases à appel
  accepté). Même effet que le plan §2.5, **zéro migration**, rien à ajouter dans
  `AppealService` (le statut d'appel est déjà écrit).
- **Gravité de secours** pour les sanctions manuelles sans evidence automod
  (`warn→basse`, `mute→moyenne`, `ban→haute`).
- **Composante `borne`** enregistrée quand le clamp 0–7 mord, pour que le
  breakdown affiché somme toujours au cran.

### Tests

`tests/automod/test_bareme.py` — **36 cas table-driven** (plancher, decay à la
demi-vie, poids appel accepté = 0, mult même catégorie, escalade récidive,
sévérité, plafonds confiance, bonus vétéran accordé/refusé, malus compte neuf,
plafond guild, kill-switch, bornes 0–7, invariant somme=cran, `needs_review`).
Tests nano S1 adaptés (nano ne porte plus d'actions). **Suite complète : 162
passed** (`pip install -r requirements-dev.txt && pytest`).

### Docs

`docs/AUTOMOD.md` (§2bis barème + tunables), `docs/AUTOMOD_V2_PLAN.md` (tableau de
suivi + journal S2), `docs/sessions/2026-07-12_automod-v2-session-2-bareme.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fknk8WzHNb19ePeVEkfQqJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fknk8WzHNb19ePeVEkfQqJ)_