### PR TITLE
Bot Customization: banner support + single-newline bio attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ moddy/
 │   ├── interserver.py         #   Inter-server message relay
 │   ├── social_notifications.py #  Social notifications (via moddy-feeds service)
 │   ├── automod_ai.py          #   Automod AI (applies decisions, cases+evidence, scalable features)
-│   ├── bot_customization.py   #   Bot identity per guild (nick/avatar/bio premium + name style free)
+│   ├── bot_customization.py   #   Bot identity per guild (nick/avatar/banner/bio + name style)
 │   ├── voice_transcription.py #   Voice message transcription (button or automatic)
 │   └── configs/               #   Components V2 config UIs per module
 │       ├── adaptive_slowmode_config.py
@@ -342,7 +342,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/WELCOME_MESSAGES.md](docs/WELCOME_MESSAGES.md) | Welcome messages module — config schema, placeholders, backend/dashboard contract |
 | [docs/AUTOMOD_AI.md](docs/AUTOMOD_AI.md) | Automod AI — detection pipeline, nano decider, scalable features, rules safety check |
 | [docs/AUTOMOD_AI_CONFIG.md](docs/AUTOMOD_AI_CONFIG.md) | Automod AI configuration schema in DB (backend / dashboard integration) |
-| [docs/BOT_CUSTOMIZATION.md](docs/BOT_CUSTOMIZATION.md) | Bot Customization — per-guild nickname/avatar/bio + name styles, Redis dashboard contract |
+| [docs/BOT_CUSTOMIZATION.md](docs/BOT_CUSTOMIZATION.md) | Bot Customization — per-guild nickname/avatar/banner/bio + name styles, Redis dashboard contract |
 | [docs/PREMIUM.md](docs/PREMIUM.md) | **Premium gating** — how to check whether a server (or a user) is premium |
 | [docs/STAFF_SYSTEM.md](docs/STAFF_SYSTEM.md) | Staff/dev commands, permissions, roles |
 | [docs/MODERATION_CASES.md](docs/MODERATION_CASES.md) | Moderation cases/sanctions, the case service & sources, auto-sync |

--- a/docs/BOT_CUSTOMIZATION.md
+++ b/docs/BOT_CUSTOMIZATION.md
@@ -107,7 +107,7 @@ server. Only the *user portion* is stored in the DB and shown back in the
 modal, so the suffix never gets duplicated when a server edits its bio.
 
 The 190-character member-bio budget is shared: `MAX_BIO_LENGTH` is
-`190 - len(attribution) - len("\n\n")` = **136** characters for the server.
+`190 - len(attribution) - len("\n")` = **137** characters for the server.
 `tests/test_bot_customization.py` pins that arithmetic — if the attribution
 text changes, the test is what catches the overflow.
 

--- a/docs/BOT_CUSTOMIZATION.md
+++ b/docs/BOT_CUSTOMIZATION.md
@@ -7,6 +7,7 @@ server never sees another server's customization.
 |---|---|---|
 | Nickname | ❌ | ✅ |
 | Avatar | ❌ | ✅ |
+| Banner | ❌ | ✅ |
 | Bio | ❌ | ✅ |
 | Name style (font, effect, colours) | ✅ | ✅ |
 
@@ -44,7 +45,7 @@ the server's own audit log — not just in our technical logs.
 |---|---|---|
 | `nick` | `?string` | max 32 chars. Requires `CHANGE_NICKNAME`. |
 | `avatar` | `?string` | [data URI, base64](https://docs.discord.com/developers/reference#image-data) |
-| `banner` | `?string` | data URI — **not exposed by the module** (see *Not implemented* below) |
+| `banner` | `?string` | data URI, same handling as `avatar` |
 | `bio` | `?string` | member bio, 190 chars including our attribution line |
 
 ### Undocumented fields — name styles
@@ -90,7 +91,8 @@ Gotchas, all encoded in `normalize_style` / `_style_payload`:
 - **There is no GET.** The active style cannot be read back from Discord, which
   is why we store it (see the schema below).
 - The style does **not** reliably survive a bot restart, unlike the nickname,
-  the avatar and the bio which Discord stores. Hence `resync_style()`.
+  the avatar, the banner and the bio which Discord stores. Hence
+  `resync_style()`.
 
 ---
 
@@ -126,6 +128,8 @@ out of customization is not carrying our line.
   "bio": "Le bot de notre serveur",
   "avatar_hash": "a_1c9e…",
   "avatar_source": null,
+  "banner_hash": "b_77f2…",
+  "banner_source": null,
   "style": { "font_id": 7, "effect_id": 2, "colors": [16711680, 255] },
   "updated_at": "2026-08-08T14:31:07+00:00",
   "updated_by": 942386103000000000
@@ -136,16 +140,16 @@ out of customization is not carrying our line.
 |---|---|
 | `nickname` | user-set nickname, `null` = Moddy's default name |
 | `bio` | **user portion only**, attribution excluded |
-| `avatar_hash` | hash returned by the API — used to build the CDN preview URL. The image itself is never stored. |
-| `avatar_source` | last source URL for a dashboard-set avatar, informational |
+| `avatar_hash` / `banner_hash` | hashes returned by the API — used to build the CDN preview URLs. The images themselves are never stored. |
+| `avatar_source` / `banner_source` | last source URL for a dashboard-set image, informational |
 | `style.colors` | 24-bit ints (not hex strings) |
 
 The module is `enabled` when any of these is set — there is no separate on/off
 switch, an empty configuration is simply off.
 
-Guild avatar preview URL:
+Guild asset preview URLs:
 `https://cdn.discordapp.com/guilds/{guild_id}/users/{bot_id}/avatars/{hash}.png`
-(`.gif` when the hash starts with `a_`).
+and `…/banners/{hash}.png` (`.gif` when the hash starts with `a_`).
 
 ---
 
@@ -155,7 +159,8 @@ Everything — `/config`, the dashboard, a reset — goes through
 
 ```python
 await module.apply_customization(
-    nickname=..., bio=..., avatar=(bytes, content_type), style={...},
+    nickname=..., bio=..., avatar=(bytes, content_type),
+    banner=(bytes, content_type), style={...},
     actor_id=..., source="config" | "dashboard",
 )
 ```
@@ -180,7 +185,7 @@ for the dashboard:
 `rejected_by_discord`, `discord_error`, `save_failed`, `empty_update`,
 `guild_not_found`, `internal_error`.
 
-### Avatar guard rails
+### Image guard rails (avatar and banner)
 
 - allowed: `image/png`, `image/jpeg`, `image/gif`, `image/webp`
 - max **8 MiB**, enforced on the attachment size *and* on the downloaded bytes
@@ -214,9 +219,10 @@ See [TECHNICAL_LOGS.md](TECHNICAL_LOGS.md).
   would be lying. The panel therefore has no Save/Cancel, only Edit / Reset per
   section and a global Reset.
 - **Identity modal** (premium): nickname `TextInput`, bio `TextInput`
-  (paragraph), avatar `FileUpload`, plus a `TextDisplay` warning about the
-  attribution line. Leaving the upload empty keeps the current avatar — use
-  *Reset* to remove it.
+  (paragraph), avatar `FileUpload`, banner `FileUpload`. That is Discord's hard
+  ceiling of 5 top-level components, so the attribution warning lives on the
+  panel instead of in the modal. Leaving an upload empty keeps the current
+  image — use *Reset* to remove it.
 - **Style modal** (everyone): font `Select`, effect `Select`, two colour
   `TextInput`s. Colour 2 is only read by the gradient effect.
 - Non-premium servers see the identity section rendered but **locked**, with a
@@ -249,11 +255,21 @@ and `BotCustomizationModule.handle_backend_task`.
 
 Task (stream `moddy:tasks`):
 
+```
+XADD moddy:tasks * type bot_customization_update guild_id 123456789 payload '<json>'
+```
+
+with `payload` being:
+
 ```json
 {
-  "type": "bot_customization_update",
-  "guild_id": "123456789",
-  "payload": "{\"request_id\":\"…\",\"actor_id\":\"…\",\"nickname\":\"Guardian\",\"style\":{...}}"
+  "request_id": "b3f1a2c4-…",
+  "actor_id": "942386103000000000",
+  "nickname": "Guardian",
+  "bio": "Le bot de notre serveur",
+  "avatar_url": "https://cdn.dashboard.moddy.app/uploads/abc.png",
+  "banner_url": "https://cdn.dashboard.moddy.app/uploads/def.png",
+  "style": { "font_id": 7, "effect_id": 2, "colors": ["#FF0000", "#0000FF"] }
 }
 ```
 
@@ -263,7 +279,8 @@ Result (channel `moddy:dashboard`):
 {
   "type": "bot_customization_update_result",
   "request_id": "…", "guild_id": 123456789,
-  "ok": true, "nickname": "Guardian", "avatar_hash": "a_1c9e…", "style": {...}
+  "ok": true, "nickname": "Guardian", "avatar_hash": "a_1c9e…",
+  "banner_hash": "b_77f2…", "style": {...}
 }
 ```
 
@@ -275,8 +292,6 @@ task — the backend's check is a UX filter, not a trust boundary.
 
 ## Not implemented (deliberately)
 
-- **Banner.** The endpoint supports `banner`, and the module's write path would
-  take it with a two-line change, but it was not part of the requested scope.
 - **Automatic revert on premium loss.** When a guild stops being premium the
   stored identity stays applied; the panel simply locks. Reverting would need a
   backend-driven sweep on `premium_deactivated`.

--- a/docs/PREMIUM.md
+++ b/docs/PREMIUM.md
@@ -107,7 +107,7 @@ feature).
 
 | Feature | Free | Premium |
 |---|---|---|
-| Bot Customization — nickname / avatar / bio | ❌ | ✅ |
+| Bot Customization — nickname / avatar / banner / bio | ❌ | ✅ |
 | Bot Customization — name style (font, effect, colours) | ✅ | ✅ |
 | Social Notifications — accounts per platform | `FREE_PER_PLATFORM_LIMIT` | `PREMIUM_PER_PLATFORM_LIMIT` |
 | Social Notifications — poll interval | slow tier | fast tier |

--- a/docs/sessions/2026-08-08_bot-customization-module.md
+++ b/docs/sessions/2026-08-08_bot-customization-module.md
@@ -56,7 +56,7 @@ a cached `utils.subscription.is_guild_premium` helper and wired the existing
   stored by Discord; the name style is not guaranteed to survive a restart, so
   `resync_style()` re-applies it once per process per guild.
 - **Only the user portion of the bio is stored**, so the attribution suffix is
-  never duplicated when a server re-edits its bio. `MAX_BIO_LENGTH` (136) is
+  never duplicated when a server re-edits its bio. `MAX_BIO_LENGTH` (137) is
   derived from the 190-char limit minus the suffix, and a test pins the
   arithmetic so a longer attribution text fails loudly.
 - **Premium is re-checked on the modal submit**, not just when rendering the

--- a/docs/sessions/2026-08-08_bot-customization-module.md
+++ b/docs/sessions/2026-08-08_bot-customization-module.md
@@ -5,9 +5,9 @@
 New server module **`bot_customization`**: a server can make Moddy look like
 its own bot, per-guild.
 
-- **Premium** (guild covered by an active subscription): nickname, avatar, bio.
-  The bio always keeps a trailing `<a:Rocket:…> Powered by @**Moddy**` line that
-  the server cannot remove.
+- **Premium** (guild covered by an active subscription): nickname, avatar,
+  banner, bio. The bio always keeps a trailing `<a:Rocket:…> Powered by
+  @**Moddy**` line that the server cannot remove.
 - **Free**: the name style (font, effect, colours) applied to the bot's display
   name, via the undocumented `display_name_font_id` / `display_name_effect_id` /
   `display_name_colors` fields.
@@ -66,10 +66,17 @@ a cached `utils.subscription.is_guild_premium` helper and wired the existing
 - **Locked, not hidden**, for non-premium servers: the identity section renders
   with a lock note and a dashboard link.
 
+## Follow-up commits
+
+- Single newline (not double) before the attribution line — the double one
+  rendered an empty line in the bio. `MAX_BIO_LENGTH` 136 → 137.
+- **Banner** added alongside the avatar. Avatar and banner now share one code
+  path in `apply_customization` (`MAX_IMAGE_BYTES`, `ALLOWED_IMAGE_TYPES`), and
+  the identity modal is at Discord's ceiling of 5 top-level components, so the
+  attribution warning moved from the modal to the panel.
+
 ## Follow-ups
 
-- **Banner** is supported by the endpoint and would be a two-line change in the
-  write path, but was out of the requested scope.
 - **No automatic revert on premium loss**: the stored identity stays applied and
   the panel just locks. A backend sweep on `premium_deactivated` would be needed.
 - The 190-character member-bio limit is assumed from Discord's user-bio limit;

--- a/locales/de.json
+++ b/locales/de.json
@@ -1804,7 +1804,7 @@
       },
       "identity": {
         "section_title": "Identität",
-        "section_description": "Moddys Spitzname, Avatar und Bio auf diesem Server",
+        "section_description": "Moddys Spitzname, Avatar, Banner und Bio auf diesem Server",
         "modal_title": "Moddys Identität",
         "nickname_label": "Spitzname",
         "nickname_description": "Leer lassen, um den ursprünglichen Namen zu behalten",
@@ -1812,14 +1812,16 @@
         "bio_description": "Maximal {max} Zeichen, leer lassen zum Entfernen",
         "avatar_label": "Avatar",
         "avatar_description": "PNG, JPEG, GIF oder WEBP — maximal 8 MB",
+        "banner_label": "Banner",
+        "banner_description": "PNG, JPEG, GIF oder WEBP — maximal 8 MB",
         "attribution_note": "-# Die Bio endet immer mit der Zeile <a:Rocket:1535783839870353499> Powered by @**Moddy**, die nicht entfernt werden kann.",
         "edit": "Identität bearbeiten",
         "reset": "Zurücksetzen"
       },
       "premium": {
         "title": "Premium-Funktion",
-        "description": "Spitzname, Avatar und Bio von Moddy anzupassen ist Premium-Servern vorbehalten.",
-        "locked": "Spitzname, Avatar und Bio erfordern ein Moddy-Max-Abo auf diesem Server.",
+        "description": "Spitzname, Avatar, Banner und Bio von Moddy anzupassen ist Premium-Servern vorbehalten.",
+        "locked": "Spitzname, Avatar, Banner und Bio erfordern ein Moddy-Max-Abo auf diesem Server.",
         "button": "Premium holen"
       },
       "style": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1804,7 +1804,7 @@
       },
       "identity": {
         "section_title": "Identity",
-        "section_description": "Moddy's nickname, avatar and bio on this server",
+        "section_description": "Moddy's nickname, avatar, banner and bio on this server",
         "modal_title": "Moddy's identity",
         "nickname_label": "Nickname",
         "nickname_description": "Leave empty to restore the original name",
@@ -1812,14 +1812,16 @@
         "bio_description": "{max} characters max, leave empty to remove it",
         "avatar_label": "Avatar",
         "avatar_description": "PNG, JPEG, GIF or WEBP — 8 MB max",
+        "banner_label": "Banner",
+        "banner_description": "PNG, JPEG, GIF or WEBP — 8 MB max",
         "attribution_note": "-# The bio always ends with the <a:Rocket:1535783839870353499> Powered by @**Moddy** line, which cannot be removed.",
         "edit": "Edit identity",
         "reset": "Reset"
       },
       "premium": {
         "title": "Premium feature",
-        "description": "Customizing Moddy's nickname, avatar and bio is reserved for premium servers.",
-        "locked": "Nickname, avatar and bio require a Moddy Max subscription on this server.",
+        "description": "Customizing Moddy's nickname, avatar, banner and bio is reserved for premium servers.",
+        "locked": "Nickname, avatar, banner and bio require a Moddy Max subscription on this server.",
         "button": "Get premium"
       },
       "style": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1804,7 +1804,7 @@
       },
       "identity": {
         "section_title": "Identidad",
-        "section_description": "Apodo, avatar y biografía de Moddy en este servidor",
+        "section_description": "Apodo, avatar, banner y biografía de Moddy en este servidor",
         "modal_title": "Identidad de Moddy",
         "nickname_label": "Apodo",
         "nickname_description": "Déjalo vacío para restaurar el nombre original",
@@ -1812,14 +1812,16 @@
         "bio_description": "{max} caracteres como máximo, vacío para eliminarla",
         "avatar_label": "Avatar",
         "avatar_description": "PNG, JPEG, GIF o WEBP — 8 MB como máximo",
+        "banner_label": "Banner",
+        "banner_description": "PNG, JPEG, GIF o WEBP — 8 MB como máximo",
         "attribution_note": "-# La biografía siempre termina con la línea <a:Rocket:1535783839870353499> Powered by @**Moddy**, que no se puede quitar.",
         "edit": "Editar identidad",
         "reset": "Restablecer"
       },
       "premium": {
         "title": "Función premium",
-        "description": "Personalizar el apodo, el avatar y la biografía de Moddy está reservado a los servidores premium.",
-        "locked": "El apodo, el avatar y la biografía requieren una suscripción Moddy Max en este servidor.",
+        "description": "Personalizar el apodo, el avatar, el banner y la biografía de Moddy está reservado a los servidores premium.",
+        "locked": "El apodo, el avatar, el banner y la biografía requieren una suscripción Moddy Max en este servidor.",
         "button": "Obtener premium"
       },
       "style": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1803,7 +1803,7 @@
       },
       "identity": {
         "section_title": "Identité",
-        "section_description": "Pseudo, avatar et bio de Moddy sur ce serveur",
+        "section_description": "Pseudo, avatar, bannière et bio de Moddy sur ce serveur",
         "modal_title": "Identité de Moddy",
         "nickname_label": "Pseudo",
         "nickname_description": "Laisse vide pour revenir au nom d'origine",
@@ -1811,14 +1811,16 @@
         "bio_description": "{max} caractères maximum, laisse vide pour la retirer",
         "avatar_label": "Avatar",
         "avatar_description": "PNG, JPEG, GIF ou WEBP — 8 Mo maximum",
+        "banner_label": "Bannière",
+        "banner_description": "PNG, JPEG, GIF ou WEBP — 8 Mo maximum",
         "attribution_note": "-# La bio se termine toujours par la ligne <a:Rocket:1535783839870353499> Powered by @**Moddy**, elle ne peut pas être retirée.",
         "edit": "Modifier l'identité",
         "reset": "Réinitialiser"
       },
       "premium": {
         "title": "Fonctionnalité premium",
-        "description": "La personnalisation du pseudo, de l'avatar et de la bio de Moddy est réservée aux serveurs premium.",
-        "locked": "Le pseudo, l'avatar et la bio nécessitent un abonnement Moddy Max sur ce serveur.",
+        "description": "La personnalisation du pseudo, de l'avatar, de la bannière et de la bio de Moddy est réservée aux serveurs premium.",
+        "locked": "Le pseudo, l'avatar, la bannière et la bio nécessitent un abonnement Moddy Max sur ce serveur.",
         "button": "Passer en premium"
       },
       "style": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1804,7 +1804,7 @@
       },
       "identity": {
         "section_title": "Identidade",
-        "section_description": "Apelido, avatar e bio do Moddy neste servidor",
+        "section_description": "Apelido, avatar, banner e bio do Moddy neste servidor",
         "modal_title": "Identidade do Moddy",
         "nickname_label": "Apelido",
         "nickname_description": "Deixe vazio para voltar ao nome original",
@@ -1812,14 +1812,16 @@
         "bio_description": "{max} caracteres no máximo, vazio para remover",
         "avatar_label": "Avatar",
         "avatar_description": "PNG, JPEG, GIF ou WEBP — 8 MB no máximo",
+        "banner_label": "Banner",
+        "banner_description": "PNG, JPEG, GIF ou WEBP — 8 MB no máximo",
         "attribution_note": "-# A bio sempre termina com a linha <a:Rocket:1535783839870353499> Powered by @**Moddy**, que não pode ser removida.",
         "edit": "Editar identidade",
         "reset": "Redefinir"
       },
       "premium": {
         "title": "Recurso premium",
-        "description": "Personalizar o apelido, o avatar e a bio do Moddy é exclusivo dos servidores premium.",
-        "locked": "Apelido, avatar e bio exigem uma assinatura Moddy Max neste servidor.",
+        "description": "Personalizar o apelido, o avatar, o banner e a bio do Moddy é exclusivo dos servidores premium.",
+        "locked": "Apelido, avatar, banner e bio exigem uma assinatura Moddy Max neste servidor.",
         "button": "Assinar premium"
       },
       "style": {

--- a/modules/bot_customization.py
+++ b/modules/bot_customization.py
@@ -56,7 +56,7 @@ MAX_BIO_TOTAL_LENGTH = 190
 # The attribution line appended to every customized bio. Servers cannot remove
 # it — it is re-appended on every write.
 BIO_ATTRIBUTION = "<a:Rocket:1535783839870353499> Powered by @**Moddy**"
-BIO_SEPARATOR = "\n\n"
+BIO_SEPARATOR = "\n"
 MAX_BIO_LENGTH = MAX_BIO_TOTAL_LENGTH - len(BIO_ATTRIBUTION) - len(BIO_SEPARATOR)
 
 # Avatar upload guard rails. Discord accepts a bit more, but a server-supplied

--- a/modules/bot_customization.py
+++ b/modules/bot_customization.py
@@ -8,15 +8,15 @@ server never sees the customization of this one.
 Two tiers:
 
 - **Premium** (guild linked to an active subscription, see ``docs/PREMIUM.md``):
-  nickname, avatar and bio. The bio always keeps a trailing attribution line
+  nickname, avatar, banner and bio. The bio keeps a trailing attribution line
   (``Powered by @**Moddy**``) which the server cannot remove.
 - **Free**: the *name style* (font, effect, colours) applied to the bot's
   display name. This is the undocumented ``display_name_font_id`` /
   ``display_name_effect_id`` / ``display_name_colors`` trio — see
   ``docs/BOT_CUSTOMIZATION.md``.
 
-Persistence asymmetry, and why ``resync_style`` exists: nickname, avatar and
-bio are stored by Discord and survive anything. The name style does **not**
+Persistence asymmetry, and why ``resync_style`` exists: nickname, avatar,
+banner and bio are stored by Discord and survive anything. The name style does **not**
 reliably survive a bot restart, so it is re-applied once per process the first
 time the module is loaded for a guild.
 
@@ -59,10 +59,11 @@ BIO_ATTRIBUTION = "<a:Rocket:1535783839870353499> Powered by @**Moddy**"
 BIO_SEPARATOR = "\n"
 MAX_BIO_LENGTH = MAX_BIO_TOTAL_LENGTH - len(BIO_ATTRIBUTION) - len(BIO_SEPARATOR)
 
-# Avatar upload guard rails. Discord accepts a bit more, but a server-supplied
-# file is downloaded into memory before being base64-encoded, so we stay low.
-MAX_AVATAR_BYTES = 8 * 1024 * 1024
-ALLOWED_AVATAR_TYPES = {
+# Avatar / banner upload guard rails. Discord accepts a bit more, but a
+# server-supplied file is downloaded into memory before being base64-encoded,
+# so we stay low.
+MAX_IMAGE_BYTES = 8 * 1024 * 1024
+ALLOWED_IMAGE_TYPES = {
     "image/png": "png",
     "image/jpeg": "jpeg",
     "image/jpg": "jpeg",
@@ -225,7 +226,7 @@ def style_is_empty(style: Optional[Dict[str, Any]]) -> bool:
 def to_data_uri(data: bytes, content_type: str) -> str:
     """Build the ``data:image/png;base64,…`` URI Discord expects."""
     mime = content_type.split(";")[0].strip().lower()
-    if mime not in ALLOWED_AVATAR_TYPES:
+    if mime not in ALLOWED_IMAGE_TYPES:
         raise CustomizationError("invalid_image_type", mime)
     encoded = base64.b64encode(data).decode("ascii")
     return f"data:{mime};base64,{encoded}"
@@ -240,13 +241,13 @@ async def download_image(url: str) -> Tuple[bytes, str]:
                 if response.status != 200:
                     raise CustomizationError("image_download_failed", str(response.status))
                 content_type = (response.headers.get("Content-Type") or "").split(";")[0].strip().lower()
-                if content_type not in ALLOWED_AVATAR_TYPES:
+                if content_type not in ALLOWED_IMAGE_TYPES:
                     raise CustomizationError("invalid_image_type", content_type or "unknown")
                 length = response.headers.get("Content-Length")
-                if length and int(length) > MAX_AVATAR_BYTES:
+                if length and int(length) > MAX_IMAGE_BYTES:
                     raise CustomizationError("image_too_large", length)
-                data = await response.content.read(MAX_AVATAR_BYTES + 1)
-                if len(data) > MAX_AVATAR_BYTES:
+                data = await response.content.read(MAX_IMAGE_BYTES + 1)
+                if len(data) > MAX_IMAGE_BYTES:
                     raise CustomizationError("image_too_large", str(len(data)))
                 return data, content_type
     except CustomizationError:
@@ -272,6 +273,7 @@ class BotCustomizationModule(ModuleBase):
         self.nickname: Optional[str] = None
         self.bio: Optional[str] = None
         self.avatar_hash: Optional[str] = None
+        self.banner_hash: Optional[str] = None
         self.style: Dict[str, Any] = {"font_id": None, "effect_id": None, "colors": []}
 
     # ----------------------------------------------------------------- #
@@ -284,6 +286,8 @@ class BotCustomizationModule(ModuleBase):
             "bio": None,
             "avatar_hash": None,
             "avatar_source": None,
+            "banner_hash": None,
+            "banner_source": None,
             "style": {"font_id": None, "effect_id": None, "colors": []},
             "updated_at": None,
             "updated_by": None,
@@ -295,6 +299,7 @@ class BotCustomizationModule(ModuleBase):
             self.nickname = self.config.get("nickname")
             self.bio = self.config.get("bio")
             self.avatar_hash = self.config.get("avatar_hash")
+            self.banner_hash = self.config.get("banner_hash")
             raw_style = self.config.get("style") or {}
             self.style = {
                 "font_id": raw_style.get("font_id"),
@@ -304,7 +309,7 @@ class BotCustomizationModule(ModuleBase):
             # "Configured" is what makes the module active — there is no
             # separate on/off switch, an empty configuration is simply off.
             self.enabled = bool(
-                self.nickname or self.bio or self.avatar_hash
+                self.nickname or self.bio or self.avatar_hash or self.banner_hash
                 or not style_is_empty(self.style)
             )
             return True
@@ -363,6 +368,8 @@ class BotCustomizationModule(ModuleBase):
         bio: Any = UNSET,
         avatar: Any = UNSET,          # (bytes, content_type) tuple, or None to remove
         avatar_source: Optional[str] = None,   # bookkeeping only (dashboard URL)
+        banner: Any = UNSET,          # same shape as avatar
+        banner_source: Optional[str] = None,
         style: Any = UNSET,
         actor_id: Optional[int] = None,
         source: str = "config",
@@ -397,18 +404,23 @@ class BotCustomizationModule(ModuleBase):
             changes["bio"] = bio or "reset"
             config["bio"] = bio
 
-        if not isinstance(avatar, _Unset):
-            if avatar is None:
-                payload["avatar"] = None
-                changes["avatar"] = "reset"
-                config["avatar_hash"] = None
-                config["avatar_source"] = None
+        # Avatar and banner are the same kind of field (a data URI or null),
+        # so they share one code path.
+        images = {"avatar": (avatar, avatar_source), "banner": (banner, banner_source)}
+        for field, (image, _url) in images.items():
+            if isinstance(image, _Unset):
+                continue
+            if image is None:
+                payload[field] = None
+                changes[field] = "reset"
+                config[f"{field}_hash"] = None
+                config[f"{field}_source"] = None
             else:
-                data, content_type = avatar
-                if len(data) > MAX_AVATAR_BYTES:
+                data, content_type = image
+                if len(data) > MAX_IMAGE_BYTES:
                     raise CustomizationError("image_too_large", str(len(data)))
-                payload["avatar"] = to_data_uri(data, content_type)
-                changes["avatar"] = f"{len(data)} bytes ({content_type})"
+                payload[field] = to_data_uri(data, content_type)
+                changes[field] = f"{len(data)} bytes ({content_type})"
 
         if not isinstance(style, _Unset):
             normalized = normalize_style(style)
@@ -435,9 +447,11 @@ class BotCustomizationModule(ModuleBase):
                             source=source, error=f"{error}: {exc}")
             raise CustomizationError(error, str(exc))
 
-        if not isinstance(avatar, _Unset) and avatar is not None:
-            config["avatar_hash"] = (member_data or {}).get("avatar")
-            config["avatar_source"] = avatar_source
+        for field, (image, url) in images.items():
+            if isinstance(image, _Unset) or image is None:
+                continue
+            config[f"{field}_hash"] = (member_data or {}).get(field)
+            config[f"{field}_source"] = url
 
         config["updated_at"] = datetime.now(timezone.utc).isoformat()
         config["updated_by"] = actor_id
@@ -497,7 +511,9 @@ class BotCustomizationModule(ModuleBase):
             actor_id = None
 
         kwargs: Dict[str, Any] = {}
-        wants_premium = any(k in payload for k in ("nickname", "bio", "avatar_url"))
+        wants_premium = any(
+            k in payload for k in ("nickname", "bio", "avatar_url", "banner_url")
+        )
         if wants_premium and not await is_guild_premium(self.bot, self.guild_id):
             return {"ok": False, "error": "premium_required"}
 
@@ -505,10 +521,13 @@ class BotCustomizationModule(ModuleBase):
             kwargs["nickname"] = payload["nickname"]
         if "bio" in payload:
             kwargs["bio"] = payload["bio"]
-        if "avatar_url" in payload:
-            url = payload["avatar_url"]
-            kwargs["avatar"] = None if not url else await download_image(url)
-            kwargs["avatar_source"] = url or None
+        for field in ("avatar", "banner"):
+            key = f"{field}_url"
+            if key not in payload:
+                continue
+            url = payload[key]
+            kwargs[field] = None if not url else await download_image(url)
+            kwargs[f"{field}_source"] = url or None
         if "style" in payload:
             kwargs["style"] = payload["style"]
 
@@ -527,6 +546,7 @@ class BotCustomizationModule(ModuleBase):
             "nickname": config.get("nickname"),
             "bio": config.get("bio"),
             "avatar_hash": config.get("avatar_hash"),
+            "banner_hash": config.get("banner_hash"),
             "style": config.get("style"),
         }
 

--- a/modules/configs/bot_customization_config.py
+++ b/modules/configs/bot_customization_config.py
@@ -3,10 +3,14 @@ Configuration UI for the Bot Customization module.
 
 Two sections, two tiers:
 
-- **Identity** (premium only): nickname, avatar and bio, all edited from a
-  single Modal V2 — the avatar goes through a ``FileUpload`` component, so the
-  server uploads an image instead of pasting a URL. Non-premium servers see the
-  section locked with a link to the dashboard.
+- **Identity** (premium only): nickname, bio, avatar and banner, all edited
+  from a single Modal V2 — the images go through ``FileUpload`` components, so
+  the server uploads a file instead of pasting a URL. Non-premium servers see
+  the section locked with a link to the dashboard.
+
+  The modal is at Discord's hard ceiling of 5 top-level components (3 inputs +
+  2 uploads); the attribution warning therefore lives on the panel, not in the
+  modal.
 - **Name style** (free for everyone): font + effect + colours.
 
 There is no draft/save cycle here: a modal submit patches Discord immediately
@@ -29,7 +33,7 @@ from modules.bot_customization import (
     EFFECT_KEYS,
     EFFECTS,
     FONTS,
-    MAX_AVATAR_BYTES,
+    MAX_IMAGE_BYTES,
     MAX_BIO_LENGTH,
     MAX_NICKNAME_LENGTH,
     MODULE_ID,
@@ -42,7 +46,8 @@ from modules.bot_customization import (
 from modules.configs._common import check_guild_perms
 from utils.components_v2 import create_error_message, create_success_message
 from utils.emojis import (
-    AT, BACK, DELETE, EDIT, IMAGE, MODDY_SQUARE, NOTE, PREMIUM, STAR, UNDONE,
+    AT, BACK, BANNER, DELETE, EDIT, IMAGE, MODDY_SQUARE, NOTE, PREMIUM, STAR,
+    UNDONE,
 )
 from utils.i18n import i18n, t
 
@@ -61,13 +66,16 @@ DASHBOARD_URL = "https://dashboard.moddy.app/select-premium-servers"
 NONE_VALUE = "none"
 
 
-def _guild_avatar_url(bot, guild_id: int, avatar_hash: str) -> Optional[str]:
-    """CDN URL of the bot's per-guild avatar (not exposed by discord.py)."""
-    if not bot or not bot.user or not avatar_hash:
+def _guild_asset_url(bot, guild_id: int, kind: str, asset_hash: str) -> Optional[str]:
+    """CDN URL of the bot's per-guild avatar/banner (not exposed by discord.py).
+
+    ``kind`` is ``avatars`` or ``banners``.
+    """
+    if not bot or not bot.user or not asset_hash:
         return None
-    ext = "gif" if avatar_hash.startswith("a_") else "png"
+    ext = "gif" if asset_hash.startswith("a_") else "png"
     return (f"https://cdn.discordapp.com/guilds/{guild_id}/users/"
-            f"{bot.user.id}/avatars/{avatar_hash}.{ext}?size=256")
+            f"{bot.user.id}/{kind}/{asset_hash}.{ext}?size=256")
 
 
 # =========================================================================== #
@@ -75,7 +83,7 @@ def _guild_avatar_url(bot, guild_id: int, avatar_hash: str) -> Optional[str]:
 # =========================================================================== #
 
 class BotIdentityModal(BaseModal):
-    """Nickname + bio + avatar upload, premium only."""
+    """Nickname + bio + avatar + banner upload, premium only."""
 
     def __init__(self, bot, locale: str, config: Dict[str, Any]):
         super().__init__(
@@ -117,10 +125,11 @@ class BotIdentityModal(BaseModal):
             component=self.avatar_input,
         ))
 
-        # The attribution line is not negotiable — say so before submit rather
-        # than surprising the server afterwards.
-        self.add_item(ui.TextDisplay(
-            t('modules.bot_customization.identity.attribution_note', locale=locale)
+        self.banner_input = ui.FileUpload(min_values=0, max_values=1, required=False)
+        self.add_item(ui.Label(
+            text=t('modules.bot_customization.identity.banner_label', locale=locale),
+            description=t('modules.bot_customization.identity.banner_description', locale=locale),
+            component=self.banner_input,
         ))
 
     async def on_submit(self, interaction: discord.Interaction):
@@ -128,7 +137,8 @@ class BotIdentityModal(BaseModal):
             interaction,
             nickname=self.nickname_input.value,
             bio=self.bio_input.value,
-            attachments=list(self.avatar_input.values or []),
+            avatars=list(self.avatar_input.values or []),
+            banners=list(self.banner_input.values or []),
         )
 
 
@@ -248,7 +258,7 @@ async def _get_module(bot, guild_id: int) -> BotCustomizationModule:
 
 
 async def _read_attachment(attachment: discord.Attachment) -> tuple[bytes, str]:
-    if attachment.size > MAX_AVATAR_BYTES:
+    if attachment.size > MAX_IMAGE_BYTES:
         raise CustomizationError("image_too_large", str(attachment.size))
     content_type = (attachment.content_type or "").split(";")[0].strip().lower()
     data = await attachment.read()
@@ -256,7 +266,8 @@ async def _read_attachment(attachment: discord.Attachment) -> tuple[bytes, str]:
 
 
 async def _submit_identity(interaction: discord.Interaction, *, nickname: str,
-                           bio: str, attachments: List[discord.Attachment]):
+                           bio: str, avatars: List[discord.Attachment],
+                           banners: List[discord.Attachment]):
     if not await check_guild_perms(interaction):
         return
 
@@ -279,8 +290,12 @@ async def _submit_identity(interaction: discord.Interaction, *, nickname: str,
 
     kwargs: Dict[str, Any] = {"nickname": nickname, "bio": bio}
     try:
-        if attachments:
-            kwargs["avatar"] = await _read_attachment(attachments[0])
+        # An empty upload keeps the current image — removing one is what the
+        # Reset button is for.
+        if avatars:
+            kwargs["avatar"] = await _read_attachment(avatars[0])
+        if banners:
+            kwargs["banner"] = await _read_attachment(banners[0])
         await module.apply_customization(
             actor_id=interaction.user.id, source="config", **kwargs
         )
@@ -424,7 +439,9 @@ class BotCustomizationConfigView(BaseView):
         nickname = self.config.get("nickname")
         bio = self.config.get("bio")
         avatar_hash = self.config.get("avatar_hash")
+        banner_hash = self.config.get("banner_hash")
         none_label = t('modules.bot_customization.config.not_set', locale=self.locale)
+        custom_label = t('modules.bot_customization.config.custom', locale=self.locale)
 
         body = (
             f"**{PREMIUM} {t('modules.bot_customization.identity.section_title', locale=self.locale)}**\n"
@@ -432,12 +449,14 @@ class BotCustomizationConfigView(BaseView):
             f"{AT} **{t('modules.bot_customization.identity.nickname_label', locale=self.locale)}** — "
             f"`{nickname or none_label}`\n"
             f"{IMAGE} **{t('modules.bot_customization.identity.avatar_label', locale=self.locale)}** — "
-            f"`{t('modules.bot_customization.config.custom', locale=self.locale) if avatar_hash else none_label}`\n"
+            f"`{custom_label if avatar_hash else none_label}`\n"
+            f"{BANNER} **{t('modules.bot_customization.identity.banner_label', locale=self.locale)}** — "
+            f"`{custom_label if banner_hash else none_label}`\n"
             f"{NOTE} **{t('modules.bot_customization.identity.bio_label', locale=self.locale)}** — "
             f"`{bio or none_label}`"
         )
 
-        avatar_url = _guild_avatar_url(self.bot, self.guild_id, avatar_hash) if avatar_hash else None
+        avatar_url = _guild_asset_url(self.bot, self.guild_id, "avatars", avatar_hash)
         if avatar_url:
             container.add_item(ui.Section(
                 ui.TextDisplay(body),
@@ -445,6 +464,19 @@ class BotCustomizationConfigView(BaseView):
             ))
         else:
             container.add_item(ui.TextDisplay(body))
+
+        # The banner is wide — it gets the full-width gallery, not a thumbnail.
+        banner_url = _guild_asset_url(self.bot, self.guild_id, "banners", banner_hash)
+        if banner_url:
+            container.add_item(ui.MediaGallery(
+                discord.MediaGalleryItem(media=banner_url),
+            ))
+
+        # The attribution line is not negotiable — say so here, since the modal
+        # has no room left for a note.
+        container.add_item(ui.TextDisplay(
+            t('modules.bot_customization.identity.attribution_note', locale=self.locale)
+        ))
 
         # Registration shell (bot is None): render both branches' buttons so
         # discord.py learns every custom_id — see docs/PERSISTENT_VIEWS.md.
@@ -466,7 +498,7 @@ class BotCustomizationConfigView(BaseView):
                 style=discord.ButtonStyle.secondary,
                 emoji=discord.PartialEmoji.from_str(UNDONE),
                 custom_id=_CID_RESET_IDENTITY,
-                disabled=not (nickname or bio or avatar_hash) and not is_shell,
+                disabled=not (nickname or bio or avatar_hash or banner_hash) and not is_shell,
             )
             reset_btn.callback = self.on_reset_identity
             row.add_item(reset_btn)
@@ -547,7 +579,8 @@ class BotCustomizationConfigView(BaseView):
         is_shell = self.bot is None
         has_config = bool(
             self.config.get("nickname") or self.config.get("bio")
-            or self.config.get("avatar_hash") or not style_is_empty(self.style)
+            or self.config.get("avatar_hash") or self.config.get("banner_hash")
+            or not style_is_empty(self.style)
         )
         if has_config or is_shell:
             delete_btn = ui.Button(
@@ -616,7 +649,8 @@ class BotCustomizationConfigView(BaseView):
 
         kwargs: Dict[str, Any] = {}
         if identity:
-            kwargs.update({"nickname": None, "bio": None, "avatar": None})
+            kwargs.update({"nickname": None, "bio": None,
+                           "avatar": None, "banner": None})
         if style:
             kwargs["style"] = None
 


### PR DESCRIPTION
Follow-ups to #322, rebased onto `main` now that it has been merged. Replaces #323, which targeted the pre-merge branch.

## 1. Single newline before the attribution line

The separator was `\n\n`, which rendered an empty line between the server's bio and `Powered by @**Moddy**`. Nothing required it — it was an arbitrary choice. Now a single `\n`, so the attribution sits directly under the bio.

Side effect: the server gets one more character, `MAX_BIO_LENGTH` 136 → 137. The existing test pins the arithmetic (`len(build_bio("x" * MAX_BIO_LENGTH)) == 190`), so it followed automatically.

## 2. Banner

`PATCH /guilds/{id}/members/@me` already supported `banner`; it is now exposed as a premium field next to the avatar.

- Avatar and banner share **one** code path in `apply_customization` (`MAX_IMAGE_BYTES`, `ALLOWED_IMAGE_TYPES`) instead of duplicating the download / validate / data-URI / hash-bookkeeping logic. `MAX_AVATAR_BYTES` and `ALLOWED_AVATAR_TYPES` were renamed accordingly.
- Config schema gains `banner_hash` / `banner_source`, mirroring the avatar pair. The image itself is still never stored.
- The identity modal now carries two `FileUpload` components, putting it at **Discord's hard ceiling of 5 top-level components**. The attribution warning therefore moved out of the modal and onto the panel, where the banner also gets a full-width `MediaGallery` preview (a thumbnail would waste a wide image).
- Backend contract: `banner_url` on the task payload, `banner_hash` on the result. Same field-presence semantics — absent key = untouched, explicit `null` = reset. Premium is re-checked bot-side for it like the other identity fields.

## Testing

`709 passed` — including the persistence contract suite and the module's own validation tests. Manually exercised the write path against a stubbed HTTP layer: combined avatar+banner patch, banner-only reset through the backend task, and the non-premium refusal.

## Docs

`docs/BOT_CUSTOMIZATION.md`, `docs/PREMIUM.md`, `CLAUDE.md` and the session log updated; the banner is no longer listed under "not implemented".


---
_Generated by [Claude Code](https://claude.ai/code/session_01QZuqmhPKpp9TC5Q6yovhva)_