### PR TITLE
docs: Add comprehensive persistent views migration guide (Appendices A–D)

### DIFF
--- a/docs/PERSISTENT_VIEWS.md
+++ b/docs/PERSISTENT_VIEWS.md
@@ -241,3 +241,894 @@ tests or at the top of `register_persistent`.
 - **`cogs/webhook.py::WebhookView`** — displays webhook tokens / URLs which
   are secret and should not be re-rendered after a restart. Keep as-is;
   users re-run the command.
+
+---
+
+## Appendix A — View inventory & auth mapping
+
+Every `discord.ui.View` / `ui.LayoutView` / `BaseView` subclass in the
+repository, as of the recon pass. `tests/` is excluded.
+
+**How to read the columns**
+
+- *# children* counts interactive component **construction sites**
+  (`ui.Button` / `ui.Select` / `ui.ChannelSelect` / `ui.RoleSelect` /
+  `ui.UserSelect`) found statically in the class body. Most `_build_view`
+  methods are branchy, so the number of children on a given rendered message
+  is usually **lower**. Treat it as "how much surface has to get a
+  `custom_id`", not as an exact runtime count.
+- *Persistent?* = `__persistent__ = True` **and** present in
+  `utils/persistent_views.py::_collect_persistent_view_classes()`.
+- *Timeout* is what the class passes to `super().__init__`; `—` means it
+  inherits `BaseView`'s `timeout=None`.
+
+### A.1 — `cogs/`
+
+| Class | File | `__init__` signature | # children | Timeout | Persistent? | Proposed auth model | Why |
+|---|---|---|---|---|---|---|---|
+| `AvatarView` | [cogs/avatar.py:18](../cogs/avatar.py) | `(user_data, moddy_attributes, locale, user_verification_data=None)` | 0 | — | No | **Public** | Renders a public avatar card; no interactive child exists, so persistence is a no-op (see B.4). |
+| `BannerView` | [cogs/banner.py:18](../cogs/banner.py) | `(user_data, moddy_attributes, locale, user_verification_data=None)` | 0 | — | No | **Public** | Same as `AvatarView` — static banner card, nothing dispatchable. |
+| `ConfigMainView` | [cogs/config.py:19](../cogs/config.py) | `(bot, guild_id, user_id, locale)` | 1 | 300 s | No | **Guild permission** | The module select routes into every guild config panel; a click mutates guild scope, so `manage_guild` must be re-checked. Has an `interaction_check`, but it compares against the in-memory `user_id`. |
+| `EmojiView` | [cogs/emoji.py:20](../cogs/emoji.py) | `(emoji_data, locale, bot=None)` | 0 | 180 s | No | **Public** | Static emoji info card. Only the 180 s timeout needs removing. |
+| `EmojiNavigationView` | [cogs/emoji.py:87](../cogs/emoji.py) | `(emoji_list, locale, bot, author)` | 3 | 180 s | No | **Owner only** | Paginates the invoker's scanned emoji list and already gates on `author` via `interaction_check`; the emoji list itself is unsaved in-memory state (see B.1). |
+| `BaseView` | [cogs/error_handler.py:166](../cogs/error_handler.py) | `(*, timeout=None, **kwargs)` | 0 | None | n/a | n/a | Abstract base class, never instantiated directly. |
+| `ErrorView` | [cogs/error_handler.py:419](../cogs/error_handler.py) | see file | 2 | None | No — **excluded** | n/a | URL-only buttons (see "Deliberate exclusions"). |
+| `PermissionErrorView` | [cogs/error_handler.py:861](../cogs/error_handler.py) | `()` (nested in a function) | 1 | None | No — **excluded** | n/a | URL-only button, function-local class (see B.5). |
+| `CooldownErrorView` | [cogs/error_handler.py:892](../cogs/error_handler.py) | `()` (nested) | 0 | None | No — **excluded** | n/a | No interactive child. |
+| `NotFoundView` | [cogs/error_handler.py:917](../cogs/error_handler.py) | `()` (nested) | 0 | None | No — **excluded** | n/a | No interactive child. |
+| `ReportView` | [cogs/interserver_commands.py:126](../cogs/interserver_commands.py) | `(bot, moddy_id, reporter_id, author_mention, guild_name, guild_id, reporter_mention, content)` | 3 | — | No | **Staff rank** | Claim / Processed / Skip buttons on an inter-server abuse report. `on_claim` already re-runs `staff_permissions.get_user_roles` against `MODERATOR`+ ([cogs/interserver_commands.py:191-199](../cogs/interserver_commands.py)), so the auth model is already correct — but the class is function-local (B.5) and its `claimed_by` lives only in memory (B.1). |
+| `InfoView` | [cogs/interserver_commands.py:329](../cogs/interserver_commands.py) | nested | 0 | — | No | **Public** | Static info card. |
+| `ProcessedView` | [cogs/interserver_commands.py:365](../cogs/interserver_commands.py) | nested | 0 | — | No | **Public** | Static confirmation card. |
+| `InviteView` | [cogs/invite.py:20](../cogs/invite.py) | `(invite_data, locale)` | 3 | 180 s | No | **Public** | Shows a public invite's metadata; the buttons only toggle between rendered panes of data already fetched. Note the "Raw Data" button is marked `# TEMP` in the source — confirm it ships (B.5). |
+| `ServerInfoView` | [cogs/invite.py:375](../cogs/invite.py) | `(invite_data, locale)` | 1 | 180 s | No | **Public** | Back button into `InviteView`; same public invite payload. Its `invite_data` is unsaved in-memory state (B.1). |
+| `AttributionView` | [cogs/moddy.py:25](../cogs/moddy.py) | `(bot=None, locale="en-US", user_id=None)` | 1 | — | **Yes** | **Public** | Already migrated. Reference implementation for the stateless/public case. |
+| `WeSupportView` | [cogs/moddy.py:109](../cogs/moddy.py) | `(bot=None, locale="en-US", user_id=None)` | 1 | — | **Yes** | **Public** | Already migrated. |
+| `ModdyMainView` | [cogs/moddy.py:174](../cogs/moddy.py) | `(bot=None, locale="en-US", user_id=None)` | 2 | — | **Yes** | **Public** | Already migrated; the canonical `if self.bot is not None:` guard example. |
+| `PreferencesView` | [cogs/preferences.py:110](../cogs/preferences.py) | `(bot, user_id, locale, user_data)` | 2 | 300 s | No | **Owner only** | Reads and writes the clicker's own user row (timezone, incognito). Subclasses `LayoutView` directly, not `BaseView` (B.5). custom_ids `"timezone_btn"` / `"back_btn"` are un-namespaced and collide (B.5). |
+| `RemindersManageView` | [cogs/reminder.py:478](../cogs/reminder.py) | `(bot, user_id, reminders, locale, user_tz, show_history=False, past_reminders=None, original_interaction=None)` | 5 | 300 s | No | **Owner only** | Lists, edits and deletes the clicker's personal reminders; already has an owner `interaction_check`. Subclasses `LayoutView` directly (B.5); holds `reminders`, `past_reminders`, `show_history` and an `original_interaction` in memory (B.1). |
+| `RollView` | [cogs/roll.py:17](../cogs/roll.py) | `(result, max_value, locale)` | 0 | — | No | **Public** | Static dice result. Nothing to register. |
+| `SavedMessagesLibraryView` | [cogs/saved_messages.py:222](../cogs/saved_messages.py) | `(bot, user_id, messages, locale, …)` | 8 | 300 s | No | **Owner only** | Browses and deletes the clicker's bookmarked messages. Subclasses `LayoutView` directly (B.5); paginated over an in-memory `messages` slice (B.1); un-namespaced custom_ids collide with `reminder.py` (B.5). |
+| `SubscriptionView` | [cogs/subscription.py:27](../cogs/subscription.py) | `(bot, user_id, sub, servers, locale)` | 3 | 300 s | No | **Public** (URL-only) | All three children are `ButtonStyle.link` buttons ([cogs/subscription.py:99-115](../cogs/subscription.py)) — nothing dispatches. The **only** required change is dropping `timeout=300`; do not register it. |
+| `TextResultView` | [cogs/text_tools.py:109](../cogs/text_tools.py) | `(*, title, body, footer, accent, meta=None, code_block=True)` | 0 | — | No | **Public** | Docstring states it is purely informational; no interactive child. |
+| `TranslateView` | [cogs/translate.py:21](../cogs/translate.py) | `(bot, original_text, translated_text, from_lang, current_to_lang, locale, author)` | 1 | 120 s | No | **Owner only** | The target-language select re-translates; already author-gated. Holds `original_text` in memory, which is not recoverable from the DB (B.1 — the hard case). |
+| `UserInfoView` | [cogs/user.py:42](../cogs/user.py) | `(user_data, bot_data, moddy_attributes, locale, author_id, bot, user_verification_data=None)` | 5 | 180 s | No | **Public** | Shows public Discord profile data (avatar / banner / description panes). It carries an `author_id` but no `interaction_check` was found, so it is effectively public today — **keep it public rather than tightening behaviour during a mechanical migration.** |
+| `WebhookView` | [cogs/webhook.py:19](../cogs/webhook.py) | `(webhook_data, author, locale)` | 4 | 300 s | No — **excluded** | n/a | Renders webhook tokens/URLs. Already an agreed exclusion. |
+
+### A.2 — `modules/`
+
+| Class | File | `__init__` signature | # children | Timeout | Persistent? | Proposed auth model | Why |
+|---|---|---|---|---|---|---|---|
+| `AdaptiveSlowmodeChannelConfigView` | [modules/configs/adaptive_slowmode_config.py:66](../modules/configs/adaptive_slowmode_config.py) | `(bot, guild_id, user_id, locale, parent_view, channel_id=None, channel_config=None)` | 6 | 300 s | No | **Guild permission** | Edits per-channel slowmode bounds for a guild. `parent_view` is a required positional with no default and cannot be reconstructed (B.1 — the hardest case in the repo). |
+| `AdaptiveSlowmodeConfigView` | [modules/configs/adaptive_slowmode_config.py:364](../modules/configs/adaptive_slowmode_config.py) | `(bot, guild_id, user_id, locale, current_config=None)` | 7 | 300 s | No | **Guild permission** | Guild slowmode panel with Save/Cancel; holds a `working_config` deep copy (B.1). |
+| `AutoRestoreRolesConfigView` | [modules/configs/auto_restore_roles_config.py:18](../modules/configs/auto_restore_roles_config.py) | `(bot, guild_id, user_id, locale, current_config=None)` | 8 | 300 s | No | **Guild permission** | Chooses which guild roles get restored on rejoin; `working_config` (B.1). Zero `custom_id`s today. |
+| `AutoRoleConfigView` | [modules/configs/auto_role_config.py:18](../modules/configs/auto_role_config.py) | `(bot, guild_id, user_id, locale, current_config=None)` | 6 | 300 s | No | **Guild permission** | Assigns guild roles to joiners; `working_config` (B.1). Zero `custom_id`s today. |
+| `AutomodAIConfigView` | [modules/configs/automod_ai_config.py:145](../modules/configs/automod_ai_config.py) | `(bot, guild_id, user_id, locale="en-US", current_config=None)` | 14 | 300 s | No | **Guild permission** | The largest config panel — toggles automod enforcement for the guild. `working_config` plus lazily-loaded `_precedent_count` / `_precedent_last` (B.1). Zero `custom_id`s today. |
+| `AutomodAIPrecedentsView` | [modules/configs/automod_ai_precedents_view.py:31](../modules/configs/automod_ai_precedents_view.py) | `(bot, guild_id, user_id, locale="en-US", parent=None)` | 4 | 300 s | No | **Guild permission** | Paginated browse/delete over `automod_precedents` rows for the guild. `rows` are re-fetchable via `load()`, so state loss is cheap; `parent` is not (B.1). |
+| `InterServerConfigView` | [modules/configs/interserver_config.py:18](../modules/configs/interserver_config.py) | `(bot, guild_id, user_id, locale, current_config=None)` | 6 | 300 s | No | **Guild permission** | Named in the doc body as the `working_config` exemplar. |
+| `SocialNotificationsConfigView` | [modules/configs/social_notifications_config.py:286](../modules/configs/social_notifications_config.py) | `(bot=None, guild_id=None, user_id=None, …)` | 4 | — | **Yes** | **Guild permission** | Already migrated. Reference implementation for the guild-permission case. |
+| `AddSubscriptionView` | [modules/configs/social_notifications_config.py:479](../modules/configs/social_notifications_config.py) | `(bot=None, guild_id=None, locale="en-US", …)` | 7 | — | **Partly** | **Guild permission** | Has `__persistent__`-style shape and full `custom_id`s, but is **not** in `_collect_persistent_view_classes()`. Either add it or document why the parent registration is sufficient (B.5). |
+| `ManageSubscriptionView` | [modules/configs/social_notifications_config.py:774](../modules/configs/social_notifications_config.py) | `(bot=None, guild_id=None, locale="en-US", …)` | 6 | — | **Partly** | **Guild permission** | Same as above — migrated in shape, unregistered in fact. |
+| `StarboardConfigView` | [modules/configs/starboard_config.py:92](../modules/configs/starboard_config.py) | `(bot, guild_id, user_id, locale, current_config=None)` | 7 | 300 s | No | **Guild permission** | Guild starboard channel/threshold/emoji; `working_config` (B.1). 6 of 7 children already have (un-namespaced) custom_ids. |
+| `WelcomeChannelConfigView` | [modules/configs/welcome_channel_config.py:119](../modules/configs/welcome_channel_config.py) | `(bot, guild_id, user_id, locale, current_config=None)` | 13 | 300 s | No | **Guild permission** | Guild welcome message + embed builder; `working_config` (B.1). Un-namespaced custom_ids collide 1:1 with `welcome_dm_config.py` (B.5 — the worst collision in the repo). |
+| `WelcomeDmConfigView` | [modules/configs/welcome_dm_config.py:119](../modules/configs/welcome_dm_config.py) | `(bot, guild_id, user_id, locale, current_config=None)` | 11 | 300 s | No | **Guild permission** | Same panel shape for the DM variant; identical custom_ids to the channel variant (B.5). |
+| `WelcomeView` | [modules/interserver.py:444](../modules/interserver.py) | `()` (function-local) | 0 | — | No | **Public** | Static DM card. Nothing to register. |
+| `StaffLogView` | [modules/interserver.py:507](../modules/interserver.py) | `(moddy_id, author_info, server_info, content_preview, success_count, total_count, is_moddy_team)` (function-local) | 0 | — | No | **Public** | Static log card. Nothing to register. |
+
+### A.3 — `staff/`
+
+| Class | File | `__init__` signature | # children | Timeout | Persistent? | Proposed auth model | Why |
+|---|---|---|---|---|---|---|---|
+| `EmojiPreviewView` | [staff/commands/dev/emoji_preview.py:49](../staff/commands/dev/emoji_preview.py) | `(partial_emoji, emoji_str)` | 3 | — | No | **Staff rank** | Dev-only emoji rendering preview; the select and sample buttons only re-render the same emoji. One child is a URL button. |
+| `ServerListView` | [staff/commands/dev/serverlist.py:13](../staff/commands/dev/serverlist.py) | `(bot, author_id, guilds, locale, per_page=10)` | 2 | 300 s | No | **Staff rank** | Paginates the bot's full guild list — dev-visible data. Already author-gated; the `guilds` snapshot is in memory but trivially re-derivable from `bot.guilds` (B.1). |
+| `SqlConfirmView` | [staff/commands/dev/sql.py:48](../staff/commands/dev/sql.py) | `(bot, author_id, query, locale)` | 2 | 60 s | No — **recommend exclusion** | n/a | Confirm/cancel gate on an arbitrary SQL statement. The pending `query` string is the entire payload and must not be re-runnable after a restart (B.4). |
+| `BannerTypeSelectView` | [staff/commands/manage/banner/_modals.py:108](../staff/commands/manage/banner/_modals.py) | `(bot, author_id, locale, banner_id=None, prefill=None)` | 2 | 180 s | No | **Staff rank** | Two buttons that each open a modal. Carries a `prefill` dict of unsaved banner content (B.1). |
+| `StaffManagerPanel` | [staff/commands/manage/staff.py:35](../staff/commands/manage/staff.py) | `(*, bot, target, modifier, locale, …)` | 5 | 600 s | No | **Staff rank** | Grants and revokes staff roles/permissions — the highest-privilege panel in the bot. `target` and `modifier` are `discord.User` objects; a persistent version must encode `target_id` and re-fetch (B.1, B.2). |
+| `HelpView` | [staff/commands/team/help.py:34](../staff/commands/team/help.py) | `(*, bot, author_id, locale, data)` | 1 | 300 s | No | **Staff rank** | Department select over the staff command catalogue; `data` is a rebuildable registry snapshot. Lowest-risk staff view to migrate first. |
+| `_ModalButtonView` | [staff/framework/context.py:168](../staff/framework/context.py) | `(*, bot, author_id, modal_factory, label, …)` | 1 | 300 s | No — **recommend exclusion** | n/a | Generic "click to open a modal" shim whose behaviour is a `modal_factory` **callable** held in memory. Not serialisable into a custom_id (B.1, B.4). |
+| `ConfirmView` | [staff/framework/views.py:16](../staff/framework/views.py) | `(*, bot, author_id, locale, title, description, …)` | 2 | 60 s | No — **recommend exclusion** | n/a | Generic confirm/cancel whose "yes" branch is an in-memory callback. Same problem as `_ModalButtonView` (B.4). |
+
+### A.4 — `utils/`
+
+| Class | File | `__init__` signature | # children | Timeout | Persistent? | Proposed auth model | Why |
+|---|---|---|---|---|---|---|---|
+| `AppealPersistence` | [utils/appeal_views.py:850](../utils/appeal_views.py) | inherited | 0 | — | **Yes** | **Staff rank** (per-item) | Marker view; `register_persistent` calls `bot.add_dynamic_items(...)` for the five appeal buttons. Reference implementation for the `DynamicItem` case. |
+| `ShadowAnnotationPersistence` | [utils/automod_shadow_views.py:248](../utils/automod_shadow_views.py) | inherited | 0 | — | **Yes** | **Guild permission** (per-item) | Same marker pattern for `ShadowAnnotateButton`, which re-checks `manage_messages` on click. |
+| `CaseCreationView` | [utils/case_management_views.py:63](../utils/case_management_views.py) | `(*, bot, staff_id, subject_type, subject_id, subject_name, …)` | 4 | 300 s | No | **Staff rank** | Multi-step case creation wizard. The half-built case exists only in memory before Confirm (B.1). |
+| `AddSanctionView` | [utils/case_management_views.py:273](../utils/case_management_views.py) | `(*, bot, staff_id, case_id, reference, …)` | 1 | 300 s | No | **Staff rank** | Action select bound to an existing `case_id` — a good `DynamicItem` candidate (B.2). |
+| `RevokeSanctionView` | [utils/case_management_views.py:379](../utils/case_management_views.py) | `(*, bot, staff_id, reference, …)` | 1 | 300 s | No | **Staff rank** | Select over a case's active sanctions; keyed by `reference` (B.2). |
+| `CasesBrowserView` | [utils/cases_views.py:167](../utils/cases_views.py) | `(bot=None, *, mode="server", viewer_id=None, locale="en-US", …)` | 19 | None | **Yes** | **Owner only** (user mode) / **Guild permission** (server mode) | Already migrated. The reference for a mode-parameterised custom_id (`…:{mode}`) and for a `_build_shell()` fallback. |
+| `StaffHelpView` | [utils/staff_help_view.py:128](../utils/staff_help_view.py) | `(bot, user_id, user_roles)` | 1 | 180 s | No | **Staff rank** | Legacy staff help category select. `user_roles` is a `List[StaffRole]` that must be re-derived per click. Overlaps with `staff/commands/team/help.py::HelpView` — confirm both are still reachable before migrating either. |
+
+### A.5 — Out of scope
+
+| Class | File | Why |
+|---|---|---|
+| `FallbackErrorView` | [bot.py:950](../bot.py) | Last-resort error card used when the error handler itself is unavailable. URL button only, `timeout=None`. Must not depend on any registry. |
+
+
+---
+
+## Appendix B — Edge cases
+
+Views that do **not** drop cleanly through the 10-step cookbook, grouped by
+failure mode. A view can appear in more than one group.
+
+Unless a row says otherwise, the accepted UX is the one already stated in
+"State reconstruction → Working-copy / pending edits": **rebuild from the DB
+on the next click and let the user re-apply unsaved edits.** The rows below
+only spell out what is actually lost, so the migration agent can write the
+right i18n string instead of inventing one.
+
+### B.1 — Non-reconstructible in-memory state
+
+#### B.1.a — `working_config` panels (the standard case)
+
+Eight guild config panels follow the identical `current_config` /
+`working_config` / `has_changes` shape:
+
+| View | File | What is lost on restart |
+|---|---|---|
+| `AdaptiveSlowmodeConfigView` | [modules/configs/adaptive_slowmode_config.py:364](../modules/configs/adaptive_slowmode_config.py) | Added/removed/edited channel entries not yet saved |
+| `AutoRestoreRolesConfigView` | [modules/configs/auto_restore_roles_config.py:18](../modules/configs/auto_restore_roles_config.py) | Mode, excluded/included role selections, log channel |
+| `AutoRoleConfigView` | [modules/configs/auto_role_config.py:18](../modules/configs/auto_role_config.py) | Member-role and bot-role selections |
+| `AutomodAIConfigView` | [modules/configs/automod_ai_config.py:145](../modules/configs/automod_ai_config.py) | Every toggle, severity, max-action, language, indications text, immune roles/channels |
+| `InterServerConfigView` | [modules/configs/interserver_config.py:18](../modules/configs/interserver_config.py) | Channel + relay type (already named in the doc body) |
+| `StarboardConfigView` | [modules/configs/starboard_config.py:92](../modules/configs/starboard_config.py) | Channel, reaction count, emoji |
+| `WelcomeChannelConfigView` | [modules/configs/welcome_channel_config.py:119](../modules/configs/welcome_channel_config.py) | Channel, message text, embed title/description/colour, all toggles |
+| `WelcomeDmConfigView` | [modules/configs/welcome_dm_config.py:119](../modules/configs/welcome_dm_config.py) | Message text, embed title/description/colour, all toggles |
+
+**Proposed UX (all eight):** on a click that lands on the shell, re-read the
+saved config via `bot.module_manager.get_module_config(guild_id, module_id)`,
+rebuild with `has_changes = False`, and surface a one-line notice above the
+panel ("your unsaved changes were lost, the panel was reloaded"). One shared
+i18n key, not eight.
+
+> The `IndicationsModal` on `AutomodAIConfigView`
+> ([modules/configs/automod_ai_config.py:89](../modules/configs/automod_ai_config.py))
+> writes into `parent.working_config`, so it is a second, indirect path into
+> the same loss. Same treatment.
+
+#### B.1.b — Views holding a parent view reference
+
+These take another **live view object** as a constructor argument. It cannot
+be encoded in a custom_id and cannot be rebuilt from `interaction`.
+
+| View | Argument | Notes |
+|---|---|---|
+| `AdaptiveSlowmodeChannelConfigView` | `parent_view` — **required positional, no default** | Step 2 of the cookbook (make every arg optional) is not enough: the Back/Save callbacks call into `parent_view`. Proposed fix: drop the reference and have Back **construct a fresh `AdaptiveSlowmodeConfigView` from the DB**, which is what the user perceives anyway. |
+| `AutomodAIPrecedentsView` | `parent=None` | Already optional. Back should build a fresh `AutomodAIConfigView` from the DB. |
+| `BannerTypeSelectView` | `prefill=None` | An unsaved banner draft; the two buttons prefill a modal from it. Lost on restart → user re-enters. |
+| `ReminderSelectForEdit` / `ReminderSelectForDelete` / `ReminderAddModal` / `ReminderEditModal` | `parent_view=None` | Used to call `parent_view.refresh()` after a mutation. Replace with a rebuild-from-DB helper keyed on `interaction.user.id`. |
+| `AddNoteModal` / `EditNoteModal` / `ViewMessageModal` | `parent_view` | Same pattern in [cogs/saved_messages.py](../cogs/saved_messages.py). `ViewMessageModal` takes `parent_view` as a **required positional**. |
+
+#### B.1.c — State that is genuinely not in the database
+
+This is the group where "rebuild from DB" is **not** an available answer,
+because there is no row to read back.
+
+| View | State | Consequence | Proposal |
+|---|---|---|---|
+| `TranslateView` ([cogs/translate.py:21](../cogs/translate.py)) | `original_text`, `translated_text`, `from_lang` | Translations are not persisted. After a restart the language select has nothing to re-translate. | `NEEDS DECISION` — either (a) leave non-persistent and accept that the select dies on restart, or (b) re-read the source text from `interaction.message` and re-call the gateway (costs a DeepL call per click). Recommend (a): a translation card is short-lived and re-running `/translate` is cheap. |
+| `EmojiNavigationView` ([cogs/emoji.py:87](../cogs/emoji.py)) | `emoji_list` — the scanned result set | Pagination has no pages to page through. | Re-scan the guild's emojis on click (cheap, `guild.emojis` is cached), clamp the page from the custom_id. |
+| `InviteView` / `ServerInfoView` ([cogs/invite.py](../cogs/invite.py)) | `invite_data` — the fetched invite payload | Nothing to render on the other pane. | Encode the invite code in the custom_id and re-fetch. If that is judged too heavy, exclude both (they are throwaway lookup cards). |
+| `CaseCreationView` ([utils/case_management_views.py:63](../utils/case_management_views.py)) | The half-built case before Confirm | The wizard cannot complete. | Accept the loss and restart the wizard — a partially-built moderation case must **not** be silently resurrected. |
+| `SqlConfirmView` ([staff/commands/dev/sql.py:48](../staff/commands/dev/sql.py)) | `query` | See B.4 — deliberate exclusion. |
+| `ConfirmView` / `_ModalButtonView` (staff framework) | A Python callable | See B.4 — deliberate exclusion. |
+| `StaffManagerPanel` ([staff/commands/manage/staff.py:35](../staff/commands/manage/staff.py)) | `target` and `modifier` as `discord.User` objects | The panel does not know whose permissions it is editing. | Encode `target_id` in the custom_id (B.2) and re-fetch; derive `modifier` from `interaction.user`. |
+| `ReportView` ([cogs/interserver_commands.py:126](../cogs/interserver_commands.py)) | `claimed_by`, `content` | A claimed report reverts to unclaimed. | `NEEDS DECISION` — whether claim state is worth a DB column is a product call, not a migration call. |
+
+#### B.1.d — Snapshots that are cheap to re-derive (low risk)
+
+`RemindersManageView.reminders`, `SavedMessagesLibraryView.messages`,
+`AutomodAIPrecedentsView.rows`, `ServerListView.guilds`,
+`PreferencesView.user_data`, `HelpView.data`, `StaffHelpView.user_roles`,
+`CasesBrowserView.rows`. Each is a straight re-read (DB, `bot.guilds`, or the
+staff registry). No UX decision needed — just re-fetch in the callback.
+
+### B.2 — Requires `DynamicItem`
+
+A `custom_id` must encode a variable id, parsed back out by regex. See
+Appendix C for the full worked example.
+
+| View / item | Id to encode | Why a static constant will not do |
+|---|---|---|
+| `RemindersManageView` ([cogs/reminder.py:478](../cogs/reminder.py)) | `user_id` | Owner-only, and the same button constant would otherwise be shared by every user's card. |
+| `SavedMessagesLibraryView` ([cogs/saved_messages.py:222](../cogs/saved_messages.py)) | `user_id` + `page` (+ `detail_id` on the detail screen) | Owner-only **and** paginated; the page index has to survive. |
+| `PreferencesView` ([cogs/preferences.py:110](../cogs/preferences.py)) | `user_id` | Owner-only. |
+| `EmojiNavigationView` ([cogs/emoji.py:87](../cogs/emoji.py)) | `author_id` + `page` | Owner-only and paginated. |
+| `TranslateView` ([cogs/translate.py:21](../cogs/translate.py)) | `author_id` | Owner-only — only if B.1.c is resolved as "keep it". |
+| `AddSanctionView` ([utils/case_management_views.py:273](../utils/case_management_views.py)) | `case_id` (UUID) | The select acts on one specific case row. |
+| `RevokeSanctionView` ([utils/case_management_views.py:379](../utils/case_management_views.py)) | case `reference` | Same. |
+| `StaffManagerPanel` ([staff/commands/manage/staff.py:35](../staff/commands/manage/staff.py)) | `target_id` | The panel must know whose staff record it edits. |
+| `ServerListView` ([staff/commands/dev/serverlist.py:13](../staff/commands/dev/serverlist.py)) | `author_id` + `page` | Owner-only and paginated. |
+| `ReportView` ([cogs/interserver_commands.py:126](../cogs/interserver_commands.py)) | `moddy_id` | Identifies the relayed message being reported. |
+| `AutomodAIPrecedentsView` ([modules/configs/automod_ai_precedents_view.py:31](../modules/configs/automod_ai_precedents_view.py)) | `guild_id` + `page` | Guild-scoped and paginated. |
+
+Guild config panels **do not** need `DynamicItem`: `interaction.guild_id` is
+already on the interaction, so a static constant plus a re-checked
+`manage_guild` is sufficient. That is exactly what
+`SocialNotificationsConfigView` does today — copy it, don't over-engineer.
+
+Existing in-repo `DynamicItem` implementations to copy from:
+[`ShadowAnnotateButton`](../utils/automod_shadow_views.py) (simplest) and the
+five buttons in [`utils/appeal_views.py`](../utils/appeal_views.py). Note the
+`_guarded` decorator in both files — dynamic items dispatched via
+`bot.add_dynamic_items` have **no live `BaseView`**, so `BaseView.on_error`
+never fires and errors would otherwise vanish. Every new `DynamicItem`
+callback must be wrapped the same way.
+
+### B.3 — Unguarded `self.bot` access in the build method
+
+These will raise `AttributeError` on `None` the moment
+`register_all_persistent_views` constructs the shell with `bot=None`. Verified
+by walking each class's `_build_view` / `build_view` AST.
+
+| View | Build-method access |
+|---|---|
+| `ConfigMainView` ([cogs/config.py:62](../cogs/config.py)) | `self.bot.module_manager.get_available_modules()` |
+| `AdaptiveSlowmodeChannelConfigView` | `self.bot.get_channel(...)`, `self.bot.get_guild(...)` |
+| `AdaptiveSlowmodeConfigView` | `self.bot.get_guild(self.guild_id)` |
+| `AutoRestoreRolesConfigView` | `self.bot.get_guild(...)` ×4 |
+| `AutoRoleConfigView` | `self.bot.get_guild(...)` ×2 |
+| `InterServerConfigView` | `self.bot.get_channel(self.working_config['channel_id'])` |
+| `StarboardConfigView` | `self.bot.get_channel(self.working_config['channel_id'])` |
+| `WelcomeChannelConfigView` | `self.bot.get_channel(self.working_config['channel_id'])` |
+| `SubscriptionView` | `self.bot.get_guild(int(sid))` — moot once it is left unregistered (A.1) |
+| `TranslateView` | `self.bot.get_cog('Translate')` |
+| `AddSubscriptionView` | `self.bot.get_channel(...)`, `self.bot.get_guild(...)` — **already migrated in shape but these two lines are unguarded**, so registering it today (B.5) would fail at startup. Fix before adding it to the registry. |
+
+Already correct — use as the pattern:
+`ModdyMainView` (`if self.bot is not None:`),
+`ManageSubscriptionView` (`... if self.bot else None`),
+`CasesBrowserView._build_list` (`... if self.bot else None`).
+
+### B.4 — Should be excluded entirely
+
+Beyond the three exclusions already in the doc body (`BaseModal`, `ErrorView`,
+`WebhookView`):
+
+| View | Rationale |
+|---|---|
+| `SqlConfirmView` ([staff/commands/dev/sql.py:48](../staff/commands/dev/sql.py)) | Confirming an arbitrary SQL statement after a restart would execute a query the operator typed in a different process lifetime, with no visible context. Its short `timeout=60` is a **safety feature**, not an oversight — keep it. |
+| `ConfirmView` ([staff/framework/views.py:16](../staff/framework/views.py)) | Generic confirm/cancel; the "yes" branch is an in-memory Python callback with no stable identity. Persisting it would dispatch a click to a shell that does not know what it is confirming. Its `timeout=60` is likewise deliberate. |
+| `_ModalButtonView` ([staff/framework/context.py:168](../staff/framework/context.py)) | Same: behaviour is a `modal_factory` callable. Not serialisable. |
+| `FallbackErrorView` ([bot.py:950](../bot.py)) | Runs when the error handler itself is unavailable. It must not depend on the registry it may be reporting a failure in. URL button only. |
+| `PermissionErrorView`, `CooldownErrorView`, `NotFoundView` ([cogs/error_handler.py](../cogs/error_handler.py)) | URL-only or zero interactive children, and function-local. Nothing to dispatch. |
+| Every view with **0 interactive children** — `AvatarView`, `BannerView`, `EmojiView`, `RollView`, `TextResultView`, `InfoView`, `ProcessedView`, `WelcomeView`, `StaffLogView` | `bot.add_view` on a childless view is a no-op. **Do not add `__persistent__` to these.** The only change they may need is dropping a stale `timeout=` (`EmojiView` has `timeout=180`), which is cosmetic since there is nothing to expire. |
+
+### B.5 — Other things worth knowing before starting
+
+1. **Un-namespaced `custom_id` collisions — the biggest correctness hazard.**
+   Discord dispatches on `(component_type, custom_id)` globally. Several
+   already-set custom_ids are bare strings that collide across unrelated
+   views:
+   - `"back_btn"` — `cogs/reminder.py`, `cogs/saved_messages.py`,
+     `cogs/preferences.py`, `modules/configs/interserver_config.py`,
+     `modules/configs/starboard_config.py`,
+     `modules/configs/welcome_channel_config.py`,
+     `modules/configs/welcome_dm_config.py`
+   - `"save_btn"` / `"cancel_btn"` / `"delete_btn"` — the same five config panels
+   - `"edit_message"`, `"toggle_embed"`, `"toggle_thumbnail"`,
+     `"toggle_author"`, `"edit_embed_title"`, `"edit_embed_color"`,
+     `"edit_embed_description"` — **identical in
+     `welcome_channel_config.py` and `welcome_dm_config.py`**
+   - `"prev_btn"` / `"next_btn"` / `"page_info"` — `cogs/saved_messages.py`
+     vs `"prev_emoji_btn"`/`"next_emoji_btn"`/`"page_info"` in `cogs/emoji.py`
+     (`"page_info"` collides exactly)
+
+   Today this is harmless because none of these views are registered — the
+   live in-memory view always wins. **The moment two colliding views are both
+   registered, one silently shadows the other.** Rule for the migration:
+   never register a view until every one of its custom_ids has been renamed
+   to `moddy:<cog>:<view>:<action>`.
+
+2. **Three views bypass `BaseView` entirely** and subclass `LayoutView`
+   directly: `PreferencesView` ([cogs/preferences.py:110](../cogs/preferences.py)),
+   `RemindersManageView` ([cogs/reminder.py:478](../cogs/reminder.py)),
+   `SavedMessagesLibraryView` ([cogs/saved_messages.py:222](../cogs/saved_messages.py)).
+   They get no centralized error handling and no `__persistent__` hook. They
+   must be re-parented to `BaseView` **before** migration — that is a
+   behaviour change (errors start routing to the handler) and deserves its own
+   commit.
+
+3. **Three views are already migrated in shape but never registered.**
+   `AddSubscriptionView` and `ManageSubscriptionView`
+   ([modules/configs/social_notifications_config.py](../modules/configs/social_notifications_config.py))
+   have optional-arg constructors and full namespaced custom_ids, but are
+   absent from `_collect_persistent_view_classes()`. Their buttons therefore
+   still die on restart. Either register them (after fixing the unguarded
+   `self.bot` in `AddSubscriptionView._build_view`, B.3) or add a comment
+   explaining why not. This is the cheapest real win in the whole migration.
+
+4. **Function-local view classes cannot be registered at all.** `ReportView`,
+   `InfoView`, `ProcessedView` ([cogs/interserver_commands.py](../cogs/interserver_commands.py)),
+   `WelcomeView`, `StaffLogView` ([modules/interserver.py](../modules/interserver.py)),
+   `PermissionErrorView`, `CooldownErrorView`, `NotFoundView`
+   ([cogs/error_handler.py](../cogs/error_handler.py)) are defined **inside
+   functions**. `_collect_persistent_view_classes()` cannot import them.
+   `ReportView` is the only one of these with dispatchable buttons, so it is
+   the only one that needs hoisting to module level — a refactor, not a
+   mechanical edit. Flag it, don't attempt it in the same commit.
+
+5. **`StaffHelpView` and `HelpView` overlap.**
+   [utils/staff_help_view.py:128](../utils/staff_help_view.py) and
+   [staff/commands/team/help.py:34](../staff/commands/team/help.py) both render
+   a staff command catalogue with a category select.
+   `UNKNOWN — needs human input`: whether the `utils/` one is still reachable.
+   Do not migrate both; confirm first.
+
+6. **`InviteView` ships a button labelled `Raw Data` marked `# TEMP: … for
+   debugging`** ([cogs/invite.py:73](../cogs/invite.py)), duplicated in the
+   non-guild branch. `UNKNOWN — needs human input`: whether it should be
+   removed rather than given a permanent custom_id.
+
+7. **`discord.py` is not installed in the current dev/test environment.**
+   `requirements-dev.txt` pins only `pytest` and `pytest-asyncio`; the existing
+   `tests/automod/` suite is deliberately Discord-free. Any persistence smoke
+   test needs `pip install -r requirements.txt` first — see Appendix D.
+
+---
+
+## Appendix C — `DynamicItem` reference implementation
+
+Step 6 of the cookbook says "use a `DynamicItem` subclass when the id is
+encoded with a regex". This appendix is the worked example.
+
+**When you need this**: only when the callback needs an id that is **not
+already on the interaction**. `interaction.user.id`, `interaction.guild_id`
+and `interaction.channel_id` are always available, so a guild config panel
+never needs a `DynamicItem` — a static `custom_id` constant plus a re-checked
+permission is enough (that is what `SocialNotificationsConfigView` does).
+
+You need a `DynamicItem` when the id is **the owner of the message rather
+than the clicker** (owner-only views: the point is to reject a *different*
+user), or when it is a page index, a case UUID, or any other per-message
+value.
+
+**Subject chosen**: `RemindersManageView`
+([cogs/reminder.py:478](../cogs/reminder.py)) — owner-only, five buttons, a
+`show_history` sub-screen, and custom_ids that currently collide with three
+other views. It is the most representative user-scoped view in the codebase.
+
+### C.1 — Before
+
+```python
+# cogs/reminder.py (abridged, as it exists today)
+
+class RemindersManageView(LayoutView):          # (1) not a BaseView
+    """Main view for managing reminders"""
+
+    def __init__(self, bot, user_id: int, reminders: List[Dict], locale: str,
+                 user_tz: ZoneInfo, show_history: bool = False,
+                 past_reminders: List[Dict] = None,
+                 original_interaction: discord.Interaction = None):
+        super().__init__(timeout=300)           # (2) dies after 5 minutes
+        self.bot = bot
+        self.user_id = user_id                  # (3) owner kept in memory only
+        self.reminders = reminders              # (4) unsaved snapshot
+        self.show_history = show_history
+        self._build_view()
+
+    def _build_view(self):
+        self.clear_items()
+        container = Container()
+        ...
+        add_btn = discord.ui.Button(
+            label=t("commands.reminder.buttons.add", locale=self.locale),
+            style=discord.ButtonStyle.success,
+            custom_id="add_btn",                # (5) collides globally
+        )
+        add_btn.callback = self.add_callback    # (6) bound to THIS instance
+        btn_row1.add_item(add_btn)
+        ...
+
+    async def interaction_check(self, interaction) -> bool:
+        # (7) compares against self.user_id — empty on a restarted shell
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                t("commands.reminder.errors.author_only", interaction),
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def add_callback(self, interaction: discord.Interaction):
+        modal = ReminderAddModal(self.locale, self.bot, parent_view=self)
+        await interaction.response.send_modal(modal)
+```
+
+Seven problems, numbered above. After a restart `self.user_id` is `None`, so
+`interaction_check` rejects **everyone** — and before that, `timeout=300`
+means the buttons are already dead.
+
+### C.2 — After
+
+```python
+# cogs/reminder.py
+from __future__ import annotations
+
+import re
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseView
+from utils.components_v2 import create_error_message
+from utils.i18n import i18n, t
+
+# --------------------------------------------------------------------------- #
+# custom_id template
+#
+#   moddy:rem:manage:<action>:<owner_id>[:<page>]
+#
+# `owner_id` is the user the card was rendered FOR. It is compared against
+# interaction.user.id on every click. A Discord snowflake is public
+# information already visible in the message, so encoding it leaks nothing.
+# --------------------------------------------------------------------------- #
+
+_ACTIONS = "add|edit|delete|history|back"
+_CID_TEMPLATE = rf"moddy:rem:manage:(?P<action>{_ACTIONS}):(?P<owner>\d{{17,20}})"
+
+
+def _guarded(callback):
+    """Route DynamicItem callback errors to the central error handler.
+
+    A DynamicItem dispatched via ``bot.add_dynamic_items`` has no live
+    ``BaseView``, so ``BaseView.on_error`` never fires. Without this wrapper
+    an exception in the callback is swallowed and the user just sees
+    "This interaction failed". Copied from ``utils/appeal_views.py``.
+    """
+    async def wrapper(self, interaction: discord.Interaction):
+        try:
+            await callback(self, interaction)
+        except Exception as e:  # noqa: BLE001 — funnel everything to the handler
+            from cogs.error_handler import report_component_error
+            await report_component_error(interaction, e, self.__class__.__name__)
+    return wrapper
+
+
+class ReminderManageButton(ui.DynamicItem[ui.Button], template=_CID_TEMPLATE):
+    """One button on the /reminder manage card. Auth: owner only.
+
+    The owner id is encoded in the custom_id so a restarted bot can still
+    tell the card's owner from a passer-by clicking someone else's buttons.
+    """
+
+    _STYLE = {
+        "add":     discord.ButtonStyle.success,
+        "edit":    discord.ButtonStyle.primary,
+        "delete":  discord.ButtonStyle.danger,
+        "history": discord.ButtonStyle.secondary,
+        "back":    discord.ButtonStyle.secondary,
+    }
+    _EMOJI = {
+        "add":     "<:add:1520000000000000001>",
+        "edit":    "<:edit:1520000000000000002>",
+        "delete":  "<:delete:1520000000000000003>",
+        "history": "<:history:1520000000000000004>",
+        "back":    "<:back:1519795556665397431>",
+    }
+
+    def __init__(self, action: str, owner_id: int, *,
+                 locale: str = "en-US", disabled: bool = False):
+        super().__init__(
+            ui.Button(
+                label=t(f"commands.reminder.buttons.{action}", locale=locale)[:80],
+                style=self._STYLE[action],
+                emoji=discord.PartialEmoji.from_str(self._EMOJI[action]),
+                custom_id=f"moddy:rem:manage:{action}:{owner_id}",
+                disabled=disabled,
+            )
+        )
+        self.action = action
+        self.owner_id = owner_id
+
+    # -- reconstruction after a restart ---------------------------------- #
+    @classmethod
+    async def from_custom_id(cls, interaction: discord.Interaction,
+                             item: ui.Button, match: re.Match):
+        """Rebuild the item from the clicked custom_id.
+
+        Runs on EVERY click once the item is registered — the live instance is
+        not reused. Keep it cheap and side-effect free: no DB, no API calls.
+        Locale is deliberately re-derived here, never encoded in the id.
+        """
+        return cls(
+            match["action"],
+            int(match["owner"]),
+            locale=i18n.get_user_locale(interaction),
+        )
+
+    # -- ownership check -------------------------------------------------- #
+    async def _reject_if_not_owner(self, interaction: discord.Interaction) -> bool:
+        """Return True (and answer ephemerally) if the clicker is not the owner."""
+        if interaction.user.id == self.owner_id:
+            return False
+        locale = i18n.get_user_locale(interaction)
+        await interaction.response.send_message(
+            view=create_error_message(
+                t("commands.reminder.errors.author_only_title", locale=locale),
+                t("commands.reminder.errors.author_only", locale=locale),
+            ),
+            ephemeral=True,
+        )
+        return True
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if await self._reject_if_not_owner(interaction):
+            return
+
+        # Re-derive EVERYTHING from the interaction — there is no live view.
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        user_id = interaction.user.id
+
+        if self.action == "add":
+            await interaction.response.send_modal(
+                ReminderAddModal(locale, bot, owner_id=user_id)
+            )
+            return
+
+        # Every other action re-reads from the DB and re-renders in place.
+        view = await RemindersManageView.build_for(
+            bot, user_id, locale, show_history=(self.action == "history")
+        )
+        await interaction.response.edit_message(view=view)
+```
+
+The view itself becomes a thin renderer — it holds no authorization state at
+all, because the buttons carry it:
+
+```python
+class RemindersManageView(BaseView):
+    """Reminder management card. Persistent: yes (via ReminderManageButton).
+
+    Auth: owner only — enforced per-button by the encoded owner_id, NOT by
+    interaction_check (which cannot work on a restarted shell).
+    """
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, owner_id: int | None = None,
+                 locale: str = "en-US", reminders: list | None = None,
+                 past_reminders: list | None = None,
+                 user_tz=None, show_history: bool = False):
+        super().__init__()                      # timeout=None
+        self.bot = bot
+        self.owner_id = owner_id
+        self.locale = locale
+        self.reminders = reminders or []
+        self.past_reminders = past_reminders or []
+        self.user_tz = user_tz
+        self.show_history = show_history
+        self._build_view()
+
+    @classmethod
+    async def build_for(cls, bot, owner_id: int, locale: str, *,
+                        show_history: bool = False) -> "RemindersManageView":
+        """Fetch fresh state and return a rendered view. The ONLY constructor
+        callers should use — it guarantees the data is not a stale snapshot."""
+        reminders = await bot.db.get_user_reminders(owner_id)
+        past = await bot.db.get_user_past_reminders(owner_id) if show_history else []
+        tz = await get_user_timezone(bot, owner_id, locale)
+        return cls(bot, owner_id, locale, reminders, past, tz, show_history)
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container()
+        # ... TextDisplays, guarded with `if self.bot is not None:` where they
+        #     touch live bot state ...
+
+        row = ui.ActionRow()
+        if self.show_history:
+            row.add_item(ReminderManageButton(
+                "back", self.owner_id or 0, locale=self.locale))
+        else:
+            row.add_item(ReminderManageButton(
+                "add", self.owner_id or 0, locale=self.locale))
+            row.add_item(ReminderManageButton(
+                "edit", self.owner_id or 0, locale=self.locale,
+                disabled=not self.reminders))
+            row.add_item(ReminderManageButton(
+                "delete", self.owner_id or 0, locale=self.locale,
+                disabled=not self.reminders))
+            row.add_item(ReminderManageButton(
+                "history", self.owner_id or 0, locale=self.locale))
+        container.add_item(row)
+        self.add_item(container)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: owner only — owner_id is encoded in each button's
+        custom_id and compared to interaction.user.id on click."""
+        bot.add_dynamic_items(ReminderManageButton)
+```
+
+Then in [`utils/persistent_views.py`](../utils/persistent_views.py):
+
+```python
+from cogs.reminder import RemindersManageView
+...
+    # Group 6 — /reminder manage (owner-only dynamic items)
+    RemindersManageView,
+```
+
+### C.3 — Things that bite
+
+- **`bot.add_dynamic_items(Cls)`, not `bot.add_view(cls())`.** A view whose
+  children are `DynamicItem`s does not need `add_view` at all; registering the
+  item class is what makes dispatch work. `AppealPersistence` and
+  `ShadowAnnotationPersistence` are marker views that do exactly this and add
+  no children of their own — that pattern is fine when the buttons live on
+  several different cards.
+- **Wrap the callback in `_guarded`.** Non-negotiable: without a live
+  `BaseView`, `BaseView.on_error` is never invoked and exceptions disappear.
+- **`from_custom_id` runs on every click**, not only after a restart. It must
+  be cheap and free of side effects. Put DB reads in `callback`.
+- **Regex escaping in f-strings.** `\d{17,20}` inside an f-string needs
+  doubled braces: `rf"...\d{{17,20}}"`. Both existing implementations sidestep
+  this by defining `_UUID` as a plain module constant and interpolating it —
+  copy that if the template gets long.
+- **The template must match the emitted `custom_id` exactly.** A mismatch
+  fails silently: the click is simply never dispatched. Assert it in the smoke
+  test (Appendix D).
+- **100-character limit** on `custom_id`. `moddy:rem:manage:history:` +
+  a 20-digit snowflake is 45 — fine. Watch it when encoding two UUIDs.
+- **Do not encode `locale`.** Re-derive with `i18n.get_user_locale(interaction)`
+  so a card rendered in French answers an English clicker in English.
+- **`create_error_message(title, description)` needs two strings.** Today's
+  owner checks pass a single bare string to `send_message`. `author_only`
+  exists in the locale files but there is no matching **title** key — the
+  migration must add one (e.g. `commands.reminder.errors.author_only_title`)
+  to both `locales/fr.json` and `locales/en-US.json`, or reuse a shared
+  `errors.not_your_message.title`. Decide once and apply it to every
+  owner-only view rather than inventing a key per cog.
+
+---
+
+## Appendix D — Verification command
+
+### D.1 — Current state of the test setup
+
+| Fact | Value |
+|---|---|
+| Runner | `pytest` (config in [`pytest.ini`](../pytest.ini)) |
+| `testpaths` | `tests` |
+| Collected files | `test_*.py` only — the other files in `tests/` (`Test V2.py`, `404 disboard test.py`, …) are manual scratch scripts and are **not** collected |
+| Event loop | `pytest-asyncio` with `asyncio_mode = auto` — an `async def test_…` gets a loop with no decorator and no fixture |
+| `sys.path` | [`conftest.py`](../conftest.py) at the repo root inserts the root, so `import utils` / `import cogs` work from anywhere |
+| Existing suites | [`tests/automod/`](../tests/automod) — deliberately Discord-free pure-Python |
+| Dev deps | [`requirements-dev.txt`](../requirements-dev.txt) — `pytest`, `pytest-asyncio` only. **`discord.py` is NOT installed by it.** |
+| CI | No `.github/workflows` in the repo; `make test` runs `pytest -q` |
+
+**There is no persistent-views test file today.** The spec for one is in D.3.
+
+### D.2 — The command to run after each module
+
+```bash
+# once per environment — the suite imports discord.py, which
+# requirements-dev.txt does not pull in
+pip install -r requirements.txt -r requirements-dev.txt
+
+# after migrating a module, run only its slice:
+pytest tests/test_persistent_views.py -k reminder -q
+
+# before committing, run the whole persistence suite:
+pytest tests/test_persistent_views.py -q
+
+# before opening the PR, the full suite (must stay green):
+make test
+```
+
+The `-k <module>` filter works because the parametrised test ids are the
+class names — `-k reminder` matches `RemindersManageView`, `-k welcome`
+matches both welcome panels, `-k config` matches every `*ConfigView`.
+
+> **`asyncio_mode = auto` is what makes this work.** `discord.ui.View.__init__`
+> wants a running event loop; an `async def` test body provides one. A plain
+> `def` test would raise `RuntimeError: no running event loop` on the first
+> instantiation. Every test below is therefore `async def`.
+
+### D.3 — Spec for `tests/test_persistent_views.py`
+
+Create this file (path exactly as below — `test_*` so `pytest.ini` collects
+it). **Do not create it during the recon pass**; the migration agent creates
+it in its first commit, before touching any view.
+
+```python
+"""Persistence contract tests.
+
+Every class in ``utils/persistent_views.py::_collect_persistent_view_classes()``
+must be constructible as a bare shell and must satisfy discord.py's definition
+of a persistent view. Run with:
+
+    pytest tests/test_persistent_views.py -q
+    pytest tests/test_persistent_views.py -k <module> -q
+"""
+
+import re
+
+import pytest
+
+from utils.persistent_views import _collect_persistent_view_classes
+
+# Parametrise by class so `-k <name>` filters to one module's views.
+VIEW_CLASSES = _collect_persistent_view_classes()
+IDS = [c.__name__ for c in VIEW_CLASSES]
+
+CID_RE = re.compile(r"^moddy:[a-z0-9_]+:[a-z0-9_]+:[a-z0-9_]+(:.+)?$")
+
+
+@pytest.fixture
+def shell(request):
+    """A default-constructed view — mirrors what register_persistent builds.
+
+    No bot, no guild, no user: exactly the state discord.py falls back to
+    after a restart. Constructing this is the single most valuable assertion
+    in the suite; most migration bugs are an AttributeError right here.
+    """
+    return request.param()
+
+
+@pytest.mark.parametrize("cls", VIEW_CLASSES, ids=IDS)
+async def test_shell_constructs(cls):
+    """Step 2 + step 3 of the cookbook: optional args, guarded self.bot."""
+    cls()  # must not raise
+
+
+@pytest.mark.parametrize("cls", VIEW_CLASSES, ids=IDS)
+async def test_marked_persistent(cls):
+    """Step 7: the registry skips anything without __persistent__."""
+    assert cls.__persistent__ is True
+
+
+@pytest.mark.parametrize("cls", VIEW_CLASSES, ids=IDS)
+async def test_no_timeout(cls):
+    view = cls()
+    assert view.timeout is None, (
+        f"{cls.__name__} passes a numeric timeout to super().__init__(); "
+        "a persistent view must not expire"
+    )
+
+
+@pytest.mark.parametrize("cls", VIEW_CLASSES, ids=IDS)
+async def test_is_persistent(cls):
+    """The assertion cookbook step 10 is really asking for.
+
+    Marker views (AppealPersistence, ShadowAnnotationPersistence) have zero
+    children and are trivially persistent — they register dynamic items in
+    register_persistent instead. Both cases must pass.
+    """
+    view = cls()
+    assert view.is_persistent(), (
+        f"{cls.__name__} has at least one child without a custom_id"
+    )
+
+
+@pytest.mark.parametrize("cls", VIEW_CLASSES, ids=IDS)
+async def test_custom_ids_are_namespaced(cls):
+    """Guards against the collisions catalogued in Appendix B.5."""
+    view = cls()
+    for item in view.walk_children():
+        cid = getattr(item, "custom_id", None)
+        if cid is None or getattr(item, "url", None):
+            continue
+        assert CID_RE.match(cid), (
+            f"{cls.__name__}: custom_id {cid!r} is not "
+            "moddy:<cog>:<view>:<action>[:<param>]"
+        )
+
+
+async def test_no_duplicate_custom_ids_across_registered_views():
+    """Two registered views sharing a custom_id: one silently shadows the other.
+
+    This is the test that would have caught welcome_channel_config and
+    welcome_dm_config shipping identical ids.
+    """
+    seen: dict[str, str] = {}
+    for cls in VIEW_CLASSES:
+        for item in cls().walk_children():
+            cid = getattr(item, "custom_id", None)
+            if cid is None or getattr(item, "url", None):
+                continue
+            assert cid not in seen, (
+                f"custom_id {cid!r} is used by both {seen[cid]} and "
+                f"{cls.__name__} — clicks will dispatch to only one of them"
+            )
+            seen[cid] = cls.__name__
+
+
+# --------------------------------------------------------------------------- #
+# DynamicItem templates
+#
+# A template that does not match the custom_id the item emits fails SILENTLY:
+# the click is never dispatched and the user sees "This interaction failed".
+# Add one row per DynamicItem subclass as the migration introduces them.
+# --------------------------------------------------------------------------- #
+
+def _dynamic_item_cases():
+    from utils.automod_shadow_views import ShadowAnnotateButton
+    from utils.appeal_views import (
+        AppealNewButton, AppealClaimButton, AppealInviteButton,
+        AppealDecisionButton, AppealAcceptChoiceButton,
+    )
+    _U = "0f7d9c62-3b4e-4a1f-9c2d-5e6f70819a2b"
+    return [
+        (ShadowAnnotateButton, ("ok", _U)),
+        (AppealNewButton, ("s", _U, _U)),
+        (AppealClaimButton, (_U,)),
+        (AppealInviteButton, (_U,)),
+        (AppealDecisionButton, ("accept", _U)),
+        (AppealAcceptChoiceButton, ("full", _U)),
+        # (ReminderManageButton, ("add", 123456789012345678)),  # Appendix C
+    ]
+
+
+@pytest.mark.parametrize(
+    "cls,args", _dynamic_item_cases(),
+    ids=lambda v: getattr(v, "__name__", ""),
+)
+async def test_dynamic_item_template_matches_emitted_id(cls, args):
+    item = cls(*args)
+    cid = item.item.custom_id
+    assert cls.__discord_ui_compiled_template__.fullmatch(cid), (
+        f"{cls.__name__}: template does not match its own custom_id {cid!r}"
+    )
+    assert len(cid) <= 100, f"{cls.__name__}: custom_id exceeds 100 chars"
+```
+
+**Notes for whoever writes it**
+
+- `__discord_ui_compiled_template__` is the attribute discord.py 2.7 stores
+  the compiled `template=` regex on. Confirm the name against the installed
+  version before relying on it; if it moved, re-compile the template string
+  in the test instead.
+- The `shell` fixture above is only needed if the migration adds tests that
+  want a constructed instance by name; the parametrised tests construct
+  inline. Drop it if unused.
+- These tests intentionally do **not** touch the DB, the gateway, or a live
+  bot. If a view cannot be constructed without one of those, that is the bug
+  the test is reporting — fix the view, do not mock the bot.
+
+---
+
+## Appendix E — Suggested migration order
+
+Ordered easiest/lowest-risk first. Each numbered step is one commit, so a
+regression is bisectable and revertable without unpicking anything else.
+
+The ordering follows three rules:
+1. **Infrastructure before views** — the test harness and the naming scheme
+   must exist before anything is registered, or early commits cannot be
+   verified.
+2. **Blast radius ascending** — cosmetic → public read-only → personal data →
+   guild config → moderation → staff privilege.
+3. **Never register a colliding pair separately.** `welcome_channel_config`
+   and `welcome_dm_config` share every custom_id and must move in one commit.
+
+| # | Step | Views | Risk | Rationale |
+|---|---|---|---|---|
+| 0 | Test harness | — | None | Create `tests/test_persistent_views.py` per Appendix D against the 7 already-registered classes. If it does not pass on today's code, the spec is wrong before a single view moves. |
+| 1 | Register the three ready-made views | `AddSubscriptionView`, `ManageSubscriptionView` (+ fix the unguarded `self.bot` in `AddSubscriptionView._build_view`) | Very low | Already migrated in shape (B.5.3). A one-line registry change plus a two-line guard. Proves the whole pipeline end to end with almost no new code. |
+| 2 | Timeout-only cleanups | `AvatarView`, `BannerView`, `EmojiView`, `RollView`, `TextResultView`, `SubscriptionView`, `InfoView`, `ProcessedView`, `WelcomeView`, `StaffLogView` | Very low | Zero interactive children (or URL-only). Drop the stale `timeout=180/300`, add **no** `__persistent__`, register nothing. Purely subtractive. |
+| 3 | Shared i18n keys | — | Very low | Add the owner-rejection title/description keys to `fr.json` + `en-US.json` once (see C.3), so steps 5-8 do not each invent their own. |
+| 4 | Re-parent the three `LayoutView` orphans | `PreferencesView`, `RemindersManageView`, `SavedMessagesLibraryView` | Low | `LayoutView` → `BaseView` only (B.5.2). Behaviour change: errors start reaching the central handler. Its own commit so that change is not tangled with persistence. |
+| 5 | `/moddy`-adjacent public views | `InviteView`, `ServerInfoView`, `UserInfoView` | Low | Public auth, no DB writes, and `ModdyMainView` is already the worked example for exactly this shape. Resolve the `# TEMP` Raw Data button (B.5.6) here. |
+| 6 | Owner-only, no `DynamicItem` needed | `PreferencesView` | Low | The single simplest owner-only view — 2 children, state is one DB row. Use it to validate the owner-rejection path before the harder ones. |
+| 7 | Owner-only with `DynamicItem` | `RemindersManageView`, then `SavedMessagesLibraryView`, then `EmojiNavigationView` | Medium | Appendix C is written against `RemindersManageView` — do it first and literally. `SavedMessagesLibraryView` adds pagination + a detail screen; `EmojiNavigationView` adds re-scanning (B.1.c). |
+| 8 | Small guild config panels | `AutoRoleConfigView`, `AutoRestoreRolesConfigView`, `StarboardConfigView`, `InterServerConfigView` | Medium | The standard `working_config` shape (B.1.a) at its smallest — 6-8 children each. Establishes the shared "unsaved changes were lost" notice that steps 9-10 reuse. |
+| 9 | The colliding welcome pair | `WelcomeChannelConfigView` **and** `WelcomeDmConfigView` — one commit | Medium-high | 24 children between them and a 1:1 custom_id collision (B.5.1). Splitting this commit would register two views that shadow each other. |
+| 10 | `ConfigMainView` | `ConfigMainView` | Medium-high | The router every panel returns to, and its `_build_view` calls `self.bot.module_manager` unguarded (B.3). Deliberately after the panels it routes to, so a break here is obviously this commit. |
+| 11 | Adaptive slowmode | `AdaptiveSlowmodeConfigView`, `AdaptiveSlowmodeChannelConfigView` | High | The `parent_view` required-positional problem (B.1.b) forces a real refactor of the Back/Save flow, not a mechanical edit. |
+| 12 | Automod config | `AutomodAIConfigView`, `AutomodAIPrecedentsView` | High | 14 children, the largest `working_config`, a lazily-loaded precedent count, a modal that writes into the parent, and a `parent` link. Everything hard in one panel. |
+| 13 | Case management | `AddSanctionView`, `RevokeSanctionView`, `CaseCreationView` | High | Mutates moderation records. `AddSanctionView`/`RevokeSanctionView` are clean `DynamicItem` candidates keyed on `case_id`; `CaseCreationView` may be better left non-persistent (B.1.c) — decide before starting. |
+| 14 | Staff, read-only first | `HelpView`, then `ServerListView`, then `EmojiPreviewView` | Medium | Staff rank auth, but nothing they do is destructive. `HelpView` has one select and a rebuildable registry snapshot — the gentlest introduction to re-running `staff_permissions` on click. |
+| 15 | `StaffManagerPanel` | `StaffManagerPanel` | Highest | Grants and revokes staff permissions. A dispatch bug here is a privilege-escalation bug. Needs `target_id` encoded (B.2) and the staff check re-run on every click. **Last, and reviewed by a human.** |
+| — | Deferred / not in this migration | `ReportView` (hoist out of a function first, B.5.4), `TranslateView` (B.1.c decision), `StaffHelpView` (dedupe against `HelpView` first, B.5.5) | — | Each needs a product or refactor decision that is not the migration agent's to make. |
+| — | Never | `SqlConfirmView`, `ConfirmView`, `_ModalButtonView`, `WebhookView`, `ErrorView`, `FallbackErrorView`, `PermissionErrorView`, `CooldownErrorView`, `NotFoundView`, all `BaseModal` subclasses | — | See B.4 and "Deliberate exclusions". |
+
+After every numbered step: run
+`pytest tests/test_persistent_views.py -q` and commit. Do not batch two steps
+into one commit, even when both are one-liners — the duplicate-custom_id test
+is the one most likely to fail, and a single-step commit says immediately
+which view introduced the clash.


### PR DESCRIPTION
## Summary

This PR adds four detailed appendices to `docs/PERSISTENT_VIEWS.md` that provide a complete reference for migrating Discord UI views to persistent/dynamic item registration. These appendices transform the document from a conceptual guide into an actionable migration playbook.

## Changes

- **Appendix A — View inventory & auth mapping**: A comprehensive table of all 50+ `discord.ui.View` subclasses in the codebase (across `cogs/`, `modules/`, `staff/`, and `utils/`), with columns for file location, constructor signature, child component count, timeout, persistence status, proposed auth model, and rationale. Includes three subsections for different directory trees and an "out of scope" section for views that should not be registered.

- **Appendix B — Edge cases**: Grouped failure modes for views that don't fit the standard 10-step cookbook:
  - **B.1** — Non-reconstructible in-memory state (working_config panels, parent view references, genuinely non-persisted data, cheap-to-re-derive snapshots)
  - **B.2** — Views requiring `DynamicItem` with regex-encoded ids (owner-only, paginated, or case-scoped views)
  - **B.3** — Unguarded `self.bot` access in build methods (will crash on shell construction with `bot=None`)
  - **B.4** — Views that should be excluded entirely (SQL confirm, generic callbacks, error views, childless views)
  - **B.5** — Other critical issues (un-namespaced custom_id collisions, views bypassing `BaseView`, already-migrated-but-unregistered views, function-local classes, overlapping help views, temporary debug buttons, missing discord.py in test environment)

- **Appendix C — `DynamicItem` reference implementation**: A complete worked example using `RemindersManageView` as the subject, showing:
  - Before/after code comparison (7 problems identified)
  - Full implementation of `ReminderManageButton` as a `DynamicItem` subclass with regex template
  - `from_custom_id` reconstruction method
  - Ownership check and `_guarded` error routing
  - Refactored view class that holds no authorization state
  - Registration pattern via `bot.add_dynamic_items()`
  - Common pitfalls and gotchas (100-char limit, locale handling, template matching, error message structure)

- **Appendix D — Verification command**: Placeholder section documenting the current test setup (pytest, testpaths, collected files) and noting that discord.py is not installed in the dev environment, so persistence smoke tests require `pip install -r requirements.txt`.

## Notable Details

- **Collision inventory**: B.5 documents 7 un-namespaced custom_id collisions across config panels (e.g., `"back_btn"` shared by 7 views, `"edit_embed_title"` identical in welcome_channel and welcome_dm configs). These are harmless today because views are unregistered, but will silently shadow each other once both are registered.

- **Hardest case identified**: `AdaptiveSlowmodeChannelConfigView` takes `parent_view` as a required positional argument with no default — cannot be encoded in a custom_id and cannot be rebuilt. Proposed fix: drop the reference and have Back construct a fresh parent view from the DB.

- **Already-migrated-but-unregistered**: `AddSubscriptionView` and `ManageSubscriptionView` have the right shape and custom_ids but are absent from `_collect_persistent_view_classes()`. Flagged as the cheapest real win in the migration.

- **Function-local classes**: Five views are defined inside functions and cannot be imported by the registry. `ReportView` is the only one with dispatchable buttons and needs hoisting to module level.

- **Childless views**: Explicitly noted that views with 0 interactive children (avatar, banner, emoji info, roll, text result, etc.) should **not** be marked `__persistent__` — `bot.add_view` on them is a no-op.

This documentation enables the migration team to:
1. Priorit

https://claude.ai/code/session_01E1LQrJCcSHki2Giy8FKNRW