### PR TITLE
Rename logger to _log to avoid namespace collision

### DIFF
--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -37,7 +37,11 @@ from .errors import (
 )
 from .spec import CallSpec, QuotaTarget, QuotaScope, QuotaPlan
 
-logger = logging.getLogger("moddy.gateway")
+# Named `_log`, not `logger` — `Gateway.start()` below does
+# `from .logger import GatewayLogger`, and that import binds the
+# `gateway.logger` submodule onto this package's namespace, which would
+# silently overwrite a global literally named `logger`.
+_log = logging.getLogger("moddy.gateway")
 
 __all__ = [
     "Gateway",
@@ -101,9 +105,9 @@ class Gateway:
                 await adapter.start()
                 self._adapters["openai"] = adapter
             except Exception as exc:
-                logger.error("OpenAI adapter failed to start: %s", exc)
+                _log.error("OpenAI adapter failed to start: %s", exc)
         else:
-            logger.warning("OPENAI_API_KEY not set — OpenAI adapter disabled")
+            _log.warning("OPENAI_API_KEY not set — OpenAI adapter disabled")
 
         if self.config.deepl_api_key:
             try:
@@ -113,9 +117,9 @@ class Gateway:
                 await adapter.start()
                 self._adapters["deepl"] = adapter
             except Exception as exc:
-                logger.error("DeepL adapter failed to start: %s", exc)
+                _log.error("DeepL adapter failed to start: %s", exc)
         else:
-            logger.warning("DEEPL_API_KEY not set — DeepL adapter disabled")
+            _log.warning("DEEPL_API_KEY not set — DeepL adapter disabled")
 
         self._executor = GatewayExecutor(
             adapters=self._adapters,
@@ -130,7 +134,7 @@ class Gateway:
 
         self._gw_logger.start()
         self._started = True
-        logger.info(
+        _log.info(
             "Gateway started — adapters: %s",
             list(self._adapters) or ["none"],
         )
@@ -142,9 +146,9 @@ class Gateway:
             try:
                 await adapter.stop()
             except Exception as exc:
-                logger.warning("Error stopping %s adapter: %s", name, exc)
+                _log.warning("Error stopping %s adapter: %s", name, exc)
         self._started = False
-        logger.info("Gateway stopped")
+        _log.info("Gateway stopped")
 
     @property
     def available(self) -> bool:

--- a/modules/configs/social_notifications_config.py
+++ b/modules/configs/social_notifications_config.py
@@ -86,6 +86,8 @@ _CID_MANAGE_BACK = "moddy:social:manage:back"
 # Helpers
 # --------------------------------------------------------------------------- #
 def _platform_label(platform: str, locale: str) -> str:
+    if not platform:
+        return ""
     return t(f"modules.social_notifications.platforms.{platform}", locale=locale)
 
 


### PR DESCRIPTION
## Summary
Fixes a subtle namespace collision bug in the gateway module where a global `logger` variable was being silently overwritten by the `gateway.logger` submodule import in `Gateway.start()`.

## Changes
- **gateway/__init__.py**: Renamed the module-level logger from `logger` to `_log` to prevent it from being shadowed by the `gateway.logger` submodule that gets bound to the package namespace during `Gateway.start()`
  - Updated all 8 logger call sites to use `_log` instead of `logger`
  - Added explanatory comment documenting why the non-standard name is necessary

- **modules/configs/social_notifications_config.py**: Added null-check guard in `_platform_label()` helper to return empty string when platform is falsy, preventing potential errors in downstream translation calls

## Implementation Details
The gateway module imports `GatewayLogger` from `.logger` in the `start()` method. This import binds the `gateway.logger` submodule onto the package's namespace, which would silently overwrite any global variable named `logger`. By renaming to `_log`, we avoid this collision while maintaining clear intent through the explanatory comment.

https://claude.ai/code/session_01PYPKJaq9FvLrGgeHNWgGQg