### PR TITLE
Fix string annotation resolution in incognito decorator

### DIFF
--- a/utils/incognito.py
+++ b/utils/incognito.py
@@ -7,6 +7,7 @@ import discord
 from discord import app_commands
 from typing import Optional
 import functools
+import types
 
 
 def add_incognito_option(default_value: bool = True):
@@ -57,7 +58,22 @@ def add_incognito_option(default_value: bool = True):
         wrapper.__annotations__ = func.__annotations__.copy()
         wrapper.__annotations__['incognito'] = Optional[bool]
 
-        return wrapper
+        # discord.py resolves string annotations (PEP 563, used by cogs with
+        # `from __future__ import annotations`) against `callback.__globals__`.
+        # A plain closure's __globals__ is fixed to this module, so a command
+        # parameter annotated with a constant from its own cog module (e.g.
+        # `app_commands.Range[str, 1, MAX_INPUT_LENGTH]`) would fail to resolve
+        # and silently break the whole command tree sync. Rebind the wrapper to
+        # the original callback's globals so lookups happen in the right module.
+        rebound = types.FunctionType(
+            wrapper.__code__, func.__globals__, wrapper.__name__,
+            wrapper.__defaults__, wrapper.__closure__,
+        )
+        rebound = functools.wraps(func)(rebound)
+        rebound.__annotations__ = wrapper.__annotations__
+        rebound.__kwdefaults__ = wrapper.__kwdefaults__
+
+        return rebound
 
     return decorator
 


### PR DESCRIPTION
## Summary
Fix a critical issue where the `add_incognito_option` decorator breaks command tree synchronization when used with cogs that employ `from __future__ import annotations` (PEP 563).

## Problem
When a cog uses `from __future__ import annotations`, string annotations are resolved against the callback's `__globals__`. The decorator's wrapper function is a plain closure with `__globals__` fixed to the `utils/incognito.py` module, causing resolution failures for annotations referencing constants from the cog's own module (e.g., `app_commands.Range[str, 1, MAX_INPUT_LENGTH]`). This silently breaks the entire command tree sync.

## Solution
Rebind the wrapper function to the original callback's globals using `types.FunctionType`, ensuring string annotations resolve in the correct module context. The rebound function preserves all metadata via `functools.wraps` and explicit annotation/kwdefaults assignment.

## Key Changes
- Import `types` module
- Create a new function object with the wrapper's code but the original callback's globals
- Apply `functools.wraps` to preserve metadata
- Explicitly restore `__annotations__` and `__kwdefaults__` to maintain decorator modifications
- Return the rebound function instead of the plain wrapper

This ensures compatibility with PEP 563 string annotations while maintaining all decorator functionality.

https://claude.ai/code/session_01QBhrZLy3T72gRD7ALRYFuj