### PR TITLE
Starboard: fix verification badge, add link previews and a reactors button

### DIFF
--- a/docs/COMPONENTS_V2.md
+++ b/docs/COMPONENTS_V2.md
@@ -352,9 +352,9 @@ demandé : elle utilise un vrai `discord.Embed()` (barre latérale colorée,
 avatar + nom en en-tête, timestamp natif) plutôt que Components V2, pour
 reproduire le rendu d'une app Starboard classique. Discord interdit de
 combiner un embed avec le flag `IS_COMPONENTS_V2` (donc `BaseView`/
-`ui.LayoutView`) sur le même message — le bouton "aller au message" y est
-donc un `discord.ui.View` classique (`_StarboardJumpView`), pas un
-`BaseView`. Voir le docstring de `StarboardModule` et
+`ui.LayoutView`) sur le même message — les boutons (compteur de réactions +
+"aller au message") vivent donc dans un `discord.ui.View` classique
+(`_StarboardCardView`), pas un `BaseView`. Voir le docstring de `StarboardModule` et
 [docs/PERSISTENT_VIEWS.md](PERSISTENT_VIEWS.md) (section "Deliberate
 exclusions") pour le détail. Ne pas reproduire ce pattern ailleurs sans la
 même justification explicite.

--- a/docs/PERSISTENT_VIEWS.md
+++ b/docs/PERSISTENT_VIEWS.md
@@ -401,12 +401,21 @@ was easier not to" is not one.
   children are `ButtonStyle.link` buttons (e.g. `SubscriptionView`) —
   `bot.add_view()` on these is a no-op. Do not add `__persistent__`; there
   is nothing to register.
-- **`modules/starboard.py::_StarboardJumpView`** — a link-only button (jump
-  to the starred message), same "nothing to register" case as above. It
-  also does not inherit `BaseView`: the starboard card is sent as a real
-  `discord.Embed` (documented CLAUDE.md exception, see the module's
-  docstring), and Discord rejects combining the `IS_COMPONENTS_V2` flag
-  (which `BaseView`/`ui.LayoutView` always sets) with a classic embed.
+- **`modules/starboard.py::_StarboardCardView`** — the view itself is a
+  plain, non-`BaseView` container for two children: a `ButtonStyle.link`
+  jump button (nothing to register — "zero interactive children" case
+  above applies to link buttons) and `_StarboardReactorsButton`, a
+  persistent `DynamicItem` (`template=r"moddy:starboard:reactors:..."`)
+  registered separately via `StarboardCardPersistence.register_persistent`
+  (`bot.add_dynamic_items(...)`, same pattern as
+  `utils/appeal_views.py::AppealPersistence`). Neither child needs
+  `_StarboardCardView` itself to be persistent or a `BaseView`: the
+  starboard card is sent with a real `discord.Embed` (documented CLAUDE.md
+  exception, see the module's docstring), and Discord rejects combining the
+  `IS_COMPONENTS_V2` flag (which `BaseView`/`ui.LayoutView` always sets)
+  with a classic embed. `_StarboardReactorsButton`'s callback is guarded
+  with `report_component_error` instead of a live view's `on_error`, same
+  as the appeal buttons.
 
 ---
 

--- a/docs/sessions/2026-08-07_starboard-embed-card.md
+++ b/docs/sessions/2026-08-07_starboard-embed-card.md
@@ -78,3 +78,87 @@ channel), a `discord.Embed` holding the starred message, and a
       (`discord.py` isn't installed in this environment); reviewed manually
       against `docs/PERSISTENT_VIEWS.md`'s exclusion criteria instead. Worth
       running in CI/a full environment before merge.
+
+---
+
+## Round 2 — badge fix, link previews, reactors button (same day)
+
+Follow-up requested after review of the round-1 PR (#312): the verification
+badge wasn't reliably visible, non-direct-image links (e.g. a GIF site's
+share page) showed nothing, the top content line was unwanted, and a new
+"who reacted" button was requested.
+
+### Changes Made
+
+- `modules/starboard.py`:
+  - **Badge fix**: `_build_embed()` now puts `**{display_name}**{badge}` as
+    the first line of the embed *description* (previously the badge sat
+    alone on its own line, detached from the name). This matches CLAUDE.md
+    rule #7's literal `**{name}**{badge}` format — `embed.set_author()`
+    can't render markdown/links at all, so the badge could never live
+    there; it must be in the description. `_get_author_badge()` also now
+    fetches and passes `user_verification_data` (`users.data.verification`)
+    to `get_user_verification_badge()`, matching the exact call shape
+    already used in `cogs/user.py` (previously omitted — harmless for
+    whether the badge shows, but needed for org-name completeness).
+  - **Link previews**: `_find_image_url()` → `_find_image_url()` +
+    `_fetch_link_preview_image()`. When a message contains a link that
+    isn't itself a direct image URL, the bot now does a short (5s timeout,
+    200KB cap) `aiohttp` GET and regex-extracts `og:image` /
+    `og:image:secure_url` / `twitter:image` from the HTML, so pages like a
+    GIF site's share link still show a preview image on the embed. No new
+    dependency — plain regex over the fetched HTML (no `bs4`/`lxml` in
+    `requirements.txt`).
+  - **Content line removed**: `_build_content()` deleted. The starboard
+    message is now embed-only (`channel.send(embed=..., view=...)`, no
+    `content`). The reaction count moved onto the new reactors button's
+    label instead of living in message text.
+  - **Reactors button**: added `_StarboardReactorsButton`
+    (`discord.ui.DynamicItem`, `template=r"moddy:starboard:reactors:..."`),
+    styled like the emoji + count, placed before the jump button in the new
+    `_StarboardCardView` (renamed from `_StarboardJumpView`, which now
+    holds both buttons). Clicking it fetches the original message, finds
+    the matching reaction, and replies ephemerally with the list of users
+    who reacted (`AllowedMentions.none()` so listing them doesn't ping).
+    Registered for persistence via `StarboardCardPersistence` (a
+    `BaseView` marker class that's never instantiated, only used to call
+    `bot.add_dynamic_items(_StarboardReactorsButton)` — same pattern as
+    `utils/appeal_views.py::AppealPersistence`) and added to
+    `utils/persistent_views.py`. Its callback is guarded with
+    `report_component_error` (fire-and-forget via `asyncio.create_task`)
+    rather than a live view's `on_error`, since persistent `DynamicItem`s
+    dispatched via `add_dynamic_items` have no live view instance — same
+    reasoning as the existing appeal buttons.
+  - `_update_starboard()` now edits the message's `view` (rebuilding the
+    reactors button with the new count) instead of editing `content`, since
+    there's no content line left to hold the count.
+- `locales/{fr,en-US,es-ES,pt-BR,de}.json` — added
+  `modules.starboard.message.reactors.{title,empty,not_found,more}`.
+- `docs/PERSISTENT_VIEWS.md`, `docs/COMPONENTS_V2.md` — updated the
+  `_StarboardJumpView` references to `_StarboardCardView` and documented
+  the reactors `DynamicItem`'s persistence/error-handling approach.
+
+### Decisions & Rationale
+
+- Considered adding a new `BaseClassicView(ui.View)` base class (mirroring
+  `BaseView`'s `on_error`) for views that must coexist with an embed, but
+  found the codebase already solves this exact problem for `DynamicItem`s
+  dispatched without a live view (`report_component_error` +
+  `utils/appeal_views.py`'s `_guarded` pattern) — used that instead of
+  introducing an unused abstraction.
+- The link-preview fetch is a plain `aiohttp` GET + regex, not a full HTML
+  parser: adding `bs4`/`lxml` for one `<meta>` tag felt disproportionate,
+  and the project doesn't fetch/parse arbitrary third-party HTML anywhere
+  else, so a minimal, defensively-bounded (timeout + byte cap,
+  `Content-Type` check) implementation was preferred over a new dependency.
+
+### Known Issues / Follow-ups
+
+- [ ] The link-preview fetch has no rate limiting beyond the existing
+      `reaction_count` threshold gate (a message needs enough reactions to
+      reach the starboard before we ever fetch its link). Acceptable given
+      the threshold, but worth revisiting if abused.
+- [ ] `tests/test_persistent_views.py` still could not be run in this
+      environment (no `discord.py` installed) — please run in CI before
+      merging, especially to confirm the new `DynamicItem` template doesn't
+      collide with existing custom_ids.

--- a/locales/de.json
+++ b/locales/de.json
@@ -1075,7 +1075,13 @@
       },
       "message": {
         "title": "Starboard",
-        "jump_button": "Zur Nachricht springen"
+        "jump_button": "Zur Nachricht springen",
+        "reactors": {
+          "title": "### {emoji} Personen, die reagiert haben ({count})",
+          "empty": "Noch niemand hat auf diese Nachricht reagiert.",
+          "not_found": "Die ursprüngliche Nachricht konnte nicht gefunden werden.",
+          "more": "*+ {count} weitere*"
+        }
       }
     },
     "auto_role": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1075,7 +1075,13 @@
       },
       "message": {
         "title": "Starboard",
-        "jump_button": "Jump to message"
+        "jump_button": "Jump to message",
+        "reactors": {
+          "title": "### {emoji} People who reacted ({count})",
+          "empty": "No one has reacted to this message yet.",
+          "not_found": "Couldn't find the original message.",
+          "more": "*+ {count} more*"
+        }
       }
     },
     "auto_role": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1075,7 +1075,13 @@
       },
       "message": {
         "title": "Tablón de destacados",
-        "jump_button": "Ir al mensaje"
+        "jump_button": "Ir al mensaje",
+        "reactors": {
+          "title": "### {emoji} Personas que reaccionaron ({count})",
+          "empty": "Nadie ha reaccionado a este mensaje todavía.",
+          "not_found": "No se pudo encontrar el mensaje original.",
+          "more": "*+ {count} más*"
+        }
       }
     },
     "auto_role": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1074,7 +1074,13 @@
       },
       "message": {
         "title": "Starboard",
-        "jump_button": "Aller au message"
+        "jump_button": "Aller au message",
+        "reactors": {
+          "title": "### {emoji} Personnes ayant réagi ({count})",
+          "empty": "Personne n'a réagi à ce message pour le moment.",
+          "not_found": "Impossible de retrouver le message d'origine.",
+          "more": "*+ {count} autres*"
+        }
       }
     },
     "auto_role": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1075,7 +1075,13 @@
       },
       "message": {
         "title": "Starboard",
-        "jump_button": "Ir para a mensagem"
+        "jump_button": "Ir para a mensagem",
+        "reactors": {
+          "title": "### {emoji} Pessoas que reagiram ({count})",
+          "empty": "Ainda ninguém reagiu a esta mensagem.",
+          "not_found": "Não foi possível encontrar a mensagem original.",
+          "more": "*+ {count} outras*"
+        }
       }
     },
     "auto_role": {

--- a/modules/starboard.py
+++ b/modules/starboard.py
@@ -3,16 +3,20 @@ Module Starboard - Système de tableau d'honneur pour messages populaires
 """
 
 import re
-import discord
-from typing import Dict, Any, Optional
+import asyncio
 import logging
+from typing import Dict, Any, Optional
 
+import aiohttp
+import discord
+
+from cogs.error_handler import BaseView
 from modules.module_manager import ModuleBase
 from utils.emojis import (
     STAR, is_standard_discord_emoji,
     get_user_verification_badge, format_verification_badge,
 )
-from utils.i18n import t
+from utils.i18n import t, i18n
 
 logger = logging.getLogger('moddy.modules.starboard')
 
@@ -24,30 +28,189 @@ _IMAGE_URL_RE = re.compile(
     r'https?://\S+?\.(?:png|jpe?g|gif|webp)(?:\?\S*)?',
     re.IGNORECASE,
 )
+_URL_RE = re.compile(r'https?://\S+', re.IGNORECASE)
+_OG_IMAGE_RE = [
+    re.compile(
+        rf'<meta[^>]+(?:property|name)=["\']{re.escape(prop)}["\'][^>]+content=["\']([^"\']+)["\']',
+        re.IGNORECASE,
+    )
+    for prop in ('og:image', 'og:image:secure_url', 'twitter:image')
+]
+_LINK_PREVIEW_TIMEOUT = aiohttp.ClientTimeout(total=5)
+_LINK_PREVIEW_MAX_BYTES = 200_000
+_LINK_PREVIEW_HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; Moddybot/1.0; +https://moddy.app)"}
 
 
-class _StarboardJumpView(discord.ui.View):
+def _report_dynamic_item_error(interaction: discord.Interaction, error: Exception, source: str):
+    """Route a DynamicItem callback error to the central handler (fire-and-forget)."""
+    from cogs.error_handler import report_component_error
+    asyncio.create_task(report_component_error(interaction, error, source))
+
+
+class _StarboardReactorsButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"moddy:starboard:reactors:(?P<channel_id>\d+):(?P<message_id>\d+):(?P<emoji>.+)",
+):
     """
-    Plain (non-Components-V2, non-persistent) view holding only the
+    Persistent button showing the reaction count. Clicking it lists (ephemeral)
+    who reacted with the configured emoji.
+
+    This lives on the same message as `_StarboardCardView`'s link button, next
+    to a real `discord.Embed` — see the module docstring for why that message
+    cannot use `BaseView`. Its callback is guarded with
+    `report_component_error` instead of a `BaseView.on_error`, matching the
+    pattern already used by other persistent `DynamicItem`s that ship without
+    a live view (see `utils/appeal_views.py`).
+    """
+
+    def __init__(self, channel_id: int, message_id: int, emoji: str, count: int):
+        super().__init__(
+            discord.ui.Button(
+                style=discord.ButtonStyle.secondary,
+                label=str(count),
+                emoji=emoji,
+                custom_id=f"moddy:starboard:reactors:{channel_id}:{message_id}:{emoji}",
+            )
+        )
+        self.channel_id = channel_id
+        self.message_id = message_id
+        self.emoji = emoji
+
+    @classmethod
+    async def from_custom_id(cls, interaction: discord.Interaction, item: discord.ui.Button, match: re.Match):
+        return cls(
+            channel_id=int(match["channel_id"]),
+            message_id=int(match["message_id"]),
+            emoji=match["emoji"],
+            count=0,  # Placeholder — the already-sent button keeps its rendered label.
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        try:
+            await self._show_reactors(interaction)
+        except Exception as e:
+            _report_dynamic_item_error(interaction, e, self.__class__.__name__)
+
+    async def _show_reactors(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        locale = i18n.get_user_locale(interaction)
+
+        channel = interaction.guild.get_channel(self.channel_id) if interaction.guild else None
+        if channel is None:
+            await interaction.followup.send(
+                t('modules.starboard.message.reactors.not_found', locale=locale), ephemeral=True
+            )
+            return
+
+        try:
+            message = await channel.fetch_message(self.message_id)
+        except (discord.NotFound, discord.Forbidden):
+            await interaction.followup.send(
+                t('modules.starboard.message.reactors.not_found', locale=locale), ephemeral=True
+            )
+            return
+
+        reaction = discord.utils.find(
+            lambda r: not r.is_custom_emoji() and str(r.emoji) == self.emoji, message.reactions
+        )
+        if reaction is None:
+            await interaction.followup.send(
+                t('modules.starboard.message.reactors.empty', locale=locale), ephemeral=True
+            )
+            return
+
+        users = [user async for user in reaction.users() if not user.bot]
+        if not users:
+            await interaction.followup.send(
+                t('modules.starboard.message.reactors.empty', locale=locale), ephemeral=True
+            )
+            return
+
+        max_shown = 40
+        lines = [f"- {user.mention}" for user in users[:max_shown]]
+        if len(users) > max_shown:
+            lines.append(t(
+                'modules.starboard.message.reactors.more', locale=locale,
+                count=f"`{len(users) - max_shown}`",
+            ))
+
+        title = t(
+            'modules.starboard.message.reactors.title', locale=locale,
+            emoji=self.emoji, count=f"`{len(users)}`",
+        )
+        await interaction.followup.send(
+            f"{title}\n" + "\n".join(lines),
+            ephemeral=True,
+            allowed_mentions=discord.AllowedMentions.none(),
+        )
+
+
+class StarboardCardPersistence(BaseView):
+    """Marker view used only to register the starboard card's dynamic items at startup."""
+
+    __persistent__ = True
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        bot.add_dynamic_items(_StarboardReactorsButton)
+
+
+class _StarboardCardView(discord.ui.View):
+    """
+    Plain (non-Components-V2) view holding the reactors button and the
     "jump to message" link button.
 
     This intentionally does NOT inherit from `BaseView`: `BaseView` is a
     `ui.LayoutView` (Components V2), and Discord rejects any message that
     combines the IS_COMPONENTS_V2 flag with a classic `discord.Embed` —
-    which the starboard card needs (see module docstring / CLAUDE.md
-    exception below). A link-only button has no callback and carries no
-    state, so per docs/PERSISTENT_VIEWS.md ("Deliberate exclusions") it
-    needs neither error-handler wrapping nor persistent registration —
-    `bot.add_view()` on a link-only view is a no-op.
+    which the starboard card needs (see module docstring). The jump button
+    is a link with no callback (nothing to guard or persist); the reactors
+    button is a persistent `DynamicItem` whose errors are separately routed
+    to `report_component_error` — see `_StarboardReactorsButton`. So this
+    view itself needs neither error-handler wrapping nor registration.
     """
 
-    def __init__(self, jump_url: str, label: str):
+    def __init__(self, channel_id: int, message_id: int, emoji: str, count: int,
+                 jump_url: str, jump_label: str):
         super().__init__(timeout=None)
+        self.add_item(_StarboardReactorsButton(channel_id, message_id, emoji, count))
         self.add_item(discord.ui.Button(
             style=discord.ButtonStyle.link,
-            label=label,
+            label=jump_label,
             url=jump_url,
         ))
+
+
+async def _fetch_link_preview_image(url: str) -> Optional[str]:
+    """
+    Best-effort OpenGraph/Twitter-card image lookup for a bare link that
+    isn't itself a direct image URL (e.g. a GIF site's share page). Used as
+    a fallback so starred messages that are "just a link" still show a
+    preview, matching what Discord's own link unfurling would show.
+    """
+    try:
+        async with aiohttp.ClientSession(timeout=_LINK_PREVIEW_TIMEOUT) as session:
+            async with session.get(url, headers=_LINK_PREVIEW_HEADERS) as response:
+                if response.status != 200:
+                    return None
+                content_type = response.headers.get("Content-Type", "")
+                if "text/html" not in content_type:
+                    return None
+                raw = await response.content.read(_LINK_PREVIEW_MAX_BYTES)
+    except Exception as e:
+        logger.debug(f"Starboard link preview fetch failed for {url}: {e}")
+        return None
+
+    html = raw.decode("utf-8", errors="ignore")
+    for pattern in _OG_IMAGE_RE:
+        match = pattern.search(html)
+        if match:
+            candidate = match.group(1)
+            if candidate.startswith("//"):
+                candidate = f"https:{candidate}"
+            return candidate
+
+    return None
 
 
 class StarboardModule(ModuleBase):
@@ -62,7 +225,7 @@ class StarboardModule(ModuleBase):
     feature is styled after (colored side bar, author avatar/name, native
     timestamp). This is a deliberate, explicit exception to the project's
     "Components V2 only" rule, scoped to this one card. See
-    `_build_embed()` / `_StarboardJumpView` for the implementation notes.
+    `_build_embed()` / `_StarboardCardView` for the implementation notes.
     """
 
     MODULE_ID = "starboard"
@@ -268,20 +431,25 @@ class StarboardModule(ModuleBase):
         try:
             user_db_data = await self.bot.db.get_user(author.id)
             moddy_attributes = user_db_data.get('attributes', {}) if user_db_data else {}
+            user_verification_data = (user_db_data.get('data', {}) or {}).get('verification', {}) if user_db_data else {}
         except Exception:
             moddy_attributes = {}
+            user_verification_data = {}
 
         public_flags_value = author.public_flags.value if hasattr(author, 'public_flags') else 0
         badge_emoji, _org_names, _tier = get_user_verification_badge(
-            {'public_flags': public_flags_value}, moddy_attributes
+            {'public_flags': public_flags_value}, moddy_attributes, user_verification_data
         )
         return format_verification_badge(badge_emoji)
 
-    def _find_image_url(self, message: discord.Message) -> Optional[str]:
+    async def _find_image_url(self, message: discord.Message) -> Optional[str]:
         """
-        Find an image to show on the starboard embed: the first image
-        attachment if there is one, otherwise the first bare image URL found
-        in the message content (e.g. a pasted image link).
+        Find an image to show on the starboard embed:
+        1. The first image attachment, if there is one.
+        2. Otherwise, the first bare image URL found in the message content.
+        3. Otherwise, if the message content contains any link, try fetching
+           its OpenGraph/Twitter-card image (e.g. a GIF site's share page
+           that isn't itself a direct image URL).
         """
         for attachment in message.attachments:
             content_type = attachment.content_type or ""
@@ -290,10 +458,16 @@ class StarboardModule(ModuleBase):
             if attachment.filename.lower().endswith(_IMAGE_EXTENSIONS):
                 return attachment.url
 
-        if message.content:
-            match = _IMAGE_URL_RE.search(message.content)
-            if match:
-                return match.group(0)
+        if not message.content:
+            return None
+
+        match = _IMAGE_URL_RE.search(message.content)
+        if match:
+            return match.group(0)
+
+        url_match = _URL_RE.search(message.content)
+        if url_match:
+            return await _fetch_link_preview_image(url_match.group(0))
 
         return None
 
@@ -306,12 +480,18 @@ class StarboardModule(ModuleBase):
         """
         badge = await self._get_author_badge(message.author)
 
-        description = message.content or ""
+        # Embed `author` names are plain text (no markdown/links), so the
+        # hyperlinked verification badge can't live there — it's shown as a
+        # bold-name + badge line at the top of the description instead,
+        # matching the "**{name}**{badge}" format from CLAUDE.md rule #7.
+        description_lines = []
         if badge:
-            description = f"{badge}\n{description}" if description else badge
+            description_lines.append(f"**{message.author.display_name}**{badge}")
+        if message.content:
+            description_lines.append(message.content)
 
         embed = discord.Embed(
-            description=description,
+            description="\n".join(description_lines),
             color=STARBOARD_EMBED_COLOR,
             timestamp=message.created_at,
         )
@@ -320,22 +500,22 @@ class StarboardModule(ModuleBase):
             icon_url=message.author.display_avatar.url,
         )
 
-        image_url = self._find_image_url(message)
+        image_url = await self._find_image_url(message)
         if image_url:
             embed.set_image(url=image_url)
 
         return embed
 
-    def _build_content(self, channel: discord.abc.GuildChannel, star_count: int) -> str:
-        """Top content line: reaction emoji, count, and origin channel"""
-        return f"{self.emoji} `{star_count}` | {channel.mention}"
-
-    async def _build_jump_view(self, message: discord.Message) -> _StarboardJumpView:
-        """Build the "jump to message" link button (see `_StarboardJumpView`)"""
+    async def _build_view(self, message: discord.Message, star_count: int) -> _StarboardCardView:
+        """Build the reactors-count button + "jump to message" link button (see `_StarboardCardView`)"""
         locale = await self._get_locale()
-        return _StarboardJumpView(
+        return _StarboardCardView(
+            channel_id=message.channel.id,
+            message_id=message.id,
+            emoji=self.emoji,
+            count=star_count,
             jump_url=message.jump_url,
-            label=t('modules.starboard.message.jump_button', locale=locale),
+            jump_label=t('modules.starboard.message.jump_button', locale=locale),
         )
 
     async def _update_starboard(self, message: discord.Message, star_count: int):
@@ -353,12 +533,12 @@ class StarboardModule(ModuleBase):
 
         # Check if we already have a starboard entry for this message
         if message.id in self.starboard_messages:
-            # Only the top content line (reaction counter) needs updating
+            # Only the reactors-count button needs updating
             try:
                 starboard_msg_id = self.starboard_messages[message.id]
                 starboard_msg = await starboard_channel.fetch_message(starboard_msg_id)
-                content = self._build_content(message.channel, star_count)
-                await starboard_msg.edit(content=content, allowed_mentions=discord.AllowedMentions.none())
+                view = await self._build_view(message, star_count)
+                await starboard_msg.edit(view=view)
                 logger.info(f"Updated starboard message for {message.id} (stars: {star_count})")
             except discord.NotFound:
                 # Entry was deleted, recreate it
@@ -371,20 +551,17 @@ class StarboardModule(ModuleBase):
     async def _create_starboard_message(self, channel: discord.TextChannel,
                                          original_message: discord.Message, star_count: int):
         """
-        Post a starboard entry: a content line (reaction count + origin
-        channel), the starred message rendered as an embed (see CLAUDE.md
-        exception note on the class docstring), and a jump-to-message link
-        button. `AllowedMentions.none()` on the content line and the fact
-        that mentions inside embeds never notify anyone together ensure
-        nothing in the starred message can ping.
+        Post a starboard entry: the starred message rendered as an embed
+        (see CLAUDE.md exception note on the class docstring), a reactors
+        button, and a jump-to-message link button. `AllowedMentions.none()`
+        and the fact that mentions inside embeds never notify anyone
+        together ensure nothing in the starred message can ping.
         """
         try:
-            content = self._build_content(original_message.channel, star_count)
             embed = await self._build_embed(original_message)
-            view = await self._build_jump_view(original_message)
+            view = await self._build_view(original_message, star_count)
 
             starboard_msg = await channel.send(
-                content=content,
                 embed=embed,
                 view=view,
                 allowed_mentions=discord.AllowedMentions.none(),

--- a/utils/persistent_views.py
+++ b/utils/persistent_views.py
@@ -41,6 +41,7 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
     from modules.configs.auto_role_config import AutoRoleConfigView
     from modules.configs.auto_restore_roles_config import AutoRestoreRolesConfigView
     from modules.configs.starboard_config import StarboardConfigView
+    from modules.starboard import StarboardCardPersistence
     from modules.configs.welcome_channel_config import WelcomeChannelConfigView
     from modules.configs.welcome_dm_config import WelcomeDmConfigView
     from cogs.config import ConfigMainView
@@ -79,6 +80,10 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
         AutoRoleConfigView,
         AutoRestoreRolesConfigView,
         StarboardConfigView,
+        # Group 9b — starboard card reactors button (dynamic items; the
+        # card message itself carries a real discord.Embed, see
+        # modules/starboard.py's CLAUDE.md exception note)
+        StarboardCardPersistence,
         # Group 10 — /config welcome pair (colliding custom_ids, must move together)
         WelcomeChannelConfigView,
         WelcomeDmConfigView,


### PR DESCRIPTION
## Summary
Follow-up to #312 (already merged), on top of latest `main`:
- **Verification badge fix**: the badge now renders as `**{name}**{badge}` on its own line in the embed description (matching CLAUDE.md rule #7's literal format), instead of sitting alone, detached from the name — `embed.set_author()` cannot render markdown/links at all, so it could never show there. Also passes `user_verification_data` through to `get_user_verification_badge()`, matching the exact call already used in `cogs/user.py`.
- **Link previews**: when the starred message contains a link that isn't itself a direct image URL (e.g. a GIF site's share page), the bot now does a short, bounded (5s timeout, 200KB cap) fetch and extracts `og:image` / `og:image:secure_url` / `twitter:image` from the page so the embed still shows a preview — no new dependency, plain regex over the fetched HTML.
- **Embed-only card**: removed the separate content line (reaction count + origin channel); the starboard message is now just the embed + buttons.
- **Reactors button**: added a button (emoji + reaction count) before the jump-to-message button. Clicking it replies ephemerally with the list of users who reacted (mentions rendered but never pinged via `AllowedMentions.none()`). Implemented as a persistent `discord.ui.DynamicItem`, following the same pattern as `utils/appeal_views.py`.

## Test plan
- [x] `python3 -m py_compile modules/starboard.py utils/persistent_views.py`
- [ ] `python3 -m pytest tests/test_persistent_views.py -q` — could not run locally (`discord.py` not installed in this sandbox); please run in CI before merging.
- [ ] Manual check in a test server: star a message from a verified user (badge shows), a message with a klipy.com-style GIF link (preview image shows), and click the new reactors button (ephemeral list, no pings).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01145s4Wji7MFJmMx6xPshcC

---
_Generated by [Claude Code](https://claude.ai/code/session_01145s4Wji7MFJmMx6xPshcC)_