### PR TITLE
AltGuard: UI fixes and a byte-level integration reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,21 @@ moddy/
 - See → [docs/PERSISTENT_VIEWS.md](docs/PERSISTENT_VIEWS.md) for the full
   contract, the custom_id convention, auth models, and worked examples.
 
-### 9. Language
+### 9. "Current value" only when nothing else shows it
+- Do **not** print a `Valeur actuelle : …` / `Current value: …` line under a
+  setting whose control already displays its own state. A `ChannelSelect`,
+  `RoleSelect`, `UserSelect`, `MentionableSelect` or a `Select` with
+  `default=True` on the chosen option all render the current selection
+  themselves — repeating it as text is duplicated, and the two can drift.
+- **Do** show the current value when the setting is edited through something
+  that displays nothing: a Modal (custom message, colour, thresholds…), a
+  toggle button, or a value stored but not represented by any component on
+  the panel.
+- Rule of thumb: if the user can read the answer off the control, the text
+  line is noise; if the control is a button that opens a Modal, the text line
+  is the only way to know what is stored.
+
+### 10. Language
 - Code comments, commits, PRs: **English only**
 - User-facing strings: via i18n (French + English)
 
@@ -354,6 +368,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/MODULE_SYSTEM.md](docs/MODULE_SYSTEM.md) | Creating or modifying server modules |
 | [docs/WELCOME_MESSAGES.md](docs/WELCOME_MESSAGES.md) | Welcome messages module — config schema, placeholders, backend/dashboard contract |
 | [docs/ALTGUARD.md](docs/ALTGUARD.md) | **AltGuard** — anti multi-account verification gate, consent, service contract, staff commands |
+| [docs/ALTGUARD_INTEGRATION.md](docs/ALTGUARD_INTEGRATION.md) | AltGuard ↔ bot exact wire contract — payload types, error codes, debugging |
 | [docs/AUTOMOD_AI.md](docs/AUTOMOD_AI.md) | Automod AI — detection pipeline, nano decider, scalable features, rules safety check |
 | [docs/AUTOMOD_AI_CONFIG.md](docs/AUTOMOD_AI_CONFIG.md) | Automod AI configuration schema in DB (backend / dashboard integration) |
 | [docs/BOT_CUSTOMIZATION.md](docs/BOT_CUSTOMIZATION.md) | Bot Customization — per-guild nickname/avatar/banner/bio + name styles, Redis dashboard contract |

--- a/docs/ALTGUARD.md
+++ b/docs/ALTGUARD.md
@@ -100,6 +100,9 @@ a manual verification). A lookup failure **fails closed** — the roles wait.
 
 ## Service contract
 
+> Byte-level reference (headers, exact field types, error-code mapping,
+> reproduction commands): **[ALTGUARD_INTEGRATION.md](ALTGUARD_INTEGRATION.md)**.
+
 Two transports, four messages. `ALTGUARD_BOT_TOKEN` and `ALTGUARD_API_URL` live
 in the environment ([docs/RAILWAY.md](RAILWAY.md)); the Redis is the one the bot
 already uses ([docs/REDIS_COMMUNICATION.md](REDIS_COMMUNICATION.md)).

--- a/docs/ALTGUARD_INTEGRATION.md
+++ b/docs/ALTGUARD_INTEGRATION.md
@@ -1,0 +1,229 @@
+# AltGuard ↔ bot — exact wire contract
+
+> Debugging reference. Everything below describes **what `moddy-bot` actually
+> sends and expects**, byte for byte, so the AltGuard side can be diffed
+> against it. The functional overview lives in [ALTGUARD.md](ALTGUARD.md); this
+> file is the plumbing.
+>
+> Bot implementation: [`services/altguard_client.py`](../services/altguard_client.py).
+
+---
+
+## 0. Environment (bot side)
+
+| Variable | Default | Used for |
+|---|---|---|
+| `ALTGUARD_API_URL` | `https://verify.moddy.app` | base of both HTTP endpoints. Trailing `/` is stripped at import time. |
+| `ALTGUARD_BOT_TOKEN` | *(empty)* | `Authorization: Bearer <token>` on both endpoints |
+| `REDIS_URL` / `REDIS_PASSWORD` | — | the bot's existing Redis; AltGuard must point at the **same instance** |
+
+**If `ALTGUARD_BOT_TOKEN` is empty, no HTTP call is ever made** — the member
+gets `Verification unavailable` with code `not_configured` and nothing appears
+in the AltGuard logs. That is the single most common cause of the symptom.
+
+The URL is built as plain concatenation: `ALTGUARD_API_URL + "/altguard/token"`.
+With the default that is exactly `https://verify.moddy.app/altguard/token`.
+
+---
+
+## 1. `POST /altguard/token` — bot → service
+
+Sent once per consent-modal submission.
+
+### Request
+
+```http
+POST /altguard/token HTTP/1.1
+Host: verify.moddy.app
+Authorization: Bearer <ALTGUARD_BOT_TOKEN>
+Content-Type: application/json
+
+{
+  "discord_user_id": "987654321098765432",
+  "guild_id": "123456789012345678",
+  "consent_version": "2026-08",
+  "consent_at": "2026-08-18T10:00:00.123456Z"
+}
+```
+
+| Field | Type on the wire | Notes |
+|---|---|---|
+| `discord_user_id` | **string** | snowflake as a decimal string, never an int |
+| `guild_id` | **string** | idem |
+| `consent_version` | string | `CONSENT_VERSION` in `services/altguard_client.py` — currently `"2026-08"` |
+| `consent_at` | string | ISO 8601 **UTC**, `+00:00` rewritten as `Z`. Includes microseconds. Always ≤ now, taken at modal submit, a fraction of a second before the request |
+
+- Header is `Content-Type: application/json` (aiohttp `json=` payload).
+- No other header is sent — no `User-Agent` override, no API version header,
+  no cookie.
+- Timeout: **15 s total**. Anything slower is a `network_error` for the bot.
+- The bot does **not** retry: one submit, one call.
+
+### Expected response
+
+`200` with a JSON object:
+
+```json
+{
+  "authorization_url": "https://discord.com/oauth2/authorize?...&state=...",
+  "expires_at": "2026-08-18T10:20:00Z"
+}
+```
+
+- `authorization_url` — required. Rendered as a link button. If the key is
+  missing or empty, the bot still shows the card but **without a button**
+  (silent-looking failure — worth checking if members report "nothing to click").
+- `expires_at` — optional. Parsed with `datetime.fromisoformat` after replacing
+  a trailing `Z` with `+00:00`; a naive timestamp is assumed UTC. Unparseable →
+  the countdown line is simply omitted, no error.
+- Any other key in the body is ignored.
+- The response **must** be JSON. A `200` with an HTML body (a proxy error page,
+  a redirect landing) raises `network_error` at `response.json()`.
+
+### Status → what the member sees
+
+| Status | `AltGuardError.code` | Card shown | Retried? |
+|---|---|---|---|
+| `200` | — | the link | — |
+| `400` | `bad_request` | *Verification unavailable* | never (it is a caller bug) |
+| `401` | `unauthorized` | *Verification unavailable* | never |
+| `429` | `rate_limited` | *Too many attempts* + `Retry-After` | member retries manually |
+| `5xx` | `service_unavailable` | *Verification unavailable* | member retries manually |
+| other `3xx`/`4xx` | `unexpected_status` | *Verification unavailable* | — |
+| connection refused, DNS, TLS, timeout | `network_error` | *Verification unavailable* | — |
+| `ALTGUARD_BOT_TOKEN` empty | `not_configured` | *Verification unavailable* | — |
+
+The code is printed under the card (`Technical code: …`) and logged in full:
+
+```
+[AltGuard] Token request failed for <user_id> in guild <guild_id>: <code> (<message>)
+```
+
+For `bad_request` the message carries the first 500 characters of the service's
+response body — that is where a validation error from AltGuard shows up.
+
+### Reproducing a failure by hand
+
+```bash
+curl -i -X POST "$ALTGUARD_API_URL/altguard/token" \
+  -H "Authorization: Bearer $ALTGUARD_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"discord_user_id":"987654321098765432",
+       "guild_id":"123456789012345678",
+       "consent_version":"2026-08",
+       "consent_at":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}'
+```
+
+Run it from the bot's own host: a service reachable from a laptop but not from
+Railway (private networking, IP allowlist, egress rules) is exactly the
+`network_error` case.
+
+### Checklist for the AltGuard side
+
+- [ ] Route registered at **`/altguard/token`** (not `/token`, not `/api/...`).
+- [ ] Accepts `discord_user_id` / `guild_id` as **strings** — a schema typed
+      `int` rejects the bot's payload with `400`.
+- [ ] Accepts `consent_at` **with microseconds** and a `Z` suffix.
+- [ ] Bearer scheme, not `X-Api-Key`, not Basic.
+- [ ] Answers JSON on `200`, with `authorization_url`.
+- [ ] `429` carries `Retry-After` in seconds.
+- [ ] TLS certificate valid for the host in `ALTGUARD_API_URL` (the bot never
+      disables verification).
+
+---
+
+## 2. `POST /altguard/membership/resync` — bot → service
+
+Sent 2 minutes after startup, then hourly, once per guild that has AltGuard
+configured **and** whose member cache is complete.
+
+```http
+POST /altguard/membership/resync
+Authorization: Bearer <ALTGUARD_BOT_TOKEN>
+Content-Type: application/json
+
+{"guild_id": "123456789012345678",
+ "active_discord_user_ids": ["987654321098765432", "..."]}
+```
+
+- Ids are **strings**, bots excluded, and the list is the **complete** current
+  membership — not a diff.
+- Expected: `200` with `{"reconciled": true}`. The bot only reads that boolean.
+- Same error mapping as above; failures are logged
+  (`[AltGuard] Resync failed for guild <id>: …`) and retried on the next tick.
+- A guild whose cache is incomplete (`len(guild.members) < guild.member_count`)
+  is **skipped**, so a service that sees no resync for a large guild should
+  check the bot's member intent/chunking rather than the endpoint.
+
+---
+
+## 3. `altguard:verdict` — service → bot (Redis Pub/Sub)
+
+Channel name is exactly `altguard:verdict`, on the **same Redis** as
+`moddy:*`. The bot subscribes in `bot._listen_pubsub` at startup, alongside
+`moddy:bot`, `moddy:subscription:updates` and `moddy:blacklist:updates`.
+
+The published value must be a **JSON string** (the bot connects with
+`decode_responses=True` and calls `json.loads` on `message["data"]`):
+
+```json
+{"verification_id": "3f6c…-uuid", "guild_id": 123456789012345678,
+ "discord_user_id": 987654321098765432, "verdict": "passed",
+ "score": 62, "reasons": ["cookie_match", "gpu_match"], "enforced": true}
+```
+
+| Field | Accepted | Behaviour when absent/invalid |
+|---|---|---|
+| `verification_id` | any non-empty string | **message dropped** |
+| `verdict` | `passed` \| `flagged` \| `blocked` | **message dropped** |
+| `guild_id`, `discord_user_id` | int **or** numeric string (both are `int()`-ed) | **message dropped** |
+| `score` | int or numeric string | stored as `NULL` |
+| `reasons` | list of strings | stored as `[]` |
+| `enforced` | bool | **defaults to `false`** → logged, nothing applied |
+
+Two consequences worth checking when a verdict "does nothing":
+
+1. **`enforced` must be explicitly `true`** for roles to move. Omitting it is
+   read as shadow mode by design.
+2. **`verification_id` is the idempotency key.** Re-publishing the same id (a
+   retry, a replay after reconnect) inserts nothing into
+   `altguard_verifications` and stops there — the first message wins.
+
+A verdict for a guild where the module is not configured (or not enabled — it
+needs channel + both roles) is logged at debug level and ignored.
+
+---
+
+## 4. `altguard:membership` — bot → service (Redis Pub/Sub)
+
+```json
+{"event": "membership", "guild_id": 123456789012345678,
+ "discord_user_id": 987654321098765432,
+ "state": "active", "occurred_at": "2026-08-18T10:00:00Z"}
+```
+
+- `event` is always the literal `"membership"`.
+- `guild_id` / `discord_user_id` are **ints** here (they are Redis-internal,
+  not an HTTP schema).
+- `state` ∈ `active` | `left` | `kicked` | `banned`.
+- `occurred_at` is always present, ISO 8601 UTC with `Z`.
+- Published only for guilds where the AltGuard module is enabled, and never for
+  bots.
+- Nothing is published when Redis is down; the hourly resync is the repair
+  path.
+
+---
+
+## 5. Symptom → cause table
+
+| What the member/moderator sees | Look at |
+|---|---|
+| *Verification unavailable*, code `not_configured` | `ALTGUARD_BOT_TOKEN` missing in the bot's environment |
+| code `unauthorized` | token mismatch between bot and service |
+| code `bad_request` | payload rejected — the bot's log line carries the service's own message; usually a schema expecting ints instead of strings, or a stricter `consent_at` format |
+| code `network_error` | DNS/TLS/timeout/egress; reproduce with the curl above **from the bot host** |
+| code `service_unavailable` | service returned 5xx |
+| code `unexpected_status` | a redirect or an unusual 4xx — often a wrong path returning `404`, or a proxy answering `405` |
+| Card with no button | `200` returned without `authorization_url` |
+| Verdict published, nothing happens | `enforced` not `true`; or same `verification_id` already processed; or the module is not enabled on that guild |
+| No membership events reaching the service | module disabled on the guild, Redis down, or a different Redis instance on each side |

--- a/locales/de.json
+++ b/locales/de.json
@@ -1927,11 +1927,11 @@
         "title": "AltGuard",
         "description": "Um auf den Server zuzugreifen, musst du eine **Zweitkonto-Verifizierung** bestehen\nKlicke auf den Button unten, um deinen persönlichen Verifizierungslink zu erzeugen. Er gilt 20 Minuten und ist einmalig nutzbar.",
         "button": "Verifizieren",
-        "footer": "Mit dem Klick auf diesen Button akzeptierst du unsere [**Nutzungsbedingungen** (→ moddy.app)]({terms}) und unsere [**Datenschutzerklärung** (→ moddy.app)]({privacy}). Die für diese Verifizierung erhobenen Daten sind verschlüsselt. [**Mehr erfahren** (→ moddy.app)]({data})"
+        "footer": "Mit dem Klick auf diesen Button akzeptierst du unsere [**Nutzungsbedingungen**]({terms}) und unsere [**Datenschutzerklärung**]({privacy}). Die für diese Verifizierung erhobenen Daten sind verschlüsselt. [**Mehr erfahren**]({data})"
       },
       "consent": {
         "title": "AltGuard-Verifizierung",
-        "body": "Zur Erkennung von Mehrfachkonten erhebt die Verifizierung die Merkmale deines Browsers, ein technisches Cookie, deine Discord-E-Mail-Adresse, die Liste deiner Server und deine IP-Adresse.\n\nDiese Daten sind **verschlüsselt**, werden ausschließlich für diese Erkennung verwendet und nur begrenzt gespeichert. **Das Moddy-Team und die Moderation dieses Servers haben keinen Zugriff darauf** — sie sehen nur das Ergebnis der Verifizierung.\n\n[**Erhobene Daten** (→ moddy.app)]({data}) · [**Nutzungsbedingungen** (→ moddy.app)]({terms}) · [**Datenschutzerklärung** (→ moddy.app)]({privacy})",
+        "body": "Zur Erkennung von Mehrfachkonten erhebt die Verifizierung die Merkmale deines Browsers, ein technisches Cookie, deine Discord-E-Mail-Adresse, die Liste deiner Server und deine IP-Adresse.\n\nDiese Daten sind **verschlüsselt**, werden ausschließlich für diese Erkennung verwendet und nur begrenzt gespeichert.\n\n[**Erhobene Daten**]({data}) · [**Nutzungsbedingungen**]({terms}) · [**Datenschutzerklärung**]({privacy})",
         "agree_label": "Einwilligung",
         "agree_description": "Setze beide Haken, um deinen Verifizierungslink zu erzeugen.",
         "agree_terms": "Ich akzeptiere die Nutzungsbedingungen und die Datenschutzerklärung",
@@ -1971,7 +1971,8 @@
         "bot_target": {
           "title": "Ungültiges Ziel",
           "description": "Bots durchlaufen die AltGuard-Verifizierung nicht."
-        }
+        },
+        "code": "Technischer Code: {code} — gib ihn an die Moderation weiter, wenn das Problem bestehen bleibt."
       },
       "manual": {
         "verified": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1927,11 +1927,11 @@
         "title": "AltGuard",
         "description": "To access this server, you must pass an **anti multi-account verification**\nClick the button below to generate your personal verification link. It is valid for 20 minutes and single use.",
         "button": "Verify me",
-        "footer": "By clicking this button, you accept our [**Terms of Service** (→ moddy.app)]({terms}) and our [**Privacy Policy** (→ moddy.app)]({privacy}). The data collected for this verification is encrypted. [**Learn more** (→ moddy.app)]({data})"
+        "footer": "By clicking this button, you accept our [**Terms of Service**]({terms}) and our [**Privacy Policy**]({privacy}). The data collected for this verification is encrypted. [**Learn more**]({data})"
       },
       "consent": {
         "title": "AltGuard verification",
-        "body": "To detect multiple accounts, the verification collects your browser characteristics, a technical cookie, your Discord email address, your server list and your IP address.\n\nThis data is **encrypted**, used only for that detection and kept for a limited time. **The Moddy team and this server's moderators have no access to it** — they only see the outcome of the verification.\n\n[**Collected data** (→ moddy.app)]({data}) · [**Terms of Service** (→ moddy.app)]({terms}) · [**Privacy Policy** (→ moddy.app)]({privacy})",
+        "body": "To detect multiple accounts, the verification collects your browser characteristics, a technical cookie, your Discord email address, your server list and your IP address.\n\nThis data is **encrypted**, used only for that detection and kept for a limited time.\n\n[**Collected data**]({data}) · [**Terms of Service**]({terms}) · [**Privacy Policy**]({privacy})",
         "agree_label": "Consent",
         "agree_description": "Tick both boxes to generate your verification link.",
         "agree_terms": "I accept the terms of service and the privacy policy",
@@ -1971,7 +1971,8 @@
         "bot_target": {
           "title": "Invalid target",
           "description": "Bots do not go through the AltGuard verification."
-        }
+        },
+        "code": "Technical code: {code} — pass it on to the moderators if the problem persists."
       },
       "manual": {
         "verified": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1927,11 +1927,11 @@
         "title": "AltGuard",
         "description": "Para acceder al servidor, debes superar una **verificación anti cuentas múltiples**\nHaz clic en el botón de abajo para generar tu enlace de verificación personal. Es válido 20 minutos y de un solo uso.",
         "button": "Verificarme",
-        "footer": "Al hacer clic en este botón, aceptas nuestras [**Condiciones de uso** (→ moddy.app)]({terms}) y nuestra [**Política de privacidad** (→ moddy.app)]({privacy}). Los datos recogidos en esta verificación están cifrados. [**Más información** (→ moddy.app)]({data})"
+        "footer": "Al hacer clic en este botón, aceptas nuestras [**Condiciones de uso**]({terms}) y nuestra [**Política de privacidad**]({privacy}). Los datos recogidos en esta verificación están cifrados. [**Más información**]({data})"
       },
       "consent": {
         "title": "Verificación AltGuard",
-        "body": "Para detectar cuentas múltiples, la verificación recoge las características de tu navegador, una cookie técnica, tu correo de Discord, la lista de tus servidores y tu dirección IP.\n\nEstos datos están **cifrados**, se usan únicamente para esa detección y se conservan por un tiempo limitado. **El equipo de Moddy y la moderación de este servidor no tienen acceso a ellos**: solo ven el resultado de la verificación.\n\n[**Datos recogidos** (→ moddy.app)]({data}) · [**Condiciones de uso** (→ moddy.app)]({terms}) · [**Política de privacidad** (→ moddy.app)]({privacy})",
+        "body": "Para detectar cuentas múltiples, la verificación recoge las características de tu navegador, una cookie técnica, tu correo de Discord, la lista de tus servidores y tu dirección IP.\n\nEstos datos están **cifrados**, se usan únicamente para esa detección y se conservan por un tiempo limitado.\n\n[**Datos recogidos**]({data}) · [**Condiciones de uso**]({terms}) · [**Política de privacidad**]({privacy})",
         "agree_label": "Consentimiento",
         "agree_description": "Marca las dos casillas para generar tu enlace de verificación.",
         "agree_terms": "Acepto las condiciones de uso y la política de privacidad",
@@ -1971,7 +1971,8 @@
         "bot_target": {
           "title": "Objetivo inválido",
           "description": "Los bots no pasan por la verificación de AltGuard."
-        }
+        },
+        "code": "Código técnico: {code} — comunícalo a la moderación si el problema persiste."
       },
       "manual": {
         "verified": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1926,11 +1926,11 @@
         "title": "AltGuard",
         "description": "Pour accéder au serveur, tu dois valider une **vérification anti double compte**\nClique sur le bouton ci-dessous pour générer ton lien de vérification personnel. Il est valable 20 minutes et à usage unique.",
         "button": "Se vérifier",
-        "footer": "En cliquant sur ce bouton, tu acceptes nos [**Conditions d'utilisation** (→ moddy.app)]({terms}) et notre [**Politique de confidentialité** (→ moddy.app)]({privacy}). Les données collectées dans le cadre de cette vérification sont chiffrées. [**En savoir plus** (→ moddy.app)]({data})"
+        "footer": "En cliquant sur ce bouton, tu acceptes nos [**Conditions d'utilisation**]({terms}) et notre [**Politique de confidentialité**]({privacy}). Les données collectées dans le cadre de cette vérification sont chiffrées. [**En savoir plus**]({data})"
       },
       "consent": {
         "title": "Vérification AltGuard",
-        "body": "Pour détecter les comptes multiples, la vérification collecte les caractéristiques de ton navigateur, un cookie technique, ton adresse e-mail Discord, la liste de tes serveurs et ton adresse IP.\n\nCes données sont **chiffrées**, utilisées uniquement pour cette détection et conservées pour une durée limitée. **L'équipe Moddy et la modération de ce serveur n'y ont pas accès** : elles ne voient que le résultat de la vérification.\n\n[**Données collectées** (→ moddy.app)]({data}) · [**Conditions d'utilisation** (→ moddy.app)]({terms}) · [**Politique de confidentialité** (→ moddy.app)]({privacy})",
+        "body": "Pour détecter les comptes multiples, la vérification collecte les caractéristiques de ton navigateur, un cookie technique, ton adresse e-mail Discord, la liste de tes serveurs et ton adresse IP.\n\nCes données sont **chiffrées**, utilisées uniquement pour cette détection et conservées pour une durée limitée.\n\n[**Données collectées**]({data}) · [**Conditions d'utilisation**]({terms}) · [**Politique de confidentialité**]({privacy})",
         "agree_label": "Consentement",
         "agree_description": "Coche les deux cases pour générer ton lien de vérification.",
         "agree_terms": "J'accepte les conditions d'utilisation et la politique de confidentialité",
@@ -1970,7 +1970,8 @@
         "bot_target": {
           "title": "Cible invalide",
           "description": "Les bots ne passent pas par la vérification AltGuard."
-        }
+        },
+        "code": "Code technique : {code} — communique-le à la modération si le problème persiste."
       },
       "manual": {
         "verified": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1927,11 +1927,11 @@
         "title": "AltGuard",
         "description": "Para acessar o servidor, você precisa passar por uma **verificação anti contas múltiplas**\nClique no botão abaixo para gerar seu link de verificação pessoal. Ele vale 20 minutos e é de uso único.",
         "button": "Verificar-me",
-        "footer": "Ao clicar neste botão, você aceita nossos [**Termos de uso** (→ moddy.app)]({terms}) e nossa [**Política de privacidade** (→ moddy.app)]({privacy}). Os dados coletados nesta verificação são criptografados. [**Saiba mais** (→ moddy.app)]({data})"
+        "footer": "Ao clicar neste botão, você aceita nossos [**Termos de uso**]({terms}) e nossa [**Política de privacidade**]({privacy}). Os dados coletados nesta verificação são criptografados. [**Saiba mais**]({data})"
       },
       "consent": {
         "title": "Verificação AltGuard",
-        "body": "Para detectar contas múltiplas, a verificação coleta as características do seu navegador, um cookie técnico, seu e-mail do Discord, a lista dos seus servidores e seu endereço IP.\n\nEsses dados são **criptografados**, usados apenas para essa detecção e mantidos por um tempo limitado. **A equipe do Moddy e a moderação deste servidor não têm acesso a eles**: elas só veem o resultado da verificação.\n\n[**Dados coletados** (→ moddy.app)]({data}) · [**Termos de uso** (→ moddy.app)]({terms}) · [**Política de privacidade** (→ moddy.app)]({privacy})",
+        "body": "Para detectar contas múltiplas, a verificação coleta as características do seu navegador, um cookie técnico, seu e-mail do Discord, a lista dos seus servidores e seu endereço IP.\n\nEsses dados são **criptografados**, usados apenas para essa detecção e mantidos por um tempo limitado.\n\n[**Dados coletados**]({data}) · [**Termos de uso**]({terms}) · [**Política de privacidade**]({privacy})",
         "agree_label": "Consentimento",
         "agree_description": "Marque as duas caixas para gerar seu link de verificação.",
         "agree_terms": "Aceito os termos de uso e a política de privacidade",
@@ -1971,7 +1971,8 @@
         "bot_target": {
           "title": "Alvo inválido",
           "description": "Bots não passam pela verificação do AltGuard."
-        }
+        },
+        "code": "Código técnico: {code} — informe a moderação se o problema persistir."
       },
       "manual": {
         "verified": {

--- a/modules/altguard.py
+++ b/modules/altguard.py
@@ -36,7 +36,7 @@ from db.repositories.altguard import (
     VERDICT_PASSED, VERDICT_TO_STATUS,
 )
 from modules.module_manager import ModuleBase
-from utils.emojis import ALTGUARD
+from utils.emojis import SHIELD
 
 logger = logging.getLogger('moddy.modules.altguard')
 
@@ -58,7 +58,9 @@ class AltGuardModule(ModuleBase):
     MODULE_ID = MODULE_ID
     MODULE_NAME = "AltGuard"
     MODULE_DESCRIPTION = "Anti multi-account verification before server access"
-    MODULE_EMOJI = ALTGUARD
+    # The /config picker uses the shield (it is a protection module); the
+    # animated AltGuard face is reserved for the panel message itself.
+    MODULE_EMOJI = SHIELD
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)

--- a/modules/configs/altguard_config.py
+++ b/modules/configs/altguard_config.py
@@ -89,12 +89,6 @@ class AltGuardConfigView(BaseView):
     # Rendering
     # ----------------------------------------------------------------- #
 
-    def _role_mention(self, role_id: Optional[int]) -> str:
-        return f"<@&{role_id}>" if role_id else t('modules.config.not_configured', locale=self.locale)
-
-    def _channel_mention(self, channel_id: Optional[int]) -> str:
-        return f"<#{channel_id}>" if channel_id else t('modules.config.not_configured', locale=self.locale)
-
     def _build_view(self) -> None:
         self.clear_items()
 
@@ -112,9 +106,7 @@ class AltGuardConfigView(BaseView):
         # --- Verification channel -------------------------------------- #
         container.add_item(ui.TextDisplay(
             f"**{t('modules.altguard.config.channel.section_title', locale=self.locale)}**\n"
-            f"-# {t('modules.altguard.config.channel.section_description', locale=self.locale)}\n"
-            f"-# {t('modules.config.current_value', locale=self.locale)} "
-            f"{self._channel_mention(self.working_config.get('channel_id'))}"
+            f"-# {t('modules.altguard.config.channel.section_description', locale=self.locale)}"
         ))
         container.add_item(self._channel_row(
             _CID_CHANNEL, self.working_config.get('channel_id'),
@@ -125,9 +117,7 @@ class AltGuardConfigView(BaseView):
         # --- Unverified role -------------------------------------------- #
         container.add_item(ui.TextDisplay(
             f"**{t('modules.altguard.config.unverified_role.section_title', locale=self.locale)}**\n"
-            f"-# {t('modules.altguard.config.unverified_role.section_description', locale=self.locale)}\n"
-            f"-# {t('modules.config.current_value', locale=self.locale)} "
-            f"{self._role_mention(self.working_config.get('unverified_role_id'))}"
+            f"-# {t('modules.altguard.config.unverified_role.section_description', locale=self.locale)}"
         ))
         container.add_item(self._role_row(
             _CID_UNVERIFIED, self.working_config.get('unverified_role_id'),
@@ -137,9 +127,7 @@ class AltGuardConfigView(BaseView):
         # --- Verified role ---------------------------------------------- #
         container.add_item(ui.TextDisplay(
             f"**{t('modules.altguard.config.verified_role.section_title', locale=self.locale)}**\n"
-            f"-# {t('modules.altguard.config.verified_role.section_description', locale=self.locale)}\n"
-            f"-# {t('modules.config.current_value', locale=self.locale)} "
-            f"{self._role_mention(self.working_config.get('verified_role_id'))}"
+            f"-# {t('modules.altguard.config.verified_role.section_description', locale=self.locale)}"
         ))
         container.add_item(self._role_row(
             _CID_VERIFIED, self.working_config.get('verified_role_id'),
@@ -172,9 +160,7 @@ class AltGuardConfigView(BaseView):
         # --- Log channel (optional) -------------------------------------- #
         container.add_item(ui.TextDisplay(
             f"**{t('modules.altguard.config.log_channel.section_title', locale=self.locale)}**\n"
-            f"-# {t('modules.altguard.config.log_channel.section_description', locale=self.locale)}\n"
-            f"-# {t('modules.config.current_value', locale=self.locale)} "
-            f"{self._channel_mention(self.working_config.get('log_channel_id'))}"
+            f"-# {t('modules.altguard.config.log_channel.section_description', locale=self.locale)}"
         ))
         container.add_item(self._channel_row(
             _CID_LOG_CHANNEL, self.working_config.get('log_channel_id'),

--- a/utils/altguard_views.py
+++ b/utils/altguard_views.py
@@ -87,6 +87,15 @@ class AltGuardPanelView(BaseView):
             t('modules.altguard.panel.description', locale=self.locale)
         ))
 
+        container.add_item(ui.Separator(visible=True, spacing=discord.SeparatorSpacing.small))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.altguard.panel.footer', locale=self.locale, terms=TERMS_URL, privacy=PRIVACY_URL, data=DATA_NOTICE_URL)}"
+        ))
+
+        self.add_item(container)
+
+        # The action sits OUTSIDE the container, under the card, so the button
+        # reads as the call to action rather than as part of the notice.
         button_row = ui.ActionRow()
         verify_btn = ui.Button(
             label=t('modules.altguard.panel.button', locale=self.locale),
@@ -96,14 +105,7 @@ class AltGuardPanelView(BaseView):
         )
         verify_btn.callback = self.on_verify
         button_row.add_item(verify_btn)
-        container.add_item(button_row)
-
-        container.add_item(ui.Separator(visible=True, spacing=discord.SeparatorSpacing.small))
-        container.add_item(ui.TextDisplay(
-            f"-# {t('modules.altguard.panel.footer', locale=self.locale, terms=TERMS_URL, privacy=PRIVACY_URL, data=DATA_NOTICE_URL)}"
-        ))
-
-        self.add_item(container)
+        self.add_item(button_row)
 
     async def on_verify(self, interaction: discord.Interaction) -> None:
         """Open the consent modal. Nothing leaves the bot before it is signed."""
@@ -202,7 +204,8 @@ class AltGuardConsentModal(BaseModal):
         client = getattr(bot, "altguard", None)
         if client is None or not client.configured:
             await interaction.followup.send(
-                view=build_error_card(locale, 'unavailable'), ephemeral=True,
+                view=build_error_card(locale, 'unavailable', code='not_configured'),
+                ephemeral=True,
             )
             return
 
@@ -214,13 +217,15 @@ class AltGuardConsentModal(BaseModal):
                 consent_version=CONSENT_VERSION,
             )
         except AltGuardError as e:
+            # The code is what tells a missing secret from a rejected token
+            # from a dead service — log it in full, show it discreetly.
             logger.warning(
                 f"[AltGuard] Token request failed for {interaction.user.id} "
-                f"in guild {interaction.guild_id}: {e.code}"
+                f"in guild {interaction.guild_id}: {e.code} ({e.message})"
             )
             key = 'rate_limited' if e.code == 'rate_limited' else 'unavailable'
             await interaction.followup.send(
-                view=build_error_card(locale, key, retry_after=e.retry_after),
+                view=build_error_card(locale, key, retry_after=e.retry_after, code=e.code),
                 ephemeral=True,
             )
             return
@@ -288,8 +293,17 @@ def build_link_card(locale: str, *, url: str, expires_at: Optional[str] = None) 
     return view
 
 
-def build_error_card(locale: str, key: str, *, retry_after: Optional[int] = None) -> ui.LayoutView:
-    """An ephemeral failure card. `key` selects the i18n message."""
+def build_error_card(locale: str, key: str, *, retry_after: Optional[int] = None,
+                     code: Optional[str] = None) -> ui.LayoutView:
+    """An ephemeral failure card. `key` selects the i18n message.
+
+    ``code`` is the raw :class:`~services.altguard_client.AltGuardError` code.
+    It is shown as a discreet footer because "the service is not answering"
+    covers half a dozen very different causes (missing secret, rejected token,
+    network, 5xx) and a member reporting the problem to a moderator should be
+    able to say which one. It names no internal host and leaks no signal about
+    the detection itself.
+    """
     view = ui.LayoutView(timeout=None)
     container = ui.Container(accent_colour=ERROR_ACCENT)
 
@@ -302,6 +316,11 @@ def build_error_card(locale: str, key: str, *, retry_after: Optional[int] = None
             'modules.altguard.errors.rate_limited.retry', locale=locale, seconds=retry_after,
         )
     container.add_item(ui.TextDisplay(description))
+
+    if code:
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.altguard.errors.code', locale=locale, code=f'`{code}`')}"
+        ))
 
     view.add_item(container)
     return view

--- a/utils/emojis.py
+++ b/utils/emojis.py
@@ -95,7 +95,7 @@ HAND = "<:hand:1521517865348632706>"       # appeal "claim" button
 LINK = "<:link:1521517863607734385>"       # appeal "invite" button
 PENDING = "<:pending:1521282587962900611>"  # appeal "pending" status
 ROCKET = "<a:Rocket:1535783839870353499>"  # bot customization bio attribution
-ALTGUARD = "<a:DisguisedFace:1539334637992550424>"  # AltGuard verification module
+ALTGUARD = "<a:DisguisedFace:1539405255576657981>"  # AltGuard verification panel message
 
 # =============================================================================
 # SOCIAL PLATFORMS (Social Notifications module)


### PR DESCRIPTION
Follow-up to #330 (the module itself), which is already on `main`. This branch was rebased onto `main` so the diff is only the fixes — it previously replayed the whole module because #330 was squash-merged.

## Summary

- Drop the `(→ moddy.app)` suffix appended to every link label in the panel footer and the consent modal, in all five locales.
- Remove the consent sentence claiming the Moddy team and the server's moderators have no access to the collected data.
- Panel: move the verify button out of the container, under the card, so it reads as the call to action rather than as part of the notice.
- Config panel: drop the "current value" lines under the channel/role/language selectors — the select already shows its own selection, and the two could drift. `CLAUDE.md` gains the rule: show a current value only when the control displays nothing (modal, toggle, unrepresented setting).
- Emojis: the `/config` picker uses the shield (protection module); the animated AltGuard face is reserved for the panel message, and points at the new id.
- Failure cards now carry the `AltGuardError` code as a discreet footer, and the log line carries the service's own message. "Verification unavailable" covered six unrelated causes (`not_configured`, `unauthorized`, `bad_request`, `rate_limited`, `service_unavailable`, `unexpected_status`, `network_error`) with no way to tell them apart.

New `docs/ALTGUARD_INTEGRATION.md` documents the wire contract exactly as the bot implements it, for debugging the bot ↔ service link: URL construction, headers, field types (ids are strings over HTTP, ints over Redis), the status → error-code → member-facing-card table, a `curl` to reproduce a failure from the bot host, and a symptom → cause table.

## Test plan

- [x] `python3 -m pytest -q` — full suite green (858 passed)
- [x] Manual render check: panel children are `[Container, ActionRow]` (button outside the card), config panel builds without the removed helpers, error card renders the code footer
- [x] No `(→ moddy.app)` left in any locale file
- [ ] End-to-end verification flow against a live AltGuard service (needs `ALTGUARD_API_URL` / `ALTGUARD_BOT_TOKEN` on a real deployment) — the new error codes are what will identify the current `Verification unavailable`

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GyCuuKC9tUQxL7fanpLUsz