### PR TITLE
Automod v2: audit fixes — preserve kill-switch config + doc consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,11 +133,12 @@ moddy/
 │   ├── tech_logger.py         #   Technical staff logs via webhooks (Components V2, per-event channels)
 │   ├── staff_role_permissions.py
 │   ├── staff_help_view.py
-│   ├── case_management_views.py #  Cases Views/Modals (create, sanction, comment…)
-│   ├── automod_shadow_views.py #  Shadow (dry_run) simulation card + annotation buttons
+│   ├── case_management_views.py #  Cases Views/Modals (create, sanction, comment…) — staff
+│   ├── cases_views.py         #   /cases & /mycases browser (CasesBrowserView, persistent)
+│   ├── automod_shadow_views.py #  Automod shadow-mode (dry_run) SIMULATION card + annotation buttons (persistent)
 │   ├── automod_situation_views.py #  Diffuse-harassment (situation) SIMULATION card (S8)
+│   ├── automod_render.py      #   Shared automod card helpers (barème breakdown, sanction name/accent)
 │   ├── appeal_views.py        #   Automod appeal UI (DM buttons + reviewer panels, persistent)
-│   ├── automod_shadow_views.py #  Automod shadow-mode SIMULATION card + annotation buttons (persistent)
 │   ├── moderation_cases.py    #   Cases domain model + enums + reference gen
 │   ├── embeds.py
 │   ├── announcement_setup.py

--- a/docs/AUTOMOD_V2_PLAN.md
+++ b/docs/AUTOMOD_V2_PLAN.md
@@ -1350,10 +1350,10 @@ compté ×4 dans le budget guard.
 
 ## Critères de fin
 
-- [ ] `AutomodFeature` `situation` enregistrée, config `features.situation` + UI.
-- [ ] Machine à friction testée (decay, dogpiling agrégé, TTL).
-- [ ] Prompt situation + parsing + carte shadow + annotations.
-- [ ] Documenté dans `AUTOMOD.md` §4 comme premier exemple de feature additionnelle.
+- [x] `AutomodFeature` `situation` enregistrée, config `features.situation` + UI.
+- [x] Machine à friction testée (decay, dogpiling agrégé, TTL).
+- [x] Prompt situation + parsing + carte shadow + annotations.
+- [x] Documenté dans `AUTOMOD.md` §4 comme premier exemple de feature additionnelle.
 
 ---
 ---

--- a/docs/MODERATION_CASES.md
+++ b/docs/MODERATION_CASES.md
@@ -323,10 +323,11 @@ references no longer get reused and a single case never accumulates dozens of
 sanctions. When a decision carries several actions (e.g. `delete` + `warn`),
 they are recorded on that one case.
 
-**Expiring sanctions.** nano may return `duree_heures` so warns / mutes / bans
-can be temporary. A mute uses it as the timeout length; a ban becomes a *temp
-ban* whose `expires_at` is honoured by `bot.case_expiry`, which lifts the
-Discord ban when the sanction expires (mutes are auto-cleared by Discord).
+**Expiring sanctions.** The deterministic **barème** (not nano — session 2)
+computes the sanction and its `duree_heures`, so warns / mutes / bans can be
+temporary. A mute uses it as the timeout length; a ban becomes a *temp ban*
+whose `expires_at` is honoured by `bot.case_expiry`, which lifts the Discord ban
+when the sanction expires (mutes are auto-cleared by Discord).
 
 A sanctioned member can **appeal** (see [AUTOMOD.md](AUTOMOD.md) §7):
 
@@ -342,3 +343,20 @@ A sanctioned member can **appeal** (see [AUTOMOD.md](AUTOMOD.md) §7):
   `/cases`.
 - The UI (`utils/appeal_views.py`) is fully persistent `DynamicItem` buttons +
   Modals V2, registered via `AppealPersistence`.
+
+**Appeal outcomes feed the automod back.** An appeal decision is not just
+reverted on Discord — it also reshapes future automod behaviour, with **no
+schema change** (both effects are *derived* at read time):
+
+- **Recidivism weighting (barème, session 2).** `db.list_member_sanctions`
+  derives each past sanction's `source_fiabilite` from the issuer + the latest
+  appeal status: an **accepted** appeal → `automod_appel_accepte` (weighted 0 —
+  a proven false positive never counts against the member), a **refused** appeal
+  → `automod_confirme` (a human confirmed it, weighted above a plain automod
+  sanction). An accepted appeal additionally drops the moderated message from
+  `messages_deja_moderes` (`list_automod_evidence_message_ids`).
+- **Server precedents (RAG, session 7).** `AppealService._feed_precedent` records
+  the moderated message as a precedent through `bot.precedents`: **accept** →
+  `non_sanctionnable`, **refuse** → `sanctionnable`. A **transform** ruling is
+  ambiguous (the sanction changed, not the sanctionable/not call) and is **not**
+  recorded. See [AUTOMOD.md](AUTOMOD.md) §2quinquies.

--- a/docs/sessions/2026-07-13_automod-v2-audit.md
+++ b/docs/sessions/2026-07-13_automod-v2-audit.md
@@ -1,0 +1,76 @@
+# 2026-07-13 — Automod v2 audit (sessions 1–8 consistency pass)
+
+## Goal
+
+Audit the eight Automod v2 sessions (`docs/AUTOMOD_V2_PLAN.md`) end to end:
+verify each session is actually implemented, documented, and coherent across the
+detection pipeline (`automod/`), the `/config` UI, and the moderation-cases
+system (`docs/MODERATION_CASES.md`). Fix any inconsistency or bug found.
+
+## What was verified (all green)
+
+- **Detection pipeline (`automod/`)** — every S1–S8 deliverable file is present
+  (`bareme`, `eval/`, `relations`, `routing`, `precedents`, `situation`, …).
+  `pytest tests/automod` → **314 passed**; `python -m automod.eval.run --replay`
+  → **precision/recall/F1 = 1.000** over 72 golden cases, exit 0, no baseline
+  drift.
+- **Recidivism plumbing (S2)** — `db.list_member_sanctions` derives
+  `source_fiabilite` from issuer + appeal status; keys match `bareme.POIDS_SOURCE`
+  (`.get()`-guarded, no KeyError). Accepted appeals drop the message from
+  `messages_deja_moderes`.
+- **Precedents (S7)** — `bot.precedents` wired in `bot.py`; fed from
+  `AppealService._feed_precedent` (accept→non_sanctionnable, refuse→sanctionnable,
+  transform→skipped) and from shadow `✅/❌` buttons; situation annotations are
+  correctly **not** fed as precedents.
+- **Persistent views** — shadow + situation cards share
+  `ShadowAnnotateButton` (`DynamicItem`), registered via
+  `ShadowAnnotationPersistence` in `utils/persistent_views.py`. The `/config`
+  panel is intentionally non-persistent (standard module pattern). Compliant with
+  CLAUDE.md §8.
+- **`/config` UI** — all S1–S8 knobs surfaced (dry_run, situation toggle,
+  max_action, langue_serveur, severity, precedents section + browser). Follows
+  DESIGN.md (Components V2, custom emojis, i18n, working-copy Save/Cancel).
+
+## Problems found & fixed
+
+1. **Data-loss bug — `categories_desactivees` wiped on Save**
+   (`modules/configs/automod_config.py`). `_deep_default` rebuilt the config
+   without carrying `categories_desactivees`, and `save_module_config` →
+   `update_guild_data` **replaces** the whole `modules.automod` subtree. So any
+   ops/backend-set kill-switch list was silently dropped the first time an admin
+   saved the panel. Fixed by preserving the key through the working copy (no UI
+   selector added — it stays an ops/backend field, as documented).
+
+2. **Outdated doc — `MODERATION_CASES.md` §9** said "nano may return
+   `duree_heures`". Since S2 the **barème** computes the sanction and its
+   duration; nano only qualifies. Corrected.
+
+3. **Missing coupling doc — `MODERATION_CASES.md` §9**. Added an "appeal outcomes
+   feed the automod back" note documenting the S2 recidivism weighting
+   (`source_fiabilite` derivation) and the S7 precedent feeding from appeal
+   rulings.
+
+4. **Plan checkboxes — `AUTOMOD_V2_PLAN.md`** Session 8 "Critères de fin" were
+   left unchecked though the session is complete (and tests prove it). Ticked.
+
+5. **`CLAUDE.md` structure drift** — `utils/automod_shadow_views.py` was listed
+   twice; `utils/cases_views.py` and `utils/automod_render.py` were missing.
+   De-duplicated and added.
+
+## Files modified
+
+- `modules/configs/automod_config.py` — preserve `categories_desactivees`.
+- `docs/MODERATION_CASES.md` — barème duration wording + appeal→automod coupling.
+- `docs/AUTOMOD_V2_PLAN.md` — S8 completion checkboxes.
+- `CLAUDE.md` — utils structure fixes.
+- `docs/sessions/2026-07-13_automod-v2-audit.md` — this log.
+
+## Verification
+
+`python -m py_compile modules/configs/automod_config.py` OK · 314 tests green ·
+eval runner 1.000/1.000, exit 0, no baseline drift — after the changes.
+
+## Follow-ups (not blocking)
+
+- `categories_desactivees` has no `/config` selector yet (ops/backend-only). A
+  category multi-select could be added later if servers need self-service.

--- a/modules/configs/automod_config.py
+++ b/modules/configs/automod_config.py
@@ -43,6 +43,9 @@ _DEFAULT_CONFIG = {
     "severity": ac.SEVERITY_DEFAULT,
     "max_action": "ban",
     "langue_serveur": "auto",
+    # Kill-switched AI categories (ops/backend-set; no UI selector yet). Carried
+    # through the working copy so a Save from this panel never wipes it.
+    "categories_desactivees": [],
     "dry_run": False,
     "features": {
         "content": {"enabled": False, "exempt_roles": [], "exempt_channels": []},
@@ -67,6 +70,11 @@ def _deep_default(current: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     cfg["max_action"] = max_action if max_action in ("warn", "mute", "ban") else "ban"
     langue = str(current.get("langue_serveur", "auto") or "auto")
     cfg["langue_serveur"] = langue if langue in ("auto", "fr", "en-US") else "auto"
+    # Preserve any ops/backend-set kill-switch list (no UI selector yet) so
+    # saving the panel does not silently drop it from the stored config.
+    cfg["categories_desactivees"] = [
+        str(c) for c in (current.get("categories_desactivees", []) or [])
+    ]
     cfg["dry_run"] = bool(current.get("dry_run", False))
     content = (current.get("features", {}) or {}).get("content", {}) or {}
     cfg["features"]["content"] = {


### PR DESCRIPTION
## Contexte

Passe d'audit de bout en bout sur les **8 sessions Automod v2** (`docs/AUTOMOD_V2_PLAN.md`) : vérifier que chaque session est bien **implémentée**, **documentée** et **cohérente** à travers le pipeline de détection (`automod/`), l'UI `/config` et le système de cases (`docs/MODERATION_CASES.md`).

Branche d'abord rebasée sur `AUTOMOD_V2` (fast-forward, +8 commits sessions 1→8), puis correctifs ci-dessous.

## Ce qui a été vérifié (tout vert)

- **Pipeline `automod/`** — tous les livrables S1–S8 présents. `pytest tests/automod` → **314 passed** ; `python -m automod.eval.run --replay` → **précision/rappel/F1 = 1.000** sur 72 cas golden, exit 0, aucune dérive baseline.
- **Récidive (S2)** — `db.list_member_sanctions` dérive `source_fiabilite` (issuer + statut d'appel), clés cohérentes avec `bareme.POIDS_SOURCE` (`.get()`-gardé, pas de KeyError).
- **Précédents (S7)** — `bot.precedents` câblé ; alimenté par `AppealService._feed_precedent` (accept→non_sanctionnable, refuse→sanctionnable, transform→ignoré) et les boutons shadow ✅/❌ ; les annotations `situation` ne sont **pas** enregistrées comme précédents.
- **Vues persistantes** — cartes shadow + situation partagent `ShadowAnnotateButton` (`DynamicItem`), enregistré via `ShadowAnnotationPersistence`. Conforme CLAUDE.md §8.
- **UI `/config`** — tous les réglages S1–S8 exposés (dry_run, situation, max_action, langue, sévérité, précédents + navigateur), conforme DESIGN.md.

## Problèmes trouvés & corrigés

1. **Bug perte de données — `categories_desactivees` effacé au Save** (`modules/configs/automod_config.py`). `_deep_default` reconstruisait la config sans cette clé, et `save_module_config` → `update_guild_data` **remplace** tout le sous-arbre `modules.automod`. Un kill-switch de catégorie posé par le backend/ops était donc silencieusement effacé au premier Save du panneau. Corrigé en préservant la clé dans la copie de travail (pas de sélecteur UI ajouté — reste un champ ops/backend, comme documenté).
2. **Doc obsolète — `MODERATION_CASES.md` §9** disait « nano may return `duree_heures` ». Depuis S2 c'est le **barème** qui calcule la sanction et sa durée ; nano ne fait que qualifier. Corrigé.
3. **Doc manquante — `MODERATION_CASES.md` §9** : ajout d'une note « appeal outcomes feed the automod back » documentant la pondération de récidive S2 (`source_fiabilite`) et l'alimentation des précédents S7 depuis les décisions d'appel.
4. **Checkboxes plan — `AUTOMOD_V2_PLAN.md`** : « Critères de fin » de la session 8 laissés décochés alors que la session est terminée (tests à l'appui). Cochés.
5. **Dérive `CLAUDE.md`** : `utils/automod_shadow_views.py` listé deux fois ; `utils/cases_views.py` et `utils/automod_render.py` absents. Dédoublonné et complété.

## Fichiers modifiés

- `modules/configs/automod_config.py` — préserve `categories_desactivees`.
- `docs/MODERATION_CASES.md` — durée côté barème + couplage appel→automod.
- `docs/AUTOMOD_V2_PLAN.md` — checkboxes S8.
- `CLAUDE.md` — carte `utils/` corrigée.
- `docs/sessions/2026-07-13_automod-v2-audit.md` — log de session.

## Vérification

`py_compile` OK · **314 tests verts** · runner eval **1.000/1.000**, exit 0, aucune dérive baseline — après changements.

## Suite (non bloquant)

- `categories_desactivees` n'a pas encore de sélecteur `/config` (ops/backend uniquement). Un multi-select de catégories pourrait être ajouté plus tard si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LFov2JnSXh1fP17WV5N5W

---
_Generated by [Claude Code](https://claude.ai/code/session_018LFov2JnSXh1fP17WV5N5W)_