### PR TITLE
Disable Sentry auto-enabling integrations to prevent startup crashes

### DIFF
--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -38,6 +38,14 @@ if SENTRY_DSN:
         # Set profiles_sample_rate to 1.0 to profile 100% of sampled transactions.
         # Adjust this value in production.
         profiles_sample_rate=0.1,  # 10% of sampled transactions
+        # Auto-enabled integrations import their target library at init time
+        # (e.g. the OpenAI integration imports `openai`, which imports its
+        # vendored aiohttp transport). A version mismatch in that import
+        # chain raises before this module even finishes loading, and since
+        # BaseView (defined below) is imported by nearly every cog/module,
+        # that takes the whole bot down. Disable auto-detection so a broken
+        # third-party import can never crash startup.
+        auto_enabling_integrations=False,
     )
     logger.info("Sentry initialized successfully")
 else:


### PR DESCRIPTION
## Summary
Prevents Sentry initialization from crashing the bot startup due to third-party library import mismatches by disabling auto-enabling integrations.

## Problem
Sentry's auto-enabled integrations import their target libraries at initialization time (e.g., the OpenAI integration imports `openai`, which may have vendored dependencies like aiohttp). A version mismatch in this import chain can raise an exception before the error_handler module finishes loading. Since `BaseView` (defined in error_handler) is imported by nearly every cog and module, this causes a cascading failure that crashes the entire bot startup.

## Solution
- Set `auto_enabling_integrations=False` in the Sentry initialization configuration
- This prevents Sentry from automatically importing third-party libraries during init
- A broken third-party import can no longer crash bot startup
- Sentry will still function for error tracking; integrations can be manually enabled if needed

## Implementation Details
- Added configuration parameter to `sentry_sdk.init()` call in `cogs/error_handler.py`
- Included detailed comment explaining the rationale for future maintainers

https://claude.ai/code/session_01JW3XroeSyL4MgVvm5L7sZH