### PR TITLE
Add Wolof language support and improve DeepL response logging

### DIFF
--- a/gateway/adapters/deepl.py
+++ b/gateway/adapters/deepl.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import json
 import logging
 from typing import Optional
 
@@ -52,8 +53,11 @@ class DeepLAdapter(BaseAdapter):
             f"{self._base_url}/translate", data=form
         ) as resp:
             await self._raise_for_status(resp)
-            data = await resp.json()
+            raw_body = await resp.text()
 
+        logger.debug("DeepL raw response for %r -> %s: %s", p["text"], p["target_lang"], raw_body)
+
+        data = json.loads(raw_body)
         translation = data["translations"][0]
         return AdapterResult(
             data={

--- a/locales/de.json
+++ b/locales/de.json
@@ -1791,7 +1791,8 @@
     "hu": "Ungarisch",
     "uk": "Ukrainisch",
     "bg": "Bulgarisch",
-    "lmo": "Lombardisch"
+    "lmo": "Lombardisch",
+    "wo": "Wolof"
   },
   "staff": {
     "common": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1791,7 +1791,8 @@
     "hu": "Hungarian",
     "uk": "Ukrainian",
     "bg": "Bulgarian",
-    "lmo": "Lombard"
+    "lmo": "Lombard",
+    "wo": "Wolof"
   },
   "staff": {
     "common": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1791,7 +1791,8 @@
     "hu": "Húngaro",
     "uk": "Ucraniano",
     "bg": "Búlgaro",
-    "lmo": "Lombardo"
+    "lmo": "Lombardo",
+    "wo": "Wólof"
   },
   "staff": {
     "common": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1790,7 +1790,8 @@
     "hu": "Hongrois",
     "uk": "Ukrainien",
     "bg": "Bulgare",
-    "lmo": "Lombard"
+    "lmo": "Lombard",
+    "wo": "Wolof"
   },
   "staff": {
     "common": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1791,7 +1791,8 @@
     "hu": "Húngaro",
     "uk": "Ucraniano",
     "bg": "Búlgaro",
-    "lmo": "Lombardo"
+    "lmo": "Lombardo",
+    "wo": "Uólofe"
   },
   "staff": {
     "common": {


### PR DESCRIPTION
## Summary
This PR adds support for the Wolof language (`wo`) across all localization files and improves debugging of DeepL API responses by capturing and logging the raw response body.

## Changes

### DeepL Adapter Enhancement
- **Improved response handling**: Changed from directly parsing JSON to first capturing the raw response text, enabling better debugging and error diagnostics
- **Added debug logging**: Log the raw DeepL response body with source text, target language, and response content for troubleshooting translation issues
- **Added json import**: Explicit JSON parsing after response capture for clarity

### Localization Updates
Added Wolof language translations across all supported locales:
- **en-US.json**: "Wolof"
- **de.json**: "Wolof"
- **es-ES.json**: "Wólof"
- **fr.json**: "Wolof"
- **pt-BR.json**: "Uólofe"

## Implementation Details
The DeepL adapter now:
1. Reads the response as text via `resp.text()`
2. Logs the raw body at debug level for inspection
3. Parses the JSON explicitly using `json.loads()`

This approach maintains backward compatibility while providing better observability for API interactions and potential error scenarios.

https://claude.ai/code/session_01QP6uoXivHXS8HnC1eZa6Zu