### PR TITLE
Add Bot Customization module — per-guild identity & name styles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ moddy/
 │   ├── interserver.py         #   Inter-server message relay
 │   ├── social_notifications.py #  Social notifications (via moddy-feeds service)
 │   ├── automod_ai.py          #   Automod AI (applies decisions, cases+evidence, scalable features)
+│   ├── bot_customization.py   #   Bot identity per guild (nick/avatar/bio premium + name style free)
 │   ├── voice_transcription.py #   Voice message transcription (button or automatic)
 │   └── configs/               #   Components V2 config UIs per module
 │       ├── adaptive_slowmode_config.py
@@ -79,6 +80,7 @@ moddy/
 │       ├── automod_ai_precedents_view.py  # Learned-precedents browser (S7)
 │       ├── welcome_channel_config.py      # Welcome messages list + add/manage (Modal V2)
 │       ├── voice_transcription_config.py  # Voice transcription (status, mode, channels)
+│       ├── bot_customization_config.py    # Bot customization (identity Modal V2 + name style)
 │
 ├── automod/                   # Automod AI DETECTION pipeline (decides only; no side effects)
 │   ├── engine.py              #   Shared per-bot orchestrator (funnel entry)
@@ -123,7 +125,7 @@ moddy/
 │       ├── eval_candidates.py   #   Automod eval/annotation corpus (automod_eval_candidates)
 │       ├── precedents.py        #   Automod server precedents (automod_precedents, RAG)
 │       ├── token_alerts.py, token_secrets.py
-│       ├── subscription.py    #   Subscription read-only queries
+│       ├── subscription.py    #   Subscription read-only queries (incl. is_guild_premium)
 │       ├── social.py          #   Social notifications subscriptions
 │       └── _utils.py
 │
@@ -133,7 +135,7 @@ moddy/
 │   ├── emojis.py              #   Emoji constants
 │   ├── components_v2.py       #   V2 helper functions (create_error_message, etc.)
 │   ├── staff_permissions.py   #   Permission system
-│   ├── subscription.py        #   Subscription helper (is_subscribed, get_subscription)
+│   ├── subscription.py        #   Subscription helper (is_subscribed, is_guild_premium…)
 │   ├── staff_logger.py        #   Staff action logging (also feeds technical webhook logs)
 │   ├── tech_logger.py         #   Technical staff logs via webhooks (Components V2, per-event channels)
 │   ├── staff_role_permissions.py
@@ -197,6 +199,7 @@ moddy/
     ├── internal_api/          #   pytest suite for the internal API routes
     │                          #   (FastAPI TestClient, bot + gateway stubbed)
     ├── gateway/               #   Provider rate limits + executor reservation lifecycle
+    ├── test_bot_customization.py  # Bot customization validation (bio budget, styles)
     └── test_transcription.py  #   Voice transcription helpers, guard rails, cards
 ```
 
@@ -339,6 +342,8 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/WELCOME_MESSAGES.md](docs/WELCOME_MESSAGES.md) | Welcome messages module — config schema, placeholders, backend/dashboard contract |
 | [docs/AUTOMOD_AI.md](docs/AUTOMOD_AI.md) | Automod AI — detection pipeline, nano decider, scalable features, rules safety check |
 | [docs/AUTOMOD_AI_CONFIG.md](docs/AUTOMOD_AI_CONFIG.md) | Automod AI configuration schema in DB (backend / dashboard integration) |
+| [docs/BOT_CUSTOMIZATION.md](docs/BOT_CUSTOMIZATION.md) | Bot Customization — per-guild nickname/avatar/bio + name styles, Redis dashboard contract |
+| [docs/PREMIUM.md](docs/PREMIUM.md) | **Premium gating** — how to check whether a server (or a user) is premium |
 | [docs/STAFF_SYSTEM.md](docs/STAFF_SYSTEM.md) | Staff/dev commands, permissions, roles |
 | [docs/MODERATION_CASES.md](docs/MODERATION_CASES.md) | Moderation cases/sanctions, the case service & sources, auto-sync |
 | [docs/TECHNICAL_LOGS.md](docs/TECHNICAL_LOGS.md) | Internal technical staff logs (webhook-based, per-event channels) |

--- a/bot.py
+++ b/bot.py
@@ -554,11 +554,13 @@ class ModdyBot(commands.Bot):
                 except Exception as e:
                     logger.error(f"[PubSub] Error reloading modules for guild {guild_id}: {e}")
 
-        elif event_type == "premium_activated":
-            logger.info(f"[PubSub] Premium activated for guild {guild_id}")
-
-        elif event_type == "premium_deactivated":
-            logger.info(f"[PubSub] Premium deactivated for guild {guild_id}")
+        elif event_type in ("premium_activated", "premium_deactivated"):
+            # Guild premium is cached in Redis (utils.subscription.is_guild_premium);
+            # drop the entry so the next gate check sees the new state.
+            if guild_id:
+                from utils.subscription import invalidate_guild_cache
+                await invalidate_guild_cache(self, int(guild_id))
+            logger.info(f"[PubSub] {event_type} for guild {guild_id}")
 
         elif event_type == "payment_failed":
             user_id = data.get("user_id")
@@ -630,6 +632,12 @@ class ModdyBot(commands.Bot):
             # the bot so the subscribe/DB logic lives in a single place.
             await self._process_social_task(task_type, guild_id, payload)
 
+        elif task_type == "bot_customization_update":
+            # Bot Customization: the dashboard cannot call Discord's
+            # "modify current member" endpoint itself (it is the bot's own
+            # profile), so it delegates the change to the bot.
+            await self._process_bot_customization_task(guild_id, payload)
+
         elif task_type in ("case_add_sanction", "case_revoke_sanction"):
             # Moderation cases: the backend delegates guild sanctions to the
             # bot so the Discord action (ban/timeout) and the case DB write
@@ -665,6 +673,45 @@ class ModdyBot(commands.Bot):
                 }))
             except Exception as e:
                 logger.error(f"[Stream] Could not publish social task result: {e}")
+
+    async def _process_bot_customization_task(self, guild_id: int, payload: dict):
+        """Apply a Bot Customization change requested by the dashboard and
+        publish the result back on `moddy:dashboard`, correlated by the
+        optional `request_id` from the payload."""
+        import json
+        result: dict
+        if not guild_id or not self.get_guild(guild_id):
+            result = {"ok": False, "error": "guild_not_found"}
+        else:
+            try:
+                from modules.bot_customization import (
+                    MODULE_ID, BotCustomizationModule, CustomizationError,
+                )
+                module = await self.module_manager.get_module_instance(guild_id, MODULE_ID)
+                if module is None:
+                    # No stored configuration yet — build a bare instance so a
+                    # first-time dashboard change still works.
+                    module = BotCustomizationModule(self, guild_id)
+                    await module.load_config(
+                        await self.module_manager.get_module_config(guild_id, MODULE_ID) or {}
+                    )
+                result = await module.handle_backend_task(payload)
+            except CustomizationError as e:
+                result = {"ok": False, "error": e.code, "detail": e.detail}
+            except Exception as e:
+                logger.error(f"[Stream] Bot customization task failed: {e}", exc_info=True)
+                result = {"ok": False, "error": "internal_error"}
+
+        if self.redis:
+            try:
+                await self.redis.publish("moddy:dashboard", json.dumps({
+                    "type": "bot_customization_update_result",
+                    "request_id": payload.get("request_id"),
+                    "guild_id": guild_id,
+                    **result,
+                }))
+            except Exception as e:
+                logger.error(f"[Stream] Could not publish bot customization result: {e}")
 
     async def _process_case_task(self, task_type: str, guild_id: int, payload: dict):
         """Run a guild-case sanction action requested by the backend dashboard

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -224,6 +224,14 @@ class ConfigMainView(BaseView):
                 locale,
                 module_config
             )
+        elif module_id == 'bot_customization':
+            from modules.configs.bot_customization_config import BotCustomizationConfigView
+            config_view = await BotCustomizationConfigView.create(
+                bot,
+                guild_id,
+                user_id,
+                locale
+            )
         elif module_id == 'automod_ai':
             from modules.configs.automod_ai_config import AutomodAIConfigView
             config_view = AutomodAIConfigView(

--- a/config.py
+++ b/config.py
@@ -89,6 +89,8 @@ LOG_WEBHOOK_ENV = {
     "database": "LOG_WEBHOOK_DATABASE",        # config changes / important writes
     "security": "LOG_WEBHOOK_SECURITY",        # blacklist blocks & sensitive events
     "api_call": "LOG_WEBHOOK_API_CALL",        # gateway: every outbound API call
+    # bot identity changed on a server (nickname / avatar / bio / name style)
+    "bot_customization": "LOG_WEBHOOK_BOT_CUSTOMIZATION",
 }
 
 # Resolved category -> webhook URL (only those actually configured)

--- a/docs/BOT_CUSTOMIZATION.md
+++ b/docs/BOT_CUSTOMIZATION.md
@@ -1,0 +1,282 @@
+# Bot Customization
+
+Makes Moddy look like the server's own bot. Everything is **per-guild**: a
+server never sees another server's customization.
+
+| | Free | Premium |
+|---|---|---|
+| Nickname | ❌ | ✅ |
+| Avatar | ❌ | ✅ |
+| Bio | ❌ | ✅ |
+| Name style (font, effect, colours) | ✅ | ✅ |
+
+Premium here means "this **guild** is covered by an active subscription" —
+`utils.subscription.is_guild_premium`, see [PREMIUM.md](PREMIUM.md). It is not
+a guild attribute.
+
+Files:
+
+- [`modules/bot_customization.py`](../modules/bot_customization.py) — module,
+  validation, the single write path, the backend task handler
+- [`modules/configs/bot_customization_config.py`](../modules/configs/bot_customization_config.py)
+  — `/config` panel + the two Modals V2
+- [`tests/test_bot_customization.py`](../tests/test_bot_customization.py) — validation tests
+
+---
+
+## The Discord endpoint
+
+Everything goes through **`PATCH /guilds/{guild.id}/members/@me`** ("modify
+current member"), called with the raw HTTP layer because discord.py exposes no
+wrapper for the style fields:
+
+```python
+route = discord.http.Route("PATCH", "/guilds/{guild_id}/members/@me", guild_id=guild_id)
+await bot.http.request(route, json=payload, reason="Bot customization (config) by 1234")
+```
+
+`reason` becomes the `X-Audit-Log-Reason` header, so every change is visible in
+the server's own audit log — not just in our technical logs.
+
+### Documented fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `nick` | `?string` | max 32 chars. Requires `CHANGE_NICKNAME`. |
+| `avatar` | `?string` | [data URI, base64](https://docs.discord.com/developers/reference#image-data) |
+| `banner` | `?string` | data URI — **not exposed by the module** (see *Not implemented* below) |
+| `bio` | `?string` | member bio, 190 chars including our attribution line |
+
+### Undocumented fields — name styles
+
+Not in Discord's documentation; tested and working on our instance.
+
+| Field | Type |
+|---|---|
+| `display_name_font_id` | `?int` |
+| `display_name_effect_id` | `?int` |
+| `display_name_colors` | `?int[]` (24-bit ints, 1 or 2 entries) |
+
+**Effects** (`EFFECTS` in the module — the value is how many colours the API
+requires):
+
+| ID | Name | Rendering | Colours |
+|---|---|---|---|
+| `2` | Gradient | fades between two colours, left → right | **exactly 2** |
+| `3` | Neon | glowing outline around the letters | 1 |
+| `4` | Toon | light fill + visible stroke | 1 |
+| `5` | Pop | coloured drop shadow behind the letters | 1 |
+
+**Fonts** (`FONTS` in the module):
+
+| ID | Name | Style |
+|---|---|---|
+| `3` | Cherry Bomb | bubbly, playful |
+| `4` | Chicle | round, jellybean |
+| `6` | MuseoModerno | geometric, modern |
+| `7` | Neo-Castel | gothic, medieval |
+| `8` | Pixelify Sans | pixel, 8-bit retro |
+| `10` | Sinistre | dark, gothic, jagged |
+| `12` | Zilla Slab | slab-serif, balanced |
+
+Gotchas, all encoded in `normalize_style` / `_style_payload`:
+
+- The API accepts font ids `1`–`12` and effect ids `1`–`6`, but only the ids
+  above render something distinguishable. Anything else is refused by us
+  before it reaches Discord.
+- Gradient with fewer than 2 colours → `400`.
+- **Resetting means sending `null` on all three fields** — `0` or `[]` are
+  refused.
+- **There is no GET.** The active style cannot be read back from Discord, which
+  is why we store it (see the schema below).
+- The style does **not** reliably survive a bot restart, unlike the nickname,
+  the avatar and the bio which Discord stores. Hence `resync_style()`.
+
+---
+
+## Attribution line
+
+A customized bio always ends with:
+
+```
+<a:Rocket:1535783839870353499> Powered by @**Moddy**
+```
+
+It is re-appended on every write (`build_bio`) and cannot be removed by the
+server. Only the *user portion* is stored in the DB and shown back in the
+modal, so the suffix never gets duplicated when a server edits its bio.
+
+The 190-character member-bio budget is shared: `MAX_BIO_LENGTH` is
+`190 - len(attribution) - len("\n\n")` = **136** characters for the server.
+`tests/test_bot_customization.py` pins that arithmetic — if the attribution
+text changes, the test is what catches the overflow.
+
+Clearing the bio clears everything, attribution included: a server that opted
+out of customization is not carrying our line.
+
+---
+
+## Storage
+
+`guilds.data.modules.bot_customization`:
+
+```json
+{
+  "nickname": "Guardian",
+  "bio": "Le bot de notre serveur",
+  "avatar_hash": "a_1c9e…",
+  "avatar_source": null,
+  "style": { "font_id": 7, "effect_id": 2, "colors": [16711680, 255] },
+  "updated_at": "2026-08-08T14:31:07+00:00",
+  "updated_by": 942386103000000000
+}
+```
+
+| Key | Meaning |
+|---|---|
+| `nickname` | user-set nickname, `null` = Moddy's default name |
+| `bio` | **user portion only**, attribution excluded |
+| `avatar_hash` | hash returned by the API — used to build the CDN preview URL. The image itself is never stored. |
+| `avatar_source` | last source URL for a dashboard-set avatar, informational |
+| `style.colors` | 24-bit ints (not hex strings) |
+
+The module is `enabled` when any of these is set — there is no separate on/off
+switch, an empty configuration is simply off.
+
+Guild avatar preview URL:
+`https://cdn.discordapp.com/guilds/{guild_id}/users/{bot_id}/avatars/{hash}.png`
+(`.gif` when the hash starts with `a_`).
+
+---
+
+## The single write path
+
+Everything — `/config`, the dashboard, a reset — goes through
+
+```python
+await module.apply_customization(
+    nickname=..., bio=..., avatar=(bytes, content_type), style={...},
+    actor_id=..., source="config" | "dashboard",
+)
+```
+
+Each field defaults to the `UNSET` sentinel (leave alone); passing `None`
+resets it. In one call it:
+
+1. validates (length, colours, font/effect ids, image type and size),
+2. builds one payload and issues a **single** PATCH,
+3. persists through `module_manager.save_module_config` (which reloads the live
+   instance),
+4. emits the technical log — **on failure too**.
+
+Failures raise `CustomizationError(code, detail)`. Codes are stable and double
+as i18n keys (`modules.bot_customization.errors.<code>`) and as API error codes
+for the dashboard:
+
+`premium_required`, `nickname_too_long`, `bio_too_long`, `invalid_color`,
+`invalid_font`, `invalid_effect`, `gradient_needs_two_colors`,
+`effect_needs_color`, `invalid_image_type`, `image_too_large`,
+`image_download_failed`, `missing_permissions`, `rate_limited`,
+`rejected_by_discord`, `discord_error`, `save_failed`, `empty_update`,
+`guild_not_found`, `internal_error`.
+
+### Avatar guard rails
+
+- allowed: `image/png`, `image/jpeg`, `image/gif`, `image/webp`
+- max **8 MiB**, enforced on the attachment size *and* on the downloaded bytes
+  (a dashboard URL can lie about `Content-Length`)
+- downloaded into memory, base64-encoded, never written to disk
+
+---
+
+## Technical logs
+
+Category **`bot_customization`** → `LOG_WEBHOOK_BOT_CUSTOMIZATION` (falls back
+to `LOG_WEBHOOK_DEFAULT`). One card per attempt, successful or not:
+
+```
+### Bot Customization
+Guild `Ma communauté` `123456789`
+Source `config` • By `942386103000000000`
+nickname `Guardian`
+avatar `48210 bytes (image/png)`
+✅ Applied
+```
+
+See [TECHNICAL_LOGS.md](TECHNICAL_LOGS.md).
+
+---
+
+## UI (`/config` → Bot Customization)
+
+- **No draft/save cycle.** A modal submit patches Discord immediately, because
+  the change is instantly visible in the member list — a pending "Save" button
+  would be lying. The panel therefore has no Save/Cancel, only Edit / Reset per
+  section and a global Reset.
+- **Identity modal** (premium): nickname `TextInput`, bio `TextInput`
+  (paragraph), avatar `FileUpload`, plus a `TextDisplay` warning about the
+  attribution line. Leaving the upload empty keeps the current avatar — use
+  *Reset* to remove it.
+- **Style modal** (everyone): font `Select`, effect `Select`, two colour
+  `TextInput`s. Colour 2 is only read by the gradient effect.
+- Non-premium servers see the identity section rendered but **locked**, with a
+  link to the dashboard — the feature is discoverable rather than hidden.
+- Premium is re-checked on the button click **and** on the modal submit: a
+  panel left open across a subscription lapse must not grant anything.
+- The panel is a persistent view (`BotCustomizationConfigView`, guild
+  `manage_guild` auth re-derived from the interaction). The modals are not —
+  modals never are, see [PERSISTENT_VIEWS.md](PERSISTENT_VIEWS.md).
+
+---
+
+## Startup resync
+
+`on_enable()` → `resync_style()` re-applies the stored name style **once per
+process per guild** (`bot._bot_customization_styled`), because Discord does not
+reliably keep it across a bot restart. Nickname, avatar and bio are never
+re-applied — Discord stores those.
+
+---
+
+## Dashboard integration (Redis)
+
+The dashboard cannot call the endpoint itself (it is the *bot's* own member
+profile), so it delegates: a task on the `moddy:tasks` stream, a result on the
+`moddy:dashboard` Pub/Sub channel. Full contract, including the field-presence
+semantics and every error code, in the backend section of this repository's
+integration notes — the bot side is `ModdyBot._process_bot_customization_task`
+and `BotCustomizationModule.handle_backend_task`.
+
+Task (stream `moddy:tasks`):
+
+```json
+{
+  "type": "bot_customization_update",
+  "guild_id": "123456789",
+  "payload": "{\"request_id\":\"…\",\"actor_id\":\"…\",\"nickname\":\"Guardian\",\"style\":{...}}"
+}
+```
+
+Result (channel `moddy:dashboard`):
+
+```json
+{
+  "type": "bot_customization_update_result",
+  "request_id": "…", "guild_id": 123456789,
+  "ok": true, "nickname": "Guardian", "avatar_hash": "a_1c9e…", "style": {...}
+}
+```
+
+**Key presence is the contract**: an absent key leaves the field untouched, an
+explicit `null` resets it. Premium is re-checked bot-side on every dashboard
+task — the backend's check is a UX filter, not a trust boundary.
+
+---
+
+## Not implemented (deliberately)
+
+- **Banner.** The endpoint supports `banner`, and the module's write path would
+  take it with a two-line change, but it was not part of the requested scope.
+- **Automatic revert on premium loss.** When a guild stops being premium the
+  stored identity stays applied; the panel simply locks. Reverting would need a
+  backend-driven sweep on `premium_deactivated`.

--- a/docs/PREMIUM.md
+++ b/docs/PREMIUM.md
@@ -1,0 +1,113 @@
+# Premium — how Moddy decides a server (or a user) is premium
+
+There are **two different questions** and they have two different answers.
+Mixing them up is the most common bug in this area.
+
+| Question | Helper | Source of truth |
+|---|---|---|
+| Does **this user** pay? | `utils.subscription.is_subscribed(bot, user_id)` | `users.subscription_tier` / `subscription_expires_at` |
+| Is **this server** premium? | `utils.subscription.is_guild_premium(bot, guild_id)` | `subscription_servers` ⨝ an active subscription |
+
+> ⚠️ There is **no `PREMIUM` guild attribute**. `db.has_attribute('guild', …, 'PREMIUM')`
+> is not the premium system — do not use it to gate a server feature.
+> (A `PREMIUM` *user* attribute exists for legacy staff tooling only.)
+
+---
+
+## The model
+
+A subscriber (`users.subscription_tier` set, `subscription_expires_at` in the
+future or `NULL`) picks a limited number of servers on the dashboard. Each pick
+is a row in `subscription_servers`. A guild is premium **while at least one of
+the users who selected it still has an active subscription** — so premium
+follows the payer, not the server: if the subscription lapses, every server they
+had selected silently stops being premium.
+
+```
+users (subscription_tier, subscription_expires_at)
+   │ 1
+   │
+   │ N
+subscription_servers (user_id, server_id, added_at)
+```
+
+Note the column types: `subscription_servers.user_id` and `.server_id` are
+**text**, `users.user_id` is **bigint**. The join casts (`ss.user_id::bigint`),
+and every call passes the id as `str(...)`. See
+[`db/repositories/subscription.py`](../db/repositories/subscription.py).
+
+---
+
+## Reading it from the bot
+
+```python
+from utils.subscription import is_guild_premium
+
+if not await is_guild_premium(bot, guild_id):
+    # show the locked state / refuse the premium action
+    ...
+```
+
+- **Never** call `bot.db.is_guild_premium()` directly on a hot path — the
+  helper in `utils/subscription.py` adds the Redis cache described below. The
+  repository method is the uncached fallback the helper builds on.
+- The bot **never writes** subscription data. Only the backend does.
+
+### Redis cache
+
+| Key | Value | TTL |
+|---|---|---|
+| `sub:user:{user_id}` | JSON `{tier, expires_at, stripe_customer_id}` | until expiry |
+| `sub:guild:{guild_id}` | `"1"` / `"0"` | 300 s |
+
+The guild key is written by the bot as a read-through cache and read by
+`is_guild_premium`. The short TTL is a self-healing safety net, not the primary
+invalidation path.
+
+### Invalidation (backend → bot)
+
+The backend publishes on `moddy:bot`:
+
+```json
+{ "type": "premium_activated",   "guild_id": 123456789 }
+{ "type": "premium_deactivated", "guild_id": 123456789 }
+```
+
+`ModdyBot._handle_bot_event` drops `sub:guild:{guild_id}` on either event, so
+the next check re-reads from PostgreSQL. Publish one event **per affected
+guild** when a subscription starts, renews, lapses or when the subscriber edits
+their server selection.
+
+User-scoped changes go on `moddy:subscription:updates` instead — see
+[SUBSCRIPTION_SCHEMA.md](SUBSCRIPTION_SCHEMA.md).
+
+---
+
+## Gating a feature
+
+1. Check premium **at the moment of the action**, not only when rendering the
+   UI — a panel can sit open for hours, and a stale render must never be an
+   entitlement.
+2. Check it again on anything the **dashboard** delegates to the bot: the
+   backend's own check is a UX filter, not a trust boundary.
+3. Prefer *degrading* over *hiding*: show the section with a locked state and a
+   link to `https://dashboard.moddy.app/select-premium-servers`, so servers
+   discover what they would get.
+
+[`modules/bot_customization.py`](../modules/bot_customization.py) +
+[`modules/configs/bot_customization_config.py`](../modules/configs/bot_customization_config.py)
+implement all three (premium identity, free name style), and
+[`modules/social_notifications.py`](../modules/social_notifications.py) shows
+the quota-style variant (premium raises a limit instead of unlocking a
+feature).
+
+---
+
+## What premium currently changes
+
+| Feature | Free | Premium |
+|---|---|---|
+| Bot Customization — nickname / avatar / bio | ❌ | ✅ |
+| Bot Customization — name style (font, effect, colours) | ✅ | ✅ |
+| Social Notifications — accounts per platform | `FREE_PER_PLATFORM_LIMIT` | `PREMIUM_PER_PLATFORM_LIMIT` |
+| Social Notifications — poll interval | slow tier | fast tier |

--- a/docs/TECHNICAL_LOGS.md
+++ b/docs/TECHNICAL_LOGS.md
@@ -37,6 +37,7 @@ Each category reads its own webhook URL. Any category left unset falls back to
 | `command` | `LOG_WEBHOOK_COMMAND` | Non-staff command usage (slash, context-menu, prefix) |
 | `database` | `LOG_WEBHOOK_DATABASE` | Config changes / important DB writes |
 | `security` | `LOG_WEBHOOK_SECURITY` | Sensitive events (blacklist blocks, blacklist attribute…) |
+| `bot_customization` | `LOG_WEBHOOK_BOT_CUSTOMIZATION` | Moddy's per-guild identity changed (nickname / avatar / bio / name style) |
 | _fallback_ | `LOG_WEBHOOK_DEFAULT` | Used for any category without a dedicated URL |
 
 Mapping lives in [`config.py`](../config.py) (`LOG_WEBHOOK_ENV` → `LOG_WEBHOOKS`).
@@ -58,6 +59,7 @@ Mapping lives in [`config.py`](../config.py) (`LOG_WEBHOOK_ENV` → `LOG_WEBHOOK
 | Non-staff commands | `cogs/command_logger.py` | `log_command` |
 | Attribute writes (blacklist, premium, official, verified…) | `db.set_attribute` hook | `log_attribute_change` |
 | Config / module writes | `db._update_entity_data` hook | `log_data_change` |
+| Bot identity changed on a guild | `modules/bot_customization.apply_customization` | `log_bot_customization` |
 
 ### DB write hooks
 

--- a/docs/sessions/2026-08-08_bot-customization-module.md
+++ b/docs/sessions/2026-08-08_bot-customization-module.md
@@ -1,0 +1,78 @@
+# 2026-08-08 — Bot Customization module
+
+## What was done
+
+New server module **`bot_customization`**: a server can make Moddy look like
+its own bot, per-guild.
+
+- **Premium** (guild covered by an active subscription): nickname, avatar, bio.
+  The bio always keeps a trailing `<a:Rocket:…> Powered by @**Moddy**` line that
+  the server cannot remove.
+- **Free**: the name style (font, effect, colours) applied to the bot's display
+  name, via the undocumented `display_name_font_id` / `display_name_effect_id` /
+  `display_name_colors` fields.
+
+Everything goes through `PATCH /guilds/{guild_id}/members/@me` with an
+`X-Audit-Log-Reason`, and every change — successful or failed — emits a
+technical log.
+
+Also documented the **premium system**, which had no doc: it is
+`subscription_servers` ⨝ an active subscription, *not* a guild attribute. Added
+a cached `utils.subscription.is_guild_premium` helper and wired the existing
+`premium_activated` / `premium_deactivated` Pub/Sub events to invalidate it
+(they previously only logged).
+
+## Files
+
+**New**
+- `modules/bot_customization.py` — module, validation, single write path, backend task handler
+- `modules/configs/bot_customization_config.py` — `/config` panel + two Modals V2
+- `tests/test_bot_customization.py` — validation tests (22)
+- `docs/BOT_CUSTOMIZATION.md`, `docs/PREMIUM.md`
+
+**Modified**
+- `bot.py` — `bot_customization_update` task on the `moddy:tasks` stream + guild premium cache invalidation
+- `cogs/config.py` — module routed in `/config`
+- `config.py`, `utils/tech_logger.py` — new `bot_customization` log category + `log_bot_customization`
+- `utils/subscription.py` — `is_guild_premium`, `invalidate_guild_cache`
+- `utils/emojis.py` — `ROCKET`
+- `utils/persistent_views.py` — `BotCustomizationConfigView` registered
+- `locales/{fr,en-US,es-ES,pt-BR,de}.json` — full `modules.bot_customization` block
+- `CLAUDE.md`, `docs/TECHNICAL_LOGS.md`
+
+## Decisions
+
+- **No draft/save cycle in the UI.** Every other module panel has
+  Save/Cancel/Delete, this one has Edit/Reset. A modal submit patches Discord
+  immediately and the change is instantly visible in the member list — a
+  pending "Save" button would be lying about the state.
+- **Single write path.** `apply_customization()` is the only place that
+  validates, patches, persists and logs, so `/config` and the dashboard cannot
+  drift apart. `UNSET` sentinel = leave alone, `None` = reset.
+- **The avatar image is never stored**, only the hash Discord returns (used to
+  build the CDN preview URL). Storing multi-MB base64 in `guilds.data` would be
+  a bad idea, and attachment CDN URLs expire.
+- **Only the style is re-applied on startup.** Nickname, avatar and bio are
+  stored by Discord; the name style is not guaranteed to survive a restart, so
+  `resync_style()` re-applies it once per process per guild.
+- **Only the user portion of the bio is stored**, so the attribution suffix is
+  never duplicated when a server re-edits its bio. `MAX_BIO_LENGTH` (136) is
+  derived from the 190-char limit minus the suffix, and a test pins the
+  arithmetic so a longer attribution text fails loudly.
+- **Premium is re-checked on the modal submit**, not just when rendering the
+  panel or clicking the button — a panel can sit open across a subscription
+  lapse. Same on every dashboard task: the backend's check is a UX filter, not
+  a trust boundary.
+- **Locked, not hidden**, for non-premium servers: the identity section renders
+  with a lock note and a dashboard link.
+
+## Follow-ups
+
+- **Banner** is supported by the endpoint and would be a two-line change in the
+  write path, but was out of the requested scope.
+- **No automatic revert on premium loss**: the stored identity stays applied and
+  the panel just locks. A backend sweep on `premium_deactivated` would be needed.
+- The 190-character member-bio limit is assumed from Discord's user-bio limit;
+  worth confirming empirically for bot members.
+- Backend still has to implement its half of the Redis contract (task producer +
+  result consumer) — spec delivered separately, mirrored in `docs/BOT_CUSTOMIZATION.md`.

--- a/locales/de.json
+++ b/locales/de.json
@@ -1792,6 +1792,99 @@
           "selected": "{count} Kanal/Kanäle"
         }
       }
+    },
+    "bot_customization": {
+      "name": "Bot-Anpassung",
+      "description": "Passe Moddys Identität auf diesem Server an",
+      "config": {
+        "title": "Bot-Anpassung",
+        "description": "Lass Moddy wie ein Bot deines Servers aussehen. Diese Einstellungen gelten nur hier.",
+        "not_set": "Nicht festgelegt",
+        "custom": "Angepasst"
+      },
+      "identity": {
+        "section_title": "Identität",
+        "section_description": "Moddys Spitzname, Avatar und Bio auf diesem Server",
+        "modal_title": "Moddys Identität",
+        "nickname_label": "Spitzname",
+        "nickname_description": "Leer lassen, um den ursprünglichen Namen zu behalten",
+        "bio_label": "Bio",
+        "bio_description": "Maximal {max} Zeichen, leer lassen zum Entfernen",
+        "avatar_label": "Avatar",
+        "avatar_description": "PNG, JPEG, GIF oder WEBP — maximal 8 MB",
+        "attribution_note": "-# Die Bio endet immer mit der Zeile <a:Rocket:1535783839870353499> Powered by @**Moddy**, die nicht entfernt werden kann.",
+        "edit": "Identität bearbeiten",
+        "reset": "Zurücksetzen"
+      },
+      "premium": {
+        "title": "Premium-Funktion",
+        "description": "Spitzname, Avatar und Bio von Moddy anzupassen ist Premium-Servern vorbehalten.",
+        "locked": "Spitzname, Avatar und Bio erfordern ein Moddy-Max-Abo auf diesem Server.",
+        "button": "Premium holen"
+      },
+      "style": {
+        "section_title": "Namensstil",
+        "section_description": "Schriftart, Effekt und Farben für Moddys angezeigten Namen",
+        "free_note": "Auf jedem Server verfügbar, ganz ohne Abo.",
+        "modal_title": "Namensstil",
+        "font_label": "Schriftart",
+        "font_placeholder": "Schriftart wählen",
+        "effect_label": "Effekt",
+        "effect_placeholder": "Effekt wählen",
+        "colors_label": "Farben",
+        "color1_label": "Farbe 1",
+        "color1_description": "Hexadezimalformat, zum Beispiel #5865F2",
+        "color2_label": "Farbe 2",
+        "color2_description": "Nur für den Farbverlauf (rechte Farbe)",
+        "none": "Keine",
+        "edit": "Stil bearbeiten",
+        "reset": "Zurücksetzen",
+        "effects": {
+          "gradient": {
+            "label": "Farbverlauf",
+            "description": "Verlauf zwischen zwei Farben, von links nach rechts"
+          },
+          "neon": {
+            "label": "Neon",
+            "description": "Leuchtende Kontur um die Buchstaben"
+          },
+          "toon": {
+            "label": "Toon",
+            "description": "Leichte Füllung mit deutlicher Kontur"
+          },
+          "pop": {
+            "label": "Pop",
+            "description": "Farbiger Schlagschatten hinter den Buchstaben"
+          }
+        }
+      },
+      "applied": {
+        "title": "Anpassung übernommen",
+        "description": "Die Änderungen sind auf diesem Server sofort sichtbar."
+      },
+      "reset": {
+        "title": "Anpassung zurückgesetzt",
+        "description": "Moddy sieht auf diesem Server wieder ganz normal aus."
+      },
+      "errors": {
+        "title": "Anpassung fehlgeschlagen",
+        "premium_required": "Diese Option ist Premium-Servern vorbehalten.",
+        "nickname_too_long": "Der Spitzname ist länger als 32 Zeichen.",
+        "bio_too_long": "Die Bio ist zu lang.",
+        "invalid_color": "Ungültige Farbe: nutze ein Hexadezimalformat wie #5865F2.",
+        "invalid_font": "Unbekannte Schriftart.",
+        "invalid_effect": "Unbekannter Effekt.",
+        "gradient_needs_two_colors": "Der Farbverlauf braucht genau zwei Farben.",
+        "effect_needs_color": "Dieser Effekt braucht mindestens eine Farbe.",
+        "invalid_image_type": "Nicht unterstütztes Bildformat: nutze PNG, JPEG, GIF oder WEBP.",
+        "image_too_large": "Das Bild ist größer als 8 MB.",
+        "image_download_failed": "Das Bild konnte nicht heruntergeladen werden.",
+        "missing_permissions": "Moddy darf sein eigenes Profil hier nicht bearbeiten.",
+        "rate_limited": "Zu viele Änderungen hintereinander, versuche es gleich noch einmal.",
+        "rejected_by_discord": "Discord hat diese Werte abgelehnt.",
+        "discord_error": "Discord konnte diese Änderung nicht übernehmen.",
+        "save_failed": "Die Änderung wurde übernommen, konnte aber nicht gespeichert werden."
+      }
     }
   },
   "languages": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1792,6 +1792,99 @@
           "selected": "{count} channel(s)"
         }
       }
+    },
+    "bot_customization": {
+      "name": "Bot Customization",
+      "description": "Customize Moddy's identity on this server",
+      "config": {
+        "title": "Bot Customization",
+        "description": "Make Moddy look like it belongs to your server. These settings only apply here.",
+        "not_set": "Not set",
+        "custom": "Custom"
+      },
+      "identity": {
+        "section_title": "Identity",
+        "section_description": "Moddy's nickname, avatar and bio on this server",
+        "modal_title": "Moddy's identity",
+        "nickname_label": "Nickname",
+        "nickname_description": "Leave empty to restore the original name",
+        "bio_label": "Bio",
+        "bio_description": "{max} characters max, leave empty to remove it",
+        "avatar_label": "Avatar",
+        "avatar_description": "PNG, JPEG, GIF or WEBP — 8 MB max",
+        "attribution_note": "-# The bio always ends with the <a:Rocket:1535783839870353499> Powered by @**Moddy** line, which cannot be removed.",
+        "edit": "Edit identity",
+        "reset": "Reset"
+      },
+      "premium": {
+        "title": "Premium feature",
+        "description": "Customizing Moddy's nickname, avatar and bio is reserved for premium servers.",
+        "locked": "Nickname, avatar and bio require a Moddy Max subscription on this server.",
+        "button": "Get premium"
+      },
+      "style": {
+        "section_title": "Name style",
+        "section_description": "Font, effect and colours applied to Moddy's display name",
+        "free_note": "Available on every server, no subscription needed.",
+        "modal_title": "Name style",
+        "font_label": "Font",
+        "font_placeholder": "Pick a font",
+        "effect_label": "Effect",
+        "effect_placeholder": "Pick an effect",
+        "colors_label": "Colours",
+        "color1_label": "Colour 1",
+        "color1_description": "Hexadecimal format, for example #5865F2",
+        "color2_label": "Colour 2",
+        "color2_description": "Gradient only (the right-hand colour)",
+        "none": "None",
+        "edit": "Edit style",
+        "reset": "Reset",
+        "effects": {
+          "gradient": {
+            "label": "Gradient",
+            "description": "Fades between two colours, left to right"
+          },
+          "neon": {
+            "label": "Neon",
+            "description": "Glowing outline around the letters"
+          },
+          "toon": {
+            "label": "Toon",
+            "description": "Light fill with a strong outline"
+          },
+          "pop": {
+            "label": "Pop",
+            "description": "Coloured drop shadow behind the letters"
+          }
+        }
+      },
+      "applied": {
+        "title": "Customization applied",
+        "description": "The changes are already visible on this server."
+      },
+      "reset": {
+        "title": "Customization reset",
+        "description": "Moddy is back to its original look on this server."
+      },
+      "errors": {
+        "title": "Customization failed",
+        "premium_required": "This option is reserved for premium servers.",
+        "nickname_too_long": "The nickname is longer than 32 characters.",
+        "bio_too_long": "The bio is too long.",
+        "invalid_color": "Invalid colour: use a hexadecimal format such as #5865F2.",
+        "invalid_font": "Unknown font.",
+        "invalid_effect": "Unknown effect.",
+        "gradient_needs_two_colors": "The gradient effect requires exactly two colours.",
+        "effect_needs_color": "This effect requires at least one colour.",
+        "invalid_image_type": "Unsupported image format: use PNG, JPEG, GIF or WEBP.",
+        "image_too_large": "The image is larger than 8 MB.",
+        "image_download_failed": "The image could not be downloaded.",
+        "missing_permissions": "Moddy is not allowed to edit its own profile here.",
+        "rate_limited": "Too many changes in a row, try again in a moment.",
+        "rejected_by_discord": "Discord rejected these values.",
+        "discord_error": "Discord could not apply this change.",
+        "save_failed": "The change was applied but could not be saved."
+      }
     }
   },
   "languages": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1792,6 +1792,99 @@
           "selected": "{count} canal(es)"
         }
       }
+    },
+    "bot_customization": {
+      "name": "Personalización del bot",
+      "description": "Personaliza la identidad de Moddy en este servidor",
+      "config": {
+        "title": "Personalización del bot",
+        "description": "Haz que Moddy tenga el aspecto de tu servidor. Estos ajustes solo se aplican aquí.",
+        "not_set": "Sin definir",
+        "custom": "Personalizado"
+      },
+      "identity": {
+        "section_title": "Identidad",
+        "section_description": "Apodo, avatar y biografía de Moddy en este servidor",
+        "modal_title": "Identidad de Moddy",
+        "nickname_label": "Apodo",
+        "nickname_description": "Déjalo vacío para restaurar el nombre original",
+        "bio_label": "Biografía",
+        "bio_description": "{max} caracteres como máximo, vacío para eliminarla",
+        "avatar_label": "Avatar",
+        "avatar_description": "PNG, JPEG, GIF o WEBP — 8 MB como máximo",
+        "attribution_note": "-# La biografía siempre termina con la línea <a:Rocket:1535783839870353499> Powered by @**Moddy**, que no se puede quitar.",
+        "edit": "Editar identidad",
+        "reset": "Restablecer"
+      },
+      "premium": {
+        "title": "Función premium",
+        "description": "Personalizar el apodo, el avatar y la biografía de Moddy está reservado a los servidores premium.",
+        "locked": "El apodo, el avatar y la biografía requieren una suscripción Moddy Max en este servidor.",
+        "button": "Obtener premium"
+      },
+      "style": {
+        "section_title": "Estilo del nombre",
+        "section_description": "Fuente, efecto y colores aplicados al nombre mostrado de Moddy",
+        "free_note": "Disponible en todos los servidores, sin suscripción.",
+        "modal_title": "Estilo del nombre",
+        "font_label": "Fuente",
+        "font_placeholder": "Elige una fuente",
+        "effect_label": "Efecto",
+        "effect_placeholder": "Elige un efecto",
+        "colors_label": "Colores",
+        "color1_label": "Color 1",
+        "color1_description": "Formato hexadecimal, por ejemplo #5865F2",
+        "color2_label": "Color 2",
+        "color2_description": "Solo para el degradado (color de la derecha)",
+        "none": "Ninguno",
+        "edit": "Editar estilo",
+        "reset": "Restablecer",
+        "effects": {
+          "gradient": {
+            "label": "Degradado",
+            "description": "Transición entre dos colores, de izquierda a derecha"
+          },
+          "neon": {
+            "label": "Neón",
+            "description": "Contorno luminoso alrededor de las letras"
+          },
+          "toon": {
+            "label": "Toon",
+            "description": "Relleno suave con un contorno marcado"
+          },
+          "pop": {
+            "label": "Pop",
+            "description": "Sombra de color detrás de las letras"
+          }
+        }
+      },
+      "applied": {
+        "title": "Personalización aplicada",
+        "description": "Los cambios ya son visibles en este servidor."
+      },
+      "reset": {
+        "title": "Personalización restablecida",
+        "description": "Moddy ha recuperado su aspecto original en este servidor."
+      },
+      "errors": {
+        "title": "No se pudo personalizar",
+        "premium_required": "Esta opción está reservada a los servidores premium.",
+        "nickname_too_long": "El apodo supera los 32 caracteres.",
+        "bio_too_long": "La biografía es demasiado larga.",
+        "invalid_color": "Color no válido: usa un formato hexadecimal como #5865F2.",
+        "invalid_font": "Fuente desconocida.",
+        "invalid_effect": "Efecto desconocido.",
+        "gradient_needs_two_colors": "El degradado necesita exactamente dos colores.",
+        "effect_needs_color": "Este efecto necesita al menos un color.",
+        "invalid_image_type": "Formato de imagen no compatible: usa PNG, JPEG, GIF o WEBP.",
+        "image_too_large": "La imagen supera los 8 MB.",
+        "image_download_failed": "No se pudo descargar la imagen.",
+        "missing_permissions": "Moddy no tiene permiso para editar su perfil aquí.",
+        "rate_limited": "Demasiados cambios seguidos, inténtalo de nuevo en un momento.",
+        "rejected_by_discord": "Discord rechazó estos valores.",
+        "discord_error": "Discord no pudo aplicar este cambio.",
+        "save_failed": "El cambio se aplicó pero no se pudo guardar."
+      }
     }
   },
   "languages": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1791,6 +1791,99 @@
           "selected": "{count} salon(s)"
         }
       }
+    },
+    "bot_customization": {
+      "name": "Personnalisation du bot",
+      "description": "Personnalise l'identité de Moddy sur ce serveur",
+      "config": {
+        "title": "Personnalisation du bot",
+        "description": "Donne à Moddy l'apparence de ton serveur. Ces réglages ne s'appliquent qu'ici.",
+        "not_set": "Non défini",
+        "custom": "Personnalisé"
+      },
+      "identity": {
+        "section_title": "Identité",
+        "section_description": "Pseudo, avatar et bio de Moddy sur ce serveur",
+        "modal_title": "Identité de Moddy",
+        "nickname_label": "Pseudo",
+        "nickname_description": "Laisse vide pour revenir au nom d'origine",
+        "bio_label": "Bio",
+        "bio_description": "{max} caractères maximum, laisse vide pour la retirer",
+        "avatar_label": "Avatar",
+        "avatar_description": "PNG, JPEG, GIF ou WEBP — 8 Mo maximum",
+        "attribution_note": "-# La bio se termine toujours par la ligne <a:Rocket:1535783839870353499> Powered by @**Moddy**, elle ne peut pas être retirée.",
+        "edit": "Modifier l'identité",
+        "reset": "Réinitialiser"
+      },
+      "premium": {
+        "title": "Fonctionnalité premium",
+        "description": "La personnalisation du pseudo, de l'avatar et de la bio de Moddy est réservée aux serveurs premium.",
+        "locked": "Le pseudo, l'avatar et la bio nécessitent un abonnement Moddy Max sur ce serveur.",
+        "button": "Passer en premium"
+      },
+      "style": {
+        "section_title": "Style du pseudo",
+        "section_description": "Police, effet et couleurs appliqués au nom affiché de Moddy",
+        "free_note": "Disponible sur tous les serveurs, sans abonnement.",
+        "modal_title": "Style du pseudo",
+        "font_label": "Police",
+        "font_placeholder": "Choisis une police",
+        "effect_label": "Effet",
+        "effect_placeholder": "Choisis un effet",
+        "colors_label": "Couleurs",
+        "color1_label": "Couleur 1",
+        "color1_description": "Format hexadécimal, par exemple #5865F2",
+        "color2_label": "Couleur 2",
+        "color2_description": "Uniquement pour le dégradé (couleur de droite)",
+        "none": "Aucun",
+        "edit": "Modifier le style",
+        "reset": "Réinitialiser",
+        "effects": {
+          "gradient": {
+            "label": "Dégradé",
+            "description": "Dégradé entre deux couleurs, de gauche à droite"
+          },
+          "neon": {
+            "label": "Néon",
+            "description": "Contour lumineux autour des lettres"
+          },
+          "toon": {
+            "label": "Toon",
+            "description": "Remplissage léger avec un contour marqué"
+          },
+          "pop": {
+            "label": "Pop",
+            "description": "Ombre portée colorée derrière les lettres"
+          }
+        }
+      },
+      "applied": {
+        "title": "Personnalisation appliquée",
+        "description": "Les changements sont visibles immédiatement sur ce serveur."
+      },
+      "reset": {
+        "title": "Personnalisation réinitialisée",
+        "description": "Moddy a retrouvé son apparence d'origine sur ce serveur."
+      },
+      "errors": {
+        "title": "Personnalisation impossible",
+        "premium_required": "Cette option est réservée aux serveurs premium.",
+        "nickname_too_long": "Le pseudo dépasse 32 caractères.",
+        "bio_too_long": "La bio est trop longue.",
+        "invalid_color": "Couleur invalide : utilise un format hexadécimal comme #5865F2.",
+        "invalid_font": "Police inconnue.",
+        "invalid_effect": "Effet inconnu.",
+        "gradient_needs_two_colors": "Le dégradé nécessite exactement deux couleurs.",
+        "effect_needs_color": "Cet effet nécessite au moins une couleur.",
+        "invalid_image_type": "Format d'image non supporté : utilise un PNG, JPEG, GIF ou WEBP.",
+        "image_too_large": "L'image dépasse 8 Mo.",
+        "image_download_failed": "Impossible de télécharger l'image.",
+        "missing_permissions": "Moddy n'a pas la permission de modifier son profil ici.",
+        "rate_limited": "Trop de modifications d'affilée, réessaie dans quelques instants.",
+        "rejected_by_discord": "Discord a refusé ces valeurs.",
+        "discord_error": "Discord n'a pas pu appliquer ce changement.",
+        "save_failed": "Le changement a été appliqué mais n'a pas pu être enregistré."
+      }
     }
   },
   "languages": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1792,6 +1792,99 @@
           "selected": "{count} canal(is)"
         }
       }
+    },
+    "bot_customization": {
+      "name": "Personalização do bot",
+      "description": "Personalize a identidade do Moddy neste servidor",
+      "config": {
+        "title": "Personalização do bot",
+        "description": "Deixe o Moddy com a cara do seu servidor. Estas configurações valem só aqui.",
+        "not_set": "Não definido",
+        "custom": "Personalizado"
+      },
+      "identity": {
+        "section_title": "Identidade",
+        "section_description": "Apelido, avatar e bio do Moddy neste servidor",
+        "modal_title": "Identidade do Moddy",
+        "nickname_label": "Apelido",
+        "nickname_description": "Deixe vazio para voltar ao nome original",
+        "bio_label": "Bio",
+        "bio_description": "{max} caracteres no máximo, vazio para remover",
+        "avatar_label": "Avatar",
+        "avatar_description": "PNG, JPEG, GIF ou WEBP — 8 MB no máximo",
+        "attribution_note": "-# A bio sempre termina com a linha <a:Rocket:1535783839870353499> Powered by @**Moddy**, que não pode ser removida.",
+        "edit": "Editar identidade",
+        "reset": "Redefinir"
+      },
+      "premium": {
+        "title": "Recurso premium",
+        "description": "Personalizar o apelido, o avatar e a bio do Moddy é exclusivo dos servidores premium.",
+        "locked": "Apelido, avatar e bio exigem uma assinatura Moddy Max neste servidor.",
+        "button": "Assinar premium"
+      },
+      "style": {
+        "section_title": "Estilo do nome",
+        "section_description": "Fonte, efeito e cores aplicados ao nome exibido do Moddy",
+        "free_note": "Disponível em todos os servidores, sem assinatura.",
+        "modal_title": "Estilo do nome",
+        "font_label": "Fonte",
+        "font_placeholder": "Escolha uma fonte",
+        "effect_label": "Efeito",
+        "effect_placeholder": "Escolha um efeito",
+        "colors_label": "Cores",
+        "color1_label": "Cor 1",
+        "color1_description": "Formato hexadecimal, por exemplo #5865F2",
+        "color2_label": "Cor 2",
+        "color2_description": "Apenas para o degradê (cor da direita)",
+        "none": "Nenhum",
+        "edit": "Editar estilo",
+        "reset": "Redefinir",
+        "effects": {
+          "gradient": {
+            "label": "Degradê",
+            "description": "Transição entre duas cores, da esquerda para a direita"
+          },
+          "neon": {
+            "label": "Neon",
+            "description": "Contorno luminoso ao redor das letras"
+          },
+          "toon": {
+            "label": "Toon",
+            "description": "Preenchimento leve com contorno marcante"
+          },
+          "pop": {
+            "label": "Pop",
+            "description": "Sombra colorida atrás das letras"
+          }
+        }
+      },
+      "applied": {
+        "title": "Personalização aplicada",
+        "description": "As mudanças já aparecem neste servidor."
+      },
+      "reset": {
+        "title": "Personalização redefinida",
+        "description": "O Moddy voltou à aparência original neste servidor."
+      },
+      "errors": {
+        "title": "Não foi possível personalizar",
+        "premium_required": "Esta opção é exclusiva dos servidores premium.",
+        "nickname_too_long": "O apelido passa de 32 caracteres.",
+        "bio_too_long": "A bio é longa demais.",
+        "invalid_color": "Cor inválida: use um formato hexadecimal como #5865F2.",
+        "invalid_font": "Fonte desconhecida.",
+        "invalid_effect": "Efeito desconhecido.",
+        "gradient_needs_two_colors": "O degradê precisa de exatamente duas cores.",
+        "effect_needs_color": "Este efeito precisa de pelo menos uma cor.",
+        "invalid_image_type": "Formato de imagem não suportado: use PNG, JPEG, GIF ou WEBP.",
+        "image_too_large": "A imagem passa de 8 MB.",
+        "image_download_failed": "Não foi possível baixar a imagem.",
+        "missing_permissions": "O Moddy não tem permissão para editar o próprio perfil aqui.",
+        "rate_limited": "Muitas mudanças seguidas, tente de novo em instantes.",
+        "rejected_by_discord": "O Discord recusou estes valores.",
+        "discord_error": "O Discord não conseguiu aplicar esta mudança.",
+        "save_failed": "A mudança foi aplicada mas não pôde ser salva."
+      }
     }
   },
   "languages": {

--- a/modules/bot_customization.py
+++ b/modules/bot_customization.py
@@ -1,0 +1,574 @@
+"""
+Bot Customization module — makes Moddy look like the server's own bot.
+
+Everything here targets ``PATCH /guilds/{guild_id}/members/@me``, the endpoint
+that edits the bot's *per-guild* member profile. Nothing is global: another
+server never sees the customization of this one.
+
+Two tiers:
+
+- **Premium** (guild linked to an active subscription, see ``docs/PREMIUM.md``):
+  nickname, avatar and bio. The bio always keeps a trailing attribution line
+  (``Powered by @**Moddy**``) which the server cannot remove.
+- **Free**: the *name style* (font, effect, colours) applied to the bot's
+  display name. This is the undocumented ``display_name_font_id`` /
+  ``display_name_effect_id`` / ``display_name_colors`` trio — see
+  ``docs/BOT_CUSTOMIZATION.md``.
+
+Persistence asymmetry, and why ``resync_style`` exists: nickname, avatar and
+bio are stored by Discord and survive anything. The name style does **not**
+reliably survive a bot restart, so it is re-applied once per process the first
+time the module is loaded for a guild.
+
+Every successful or failed change goes through :meth:`apply_customization`,
+which is the single place that writes the DB, patches Discord and emits the
+technical log — no matter whether the change came from ``/config`` or from the
+dashboard through Redis.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import aiohttp
+import discord
+
+from modules.module_manager import ModuleBase
+from utils.emojis import MODDY_SQUARE
+
+logger = logging.getLogger("moddy.modules.bot_customization")
+
+MODULE_ID = "bot_customization"
+
+# --------------------------------------------------------------------------- #
+# Discord limits
+# --------------------------------------------------------------------------- #
+
+MAX_NICKNAME_LENGTH = 32
+# Discord caps a member bio at 190 characters. The attribution suffix is part
+# of that budget, so the server-editable part is what is left.
+MAX_BIO_TOTAL_LENGTH = 190
+
+# The attribution line appended to every customized bio. Servers cannot remove
+# it — it is re-appended on every write.
+BIO_ATTRIBUTION = "<a:Rocket:1535783839870353499> Powered by @**Moddy**"
+BIO_SEPARATOR = "\n\n"
+MAX_BIO_LENGTH = MAX_BIO_TOTAL_LENGTH - len(BIO_ATTRIBUTION) - len(BIO_SEPARATOR)
+
+# Avatar upload guard rails. Discord accepts a bit more, but a server-supplied
+# file is downloaded into memory before being base64-encoded, so we stay low.
+MAX_AVATAR_BYTES = 8 * 1024 * 1024
+ALLOWED_AVATAR_TYPES = {
+    "image/png": "png",
+    "image/jpeg": "jpeg",
+    "image/jpg": "jpeg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+}
+
+# --------------------------------------------------------------------------- #
+# Name styles (undocumented API — tested, see docs/BOT_CUSTOMIZATION.md)
+# --------------------------------------------------------------------------- #
+
+# font id -> human name. Discord accepts 1..12 but only these render a font
+# that is actually distinguishable; the others are the default face.
+FONTS: Dict[int, str] = {
+    3: "Cherry Bomb",
+    4: "Chicle",
+    6: "MuseoModerno",
+    7: "Neo-Castel",
+    8: "Pixelify Sans",
+    10: "Sinistre",
+    12: "Zilla Slab",
+}
+
+EFFECT_GRADIENT = 2
+EFFECT_NEON = 3
+EFFECT_TOON = 4
+EFFECT_POP = 5
+
+# effect id -> number of colours the API requires for it.
+EFFECTS: Dict[int, int] = {
+    EFFECT_GRADIENT: 2,
+    EFFECT_NEON: 1,
+    EFFECT_TOON: 1,
+    EFFECT_POP: 1,
+}
+
+# Translation key suffix per effect, used by the config UI.
+EFFECT_KEYS: Dict[int, str] = {
+    EFFECT_GRADIENT: "gradient",
+    EFFECT_NEON: "neon",
+    EFFECT_TOON: "toon",
+    EFFECT_POP: "pop",
+}
+
+MAX_COLOR = 0xFFFFFF
+
+
+class _Unset:
+    """Sentinel: 'this field is not part of the change'."""
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return "<unset>"
+
+
+UNSET = _Unset()
+
+
+class CustomizationError(Exception):
+    """A change was refused. ``code`` is a stable i18n / API error code."""
+
+    def __init__(self, code: str, detail: Optional[str] = None):
+        super().__init__(detail or code)
+        self.code = code
+        self.detail = detail
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def build_bio(user_bio: Optional[str]) -> Optional[str]:
+    """Return the bio actually sent to Discord, attribution line included."""
+    user_bio = (user_bio or "").strip()
+    if not user_bio:
+        return BIO_ATTRIBUTION
+    return f"{user_bio}{BIO_SEPARATOR}{BIO_ATTRIBUTION}"
+
+
+def parse_hex_color(raw: Optional[str]) -> Optional[int]:
+    """Parse ``#RRGGBB`` / ``RRGGBB`` into a 24-bit int, or None if empty."""
+    if raw is None:
+        return None
+    raw = raw.strip().lstrip("#")
+    if not raw:
+        return None
+    try:
+        value = int(raw, 16)
+    except ValueError:
+        raise CustomizationError("invalid_color", raw)
+    if not 0 <= value <= MAX_COLOR:
+        raise CustomizationError("invalid_color", raw)
+    return value
+
+
+def color_to_hex(value: Optional[int]) -> str:
+    return "" if value is None else f"#{value:06X}"
+
+
+def normalize_style(style: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Validate a style dict and return it in canonical form.
+
+    ``{'font_id': None, 'effect_id': None, 'colors': []}`` means "no style".
+    """
+    style = style or {}
+    font_id = style.get("font_id")
+    effect_id = style.get("effect_id")
+    colors = list(style.get("colors") or [])
+
+    if font_id is not None:
+        try:
+            font_id = int(font_id)
+        except (TypeError, ValueError):
+            raise CustomizationError("invalid_font")
+        if font_id not in FONTS:
+            raise CustomizationError("invalid_font")
+
+    if effect_id is not None:
+        try:
+            effect_id = int(effect_id)
+        except (TypeError, ValueError):
+            raise CustomizationError("invalid_effect")
+        if effect_id not in EFFECTS:
+            raise CustomizationError("invalid_effect")
+
+    parsed: List[int] = []
+    for color in colors:
+        if isinstance(color, str):
+            value = parse_hex_color(color)
+            if value is None:
+                continue
+        else:
+            try:
+                value = int(color)
+            except (TypeError, ValueError):
+                raise CustomizationError("invalid_color", str(color))
+            if not 0 <= value <= MAX_COLOR:
+                raise CustomizationError("invalid_color", str(color))
+        parsed.append(value)
+
+    if effect_id is None:
+        # An effect is what paints the colours — without one they are ignored.
+        parsed = []
+    else:
+        required = EFFECTS[effect_id]
+        if len(parsed) < required:
+            raise CustomizationError(
+                "gradient_needs_two_colors" if effect_id == EFFECT_GRADIENT
+                else "effect_needs_color"
+            )
+        parsed = parsed[:required]
+
+    return {"font_id": font_id, "effect_id": effect_id, "colors": parsed}
+
+
+def style_is_empty(style: Optional[Dict[str, Any]]) -> bool:
+    style = style or {}
+    return style.get("font_id") is None and style.get("effect_id") is None
+
+
+def to_data_uri(data: bytes, content_type: str) -> str:
+    """Build the ``data:image/png;base64,…`` URI Discord expects."""
+    mime = content_type.split(";")[0].strip().lower()
+    if mime not in ALLOWED_AVATAR_TYPES:
+        raise CustomizationError("invalid_image_type", mime)
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+async def download_image(url: str) -> Tuple[bytes, str]:
+    """Fetch an image URL, enforcing the type and size guard rails."""
+    timeout = aiohttp.ClientTimeout(total=30)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url) as response:
+                if response.status != 200:
+                    raise CustomizationError("image_download_failed", str(response.status))
+                content_type = (response.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+                if content_type not in ALLOWED_AVATAR_TYPES:
+                    raise CustomizationError("invalid_image_type", content_type or "unknown")
+                length = response.headers.get("Content-Length")
+                if length and int(length) > MAX_AVATAR_BYTES:
+                    raise CustomizationError("image_too_large", length)
+                data = await response.content.read(MAX_AVATAR_BYTES + 1)
+                if len(data) > MAX_AVATAR_BYTES:
+                    raise CustomizationError("image_too_large", str(len(data)))
+                return data, content_type
+    except CustomizationError:
+        raise
+    except Exception as exc:
+        raise CustomizationError("image_download_failed", str(exc))
+
+
+# --------------------------------------------------------------------------- #
+# Module
+# --------------------------------------------------------------------------- #
+
+class BotCustomizationModule(ModuleBase):
+    """Per-guild identity and name style for Moddy."""
+
+    MODULE_ID = MODULE_ID
+    MODULE_NAME = "Bot Customization"
+    MODULE_DESCRIPTION = "Personnalise l'identité de Moddy sur ce serveur"
+    MODULE_EMOJI = MODDY_SQUARE
+
+    def __init__(self, bot, guild_id: int):
+        super().__init__(bot, guild_id)
+        self.nickname: Optional[str] = None
+        self.bio: Optional[str] = None
+        self.avatar_hash: Optional[str] = None
+        self.style: Dict[str, Any] = {"font_id": None, "effect_id": None, "colors": []}
+
+    # ----------------------------------------------------------------- #
+    # Configuration
+    # ----------------------------------------------------------------- #
+
+    def get_default_config(self) -> Dict[str, Any]:
+        return {
+            "nickname": None,
+            "bio": None,
+            "avatar_hash": None,
+            "avatar_source": None,
+            "style": {"font_id": None, "effect_id": None, "colors": []},
+            "updated_at": None,
+            "updated_by": None,
+        }
+
+    async def load_config(self, config_data: Dict[str, Any]) -> bool:
+        try:
+            self.config = config_data or {}
+            self.nickname = self.config.get("nickname")
+            self.bio = self.config.get("bio")
+            self.avatar_hash = self.config.get("avatar_hash")
+            raw_style = self.config.get("style") or {}
+            self.style = {
+                "font_id": raw_style.get("font_id"),
+                "effect_id": raw_style.get("effect_id"),
+                "colors": list(raw_style.get("colors") or []),
+            }
+            # "Configured" is what makes the module active — there is no
+            # separate on/off switch, an empty configuration is simply off.
+            self.enabled = bool(
+                self.nickname or self.bio or self.avatar_hash
+                or not style_is_empty(self.style)
+            )
+            return True
+        except Exception as exc:
+            logger.error(f"Error loading bot_customization config: {exc}", exc_info=True)
+            return False
+
+    async def validate_config(self, config_data: Dict[str, Any]) -> tuple[bool, Optional[str]]:
+        nickname = config_data.get("nickname")
+        if nickname and len(nickname) > MAX_NICKNAME_LENGTH:
+            return False, "nickname_too_long"
+        bio = config_data.get("bio")
+        if bio and len(bio) > MAX_BIO_LENGTH:
+            return False, "bio_too_long"
+        try:
+            normalize_style(config_data.get("style"))
+        except CustomizationError as exc:
+            return False, exc.code
+        return True, None
+
+    # ----------------------------------------------------------------- #
+    # Style resync (the only field Discord does not reliably keep)
+    # ----------------------------------------------------------------- #
+
+    async def on_enable(self):
+        await self.resync_style()
+
+    async def resync_style(self) -> None:
+        """Re-apply the stored name style once per process for this guild."""
+        if style_is_empty(self.style) or self.bot is None:
+            return
+        applied = getattr(self.bot, "_bot_customization_styled", None)
+        if applied is None:
+            applied = set()
+            setattr(self.bot, "_bot_customization_styled", applied)
+        if self.guild_id in applied:
+            return
+        applied.add(self.guild_id)
+
+        payload = _style_payload(self.style)
+        try:
+            await patch_self_member(self.bot, self.guild_id, payload,
+                                    reason="Bot customization: name style resync")
+            logger.info(f"Name style re-applied for guild {self.guild_id}")
+        except Exception as exc:
+            logger.warning(f"Could not re-apply name style for guild {self.guild_id}: {exc}")
+
+    # ----------------------------------------------------------------- #
+    # The single write path
+    # ----------------------------------------------------------------- #
+
+    async def apply_customization(
+        self,
+        *,
+        nickname: Any = UNSET,
+        bio: Any = UNSET,
+        avatar: Any = UNSET,          # (bytes, content_type) tuple, or None to remove
+        avatar_source: Optional[str] = None,   # bookkeeping only (dashboard URL)
+        style: Any = UNSET,
+        actor_id: Optional[int] = None,
+        source: str = "config",
+    ) -> Dict[str, Any]:
+        """Patch Discord, persist the result and emit the technical log.
+
+        Every field defaults to ``UNSET`` (untouched). Passing ``None``
+        explicitly resets that field. Raises :class:`CustomizationError` when
+        the change is refused; the failure is logged too.
+        """
+        config = self.get_default_config()
+        config.update(copy.deepcopy(self.config or {}))
+
+        payload: Dict[str, Any] = {}
+        changes: Dict[str, str] = {}
+
+        if not isinstance(nickname, _Unset):
+            nickname = (nickname or "").strip() or None
+            if nickname and len(nickname) > MAX_NICKNAME_LENGTH:
+                raise CustomizationError("nickname_too_long")
+            payload["nick"] = nickname
+            changes["nickname"] = nickname or "reset"
+            config["nickname"] = nickname
+
+        if not isinstance(bio, _Unset):
+            bio = (bio or "").strip() or None
+            if bio and len(bio) > MAX_BIO_LENGTH:
+                raise CustomizationError("bio_too_long")
+            # A customized bio always carries the attribution; clearing the
+            # bio clears the whole thing, attribution included.
+            payload["bio"] = build_bio(bio) if bio else None
+            changes["bio"] = bio or "reset"
+            config["bio"] = bio
+
+        if not isinstance(avatar, _Unset):
+            if avatar is None:
+                payload["avatar"] = None
+                changes["avatar"] = "reset"
+                config["avatar_hash"] = None
+                config["avatar_source"] = None
+            else:
+                data, content_type = avatar
+                if len(data) > MAX_AVATAR_BYTES:
+                    raise CustomizationError("image_too_large", str(len(data)))
+                payload["avatar"] = to_data_uri(data, content_type)
+                changes["avatar"] = f"{len(data)} bytes ({content_type})"
+
+        if not isinstance(style, _Unset):
+            normalized = normalize_style(style)
+            payload.update(_style_payload(normalized))
+            config["style"] = normalized
+            changes["style"] = (
+                "reset" if style_is_empty(normalized)
+                else f"font={normalized['font_id']} effect={normalized['effect_id']} "
+                     f"colors={[color_to_hex(c) for c in normalized['colors']]}"
+            )
+
+        if not payload:
+            return config
+
+        try:
+            member_data = await patch_self_member(
+                self.bot, self.guild_id, payload,
+                reason=f"Bot customization ({source})"
+                       + (f" by {actor_id}" if actor_id else ""),
+            )
+        except discord.HTTPException as exc:
+            error = _http_error_code(exc)
+            await self._log(changes, success=False, actor_id=actor_id,
+                            source=source, error=f"{error}: {exc}")
+            raise CustomizationError(error, str(exc))
+
+        if not isinstance(avatar, _Unset) and avatar is not None:
+            config["avatar_hash"] = (member_data or {}).get("avatar")
+            config["avatar_source"] = avatar_source
+
+        config["updated_at"] = datetime.now(timezone.utc).isoformat()
+        config["updated_by"] = actor_id
+
+        await self._persist(config)
+        await self._log(changes, success=True, actor_id=actor_id, source=source)
+        return config
+
+    async def _persist(self, config: Dict[str, Any]) -> None:
+        """Save through the module manager so the live instance is refreshed."""
+        success, error = await self.bot.module_manager.save_module_config(
+            self.guild_id, MODULE_ID, config,
+        )
+        if not success:
+            raise CustomizationError("save_failed", error)
+        # save_module_config reloads the cached instance, but `self` may be a
+        # short-lived one built by the backend task path.
+        await self.load_config(config)
+
+    async def _log(self, changes: Dict[str, str], *, success: bool,
+                   actor_id: Optional[int], source: str,
+                   error: Optional[str] = None) -> None:
+        tech_logger = getattr(self.bot, "tech_logger", None)
+        if not tech_logger:
+            return
+        guild = self.bot.get_guild(self.guild_id)
+        try:
+            await tech_logger.log_bot_customization(
+                guild_id=self.guild_id,
+                guild_name=guild.name if guild else None,
+                changes=changes,
+                actor_id=actor_id,
+                source=source,
+                success=success,
+                error=error,
+            )
+        except Exception as exc:  # never break a customization over a log
+            logger.warning(f"Bot customization tech log failed: {exc}")
+
+    # ----------------------------------------------------------------- #
+    # Backend (dashboard) entry point
+    # ----------------------------------------------------------------- #
+
+    async def handle_backend_task(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Apply a dashboard-issued change coming from the Redis task stream.
+
+        Key presence is the contract: an absent key leaves the field alone, an
+        explicit ``null`` resets it. Premium fields are re-checked here — the
+        bot never trusts the dashboard on entitlement.
+        """
+        from utils.subscription import is_guild_premium
+
+        actor_id = payload.get("actor_id")
+        try:
+            actor_id = int(actor_id) if actor_id is not None else None
+        except (TypeError, ValueError):
+            actor_id = None
+
+        kwargs: Dict[str, Any] = {}
+        wants_premium = any(k in payload for k in ("nickname", "bio", "avatar_url"))
+        if wants_premium and not await is_guild_premium(self.bot, self.guild_id):
+            return {"ok": False, "error": "premium_required"}
+
+        if "nickname" in payload:
+            kwargs["nickname"] = payload["nickname"]
+        if "bio" in payload:
+            kwargs["bio"] = payload["bio"]
+        if "avatar_url" in payload:
+            url = payload["avatar_url"]
+            kwargs["avatar"] = None if not url else await download_image(url)
+            kwargs["avatar_source"] = url or None
+        if "style" in payload:
+            kwargs["style"] = payload["style"]
+
+        if not kwargs:
+            return {"ok": False, "error": "empty_update"}
+
+        try:
+            config = await self.apply_customization(
+                actor_id=actor_id, source="dashboard", **kwargs
+            )
+        except CustomizationError as exc:
+            return {"ok": False, "error": exc.code, "detail": exc.detail}
+
+        return {
+            "ok": True,
+            "nickname": config.get("nickname"),
+            "bio": config.get("bio"),
+            "avatar_hash": config.get("avatar_hash"),
+            "style": config.get("style"),
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Raw API access
+# --------------------------------------------------------------------------- #
+
+def _style_payload(style: Dict[str, Any]) -> Dict[str, Any]:
+    """Map a canonical style dict onto the three API fields.
+
+    Resetting means sending ``null`` on all three — ``0`` / ``[]`` are refused
+    by the API.
+    """
+    if style_is_empty(style):
+        return {
+            "display_name_font_id": None,
+            "display_name_effect_id": None,
+            "display_name_colors": None,
+        }
+    colors = style.get("colors") or []
+    return {
+        "display_name_font_id": style.get("font_id"),
+        "display_name_effect_id": style.get("effect_id"),
+        "display_name_colors": colors or None,
+    }
+
+
+async def patch_self_member(bot, guild_id: int, payload: Dict[str, Any],
+                            *, reason: Optional[str] = None) -> Dict[str, Any]:
+    """``PATCH /guilds/{guild_id}/members/@me`` — returns the updated member."""
+    route = discord.http.Route(
+        "PATCH", "/guilds/{guild_id}/members/@me", guild_id=guild_id,
+    )
+    return await bot.http.request(route, json=payload, reason=reason)
+
+
+def _http_error_code(exc: discord.HTTPException) -> str:
+    if exc.status == 403:
+        return "missing_permissions"
+    if exc.status == 429:
+        return "rate_limited"
+    if exc.status == 400:
+        return "rejected_by_discord"
+    return "discord_error"

--- a/modules/configs/bot_customization_config.py
+++ b/modules/configs/bot_customization_config.py
@@ -1,0 +1,658 @@
+"""
+Configuration UI for the Bot Customization module.
+
+Two sections, two tiers:
+
+- **Identity** (premium only): nickname, avatar and bio, all edited from a
+  single Modal V2 — the avatar goes through a ``FileUpload`` component, so the
+  server uploads an image instead of pasting a URL. Non-premium servers see the
+  section locked with a link to the dashboard.
+- **Name style** (free for everyone): font + effect + colours.
+
+There is no draft/save cycle here: a modal submit patches Discord immediately
+(the change *is* visible in the member list right away), so a pending "Save"
+button would be lying. Everything funnels through
+``BotCustomizationModule.apply_customization`` which persists, patches and
+technical-logs in one place.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseModal, BaseView
+from modules.bot_customization import (
+    EFFECT_KEYS,
+    EFFECTS,
+    FONTS,
+    MAX_AVATAR_BYTES,
+    MAX_BIO_LENGTH,
+    MAX_NICKNAME_LENGTH,
+    MODULE_ID,
+    BotCustomizationModule,
+    CustomizationError,
+    color_to_hex,
+    parse_hex_color,
+    style_is_empty,
+)
+from modules.configs._common import check_guild_perms
+from utils.components_v2 import create_error_message, create_success_message
+from utils.emojis import (
+    AT, BACK, DELETE, EDIT, IMAGE, MODDY_SQUARE, NOTE, PREMIUM, STAR, UNDONE,
+)
+from utils.i18n import i18n, t
+
+logger = logging.getLogger("moddy.modules.bot_customization_config")
+
+_CID_EDIT_IDENTITY = "moddy:bot_customization:config:edit_identity"
+_CID_RESET_IDENTITY = "moddy:bot_customization:config:reset_identity"
+_CID_EDIT_STYLE = "moddy:bot_customization:config:edit_style"
+_CID_RESET_STYLE = "moddy:bot_customization:config:reset_style"
+_CID_BACK = "moddy:bot_customization:config:back"
+_CID_RESET_ALL = "moddy:bot_customization:config:reset_all"
+
+DASHBOARD_URL = "https://dashboard.moddy.app/select-premium-servers"
+
+# Sentinel select value for "no font" / "no effect".
+NONE_VALUE = "none"
+
+
+def _guild_avatar_url(bot, guild_id: int, avatar_hash: str) -> Optional[str]:
+    """CDN URL of the bot's per-guild avatar (not exposed by discord.py)."""
+    if not bot or not bot.user or not avatar_hash:
+        return None
+    ext = "gif" if avatar_hash.startswith("a_") else "png"
+    return (f"https://cdn.discordapp.com/guilds/{guild_id}/users/"
+            f"{bot.user.id}/avatars/{avatar_hash}.{ext}?size=256")
+
+
+# =========================================================================== #
+# Modals (V2)
+# =========================================================================== #
+
+class BotIdentityModal(BaseModal):
+    """Nickname + bio + avatar upload, premium only."""
+
+    def __init__(self, bot, locale: str, config: Dict[str, Any]):
+        super().__init__(
+            title=t('modules.bot_customization.identity.modal_title', locale=locale),
+            timeout=None,
+        )
+        self.bot = bot
+        self.locale = locale
+
+        self.nickname_input = ui.TextInput(
+            style=discord.TextStyle.short,
+            default=config.get("nickname") or "",
+            max_length=MAX_NICKNAME_LENGTH,
+            required=False,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.bot_customization.identity.nickname_label', locale=locale),
+            description=t('modules.bot_customization.identity.nickname_description', locale=locale),
+            component=self.nickname_input,
+        ))
+
+        self.bio_input = ui.TextInput(
+            style=discord.TextStyle.paragraph,
+            default=config.get("bio") or "",
+            max_length=MAX_BIO_LENGTH,
+            required=False,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.bot_customization.identity.bio_label', locale=locale),
+            description=t('modules.bot_customization.identity.bio_description',
+                          locale=locale, max=MAX_BIO_LENGTH),
+            component=self.bio_input,
+        ))
+
+        self.avatar_input = ui.FileUpload(min_values=0, max_values=1, required=False)
+        self.add_item(ui.Label(
+            text=t('modules.bot_customization.identity.avatar_label', locale=locale),
+            description=t('modules.bot_customization.identity.avatar_description', locale=locale),
+            component=self.avatar_input,
+        ))
+
+        # The attribution line is not negotiable — say so before submit rather
+        # than surprising the server afterwards.
+        self.add_item(ui.TextDisplay(
+            t('modules.bot_customization.identity.attribution_note', locale=locale)
+        ))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await _submit_identity(
+            interaction,
+            nickname=self.nickname_input.value,
+            bio=self.bio_input.value,
+            attachments=list(self.avatar_input.values or []),
+        )
+
+
+class NameStyleModal(BaseModal):
+    """Font, effect and colours of the bot's display name (free tier)."""
+
+    def __init__(self, bot, locale: str, style: Dict[str, Any]):
+        super().__init__(
+            title=t('modules.bot_customization.style.modal_title', locale=locale),
+            timeout=None,
+        )
+        self.bot = bot
+        self.locale = locale
+
+        font_id = style.get("font_id")
+        self.font_select = ui.Select(
+            placeholder=t('modules.bot_customization.style.font_placeholder', locale=locale),
+            options=[
+                discord.SelectOption(
+                    label=t('modules.bot_customization.style.none', locale=locale),
+                    value=NONE_VALUE,
+                    default=font_id is None,
+                )
+            ] + [
+                discord.SelectOption(
+                    label=name, value=str(fid), default=(font_id == fid),
+                )
+                for fid, name in FONTS.items()
+            ],
+            min_values=1,
+            max_values=1,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.bot_customization.style.font_label', locale=locale),
+            component=self.font_select,
+        ))
+
+        effect_id = style.get("effect_id")
+        self.effect_select = ui.Select(
+            placeholder=t('modules.bot_customization.style.effect_placeholder', locale=locale),
+            options=[
+                discord.SelectOption(
+                    label=t('modules.bot_customization.style.none', locale=locale),
+                    value=NONE_VALUE,
+                    default=effect_id is None,
+                )
+            ] + [
+                discord.SelectOption(
+                    label=t(f'modules.bot_customization.style.effects.{key}.label', locale=locale),
+                    description=t(f'modules.bot_customization.style.effects.{key}.description',
+                                  locale=locale)[:100],
+                    value=str(eid),
+                    default=(effect_id == eid),
+                )
+                for eid, key in EFFECT_KEYS.items()
+            ],
+            min_values=1,
+            max_values=1,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.bot_customization.style.effect_label', locale=locale),
+            component=self.effect_select,
+        ))
+
+        colors: List[int] = list(style.get("colors") or [])
+        self.color1_input = ui.TextInput(
+            style=discord.TextStyle.short,
+            default=color_to_hex(colors[0]) if len(colors) > 0 else "",
+            max_length=7,
+            required=False,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.bot_customization.style.color1_label', locale=locale),
+            description=t('modules.bot_customization.style.color1_description', locale=locale),
+            component=self.color1_input,
+        ))
+
+        self.color2_input = ui.TextInput(
+            style=discord.TextStyle.short,
+            default=color_to_hex(colors[1]) if len(colors) > 1 else "",
+            max_length=7,
+            required=False,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.bot_customization.style.color2_label', locale=locale),
+            description=t('modules.bot_customization.style.color2_description', locale=locale),
+            component=self.color2_input,
+        ))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        values = self.font_select.values or [NONE_VALUE]
+        font_raw = values[0]
+        effect_values = self.effect_select.values or [NONE_VALUE]
+        effect_raw = effect_values[0]
+
+        await _submit_style(
+            interaction,
+            font_id=None if font_raw == NONE_VALUE else int(font_raw),
+            effect_id=None if effect_raw == NONE_VALUE else int(effect_raw),
+            color1=self.color1_input.value,
+            color2=self.color2_input.value,
+        )
+
+
+# =========================================================================== #
+# Submit handlers (shared by the modals — never hold view state)
+# =========================================================================== #
+
+async def _get_module(bot, guild_id: int) -> BotCustomizationModule:
+    """Live module instance, or a fresh one when nothing is configured yet."""
+    module = await bot.module_manager.get_module_instance(guild_id, MODULE_ID)
+    if module is None:
+        module = BotCustomizationModule(bot, guild_id)
+        config = await bot.module_manager.get_module_config(guild_id, MODULE_ID)
+        await module.load_config(config or {})
+    return module
+
+
+async def _read_attachment(attachment: discord.Attachment) -> tuple[bytes, str]:
+    if attachment.size > MAX_AVATAR_BYTES:
+        raise CustomizationError("image_too_large", str(attachment.size))
+    content_type = (attachment.content_type or "").split(";")[0].strip().lower()
+    data = await attachment.read()
+    return data, content_type
+
+
+async def _submit_identity(interaction: discord.Interaction, *, nickname: str,
+                           bio: str, attachments: List[discord.Attachment]):
+    if not await check_guild_perms(interaction):
+        return
+
+    bot = interaction.client
+    locale = i18n.get_user_locale(interaction)
+    await interaction.response.defer()
+
+    from utils.subscription import is_guild_premium
+    if not await is_guild_premium(bot, interaction.guild_id):
+        await interaction.followup.send(
+            view=create_error_message(
+                t('modules.bot_customization.premium.title', locale=locale),
+                t('modules.bot_customization.premium.description', locale=locale),
+            ),
+            ephemeral=True,
+        )
+        return
+
+    module = await _get_module(bot, interaction.guild_id)
+
+    kwargs: Dict[str, Any] = {"nickname": nickname, "bio": bio}
+    try:
+        if attachments:
+            kwargs["avatar"] = await _read_attachment(attachments[0])
+        await module.apply_customization(
+            actor_id=interaction.user.id, source="config", **kwargs
+        )
+    except CustomizationError as exc:
+        await _send_error(interaction, locale, exc)
+        return
+
+    await interaction.followup.send(
+        view=create_success_message(
+            t('modules.bot_customization.applied.title', locale=locale),
+            t('modules.bot_customization.applied.description', locale=locale),
+        ),
+        ephemeral=True,
+    )
+    await _refresh_panel(interaction, locale)
+
+
+async def _submit_style(interaction: discord.Interaction, *, font_id: Optional[int],
+                        effect_id: Optional[int], color1: str, color2: str):
+    if not await check_guild_perms(interaction):
+        return
+
+    bot = interaction.client
+    locale = i18n.get_user_locale(interaction)
+    await interaction.response.defer()
+
+    try:
+        colors = [c for c in (parse_hex_color(color1), parse_hex_color(color2))
+                  if c is not None]
+        module = await _get_module(bot, interaction.guild_id)
+        await module.apply_customization(
+            style={"font_id": font_id, "effect_id": effect_id, "colors": colors},
+            actor_id=interaction.user.id,
+            source="config",
+        )
+    except CustomizationError as exc:
+        await _send_error(interaction, locale, exc)
+        return
+
+    await interaction.followup.send(
+        view=create_success_message(
+            t('modules.bot_customization.applied.title', locale=locale),
+            t('modules.bot_customization.applied.description', locale=locale),
+        ),
+        ephemeral=True,
+    )
+    await _refresh_panel(interaction, locale)
+
+
+async def _send_error(interaction: discord.Interaction, locale: str,
+                      exc: CustomizationError):
+    description = t(f'modules.bot_customization.errors.{exc.code}', locale=locale)
+    if description == f'modules.bot_customization.errors.{exc.code}':
+        description = t('modules.bot_customization.errors.discord_error', locale=locale)
+    await interaction.followup.send(
+        view=create_error_message(
+            t('modules.bot_customization.errors.title', locale=locale), description,
+        ),
+        ephemeral=True,
+    )
+
+
+async def _refresh_panel(interaction: discord.Interaction, locale: str):
+    """Re-render the panel the modal was opened from."""
+    try:
+        view = await BotCustomizationConfigView.create(
+            interaction.client, interaction.guild_id, interaction.user.id, locale,
+        )
+        await interaction.edit_original_response(view=view)
+    except discord.HTTPException as exc:
+        logger.debug(f"Could not refresh bot customization panel: {exc}")
+
+
+# =========================================================================== #
+# Main panel
+# =========================================================================== #
+
+class BotCustomizationConfigView(BaseView):
+    """Bot Customization configuration panel.
+
+    Persistent: yes. Auth: Manage Server in the guild (re-checked on every
+    click via check_guild_perms — never a stored user_id, which cannot
+    survive a restarted shell).
+    """
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, guild_id: Optional[int] = None,
+                 user_id: Optional[int] = None, locale: str = "en-US",
+                 current_config: Optional[Dict[str, Any]] = None,
+                 is_premium: bool = False):
+        super().__init__()  # timeout=None
+        self.bot = bot
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.locale = locale
+        self.is_premium = is_premium
+
+        config = BotCustomizationModule(bot, guild_id).get_default_config()
+        if current_config:
+            config.update(current_config)
+        self.config = config
+        self.style = config.get("style") or {"font_id": None, "effect_id": None, "colors": []}
+
+        self._build_view()
+
+    @classmethod
+    async def create(cls, bot, guild_id: int, user_id: int, locale: str
+                     ) -> "BotCustomizationConfigView":
+        """Async factory — premium state and config must be read before render."""
+        from utils.subscription import is_guild_premium
+
+        config = await bot.module_manager.get_module_config(guild_id, MODULE_ID)
+        premium = await is_guild_premium(bot, guild_id)
+        return cls(bot, guild_id, user_id, locale, config, premium)
+
+    # ----------------------------------------------------------------- #
+    # Rendering
+    # ----------------------------------------------------------------- #
+
+    def _build_view(self):
+        self.clear_items()
+
+        container = ui.Container()
+        container.add_item(ui.TextDisplay(
+            f"### {MODDY_SQUARE} {t('modules.bot_customization.config.title', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            t('modules.bot_customization.config.description', locale=self.locale)
+        ))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+        self._build_identity_section(container)
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+        self._build_style_section(container)
+
+        self.add_item(container)
+        self._add_action_buttons()
+
+    def _build_identity_section(self, container: ui.Container):
+        nickname = self.config.get("nickname")
+        bio = self.config.get("bio")
+        avatar_hash = self.config.get("avatar_hash")
+        none_label = t('modules.bot_customization.config.not_set', locale=self.locale)
+
+        body = (
+            f"**{PREMIUM} {t('modules.bot_customization.identity.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.bot_customization.identity.section_description', locale=self.locale)}\n"
+            f"{AT} **{t('modules.bot_customization.identity.nickname_label', locale=self.locale)}** — "
+            f"`{nickname or none_label}`\n"
+            f"{IMAGE} **{t('modules.bot_customization.identity.avatar_label', locale=self.locale)}** — "
+            f"`{t('modules.bot_customization.config.custom', locale=self.locale) if avatar_hash else none_label}`\n"
+            f"{NOTE} **{t('modules.bot_customization.identity.bio_label', locale=self.locale)}** — "
+            f"`{bio or none_label}`"
+        )
+
+        avatar_url = _guild_avatar_url(self.bot, self.guild_id, avatar_hash) if avatar_hash else None
+        if avatar_url:
+            container.add_item(ui.Section(
+                ui.TextDisplay(body),
+                accessory=ui.Thumbnail(media=avatar_url),
+            ))
+        else:
+            container.add_item(ui.TextDisplay(body))
+
+        # Registration shell (bot is None): render both branches' buttons so
+        # discord.py learns every custom_id — see docs/PERSISTENT_VIEWS.md.
+        is_shell = self.bot is None
+
+        if self.is_premium or is_shell:
+            row = ui.ActionRow()
+            edit_btn = ui.Button(
+                label=t('modules.bot_customization.identity.edit', locale=self.locale),
+                style=discord.ButtonStyle.primary,
+                emoji=discord.PartialEmoji.from_str(EDIT),
+                custom_id=_CID_EDIT_IDENTITY,
+            )
+            edit_btn.callback = self.on_edit_identity
+            row.add_item(edit_btn)
+
+            reset_btn = ui.Button(
+                label=t('modules.bot_customization.identity.reset', locale=self.locale),
+                style=discord.ButtonStyle.secondary,
+                emoji=discord.PartialEmoji.from_str(UNDONE),
+                custom_id=_CID_RESET_IDENTITY,
+                disabled=not (nickname or bio or avatar_hash) and not is_shell,
+            )
+            reset_btn.callback = self.on_reset_identity
+            row.add_item(reset_btn)
+            container.add_item(row)
+
+        if not self.is_premium:
+            container.add_item(ui.TextDisplay(
+                f"-# {PREMIUM} {t('modules.bot_customization.premium.locked', locale=self.locale)}"
+            ))
+            link_row = ui.ActionRow()
+            link_row.add_item(ui.Button(
+                label=t('modules.bot_customization.premium.button', locale=self.locale),
+                style=discord.ButtonStyle.link,
+                url=DASHBOARD_URL,
+            ))
+            container.add_item(link_row)
+
+    def _build_style_section(self, container: ui.Container):
+        none_label = t('modules.bot_customization.config.not_set', locale=self.locale)
+        font_id = self.style.get("font_id")
+        effect_id = self.style.get("effect_id")
+        colors = self.style.get("colors") or []
+
+        effect_label = none_label
+        if effect_id in EFFECT_KEYS:
+            effect_label = t(
+                f'modules.bot_customization.style.effects.{EFFECT_KEYS[effect_id]}.label',
+                locale=self.locale,
+            )
+
+        colors_label = ", ".join(color_to_hex(c) for c in colors) or none_label
+
+        container.add_item(ui.TextDisplay(
+            f"**{STAR} {t('modules.bot_customization.style.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.bot_customization.style.section_description', locale=self.locale)}\n"
+            f"-# {t('modules.bot_customization.style.free_note', locale=self.locale)}\n"
+            f"**{t('modules.bot_customization.style.font_label', locale=self.locale)}** — "
+            f"`{FONTS.get(font_id, none_label)}`\n"
+            f"**{t('modules.bot_customization.style.effect_label', locale=self.locale)}** — "
+            f"`{effect_label}`\n"
+            f"**{t('modules.bot_customization.style.colors_label', locale=self.locale)}** — "
+            f"`{colors_label}`"
+        ))
+
+        row = ui.ActionRow()
+        edit_btn = ui.Button(
+            label=t('modules.bot_customization.style.edit', locale=self.locale),
+            style=discord.ButtonStyle.primary,
+            emoji=discord.PartialEmoji.from_str(EDIT),
+            custom_id=_CID_EDIT_STYLE,
+        )
+        edit_btn.callback = self.on_edit_style
+        row.add_item(edit_btn)
+
+        reset_btn = ui.Button(
+            label=t('modules.bot_customization.style.reset', locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            emoji=discord.PartialEmoji.from_str(UNDONE),
+            custom_id=_CID_RESET_STYLE,
+            disabled=style_is_empty(self.style) and self.bot is not None,
+        )
+        reset_btn.callback = self.on_reset_style
+        row.add_item(reset_btn)
+        container.add_item(row)
+
+    def _add_action_buttons(self):
+        row = ui.ActionRow()
+
+        back_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str(BACK),
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            custom_id=_CID_BACK,
+        )
+        back_btn.callback = self.on_back
+        row.add_item(back_btn)
+
+        is_shell = self.bot is None
+        has_config = bool(
+            self.config.get("nickname") or self.config.get("bio")
+            or self.config.get("avatar_hash") or not style_is_empty(self.style)
+        )
+        if has_config or is_shell:
+            delete_btn = ui.Button(
+                emoji=discord.PartialEmoji.from_str(DELETE),
+                label=t('modules.config.buttons.delete', locale=self.locale),
+                style=discord.ButtonStyle.danger,
+                custom_id=_CID_RESET_ALL,
+            )
+            delete_btn.callback = self.on_reset_all
+            row.add_item(delete_btn)
+
+        self.add_item(row)
+
+    # ----------------------------------------------------------------- #
+    # Callbacks — state is always re-derived from the interaction
+    # ----------------------------------------------------------------- #
+
+    async def on_edit_identity(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+
+        from utils.subscription import is_guild_premium
+        if not await is_guild_premium(bot, interaction.guild_id):
+            await interaction.response.send_message(
+                view=create_error_message(
+                    t('modules.bot_customization.premium.title', locale=locale),
+                    t('modules.bot_customization.premium.description', locale=locale),
+                ),
+                ephemeral=True,
+            )
+            return
+
+        config = await bot.module_manager.get_module_config(interaction.guild_id, MODULE_ID) or {}
+        await interaction.response.send_modal(BotIdentityModal(bot, locale, config))
+
+    async def on_edit_style(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        config = await bot.module_manager.get_module_config(interaction.guild_id, MODULE_ID) or {}
+        style = config.get("style") or {}
+        await interaction.response.send_modal(NameStyleModal(bot, locale, style))
+
+    async def on_reset_identity(self, interaction: discord.Interaction):
+        await self._reset(interaction, identity=True, style=False)
+
+    async def on_reset_style(self, interaction: discord.Interaction):
+        await self._reset(interaction, identity=False, style=True)
+
+    async def on_reset_all(self, interaction: discord.Interaction):
+        await self._reset(interaction, identity=True, style=True)
+
+    async def _reset(self, interaction: discord.Interaction, *,
+                     identity: bool, style: bool):
+        if not await check_guild_perms(interaction):
+            return
+
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        await interaction.response.defer()
+
+        kwargs: Dict[str, Any] = {}
+        if identity:
+            kwargs.update({"nickname": None, "bio": None, "avatar": None})
+        if style:
+            kwargs["style"] = None
+
+        try:
+            module = await _get_module(bot, interaction.guild_id)
+            await module.apply_customization(
+                actor_id=interaction.user.id, source="config", **kwargs
+            )
+        except CustomizationError as exc:
+            await _send_error(interaction, locale, exc)
+            return
+
+        await interaction.followup.send(
+            view=create_success_message(
+                t('modules.bot_customization.reset.title', locale=locale),
+                t('modules.bot_customization.reset.description', locale=locale),
+            ),
+            ephemeral=True,
+        )
+        await _refresh_panel(interaction, locale)
+
+    async def on_back(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+
+        from cogs.config import ConfigMainView
+        locale = i18n.get_user_locale(interaction)
+        main_view = ConfigMainView(
+            interaction.client, interaction.guild_id, interaction.user.id, locale,
+        )
+        await interaction.response.edit_message(view=main_view)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_guild_perms(interaction)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: Manage Server in the guild (checked on every click)."""
+        bot.add_view(cls())

--- a/tests/test_bot_customization.py
+++ b/tests/test_bot_customization.py
@@ -1,0 +1,133 @@
+"""Pure-logic tests for the Bot Customization module.
+
+Nothing here touches Discord: the point is the validation layer that decides
+what we are allowed to send to ``PATCH /guilds/{id}/members/@me``.
+
+    pytest tests/test_bot_customization.py -q
+"""
+
+import pytest
+
+from modules.bot_customization import (
+    BIO_ATTRIBUTION,
+    EFFECT_GRADIENT,
+    EFFECT_NEON,
+    MAX_BIO_LENGTH,
+    MAX_BIO_TOTAL_LENGTH,
+    CustomizationError,
+    build_bio,
+    color_to_hex,
+    normalize_style,
+    parse_hex_color,
+    style_is_empty,
+    _style_payload,
+)
+
+
+# ------------------------------------------------------------------ bio
+
+def test_bio_always_carries_the_attribution():
+    assert build_bio("Hello") .endswith(BIO_ATTRIBUTION)
+    # An empty bio is the attribution alone, never nothing.
+    assert build_bio("") == BIO_ATTRIBUTION
+    assert build_bio(None) == BIO_ATTRIBUTION
+
+
+def test_bio_budget_fits_discord_limit():
+    """A maximum-length user bio plus the suffix must still fit in 190."""
+    assert len(build_bio("x" * MAX_BIO_LENGTH)) == MAX_BIO_TOTAL_LENGTH
+
+
+# ---------------------------------------------------------------- colors
+
+@pytest.mark.parametrize("raw,expected", [
+    ("#5865F2", 0x5865F2),
+    ("5865f2", 0x5865F2),
+    ("  #000000 ", 0),
+    ("", None),
+    (None, None),
+])
+def test_parse_hex_color(raw, expected):
+    assert parse_hex_color(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["nope", "#12345678", "-1"])
+def test_parse_hex_color_rejects_garbage(raw):
+    with pytest.raises(CustomizationError) as exc:
+        parse_hex_color(raw)
+    assert exc.value.code == "invalid_color"
+
+
+def test_color_to_hex_roundtrip():
+    assert color_to_hex(parse_hex_color("#5865F2")) == "#5865F2"
+    assert color_to_hex(None) == ""
+
+
+# ----------------------------------------------------------------- style
+
+def test_normalize_style_accepts_hex_strings_and_ints():
+    style = normalize_style({"font_id": 7, "effect_id": EFFECT_GRADIENT,
+                             "colors": ["#FF0000", 255]})
+    assert style == {"font_id": 7, "effect_id": EFFECT_GRADIENT,
+                     "colors": [0xFF0000, 255]}
+
+
+def test_gradient_requires_two_colors():
+    with pytest.raises(CustomizationError) as exc:
+        normalize_style({"effect_id": EFFECT_GRADIENT, "colors": [1]})
+    assert exc.value.code == "gradient_needs_two_colors"
+
+
+def test_single_color_effect_requires_one_color():
+    with pytest.raises(CustomizationError) as exc:
+        normalize_style({"effect_id": EFFECT_NEON, "colors": []})
+    assert exc.value.code == "effect_needs_color"
+
+
+def test_extra_colors_are_dropped():
+    style = normalize_style({"effect_id": EFFECT_NEON, "colors": [1, 2, 3]})
+    assert style["colors"] == [1]
+
+
+def test_colors_without_an_effect_are_dropped():
+    """Nothing paints them, so keeping them would only mislead the UI."""
+    style = normalize_style({"font_id": 3, "colors": [0xFF0000]})
+    assert style == {"font_id": 3, "effect_id": None, "colors": []}
+
+
+@pytest.mark.parametrize("style,code", [
+    ({"font_id": 5}, "invalid_font"),        # in range 1..12 but not a real face
+    ({"font_id": 99}, "invalid_font"),
+    ({"effect_id": 9}, "invalid_effect"),
+])
+def test_invalid_ids_are_refused(style, code):
+    with pytest.raises(CustomizationError) as exc:
+        normalize_style(style)
+    assert exc.value.code == code
+
+
+def test_empty_style_detection():
+    assert style_is_empty(normalize_style({}))
+    assert style_is_empty(None)
+    assert not style_is_empty(normalize_style({"font_id": 7}))
+
+
+def test_reset_payload_sends_null_not_zero():
+    """Discord refuses 0 / [] — a reset must be three explicit nulls."""
+    payload = _style_payload(normalize_style({}))
+    assert payload == {
+        "display_name_font_id": None,
+        "display_name_effect_id": None,
+        "display_name_colors": None,
+    }
+
+
+def test_style_payload_maps_to_api_fields():
+    payload = _style_payload(
+        normalize_style({"font_id": 7, "effect_id": EFFECT_NEON, "colors": [255]})
+    )
+    assert payload == {
+        "display_name_font_id": 7,
+        "display_name_effect_id": EFFECT_NEON,
+        "display_name_colors": [255],
+    }

--- a/utils/emojis.py
+++ b/utils/emojis.py
@@ -93,6 +93,7 @@ SHIELD = "<:shield:1521471376815292498>"   # automod icon
 HAND = "<:hand:1521517865348632706>"       # appeal "claim" button
 LINK = "<:link:1521517863607734385>"       # appeal "invite" button
 PENDING = "<:pending:1521282587962900611>"  # appeal "pending" status
+ROCKET = "<a:Rocket:1535783839870353499>"  # bot customization bio attribution
 
 # =============================================================================
 # SOCIAL PLATFORMS (Social Notifications module)

--- a/utils/persistent_views.py
+++ b/utils/persistent_views.py
@@ -57,6 +57,7 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
     from utils.automod_shadow_views import ShadowAnnotationPersistence
     from utils.transcription_views import TranscriptionPersistence
     from modules.configs.voice_transcription_config import VoiceTranscriptionConfigView
+    from modules.configs.bot_customization_config import BotCustomizationConfigView
 
     return [
         # Group 1 — /moddy (public informational, no user auth)
@@ -105,6 +106,9 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
         # Group 12c — the "Transcribe" button posted under voice messages
         # (dynamic item, public: anyone who sees the voice message may click)
         TranscriptionPersistence,
+        # Group 12d — /config bot customization panel (guild permission auth;
+        # its two modals are excluded like every other modal)
+        BotCustomizationConfigView,
         # Group 13 — /config automod AI panel (guild permission auth;
         # AutomodAIPrecedentsView is deliberately excluded, see
         # docs/PERSISTENT_VIEWS.md Step 12)

--- a/utils/subscription.py
+++ b/utils/subscription.py
@@ -3,6 +3,17 @@ Subscription helper — gate commands/modules on active subscriptions.
 
 Read strategy: Redis cache first (key sub:user:{user_id}), DB fallback.
 The bot never writes subscription data; only the backend does.
+
+Two scopes live here:
+
+- **User subscription** (``get_subscription`` / ``is_subscribed``): does *this
+  user* pay? Gates personal-app features.
+- **Guild premium** (``is_guild_premium``): is *this server* covered by
+  somebody's subscription? A subscriber picks up to N servers on the
+  dashboard, which fills ``subscription_servers``. This — not a ``PREMIUM``
+  attribute — is the source of truth for premium server features.
+
+See ``docs/PREMIUM.md``.
 """
 
 import json
@@ -13,10 +24,18 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger('moddy.subscription')
 
 _CACHE_KEY = "sub:user:{user_id}"
+_GUILD_CACHE_KEY = "sub:guild:{guild_id}"
+# Short TTL: the backend also invalidates explicitly on premium_activated /
+# premium_deactivated, the TTL is only there so a missed event self-heals.
+_GUILD_CACHE_TTL = 300
 
 
 def _cache_key(user_id: int) -> str:
     return _CACHE_KEY.format(user_id=user_id)
+
+
+def _guild_cache_key(guild_id: int) -> str:
+    return _GUILD_CACHE_KEY.format(guild_id=guild_id)
 
 
 def _ttl_seconds(expires_at: Optional[datetime]) -> Optional[int]:
@@ -92,6 +111,50 @@ async def is_subscribed(bot, user_id: int) -> bool:
     """Return True if the user has an active subscription."""
     sub = await get_subscription(bot, user_id)
     return bool(sub and sub.get('is_active'))
+
+
+async def is_guild_premium(bot, guild_id: int) -> bool:
+    """Return True if this guild is covered by an active subscription.
+
+    Redis-cached (``sub:guild:{guild_id}``, 5 min) on top of
+    ``db.is_guild_premium``, because premium is checked on hot paths (every
+    module config panel render, every dashboard task).
+    """
+    if bot.redis:
+        try:
+            raw = await bot.redis.get(_guild_cache_key(guild_id))
+            if raw is not None:
+                return raw == "1"
+        except Exception as e:
+            logger.warning(f"[Subscription] Redis read error for guild {guild_id}: {e}")
+
+    if not bot.db:
+        return False
+
+    try:
+        premium = await bot.db.is_guild_premium(guild_id)
+    except Exception as e:
+        logger.error(f"[Subscription] DB read error for guild {guild_id}: {e}")
+        return False
+
+    if bot.redis:
+        try:
+            await bot.redis.setex(
+                _guild_cache_key(guild_id), _GUILD_CACHE_TTL, "1" if premium else "0",
+            )
+        except Exception as e:
+            logger.warning(f"[Subscription] Redis write error for guild {guild_id}: {e}")
+
+    return bool(premium)
+
+
+async def invalidate_guild_cache(bot, guild_id: int) -> None:
+    """Evict the cached premium state of a guild (backend Pub/Sub events)."""
+    if bot.redis:
+        try:
+            await bot.redis.delete(_guild_cache_key(guild_id))
+        except Exception as e:
+            logger.warning(f"[Subscription] Guild cache invalidation error for {guild_id}: {e}")
 
 
 async def invalidate_cache(bot, user_id: int) -> None:

--- a/utils/tech_logger.py
+++ b/utils/tech_logger.py
@@ -34,7 +34,7 @@ from discord import ui, SeparatorSpacing
 from config import LOG_WEBHOOKS, LOG_WEBHOOK_DEFAULT, ENV_MODE
 from utils.emojis import (
     DONE, UNDONE, ADD, LOGOUT, MODDY, BUG, MODDYTEAM_BADGE, SETTINGS, COMMANDS,
-    SAVE, MANAGE_USER, BLACKLIST, TIME, PAUSE, CODE,
+    SAVE, MANAGE_USER, BLACKLIST, TIME, PAUSE, CODE, MODDY_SQUARE,
 )
 
 logger = logging.getLogger("moddy.tech_logger")
@@ -53,6 +53,7 @@ _ACCENTS = {
     "database": 0xFEE75C,       # yellow
     "security": 0xED4245,       # red
     "api_call": 0x99AAB5,       # grey (high-volume, neutral)
+    "bot_customization": 0x245F9F,  # premium blue
 }
 
 # Webhook display name per category (helps when several feeds are watched).
@@ -67,6 +68,7 @@ _USERNAMES = {
     "database": "Moddy • Database",
     "security": "Moddy • Security",
     "api_call": "Moddy • API Gateway",
+    "bot_customization": "Moddy • Bot Customization",
 }
 
 
@@ -487,6 +489,39 @@ class TechLogger:
             await self._dispatch("database", view)
         except Exception as exc:
             logger.warning("log_data_change failed: %s", exc)
+
+    # --------------------------------------------------- bot customization
+
+    async def log_bot_customization(
+        self,
+        *,
+        guild_id: int,
+        guild_name: Optional[str],
+        changes: dict,
+        actor_id: Optional[int] = None,
+        source: str = "config",
+        success: bool = True,
+        error: Optional[str] = None,
+    ):
+        """A server changed Moddy's per-guild identity (nickname / avatar /
+        bio / name style). Every attempt is logged, successful or not."""
+        try:
+            lines = [
+                f"**Guild** `{guild_name or '?'}` `{guild_id}`",
+                f"**Source** `{source}`"
+                + (f" • **By** `{actor_id}`" if actor_id else " • **By** `system`"),
+            ]
+            for field, value in list(changes.items())[:8]:
+                lines.append(f"**{field}** `{_trunc(value, 150)}`")
+            lines.append(f"{_b(success)} **Applied**")
+            if error:
+                lines.append(f"**Error** `{_trunc(error, 200)}`")
+            view = self._card(
+                "bot_customization", MODDY_SQUARE, "Bot Customization", lines,
+            )
+            await self._dispatch("bot_customization", view)
+        except Exception as exc:
+            logger.warning("log_bot_customization failed: %s", exc)
 
     # ------------------------------------------------------------- security
 


### PR DESCRIPTION
## Summary

Introduces the **Bot Customization** module, allowing servers to customize Moddy's appearance on a per-guild basis. Includes two tiers: premium servers can customize nickname, avatar, and bio; all servers can customize the bot's display name with fonts, effects, and colors.

## Key Changes

**New Modules & Configuration**
- `modules/bot_customization.py` — Core module handling identity (nickname, avatar, bio) and name styles (font, effect, colors). Validates all inputs, manages persistence, and provides the single write path (`apply_customization`) that patches Discord, writes the DB, and emits technical logs.
- `modules/configs/bot_customization_config.py` — Configuration UI with two sections: Identity (premium-only, Modal V2 with file upload) and Name Style (free tier, font/effect/color selects). Handles permission checks and premium gating.

**Premium System Documentation & Implementation**
- `docs/PREMIUM.md` — New documentation clarifying the premium model: guild premium is determined by `subscription_servers` ⨝ active subscription, not a guild attribute.
- `utils/subscription.py` — Added `is_guild_premium()` helper with Redis caching (300s TTL) and `invalidate_guild_cache()` for explicit invalidation.
- `bot.py` — Wired `premium_activated` / `premium_deactivated` Pub/Sub events to invalidate the guild premium cache.

**Validation & Testing**
- `tests/test_bot_customization.py` — 22 pure-logic tests covering bio attribution, color parsing, style normalization, and Discord API constraints.
- Comprehensive validation for:
  - Bio: 190-char Discord limit with mandatory attribution suffix
  - Avatar: file type & size guards (8 MB max, PNG/JPEG/GIF/WEBP only)
  - Colors: hex parsing with 24-bit range validation
  - Styles: font/effect/color combinations with effect-specific color requirements (gradient needs 2, others need 1)

**Internationalization**
- Added `bot_customization` translation keys to all 5 locale files (en-US, de, es-ES, fr, pt-BR) covering identity, premium gating, and name style UI.

**Technical Logging & Integration**
- `utils/tech_logger.py` — Added `bot_customization` category (premium blue, 0x245F9F) with `MODDY_SQUARE` emoji.
- `cogs/config.py` — Integrated module config UI into the `/config` command.
- `utils/persistent_views.py` — Registered persistent view classes for the module.
- `docs/BOT_CUSTOMIZATION.md` — Complete technical documentation of the Discord endpoint, undocumented style fields, storage schema, and the single write path.
- `docs/sessions/2026-08-08_bot-customization-module.md` — Session notes documenting the implementation.

## Implementation Details

- **Single write path**: All changes (from `/config` or dashboard) funnel through `BotCustomizationModule.apply_customization()`, ensuring consistent DB writes, Discord patches, and technical logging.
- **No draft/save cycle**: Modal submits patch Discord immediately; changes are visible in the member list right away.
- **Attribution line**: Bio always ends with `<a:Rocket:…> Powered by @**Moddy**` (non-removable). Only the user portion is stored in the DB.
- **Style persistence**: Name styles (font, effect, colors) use undocumented Discord API fields and don't reliably survive bot restarts, so `resync_style()` re-applies them on module load.
- **Per-guild isolation**: All customization is guild-specific; servers never see each other's settings.

https://claude.ai/code/session_01QZuqmhPKpp9TC5Q6yovhva