### PR TITLE
AltGuard: add `matches` field to verdict payload and log card

### DIFF
--- a/docs/ALTGUARD.md
+++ b/docs/ALTGUARD.md
@@ -65,9 +65,12 @@ no role ever moves, that field is the first thing to check.
 
 ### What the member never sees
 
-`score` and `reasons` are audit data. They appear in the guild's log channel and
-in `/mod altguard refusal`, never in anything the verified member receives. The
-service deliberately withholds them from the browser so a bypass attempt gets no
+`score`, `reasons` and `matches` (the accounts a verification matched with) are
+audit data, never shown to anything the verified member receives. `score` and
+`reasons` appear in the guild's log channel and are persisted, so they also
+show up in `/mod altguard refusal`; `matches` is not persisted — it appears on
+the log card only, at the moment the verdict is applied. The service
+deliberately withholds all three from the browser so a bypass attempt gets no
 oracle; reproducing them bot-side would break the same guarantee.
 
 ---
@@ -165,7 +168,8 @@ members as `left`.
 ```json
 {"verification_id": "uuid", "guild_id": 123, "discord_user_id": 987,
  "verdict": "passed | flagged | blocked", "score": 62,
- "reasons": ["cookie_match"], "enforced": true}
+ "reasons": ["cookie_match"], "enforced": true,
+ "matches": [{"discord_user_id": 456, "score": 62, "reasons": ["cookie_match"]}]}
 ```
 
 Routed by `bot._handle_altguard_verdict` → `AltGuard.handle_verdict`.
@@ -175,9 +179,22 @@ Routed by `bot._handle_altguard_verdict` → `AltGuard.handle_verdict`.
   logs, it never sanctions.
 - `enforced=false` is the service's shadow mode — the verdict is logged and
   nothing is applied: no role change, no message, no state write.
+- `matches` — the accounts the verification matched with, most-linked first,
+  up to five, always `[]` on a `passed` — is read defensively with
+  `verdict.get('matches', [])` and rendered on the log card only (§ "What the
+  member never sees"). Read with `.get(...)` rather than `[...]` so a bot
+  deployed ahead of the service degrades to no matches shown instead of
+  raising.
 - **Idempotency** is the `verification_id` primary key of
   `altguard_verifications`: a replayed message (Redis reconnect, service retry)
   inserts nothing, and processing stops there.
+
+> Since the AltGuard `005` migration, unconfigured guilds send `enforced:
+> true` by default (it used to be `false`), so a verdict starts applying for
+> real, immediately, on every already-configured guild the moment the service
+> deploys. Set `shadow_mode = true` in `altguard.guild_config` to observe a
+> guild before letting it sanction — see
+> [ALTGUARD_INTEGRATION.md](ALTGUARD_INTEGRATION.md).
 
 ### `altguard:membership` (bot → service)
 
@@ -207,6 +224,7 @@ account rejoining) — a resync never resurrects a banned account.
 | `verdict` | `passed` / `flagged` / `blocked` |
 | `score`, `reasons` | audit only — never shown to the member |
 | `enforced` | false = shadow mode |
+| *(not persisted)* `matches` | carried on the verdict payload only, rendered straight to the log card — not stored in this table |
 | `created_at` | |
 
 `altguard_members` — the gate state the bot acts on:

--- a/docs/ALTGUARD_INTEGRATION.md
+++ b/docs/ALTGUARD_INTEGRATION.md
@@ -169,7 +169,9 @@ The published value must be a **JSON string** (the bot connects with
 ```json
 {"verification_id": "3f6c…-uuid", "guild_id": 123456789012345678,
  "discord_user_id": 987654321098765432, "verdict": "passed",
- "score": 62, "reasons": ["cookie_match", "gpu_match"], "enforced": true}
+ "score": 62, "reasons": ["cookie_match", "gpu_match"], "enforced": true,
+ "matches": [{"discord_user_id": 456789123, "score": 62,
+              "reasons": ["cookie_match", "gpu_match"]}]}
 ```
 
 | Field | Accepted | Behaviour when absent/invalid |
@@ -180,6 +182,17 @@ The published value must be a **JSON string** (the bot connects with
 | `score` | int or numeric string | stored as `NULL` |
 | `reasons` | list of strings | stored as `[]` |
 | `enforced` | bool | **defaults to `false`** → logged, nothing applied |
+| `matches` | list of `{discord_user_id, score, reasons}`, up to 5, most-linked first, always `[]` on a `passed` | stored as `[]`; malformed entries are dropped individually |
+
+> **`matches` is audit data for the log channel, nothing else.** It names the
+> accounts a verification matched with, so a moderator can understand a
+> `blocked` verdict and undo it if it's wrong — rendered on the log card, see
+> [docs/ALTGUARD.md](ALTGUARD.md). It is
+> **never** sent to the verified member (DM or ephemeral reply): same reason as
+> `score` and `reasons` — it would tell them exactly which signal to change to
+> pass next time. Read with `payload.get("matches", [])` — the field is always
+> present on the wire, but a bot deployed ahead of the service must not break
+> on its absence.
 
 > **`enforced: true` is what applies the roles.** This is the single most
 > common reason a verification "works" end to end and yet the member keeps the

--- a/docs/sessions/2026-08-19_altguard-verdict-matches.md
+++ b/docs/sessions/2026-08-19_altguard-verdict-matches.md
@@ -1,0 +1,40 @@
+# AltGuard: `matches` field on the verdict + `enforced` default flip
+
+## What was done
+
+The AltGuard service now sends an additional `matches` field on
+`altguard:verdict` (the linked accounts a verification matched with, most-linked
+first, up to five, always `[]` on a `passed`) and, after its `005` migration,
+unconfigured guilds default to `enforced: true` instead of `false`. Neither
+changes the bot's contract — `enforced` still gates every action — but both
+needed wiring/documenting on the bot side:
+
+- `services/altguard_client.py::parse_verdict` now reads `matches` defensively
+  (`data.get("matches", [])`), sanitizing each entry (`discord_user_id` → int,
+  `score` → int or `None`, `reasons` → list of str) and dropping malformed
+  entries individually rather than the whole list.
+- `modules/altguard.py::apply_verdict` forwards `matches` to the log card.
+- `utils/altguard_views.py::build_log_card` renders a "linked accounts" block
+  when `matches` is non-empty — log channel only, never in the member DM
+  (`notify_member` was already untouched by this field and stays that way).
+- Added the `modules.altguard.logs.matches` i18n key to all five locales.
+- No production workaround existed for the "member leaves and rejoins,
+  matches against their own trace" false positive the service now fixes — grepped
+  for it, nothing to remove.
+
+## Files modified
+
+- `services/altguard_client.py` — `parse_verdict` matches parsing
+- `modules/altguard.py` — pass `matches` to the log card, docstring
+- `utils/altguard_views.py` — `build_log_card` renders matches
+- `locales/{fr,en-US,es-ES,pt-BR,de}.json` — new `matches` log label
+- `tests/test_altguard.py` — parsing + log card coverage for `matches`
+- `docs/ALTGUARD.md`, `docs/ALTGUARD_INTEGRATION.md` — documented the field
+  and the `enforced` default flip (with the `shadow_mode` observation path)
+
+## Known issues / follow-ups
+
+- `matches` is not persisted to `altguard_verifications`, so `/mod altguard
+  refusal` cannot show it after the fact — only the log card at verdict time
+  carries it. Acceptable for now since the spec scopes this to the
+  moderation log, but worth a follow-up if staff ask for it historically.

--- a/locales/de.json
+++ b/locales/de.json
@@ -1976,6 +1976,7 @@
         "member": "Mitglied",
         "score": "Punktzahl",
         "reasons": "Signale",
+        "matches": "Verknüpfte Konten",
         "reference": "Referenz",
         "shadow": "Beobachtungsmodus: das Ergebnis wurde protokolliert, es wurde nichts angewendet.",
         "manual_verify": "Manuelle Verifizierung",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1976,6 +1976,7 @@
         "member": "Member",
         "score": "Score",
         "reasons": "Signals",
+        "matches": "Linked accounts",
         "reference": "Reference",
         "shadow": "Shadow mode: the verdict was logged, no action was applied.",
         "manual_verify": "Manual verification",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1976,6 +1976,7 @@
         "member": "Miembro",
         "score": "Puntuación",
         "reasons": "Señales",
+        "matches": "Cuentas vinculadas",
         "reference": "Referencia",
         "shadow": "Modo observación: el veredicto se registra, no se aplicó ninguna acción.",
         "manual_verify": "Verificación manual",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1975,6 +1975,7 @@
         "member": "Membre",
         "score": "Score",
         "reasons": "Signaux",
+        "matches": "Comptes liés",
         "reference": "Référence",
         "shadow": "Mode observation : le verdict est journalisé, aucune action n'a été appliquée.",
         "manual_verify": "Vérification manuelle",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1976,6 +1976,7 @@
         "member": "Membro",
         "score": "Pontuação",
         "reasons": "Sinais",
+        "matches": "Contas vinculadas",
         "reference": "Referência",
         "shadow": "Modo observação: o veredicto foi registrado, nenhuma ação foi aplicada.",
         "manual_verify": "Verificação manual",

--- a/modules/altguard.py
+++ b/modules/altguard.py
@@ -18,9 +18,10 @@ What this module owns:
   ``modules/auto_role.py``, which must not hand out its roles to a human who
   has not passed the gate.
 
-What it deliberately does NOT own: the decision. Score and reasons are audit
-data, never shown to the verified user (that would hand out a bypass oracle).
-See docs/ALTGUARD.md.
+What it deliberately does NOT own: the decision. Score, reasons and matches
+(the accounts a verification matched with) are audit data for the log
+channel only, never shown to the verified user (that would hand out a
+bypass oracle). See docs/ALTGUARD.md.
 """
 
 from __future__ import annotations
@@ -527,6 +528,7 @@ class AltGuardModule(ModuleBase):
             verdict=decision,
             score=verdict['score'],
             reasons=verdict['reasons'],
+            matches=verdict.get('matches', []),
             enforced=enforced,
             enforced_missing=verdict.get('enforced_missing', False),
             verification_id=verdict['verification_id'],

--- a/services/altguard_client.py
+++ b/services/altguard_client.py
@@ -245,6 +245,31 @@ def parse_verdict(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if not isinstance(reasons, list):
         reasons = []
 
+    # Always present on the wire (`[]` on a `passed`), but read defensively
+    # with `.get` so a bot deployed ahead of the service still works: a
+    # payload without the field just yields no matches, nothing raises.
+    matches = []
+    for entry in (data.get("matches") or []):
+        if not isinstance(entry, dict):
+            continue
+        try:
+            match_user_id = int(entry["discord_user_id"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        match_score = entry.get("score")
+        try:
+            match_score = int(match_score) if match_score is not None else None
+        except (TypeError, ValueError):
+            match_score = None
+        match_reasons = entry.get("reasons") or []
+        if not isinstance(match_reasons, list):
+            match_reasons = []
+        matches.append({
+            "user_id": match_user_id,
+            "score": match_score,
+            "reasons": [str(r) for r in match_reasons],
+        })
+
     # `enforced` decides whether anything is applied, so an absent field and an
     # explicit `false` must not look alike in the logs: the first is a service
     # that forgot the field (and the guild silently never gets its roles), the
@@ -266,6 +291,7 @@ def parse_verdict(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         "verdict": verdict,
         "score": score,
         "reasons": [str(r) for r in reasons],
+        "matches": matches,
         "enforced": bool(data.get("enforced", False)),
         # Kept so the guild's log card can say "the service never sent the
         # field" rather than the ambiguous "shadow mode".

--- a/tests/test_altguard.py
+++ b/tests/test_altguard.py
@@ -163,8 +163,34 @@ def test_parse_verdict_accepts_the_documented_payload():
         "verdict": "passed",
         "score": 62,
         "reasons": ["cookie_match", "gpu_match"],
+        "matches": [],
         "enforced": True,
     }
+
+
+def test_parse_verdict_reads_matches():
+    payload = _payload(verdict="blocked", matches=[
+        {"discord_user_id": 456789123, "score": 62, "reasons": ["cookie_match", "gpu_match"]},
+    ])
+    parsed = parse_verdict(payload)
+    assert parsed["matches"] == [
+        {"user_id": 456789123, "score": 62, "reasons": ["cookie_match", "gpu_match"]},
+    ]
+
+
+def test_parse_verdict_defaults_matches_when_absent():
+    """A bot deployed ahead of the service must not choke on a missing field."""
+    assert parse_verdict(_payload())["matches"] == []
+
+
+def test_parse_verdict_drops_malformed_matches():
+    payload = _payload(matches=[
+        {"discord_user_id": "not-an-id"},
+        "not-a-dict",
+        {"discord_user_id": 111, "score": "n/a", "reasons": "not-a-list"},
+    ])
+    parsed = parse_verdict(payload)
+    assert parsed["matches"] == [{"user_id": 111, "score": None, "reasons": []}]
 
 
 def test_parse_verdict_defaults_to_shadow_mode():
@@ -457,6 +483,30 @@ def test_the_link_card_never_leaks_the_score():
                          verification_id="uuid-1")
     rendered = json.dumps(log.to_components())
     assert "62" in rendered and "cookie_match" in rendered and "uuid-1" in rendered
+
+
+def test_the_log_card_shows_matches():
+    """The audit log is the reason `matches` exists: a moderator undoing a
+    kick needs to see which account it matched with."""
+    from utils.altguard_views import build_log_card
+
+    log = build_log_card(locale="en-US", kind="verdict", user_id=42, verdict="blocked",
+                         score=62, reasons=["cookie_match"],
+                         matches=[{"user_id": 43, "score": 62,
+                                  "reasons": ["cookie_match", "gpu_match"]}],
+                         enforced=True, verification_id="uuid-1")
+    rendered = json.dumps(log.to_components())
+    assert "43" in rendered and "gpu_match" in rendered
+
+
+def test_the_log_card_omits_matches_on_a_pass():
+    from utils.altguard_views import build_log_card
+
+    log = build_log_card(locale="en-US", kind="verdict", user_id=42, verdict="passed",
+                         score=3, reasons=[], matches=[], enforced=True,
+                         verification_id="uuid-1")
+    rendered = json.dumps(log.to_components())
+    assert "Linked accounts" not in rendered
 
 
 def test_the_consent_modal_requires_both_boxes():

--- a/utils/altguard_views.py
+++ b/utils/altguard_views.py
@@ -464,6 +464,7 @@ def build_log_card(
     verdict: Optional[str] = None,
     score: Optional[int] = None,
     reasons: Optional[List[str]] = None,
+    matches: Optional[List[dict]] = None,
     enforced: bool = True,
     enforced_missing: bool = False,
     verification_id: Optional[str] = None,
@@ -472,9 +473,9 @@ def build_log_card(
 ) -> ui.LayoutView:
     """A card for the optional log channel.
 
-    Score and reasons appear **here only** — the guild's moderators are the
-    audience. They are never shown to the verified member, who would otherwise
-    learn exactly which signal to defeat next time.
+    Score, reasons and matches appear **here only** — the guild's moderators
+    are the audience. They are never shown to the verified member, who would
+    otherwise learn exactly which signal to defeat next time.
     """
     view = ui.LayoutView(timeout=None)
 
@@ -497,6 +498,18 @@ def build_log_card(
                 f"**{t('modules.altguard.logs.reference', locale=locale)}** `{verification_id}`"
             )
         container.add_item(ui.TextDisplay("\n".join(lines)))
+
+        if matches:
+            match_lines = [f"**{t('modules.altguard.logs.matches', locale=locale)}**"]
+            for match in matches:
+                match_reasons = ", ".join(f"`{r}`" for r in match.get("reasons", []))
+                line = f"- <@{match['user_id']}> (`{match['user_id']}`)"
+                if match.get("score") is not None:
+                    line += f" — {t('modules.altguard.logs.score', locale=locale)} `{match['score']}`"
+                if match_reasons:
+                    line += f" — {match_reasons}"
+                match_lines.append(line)
+            container.add_item(ui.TextDisplay("\n".join(match_lines)))
 
         if not enforced:
             container.add_item(ui.Separator(visible=True, spacing=discord.SeparatorSpacing.small))


### PR DESCRIPTION
## Summary

Adds support for the AltGuard service's new `matches` field on verdict payloads, which lists the linked accounts a verification matched with. The field is read defensively, sanitized, and rendered on the audit log card only (never shown to the verified member).

## Changes

- **`services/altguard_client.py`** — `parse_verdict()` now reads `matches` defensively with `.get("matches", [])`, sanitizing each entry (`discord_user_id` → int, `score` → int or `None`, `reasons` → list of str) and dropping malformed entries individually rather than failing the entire list.

- **`modules/altguard.py`** — `apply_verdict()` forwards `matches` from the verdict to the log card; updated module docstring to clarify that matches are audit data.

- **`utils/altguard_views.py`** — `build_log_card()` now accepts `matches` parameter and renders a "Linked accounts" block when non-empty, showing each matched account's user ID, score, and signals. Block appears on the log card only, never in member DMs.

- **Localization** — Added `modules.altguard.logs.matches` key to all five locales (en-US, fr, es-ES, pt-BR, de).

- **Tests** — Added three new test cases:
  - `test_parse_verdict_reads_matches()` — verifies field parsing and `discord_user_id` → `user_id` mapping
  - `test_parse_verdict_defaults_matches_when_absent()` — ensures graceful degradation when field is missing
  - `test_parse_verdict_drops_malformed_matches()` — confirms individual malformed entries are dropped while valid ones are kept
  - `test_the_log_card_shows_matches()` — verifies matches render on the log card
  - `test_the_log_card_omits_matches_on_a_pass()` — confirms matches block is absent when verdict is `passed`

- **Documentation** — Updated `docs/ALTGUARD.md` and `docs/ALTGUARD_INTEGRATION.md` to document the `matches` field, its audit-only nature, and the `enforced` default flip in the service's `005` migration. Added session notes in `docs/sessions/2026-08-19_altguard-verdict-matches.md`.

## Implementation Details

- `matches` is always present on the wire (empty list on a `passed` verdict) but read with `.get()` so a bot deployed ahead of the service degrades gracefully instead of raising.
- Each match entry is validated individually; malformed entries (missing `discord_user_id`, non-dict, invalid types) are skipped without affecting the rest.
- The field is **not persisted** to `altguard_verifications`, so it appears on the log card at verdict time only — not in `/mod altguard refusal` historical lookups.
- Matches are never sent to the verified member (DM or ephemeral reply), maintaining the same security guarantee as `score` and `reasons` (prevents bypass oracle).

https://claude.ai/code/session_01Kp71jzXex7FehJceDbzRvG