### PR TITLE
Fix AI sanction-reason prefill silently failing on timeout overrun

### DIFF
--- a/cogs/moderation_commands.py
+++ b/cogs/moderation_commands.py
@@ -286,7 +286,9 @@ _LOCALE_TO_LANGUAGE: dict[str, str] = {
 
 _AI_SENTINEL_NO_REASON = "NO_REASON"
 _AI_SENTINEL_INJECTION = "INJECTION_DETECTED"
-_AI_TOTAL_TIMEOUT = 2.5  # seconds — must leave room for send_modal within the 3 s window
+_AI_TOTAL_TIMEOUT = 2.8  # seconds — must leave room for send_modal within the 3 s window
+_AI_FETCH_TIMEOUT = 1.2  # seconds — budget for the message-history scan
+_AI_CHAT_MIN_TIMEOUT = 1.0  # seconds — floor left for the OpenAI call, even if the fetch was slow
 _AI_MODEL = "gpt-4.1-nano"
 
 
@@ -377,10 +379,11 @@ async def _get_ai_suggested_reason(
     }
     action_label = action_labels.get(action, action)
 
+    fetch_start = time.monotonic()
     try:
         messages_content = await asyncio.wait_for(
             _fetch_recent_user_messages(guild, user),
-            timeout=1.5,
+            timeout=_AI_FETCH_TIMEOUT,
         )
     except asyncio.TimeoutError:
         logger.debug("[AI reason] message fetch timed out for user %s", user.id)
@@ -388,6 +391,12 @@ async def _get_ai_suggested_reason(
     except Exception as exc:
         logger.debug("[AI reason] message fetch error: %s", exc)
         return None
+
+    # Allocate whatever remains of the total budget to the OpenAI call, with a
+    # floor — otherwise a slow-but-within-budget fetch starves the AI call and
+    # it gets cut off by the outer _AI_TOTAL_TIMEOUT before it can even try.
+    elapsed = time.monotonic() - fetch_start
+    chat_timeout = max(_AI_CHAT_MIN_TIMEOUT, _AI_TOTAL_TIMEOUT - elapsed - 0.2)
 
     if not messages_content:
         return None
@@ -430,7 +439,7 @@ async def _get_ai_suggested_reason(
                 call_type="ban_reason",
                 metadata={"guild_id": guild.id, "user_id": user.id},
             ),
-            timeout=1.8,
+            timeout=chat_timeout,
         )
     except asyncio.TimeoutError:
         logger.debug("[AI reason] OpenAI call timed out for user %s", user.id)


### PR DESCRIPTION
## Summary
- The AI sanction-reason prefill (`/ban`, `/kick`, `/mute`, `/warn`) uses a global 2.5s budget split into two sequential fixed timeouts: 1.5s for the recent-message fetch and 1.8s for the OpenAI call. Those sum to 3.3s, more than the 2.5s outer budget, so whenever the fetch took more than ~0.7s the outer `wait_for` would cancel the whole flow before the OpenAI call could even complete — even if that call was itself well within its own 1.8s timeout.
- All failures in this path are silenced (`except Exception: return None`), so the modal just opens with an empty reason field with nothing visible in the logs.
- This change tracks elapsed time after the message fetch and gives the OpenAI call whatever remains of the (slightly widened) total budget, with a floor, instead of a fixed timeout that could already exceed what's left.

## Test plan
- [x] `python3 -m py_compile cogs/moderation_commands.py`
- [ ] Manually trigger `/ban`, `/kick`, `/mute`, or `/warn` on a user with recent messages and confirm the reason field prefills consistently

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdCRK5qsFAUrpgTsCL18Ck)_