### PR TITLE
Starboard: Use message forwarding & restrict to standard emojis

### DIFF
--- a/docs/sessions/2026-08-06_starboard-rework.md
+++ b/docs/sessions/2026-08-06_starboard-rework.md
@@ -1,0 +1,60 @@
+# Session: Starboard Module Rework
+
+**Date:** 2026-08-06
+**Agent:** Claude Code
+
+## Summary
+
+Reworked the Starboard module to use Discord's native message forwarding
+(`message_reference.type = FORWARD`) instead of a hand-built embed copy, and
+restricted the trigger reaction to standard Discord Unicode emojis (custom
+guild emojis are now rejected both in config and at runtime). The reaction
+emoji is now user-configurable via a modal in `/config`.
+
+## Changes Made
+
+- `modules/starboard.py` — Replaced the embed-based starboard card with a
+  Components V2 message that forwards the original message
+  (`discord.MessageReference(..., type=discord.MessageReferenceType.forward)`)
+  and attaches a card with a disabled counter button (emoji + count) and a
+  link button to jump to the original message, matching the target JSON
+  layout exactly (`TextDisplay` + `ActionRow`, no `Container` wrapper).
+  Reaction counting/matching now explicitly rejects custom emojis
+  (`PartialEmoji.is_custom_emoji()`), and `validate_config` rejects any
+  configured emoji that isn't a standard Discord Unicode emoji. Added the
+  verification badge (rule #7) next to the forwarded author's display name.
+- `modules/configs/starboard_config.py` — Added an `EmojiModal` (mirrors the
+  existing `ReactionCountModal`) letting admins type the trigger emoji, with
+  inline validation rejecting custom emojis / non-emoji text before saving.
+- `utils/emojis.py` — Added `is_standard_discord_emoji()`, a small
+  range-based Unicode validator (covers simple emojis, variation selectors,
+  keycap sequences, flag sequences and ZWJ sequences) since
+  `PartialEmoji.is_unicode_emoji()` only tells us something *isn't* a custom
+  emoji, not that it's an actual emoji.
+- `locales/fr.json`, `locales/en-US.json` — Added
+  `modules.starboard.config.emoji.*` (section title/description, edit
+  button, modal labels/errors) and `modules.starboard.message.*` (title,
+  jump button) keys; removed the now-inaccurate hardcoded "⭐" from the
+  reaction_count description since the emoji is configurable.
+
+## Decisions & Rationale
+
+- Used `discord.MessageReference(type=MessageReferenceType.forward)` +
+  `channel.send(view=..., reference=...)` directly instead of the
+  `Message.forward()` convenience method, because the latter only supports
+  sending a bare forward with no content/components — we need the forward
+  **and** the counter/jump-link card in the same message.
+- Standard-emoji validation is done with hand-rolled Unicode ranges rather
+  than pulling in the `emoji` PyPI package (not a project dependency and
+  overkill for validating a single reaction emoji).
+- Kept `str(payload.emoji) != self.emoji` as the core match (already correct
+  for standard emojis, since Discord's raw reaction payload carries the
+  Unicode character itself, not a `:shortcode:`), and added an explicit
+  `is_custom_emoji()` guard for clarity/defense-in-depth.
+
+## Known Issues / Follow-ups
+
+- [ ] No admin-facing emoji picker component exists in Components V2 (no
+      native Discord "emoji select" type), so emoji configuration is
+      modal/text-input based — acceptable, but a future improvement could
+      offer a curated `ui.Select` of popular reaction emojis.

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1048,7 +1048,7 @@
         },
         "reaction_count": {
           "section_title": "Required reaction count",
-          "section_description": "Number of ⭐ reactions needed for a message to appear in the starboard",
+          "section_description": "Number of reactions needed for a message to appear in the starboard",
           "edit_button": "Edit threshold",
           "modal": {
             "label": "Reaction count",
@@ -1056,7 +1056,22 @@
             "error_range": "Reaction count must be between 1 and 100",
             "error_invalid": "Please enter a valid number"
           }
+        },
+        "emoji": {
+          "section_title": "Reaction emoji",
+          "section_description": "Standard Discord emoji to react with to trigger the starboard (custom emojis are not allowed)",
+          "edit_button": "Edit emoji",
+          "modal": {
+            "label": "Emoji",
+            "placeholder": "⭐",
+            "error_custom": "Custom emojis are not allowed, please choose a standard Discord emoji",
+            "error_invalid": "Invalid emoji, please enter a standard Discord emoji"
+          }
         }
+      },
+      "message": {
+        "title": "Starboard",
+        "jump_button": "Jump to message"
       }
     },
     "auto_role": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1047,7 +1047,7 @@
         },
         "reaction_count": {
           "section_title": "Nombre de réactions requis",
-          "section_description": "Nombre de réactions ⭐ nécessaires pour qu'un message apparaisse dans le starboard",
+          "section_description": "Nombre de réactions nécessaires pour qu'un message apparaisse dans le starboard",
           "edit_button": "Modifier le seuil",
           "modal": {
             "label": "Nombre de réactions",
@@ -1055,7 +1055,22 @@
             "error_range": "Le nombre de réactions doit être entre 1 et 100",
             "error_invalid": "Veuillez entrer un nombre valide"
           }
+        },
+        "emoji": {
+          "section_title": "Émoji de réaction",
+          "section_description": "Émoji Discord standard à utiliser en réaction pour déclencher le starboard (les émojis personnalisés ne sont pas autorisés)",
+          "edit_button": "Modifier l'émoji",
+          "modal": {
+            "label": "Émoji",
+            "placeholder": "⭐",
+            "error_custom": "Les émojis personnalisés ne sont pas autorisés, choisissez un émoji standard de Discord",
+            "error_invalid": "Émoji invalide, veuillez entrer un émoji standard de Discord"
+          }
         }
+      },
+      "message": {
+        "title": "Starboard",
+        "jump_button": "Aller au message"
       }
     },
     "auto_role": {

--- a/modules/configs/starboard_config.py
+++ b/modules/configs/starboard_config.py
@@ -10,9 +10,48 @@ import logging
 
 from utils.i18n import t
 from cogs.error_handler import BaseView, BaseModal
-from utils.emojis import STAR, REQUIRED_FIELDS, EDIT, BACK, SAVE, UNDONE, DELETE
+from utils.emojis import STAR, REQUIRED_FIELDS, EDIT, BACK, SAVE, UNDONE, DELETE, is_standard_discord_emoji
 
 logger = logging.getLogger('moddy.modules.starboard_config')
+
+
+class EmojiModal(BaseModal, title="Émoji de réaction"):
+    """Modal pour éditer l'émoji de réaction du starboard"""
+
+    def __init__(self, locale: str, current_value: str, callback_func):
+        super().__init__(timeout=300)
+        self.locale = locale
+        self.callback_func = callback_func
+
+        self.emoji_input = ui.TextInput(
+            label=t('modules.starboard.config.emoji.modal.label', locale=locale),
+            placeholder=t('modules.starboard.config.emoji.modal.placeholder', locale=locale),
+            default=current_value,
+            style=discord.TextStyle.short,
+            max_length=8,
+            required=True
+        )
+        self.add_item(self.emoji_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        value = self.emoji_input.value.strip()
+
+        partial_emoji = discord.PartialEmoji.from_str(value)
+        if partial_emoji.is_custom_emoji():
+            await interaction.response.send_message(
+                t('modules.starboard.config.emoji.modal.error_custom', locale=self.locale),
+                ephemeral=True
+            )
+            return
+
+        if not is_standard_discord_emoji(value):
+            await interaction.response.send_message(
+                t('modules.starboard.config.emoji.modal.error_invalid', locale=self.locale),
+                ephemeral=True
+            )
+            return
+
+        await self.callback_func(interaction, value)
 
 
 class ReactionCountModal(BaseModal, title="Nombre de réactions"):
@@ -143,6 +182,26 @@ class StarboardConfigView(BaseView):
 
         container.add_item(reaction_row)
 
+        # Reaction emoji configuration (standard Discord emojis only, no custom emoji)
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.starboard.config.emoji.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.starboard.config.emoji.section_description', locale=self.locale)}\n"
+            f"-# {t('modules.config.current_value', locale=self.locale)} {self.working_config['emoji']}"
+        ))
+
+        emoji_row = ui.ActionRow()
+
+        edit_emoji_btn = ui.Button(
+            label=t('modules.starboard.config.emoji.edit_button', locale=self.locale),
+            style=discord.ButtonStyle.primary,
+            emoji=discord.PartialEmoji.from_str(EDIT),
+            custom_id="edit_emoji"
+        )
+        edit_emoji_btn.callback = self.on_edit_emoji
+        emoji_row.add_item(edit_emoji_btn)
+
+        container.add_item(emoji_row)
+
         self.add_item(container)
 
         # Add action buttons at the bottom
@@ -230,6 +289,26 @@ class StarboardConfigView(BaseView):
     async def _on_reaction_count_edited(self, interaction: discord.Interaction, new_count: int):
         """Callback after reaction count edit"""
         self.working_config['reaction_count'] = new_count
+        self.has_changes = True
+        self._build_view()
+        await interaction.response.edit_message(view=self)
+
+    async def on_edit_emoji(self, interaction: discord.Interaction):
+        """Edit reaction emoji"""
+        if not await self.check_user(interaction):
+            return
+
+        modal = EmojiModal(
+            self.locale,
+            self.working_config['emoji'],
+            self._on_emoji_edited
+        )
+        modal.bot = self.bot  # Set bot for error handling
+        await interaction.response.send_modal(modal)
+
+    async def _on_emoji_edited(self, interaction: discord.Interaction, new_emoji: str):
+        """Callback after reaction emoji edit"""
+        self.working_config['emoji'] = new_emoji
         self.has_changes = True
         self._build_view()
         await interaction.response.edit_message(view=self)

--- a/modules/starboard.py
+++ b/modules/starboard.py
@@ -7,7 +7,11 @@ from typing import Dict, Any, Optional
 import logging
 
 from modules.module_manager import ModuleBase
-from utils.emojis import STAR, MESSAGE, TEXT
+from utils.emojis import (
+    STAR, is_standard_discord_emoji,
+    get_user_verification_badge, format_verification_badge,
+)
+from utils.i18n import t
 
 logger = logging.getLogger('moddy.modules.starboard')
 
@@ -15,8 +19,9 @@ logger = logging.getLogger('moddy.modules.starboard')
 class StarboardModule(ModuleBase):
     """
     Module de starboard (tableau d'honneur)
-    Envoie automatiquement les messages qui reçoivent un nombre X de réactions étoiles
-    dans un salon dédié avec le contenu, l'auteur, le nombre de réactions et le lien
+    Forward automatiquement les messages qui reçoivent un nombre X de réactions
+    (un émoji standard Discord, configurable) dans un salon dédié, avec un
+    compteur de réactions et un lien vers le message d'origine.
     """
 
     MODULE_ID = "starboard"
@@ -31,8 +36,8 @@ class StarboardModule(ModuleBase):
         self.channel_id: Optional[int] = None
 
         # Starboard configuration
-        self.reaction_count: int = 5  # Number of star reactions required
-        self.emoji: str = "⭐"  # Star emoji
+        self.reaction_count: int = 5  # Number of reactions required
+        self.emoji: str = "⭐"  # Standard Discord unicode emoji that triggers the starboard
 
         # Track sent starboard messages to update them in real-time
         # Format: {original_message_id: starboard_message_id}
@@ -82,9 +87,6 @@ class StarboardModule(ModuleBase):
             if not perms.send_messages:
                 return False, f"Je n'ai pas la permission d'envoyer des messages dans {channel.mention}"
 
-            if not perms.embed_links:
-                return False, f"Je n'ai pas la permission d'envoyer des embeds dans {channel.mention}"
-
         except Exception as e:
             return False, f"Erreur de validation du salon : {str(e)}"
 
@@ -92,6 +94,19 @@ class StarboardModule(ModuleBase):
         reaction_count = config_data.get('reaction_count', 5)
         if not isinstance(reaction_count, int) or reaction_count < 1 or reaction_count > 100:
             return False, "Le nombre de réactions doit être entre 1 et 100"
+
+        # Validate the reaction emoji: only standard Discord emojis are accepted,
+        # never a custom/guild emoji.
+        emoji = config_data.get('emoji', "⭐")
+        if not isinstance(emoji, str) or not emoji:
+            return False, "Un émoji de réaction est requis"
+
+        partial_emoji = discord.PartialEmoji.from_str(emoji)
+        if partial_emoji.is_custom_emoji():
+            return False, "Seuls les émojis standards de Discord sont autorisés (pas d'émoji personnalisé)"
+
+        if not is_standard_discord_emoji(emoji):
+            return False, "Émoji invalide, veuillez choisir un émoji standard de Discord"
 
         return True, None
 
@@ -111,8 +126,9 @@ class StarboardModule(ModuleBase):
         if not self.enabled or not self.channel_id:
             return
 
-        # Only track star emoji
-        if str(payload.emoji) != self.emoji:
+        # Only standard Discord emojis can trigger the starboard, and only the
+        # one configured for this server.
+        if payload.emoji.is_custom_emoji() or str(payload.emoji) != self.emoji:
             return
 
         try:
@@ -136,12 +152,8 @@ class StarboardModule(ModuleBase):
                 logger.warning(f"Message {payload.message_id} not found")
                 return
 
-            # Count star reactions
-            star_count = 0
-            for reaction in message.reactions:
-                if str(reaction.emoji) == self.emoji:
-                    star_count = reaction.count
-                    break
+            # Count reactions matching the configured emoji
+            star_count = self._count_reactions(message)
 
             # Check if we should send/update starboard entry
             if star_count >= self.reaction_count:
@@ -160,8 +172,7 @@ class StarboardModule(ModuleBase):
         if not self.enabled or not self.channel_id:
             return
 
-        # Only track star emoji
-        if str(payload.emoji) != self.emoji:
+        if payload.emoji.is_custom_emoji() or str(payload.emoji) != self.emoji:
             return
 
         # Check if this message has a starboard entry
@@ -184,12 +195,7 @@ class StarboardModule(ModuleBase):
             except discord.NotFound:
                 return
 
-            # Count star reactions
-            star_count = 0
-            for reaction in message.reactions:
-                if str(reaction.emoji) == self.emoji:
-                    star_count = reaction.count
-                    break
+            star_count = self._count_reactions(message)
 
             # Update or remove starboard entry
             if star_count >= self.reaction_count:
@@ -200,6 +206,68 @@ class StarboardModule(ModuleBase):
 
         except Exception as e:
             logger.error(f"Error updating starboard on reaction remove: {e}", exc_info=True)
+
+    def _count_reactions(self, message: discord.Message) -> int:
+        """Count how many times the configured (standard) emoji was used on this message"""
+        for reaction in message.reactions:
+            if not reaction.is_custom_emoji() and str(reaction.emoji) == self.emoji:
+                return reaction.count
+        return 0
+
+    async def _get_locale(self) -> str:
+        """Locale used for the starboard message's static UI strings (title, jump button)"""
+        try:
+            guild = self.bot.get_guild(self.guild_id)
+            return str(guild.preferred_locale) if guild and guild.preferred_locale else 'en-US'
+        except Exception:
+            return 'en-US'
+
+    async def _get_author_badge(self, author: discord.abc.User) -> str:
+        """Verification badge (hyperlinked) for the original message's author"""
+        try:
+            user_db_data = await self.bot.db.get_user(author.id)
+            moddy_attributes = user_db_data.get('attributes', {}) if user_db_data else {}
+        except Exception:
+            moddy_attributes = {}
+
+        public_flags_value = author.public_flags.value if hasattr(author, 'public_flags') else 0
+        badge_emoji, _org_names, _tier = get_user_verification_badge(
+            {'public_flags': public_flags_value}, moddy_attributes
+        )
+        return format_verification_badge(badge_emoji)
+
+    async def _build_starboard_view(self, message: discord.Message, star_count: int) -> discord.ui.LayoutView:
+        """Build the Components V2 card sent alongside the forwarded message"""
+        locale = await self._get_locale()
+        badge = await self._get_author_badge(message.author)
+
+        view = discord.ui.LayoutView(timeout=None)
+
+        view.add_item(discord.ui.TextDisplay(
+            f"### {STAR} {t('modules.starboard.message.title', locale=locale)}\n"
+            f"@**{message.author.display_name}**{badge} :"
+        ))
+
+        row = discord.ui.ActionRow()
+
+        count_button = discord.ui.Button(
+            style=discord.ButtonStyle.secondary,
+            label=str(star_count),
+            emoji=self.emoji,
+            disabled=True,
+            custom_id=f"moddy:starboard:count:{message.id}"
+        )
+        row.add_item(count_button)
+
+        jump_button = discord.ui.Button(
+            style=discord.ButtonStyle.link,
+            label=t('modules.starboard.message.jump_button', locale=locale),
+            url=message.jump_url
+        )
+        row.add_item(jump_button)
+
+        view.add_item(row)
+        return view
 
     async def _update_starboard(self, message: discord.Message, star_count: int):
         """
@@ -214,31 +282,38 @@ class StarboardModule(ModuleBase):
             logger.warning(f"Starboard channel {self.channel_id} not found or not a text channel")
             return
 
-        # Create embed
-        embed = await self._create_starboard_embed(message, star_count)
-
         # Check if we already have a starboard message for this
         if message.id in self.starboard_messages:
-            # Update existing message
+            # Update existing message (only the reaction counter changes)
             try:
                 starboard_msg_id = self.starboard_messages[message.id]
                 starboard_msg = await starboard_channel.fetch_message(starboard_msg_id)
-                await starboard_msg.edit(embed=embed)
+                view = await self._build_starboard_view(message, star_count)
+                await starboard_msg.edit(view=view)
                 logger.info(f"Updated starboard message for {message.id} (stars: {star_count})")
             except discord.NotFound:
                 # Message was deleted, create a new one
                 del self.starboard_messages[message.id]
-                await self._create_starboard_message(starboard_channel, message, embed)
+                await self._create_starboard_message(starboard_channel, message, star_count)
         else:
             # Create new starboard message
-            await self._create_starboard_message(starboard_channel, message, embed)
+            await self._create_starboard_message(starboard_channel, message, star_count)
 
     async def _create_starboard_message(self, channel: discord.TextChannel,
-                                       original_message: discord.Message, embed: discord.Embed):
-        """Create a new starboard message"""
+                                         original_message: discord.Message, star_count: int):
+        """Forward the original message to the starboard channel with the reaction card"""
         try:
-            # Send the starboard message
-            starboard_msg = await channel.send(embed=embed)
+            view = await self._build_starboard_view(original_message, star_count)
+
+            reference = discord.MessageReference(
+                message_id=original_message.id,
+                channel_id=original_message.channel.id,
+                guild_id=self.guild_id,
+                fail_if_not_exists=False,
+                type=discord.MessageReferenceType.forward,
+            )
+
+            starboard_msg = await channel.send(view=view, reference=reference)
 
             # Track it for future updates
             self.starboard_messages[original_message.id] = starboard_msg.id
@@ -246,6 +321,8 @@ class StarboardModule(ModuleBase):
             logger.info(f"Created starboard message for {original_message.id}")
         except discord.Forbidden:
             logger.warning(f"Missing permissions to send starboard message in guild {self.guild_id}")
+        except discord.HTTPException as e:
+            logger.error(f"Error forwarding message {original_message.id} to starboard: {e}")
         except Exception as e:
             logger.error(f"Error creating starboard message: {e}", exc_info=True)
 
@@ -273,63 +350,3 @@ class StarboardModule(ModuleBase):
             del self.starboard_messages[message.id]
         except Exception as e:
             logger.error(f"Error removing starboard message: {e}", exc_info=True)
-
-    async def _create_starboard_embed(self, message: discord.Message, star_count: int) -> discord.Embed:
-        """Create an embed for a starboard entry"""
-
-        # Create base embed with message content
-        embed = discord.Embed(
-            description=message.content if message.content else "*Pas de contenu texte*",
-            color=0xFFAC33,  # Gold color for starboard
-            timestamp=message.created_at
-        )
-
-        # Set author (message author)
-        embed.set_author(
-            name=message.author.display_name,
-            icon_url=message.author.display_avatar.url
-        )
-
-        # Add star count and jump link
-        embed.add_field(
-            name=f"{self.emoji} Réactions",
-            value=f"**{star_count}** {self.emoji}",
-            inline=True
-        )
-
-        embed.add_field(
-            name=f"{MESSAGE} Message",
-            value=f"[Aller au message]({message.jump_url})",
-            inline=True
-        )
-
-        embed.add_field(
-            name=f"{TEXT} Salon",
-            value=message.channel.mention,
-            inline=True
-        )
-
-        # Add image if the message has one
-        if message.attachments:
-            # Get the first image attachment
-            for attachment in message.attachments:
-                if attachment.content_type and attachment.content_type.startswith('image/'):
-                    embed.set_image(url=attachment.url)
-                    break
-
-        # Add embed image if the message has embeds with images
-        if not embed.image and message.embeds:
-            for msg_embed in message.embeds:
-                if msg_embed.image:
-                    embed.set_image(url=msg_embed.image.url)
-                    break
-                elif msg_embed.thumbnail:
-                    embed.set_thumbnail(url=msg_embed.thumbnail.url)
-                    break
-
-        # Add footer
-        embed.set_footer(
-            text=f"ID: {message.id}"
-        )
-
-        return embed

--- a/utils/emojis.py
+++ b/utils/emojis.py
@@ -351,6 +351,57 @@ CASE_TYPE_EMOJI_DEFAULT = INFO
 
 
 # =============================================================================
+# STANDARD (DISCORD-PROVIDED) UNICODE EMOJI VALIDATION
+# =============================================================================
+# Used by modules (e.g. Starboard) that must only accept reactions/config
+# values among the Unicode emojis Discord itself provides — never a custom
+# guild emoji. `discord.PartialEmoji.is_unicode_emoji()` only tells us the
+# value isn't a `<:name:id>` custom emoji, it doesn't verify the string is
+# an actual emoji, so we range-check the codepoints ourselves.
+
+_STANDARD_EMOJI_UNICODE_RANGES = (
+    (0x1F300, 0x1FAFF),  # Misc pictographs, emoticons, transport, symbols & pictographs extended-A
+    (0x2600, 0x27BF),    # Misc symbols & dingbats
+    (0x2300, 0x23FF),    # Misc technical (⌚ ⏰ ⏳ …)
+    (0x2B00, 0x2BFF),    # Misc symbols & arrows (⭐ ⚡ ➡️ …)
+    (0x2190, 0x21FF),    # Arrows
+    (0x1F1E6, 0x1F1FF),  # Regional indicator symbols (used in flag sequences)
+)
+
+
+def _is_standard_emoji_codepoint(codepoint: int) -> bool:
+    return any(low <= codepoint <= high for low, high in _STANDARD_EMOJI_UNICODE_RANGES)
+
+
+def is_standard_discord_emoji(value: str) -> bool:
+    """Check that `value` is a single Discord-standard Unicode emoji.
+
+    Rejects custom/guild emojis (``<:name:id>``) and arbitrary text. Handles
+    the variation selector (``️``), flag sequences (pairs of regional
+    indicators), keycap sequences (``#``/``*``/digit + combining keycap) and
+    ZWJ sequences (e.g. family/profession emojis).
+    """
+    if not value:
+        return False
+
+    stripped = value.replace('️', '')  # variation selector-16
+
+    # Keycap sequence: 0-9 / # / * + combining enclosing keycap (U+20E3)
+    if len(stripped) == 2 and stripped[1] == '⃣' and (stripped[0].isdigit() or stripped[0] in '#*'):
+        return True
+
+    # Flag sequence: pair of regional indicator symbols
+    if len(stripped) == 2 and all(0x1F1E6 <= ord(c) <= 0x1F1FF for c in stripped):
+        return True
+
+    # Simple emoji or ZWJ sequence (ZWJ = U+200D, e.g. family/profession emojis)
+    for part in stripped.split('‍'):
+        if len(part) != 1 or not _is_standard_emoji_codepoint(ord(part)):
+            return False
+    return True
+
+
+# =============================================================================
 # VERIFICATION BADGE UTILITIES
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Reworked the Starboard module to use Discord's native message forwarding (`MessageReference` with `type=FORWARD`) instead of hand-built embeds, and restricted the trigger reaction to standard Discord Unicode emojis only (custom guild emojis are now rejected in both config validation and at runtime).

## Changes Made

- **`modules/starboard.py`**
  - Replaced embed-based starboard card with a Components V2 message that forwards the original message and attaches a card with a disabled counter button (emoji + count) and a link button to jump to the original
  - Reaction counting now explicitly rejects custom emojis via `PartialEmoji.is_custom_emoji()`
  - Config validation rejects any emoji that isn't a standard Discord Unicode emoji
  - Added verification badge next to the forwarded author's display name
  - Extracted reaction counting logic into `_count_reactions()` helper
  - Added `_build_starboard_view()` to construct the Components V2 card with locale-aware strings
  - Removed `_create_starboard_embed()` (no longer needed)

- **`modules/configs/starboard_config.py`**
  - Added `EmojiModal` class for editing the trigger emoji via text input
  - Inline validation rejects custom emojis and invalid emoji text before saving
  - Added emoji configuration section to the config UI with edit button

- **`utils/emojis.py`**
  - Added `is_standard_discord_emoji()` function with Unicode range validation
  - Handles variation selectors, flag sequences, keycap sequences, and ZWJ sequences
  - Provides defense-in-depth validation since `PartialEmoji.is_unicode_emoji()` only tells us something *isn't* a custom emoji

- **`locales/en-US.json` & `locales/fr.json`**
  - Added `modules.starboard.config.emoji.*` keys (section title/description, edit button, modal labels/errors)
  - Added `modules.starboard.message.*` keys (title, jump button)
  - Removed hardcoded "⭐" from reaction_count description since emoji is now configurable

- **`docs/sessions/2026-08-06_starboard-rework.md`** (new)
  - Session notes documenting the rework rationale and implementation decisions

## Implementation Details

- Uses `discord.MessageReference(type=MessageReferenceType.forward)` + `channel.send(view=..., reference=...)` directly instead of the `Message.forward()` convenience method, because the latter doesn't support sending a forward with components
- Standard emoji validation uses hand-rolled Unicode ranges rather than external dependencies
- Kept `str(payload.emoji) != self.emoji` as the core match with an explicit `is_custom_emoji()` guard for clarity

https://claude.ai/code/session_017wfFCRo2AyyRdnErYMEWmT