### PR TITLE
Add HMAC-SHA256 signature verification for moddy:tasks stream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ moddy/
 │   ├── global_sanction_views.py #  Global sanction UI (notice DMs, staff panels, Modals V2)
 │   ├── embeds.py
 │   ├── announcement_setup.py
+│   ├── task_signature.py      #   moddy:tasks HMAC verification (signature, freshness, anti-replay)
 │   └── incognito.py
 │
 ├── gateway/                   # Centralized API gateway (ALL external API calls go here)
@@ -213,6 +214,7 @@ moddy/
     ├── test_global_sanctions.py   # Global sanction levels, cache TTL, user/guild context
     ├── test_global_sanction_flow.py # Groups, notices, countdown, Redis events, allowlists
     ├── test_bot_customization.py  # Bot customization validation (bio budget, styles)
+    ├── test_task_signature.py #   moddy:tasks HMAC contract (canonicalization, replay, dedup)
     └── test_transcription.py  #   Voice transcription helpers, guard rails, cards
 ```
 
@@ -384,6 +386,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 |---|---|
 | [docs/API_GATEWAY.md](docs/API_GATEWAY.md) | API Gateway — all external API calls (OpenAI, DeepL, Groq), quotas, provider rate limits, resilience, logging |
 | [docs/BACKEND-INTEGRATION.md](docs/BACKEND-INTEGRATION.md) | Bot ↔ Backend integration (Redis, Pub/Sub, Streams, `/status`) |
+| [docs/TASK_SIGNATURE.md](docs/TASK_SIGNATURE.md) | **`moddy:tasks` HMAC signature** — canonicalization, anti-replay, `TASK_STREAM_SECRET`, deployment order |
 | [docs/REDIS_COMMUNICATION.md](docs/REDIS_COMMUNICATION.md) | **Redis inter-service communication** — Pub/Sub vs Streams vs plain keys, current channel/stream inventory, checklist for wiring up a new Redis-based service |
 | [docs/SOCIAL_NOTIFICATIONS.md](docs/SOCIAL_NOTIFICATIONS.md) | Social Notifications module + `moddy-feeds` Redis contract (what the backend must mirror) |
 | [docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md](docs/SOCIAL_NOTIFICATIONS_CHANGES_2026-06-14.md) | Backend/dashboard change spec: customizable message columns, quota, error codes, task fields |

--- a/bot.py
+++ b/bot.py
@@ -608,8 +608,17 @@ class ModdyBot(commands.Bot):
             logger.debug(f"[PubSub] Unknown event type: {event_type}")
 
     async def _consume_task_stream(self):
-        """Consume Redis Stream moddy:tasks (critical guaranteed tasks from backend)."""
-        import json
+        """Consume Redis Stream moddy:tasks (critical guaranteed tasks from backend).
+
+        Every entry is HMAC-verified before it runs (see docs/TASK_SIGNATURE.md):
+        anyone with write access to Redis could otherwise inject a task and have
+        the bot execute it with its own permissions. A rejected entry is skipped
+        and logged, never retried — otherwise an attacker fills the stream with
+        invalid entries and blocks the consumer.
+        """
+        from config import TASK_STREAM_ALLOW_UNSIGNED, TASK_STREAM_SECRET
+        from utils.task_signature import TaskRejected, verify_task
+
         TASK_STREAM = "moddy:tasks"
         LAST_ID_KEY = "moddy:tasks:last_id"
 
@@ -627,11 +636,34 @@ class ModdyBot(commands.Bot):
                     for _stream, entries in messages:
                         for entry_id, fields in entries:
                             try:
-                                await self._process_task(fields)
-                                last_id = entry_id
-                                await self.redis.set(LAST_ID_KEY, last_id)
+                                await verify_task(
+                                    fields,
+                                    TASK_STREAM_SECRET,
+                                    self.redis,
+                                    allow_unsigned=TASK_STREAM_ALLOW_UNSIGNED,
+                                )
+                            except TaskRejected as e:
+                                logger.warning(
+                                    f"[Stream] Task {entry_id} rejected "
+                                    f"({e.code}{': ' + e.detail if e.detail else ''}) "
+                                    f"— type={fields.get('type')!r} "
+                                    f"guild_id={fields.get('guild_id')!r}"
+                                )
                             except Exception as e:
-                                logger.error(f"[Stream] Error processing task {entry_id}: {e}")
+                                logger.error(
+                                    f"[Stream] Could not verify task {entry_id}: {e}"
+                                )
+                            else:
+                                try:
+                                    await self._process_task(fields)
+                                except Exception as e:
+                                    logger.error(
+                                        f"[Stream] Error processing task {entry_id}: {e}"
+                                    )
+                            # The resume point always advances: a rejected or
+                            # failing entry must not be replayed forever.
+                            last_id = entry_id
+                            await self.redis.set(LAST_ID_KEY, last_id)
             except Exception as e:
                 logger.error(f"[Stream] Connection error: {e}")
                 await asyncio.sleep(5)

--- a/config.py
+++ b/config.py
@@ -54,6 +54,20 @@ REDIS_URL: Optional[str] = os.environ.get("REDIS_URL", "redis://localhost:6379")
 # Mot de passe Redis (optionnel)
 REDIS_PASSWORD: Optional[str] = os.environ.get("REDIS_PASSWORD") or None
 
+# Secret HMAC partagé backend ⇄ bot pour signer les entrées du stream
+# `moddy:tasks` - Variable Railway: TASK_STREAM_SECRET
+# Générer avec: python -c "import secrets; print(secrets.token_urlsafe(48))"
+# NE JAMAIS réutiliser REDIS_PASSWORD : le modèle de menace est précisément
+# celui d'un attaquant qui possède déjà l'accès Redis. Voir docs/TASK_SIGNATURE.md
+TASK_STREAM_SECRET: str = os.environ.get("TASK_STREAM_SECRET", "")
+
+# Fenêtre de déploiement uniquement (docs/TASK_SIGNATURE.md §6) : accepte les
+# entrées non signées tant que le backend ne signe pas encore. À remettre à
+# false dès que le backend est en production.
+TASK_STREAM_ALLOW_UNSIGNED: bool = os.environ.get(
+    "TASK_STREAM_ALLOW_UNSIGNED", "false"
+).lower() in ("true", "1", "yes")
+
 # =============================================================================
 # API KEYS
 # =============================================================================
@@ -225,6 +239,27 @@ def validate_config():
 
     if not REDIS_URL:
         print("[WARN] REDIS_URL not configured - Redis features disabled")
+
+    if not TASK_STREAM_SECRET:
+        print(
+            "[ERROR] TASK_STREAM_SECRET not configured - every moddy:tasks entry "
+            "will be rejected (bot customization, staff announcements, panel "
+            "updates and dashboard sanctions are disabled). Generate one with "
+            "`python -c \"import secrets; print(secrets.token_urlsafe(48))\"` and "
+            "set the SAME value on the bot and the backend."
+        )
+    elif len(TASK_STREAM_SECRET) < 32:
+        print(
+            f"[ERROR] TASK_STREAM_SECRET is too short ({len(TASK_STREAM_SECRET)} "
+            "chars, 32 minimum) - the backend refuses to sign below that length, "
+            "so no task will ever verify."
+        )
+
+    if TASK_STREAM_ALLOW_UNSIGNED:
+        print(
+            "[WARN] TASK_STREAM_ALLOW_UNSIGNED is enabled - unsigned moddy:tasks "
+            "entries are executed. Deployment window only, turn it off."
+        )
 
     if not DEEPL_API_KEY:
         print("[WARN] DEEPL_API_KEY not configured - translate command disabled")

--- a/docs/BACKEND-INTEGRATION.md
+++ b/docs/BACKEND-INTEGRATION.md
@@ -319,10 +319,19 @@ Le stream `moddy:tasks` contient les **tâches que le bot DOIT exécuter**. Cont
 
 ```
 Clés du message Redis :
-  type     : str   — type de tâche
-  guild_id : str   — ID du serveur (string, convertir en int)
-  payload  : str   — JSON sérialisé avec les détails
+  type      : str   — type de tâche
+  guild_id  : str   — ID du serveur (string, convertir en int)
+  payload   : str   — JSON sérialisé avec les détails
+  task_id   : str   — UUID v4, clé de déduplication
+  issued_at : str   — timestamp Unix en secondes (UTC)
+  signature : str   — HMAC-SHA256 hexadécimal des cinq champs ci-dessus
 ```
+
+> **Signature obligatoire.** Le bot vérifie `signature` avant d'exécuter quoi
+> que ce soit : une entrée non signée, mal signée, périmée ou rejouée est
+> ignorée et loggée en `warning`. Le secret partagé est `TASK_STREAM_SECRET`.
+> Contrat complet (canonicalisation, fenêtre anti-rejeu, ordre de déploiement) :
+> [TASK_SIGNATURE.md](TASK_SIGNATURE.md).
 
 ### Consumer principal
 
@@ -663,6 +672,7 @@ Certaines clés Redis sont partagées entre le backend et le bot. **Le bot doit 
 | `discord:guild:{id}:channels` | 2min | Backend | Salons du serveur |
 | `discord:guild:{id}:roles` | 2min | Backend | Rôles du serveur |
 | `moddy:tasks:last_id` | permanent | Bot | Dernier ID de stream traité |
+| `task:seen:{task_id}` | 10min | Bot | Marqueur anti-rejeu des tâches signées ([TASK_SIGNATURE.md](TASK_SIGNATURE.md)) |
 
 ### Convention pour les clés spécifiques au bot
 
@@ -989,6 +999,7 @@ async def log_error(pool, error: Exception, user_id: int | None = None, guild_id
 | Clé | Type | Description |
 |---|---|---|
 | `moddy:tasks:last_id` | String | Dernier ID de stream consommé |
+| `task:seen:{task_id}` | String | Marqueur anti-rejeu (`SET NX EX 600`) |
 
 ---
 
@@ -1003,6 +1014,12 @@ DATABASE_URL=postgresql://user:password@host:5432/dbname
 # Redis (même que le backend)
 REDIS_URL=redis://host:6379
 REDIS_PASSWORD=
+
+# Signature du stream moddy:tasks — MÊME valeur que le backend, 32 car. min
+# python -c "import secrets; print(secrets.token_urlsafe(48))"
+TASK_STREAM_SECRET=
+# Fenêtre de déploiement uniquement (voir docs/TASK_SIGNATURE.md §6)
+TASK_STREAM_ALLOW_UNSIGNED=false
 
 # Discord
 DISCORD_TOKEN=Bot token du bot

--- a/docs/RAILWAY.md
+++ b/docs/RAILWAY.md
@@ -21,6 +21,23 @@ Ce document liste toutes les variables d'environnement à configurer dans Railwa
 **Valeur :** `<mot-de-passe-redis>` (optionnel si Redis sans auth)
 **Description :** Mot de passe Redis, si requis
 
+### TASK_STREAM_SECRET
+**Valeur :** `<générer-avec-secrets.token_urlsafe(48)>` (32 caractères minimum)
+**Description :** Secret HMAC partagé backend ⇄ bot signant chaque entrée du
+stream `moddy:tasks`. **Même valeur des deux côtés.** Sans lui, le bot rejette
+toutes les tâches (bot customization, annonces staff, `update_panel`, sanctions
+dashboard) — voir [TASK_SIGNATURE.md](TASK_SIGNATURE.md)
+**Génération :** `python -c "import secrets; print(secrets.token_urlsafe(48))"`
+**Note :** ne **jamais** réutiliser `REDIS_PASSWORD` — le modèle de menace est
+celui d'un attaquant qui a déjà l'accès Redis
+
+### TASK_STREAM_ALLOW_UNSIGNED
+**Valeur :** `false` (défaut)
+**Description :** Fenêtre de déploiement uniquement : accepte les entrées
+`moddy:tasks` **sans** signature tant que le backend ne signe pas encore. Une
+signature erronée reste toujours rejetée. À repasser à `false` dès que le
+backend est en production (voir [TASK_SIGNATURE.md](TASK_SIGNATURE.md) §6)
+
 ## Sécurité de l'API interne
 
 ### INTERNAL_API_SECRET
@@ -84,6 +101,7 @@ déjà configuré (`REDIS_URL`), rien à ajouter — voir [ALTGUARD.md](ALTGUARD
 - [ ] `DATABASE_URL` (partagée avec le backend)
 - [ ] `REDIS_URL` (partagée avec le backend)
 - [ ] `REDIS_PASSWORD` (si Redis avec auth)
+- [ ] `TASK_STREAM_SECRET` (identique côté backend — sinon `moddy:tasks` est inopérant)
 - [ ] `INTERNAL_API_SECRET` (optionnel, protège `/status`)
 - [ ] `PORT` → `3000`
 - [ ] `ENV_MODE` → `production`

--- a/docs/REDIS_COMMUNICATION.md
+++ b/docs/REDIS_COMMUNICATION.md
@@ -93,7 +93,7 @@ the event was produced: task queues, command/reply RPC, notification feeds.
 
 | Stream | Producer | Consumer | Notes |
 |---|---|---|---|
-| `moddy:tasks` | Backend | Bot | Critical guaranteed tasks (`update_panel`, `send_announcement`, `social_subscribe`, …). Plain `XREAD` + `moddy:tasks:last_id` key to resume (`bot.py::_consume_task_stream`) |
+| `moddy:tasks` | Backend | Bot | Critical guaranteed tasks (`update_panel`, `send_announcement`, `social_subscribe`, …). Plain `XREAD` + `moddy:tasks:last_id` key to resume (`bot.py::_consume_task_stream`). **Every entry is HMAC-SHA256 signed** — unsigned or invalid entries are skipped, see [TASK_SIGNATURE.md](TASK_SIGNATURE.md) |
 | `feeds:commands` | Bot | `moddy-feeds` service | `subscribe` / `unsubscribe` commands, correlated by `request_id` |
 | `feeds:replies` | `moddy-feeds` service | Bot | Replies to `feeds:commands`, correlated by `request_id`, 10s timeout (`services/feeds_client.py`) |
 | `notifications:queue` | `moddy-feeds` service | Bot (consumer group `discord-bot`) | Normalized notification events, `XACK`ed unconditionally (service dedups) |
@@ -106,6 +106,7 @@ the event was produced: task queues, command/reply RPC, notification feeds.
 | `guild:{id}:config`, `discord:guild:{id}:{info,channels,roles,emojis}` | Backend | Discord/DB cache, short TTL |
 | `moddy:bot_guilds` | Backend (invalidated by Bot) | Guild list cache — bot deletes it on `on_guild_join`/`on_guild_remove` |
 | `moddy:tasks:last_id` | Bot | Resume point for `moddy:tasks` |
+| `task:seen:{task_id}` | Bot | Anti-replay marker for `moddy:tasks`, `SET NX EX 600` ([TASK_SIGNATURE.md](TASK_SIGNATURE.md)) |
 | `feeds:heartbeat` | `moddy-feeds` service | Health check, TTL ~90s |
 | `quota:{scope}:{key}:{type}:{date}` | Bot (`gateway/quota.py`) | Daily API quota counters |
 

--- a/docs/TASK_SIGNATURE.md
+++ b/docs/TASK_SIGNATURE.md
@@ -1,0 +1,167 @@
+# `moddy:tasks` signature (backend ⇄ bot contract)
+
+> **Breaking change.** The bot rejects every unsigned entry on the
+> `moddy:tasks` stream. The backend refuses to produce tasks without
+> `TASK_STREAM_SECRET`. Read [§6 Deployment order](#6-deployment-order) before
+> shipping anything to production.
+
+## 1. Why
+
+The `moddy:tasks` stream carries actions with Discord side effects: bot
+avatar/bio changes, announcements, panel updates, dashboard sanctions. Anyone
+with write access to Redis could inject an arbitrary task and have the bot
+execute it with the bot's own permissions. The backend now signs every entry
+with HMAC-SHA256; the bot refuses anything it cannot verify.
+
+## 2. The secret
+
+| | |
+|---|---|
+| Variable | `TASK_STREAM_SECRET` |
+| Minimum length | **32 characters** (the backend refuses to sign below that) |
+| Generation | `python -c "import secrets; print(secrets.token_urlsafe(48))"` |
+| Scope | shared backend ⇄ bot, **identical on both sides** |
+
+**Never** reuse `REDIS_PASSWORD`: the threat model is precisely an attacker who
+already has Redis access.
+
+## 3. Stream entry fields
+
+Six fields, all strings:
+
+| Field | Content |
+|---|---|
+| `type` | task type (`bot_customization_update`, `send_announcement`, `update_panel`, `case_add_sanction`, `social_*`…) |
+| `guild_id` | decimal guild id, `"0"` when there is no guild |
+| `payload` | the business payload, JSON-serialized compact and sorted |
+| `task_id` | UUID v4, unique per task — the deduplication key |
+| `issued_at` | Unix timestamp in seconds, UTC |
+| `signature` | lowercase hex HMAC-SHA256 of the five fields above |
+
+## 4. Canonicalization
+
+This is the most fragile part of the contract: the slightest serialization
+mismatch fails 100% of verifications.
+
+```python
+payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+fields = {
+    "type":      task_type,
+    "guild_id":  str(guild_id),
+    "payload":   payload_json,
+    "task_id":   str(uuid.uuid4()),
+    "issued_at": str(int(time.time())),
+}
+
+canonical = json.dumps(fields, separators=(",", ":"), sort_keys=True)
+signature = hmac.new(secret.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+```
+
+Rules, identical on both sides:
+
+- **Double serialization.** `payload` is a JSON *string* inside the canonical
+  object, so its quotes are escaped in `canonical`.
+- `separators=(",", ":")` — no whitespace.
+- `sort_keys=True` at both levels. The key order of `canonical` is therefore
+  always `guild_id, issued_at, payload, task_id, type`.
+- `ensure_ascii=True` (the Python default) — non-ASCII characters are escaped
+  as `\uXXXX`. A bot written in another language must reproduce that escaping.
+- The `signature` field is **excluded** from the computation.
+- UTF-8 encoding for both the secret and the canonical string.
+
+## 5. Verification on the bot side
+
+Implemented in [`utils/task_signature.py`](../utils/task_signature.py), called
+from `bot.py::_consume_task_stream` before every `_process_task`.
+
+```python
+REPLAY_WINDOW = 300   # 5 min: maximum accepted age
+CLOCK_SKEW    = 60    # tolerance when the backend clock runs ahead
+DEDUP_TTL     = 600   # > REPLAY_WINDOW, otherwise a replay becomes possible again
+```
+
+Order of checks (`verify_task`), each raising `TaskRejected(code)`:
+
+| Step | Code on failure |
+|---|---|
+| Secret configured | `no_secret` |
+| Signature present | `unsigned` |
+| All five signed fields present | `missing_field` |
+| `hmac.compare_digest(signature, expected)` | `bad_signature` |
+| `now - REPLAY_WINDOW <= issued_at <= now + CLOCK_SKEW` | `expired` / `future` |
+| `SET task:seen:{task_id} 1 NX EX 600` returns fresh | `replay` |
+
+Non-negotiable rules:
+
+1. **An entry without `signature` is rejected**, never tolerated "for
+   compatibility". That is exactly the hole the signature closes.
+2. **`hmac.compare_digest`**, never `==` — `==` leaks the signature through
+   timing.
+3. A rejected entry is skipped (the `moddy:tasks:last_id` resume point still
+   advances) and logged at `warning`, never retried: otherwise an attacker
+   fills the stream with invalid entries and blocks the consumer. The same
+   applies to an entry whose execution raises.
+4. Deduplication is keyed on `task_id`, not on content: two identical
+   legitimate announcements must be able to go out in a row.
+5. The dedup marker is only burned for an otherwise-valid entry, so garbage
+   cannot flood the `task:seen:*` keyspace.
+6. No secret ⇒ **fail closed**: nothing can be verified, so nothing is
+   executed. `config.py` logs an explicit error at boot.
+
+## 6. Deployment order
+
+Order matters, in both directions.
+
+1. Generate the secret and set it on **both** Railway services (bot and
+   backend) before deploying any code.
+2. Deploy **the bot first**, in verification mode. It already accepts signed
+   entries; there are none yet, so nothing changes — set
+   `TASK_STREAM_ALLOW_UNSIGNED=true` for that window if unsigned tasks must
+   keep flowing.
+3. Deploy the backend next. It starts signing.
+4. Once the backend is in production and tasks are going through, remove
+   `TASK_STREAM_ALLOW_UNSIGNED` (or set it to `false`) so unsigned entries are
+   rejected.
+
+The reverse order (backend first) is functionally harmless — the bot ignores
+extra fields — but leaves a window with no protection.
+
+`TASK_STREAM_ALLOW_UNSIGNED` only covers *absent* signatures; a wrong or forged
+signature is always rejected. It defaults to `false`, and `config.py` warns at
+boot while it is on.
+
+**If `TASK_STREAM_SECRET` is missing on the backend:** the service still boots,
+logs an explicit error, and every route producing a task returns `503`. The
+affected features are `bot_customization`, staff announcements
+(`POST /staff/bot/announce`) and `update_panel` on modules.
+
+**If `TASK_STREAM_SECRET` is missing on the bot:** the consumer keeps running
+but rejects every entry with `no_secret`, logged as a warning per task.
+
+## 7. What the backend does not do
+
+Anti-replay is **entirely the consumer's responsibility**. The backend supplies
+the material (`task_id`, `issued_at`) but keeps no registry: it never sees what
+gets consumed. Without §5, an attacker with Redis access can still copy a
+legitimate signed task and have it re-executed.
+
+## 8. Environment variables
+
+| Variable | Service | Default | Purpose |
+|---|---|---|---|
+| `TASK_STREAM_SECRET` | bot + backend | — | Shared HMAC secret, 32 chars minimum |
+| `TASK_STREAM_ALLOW_UNSIGNED` | bot | `false` | Deployment window only: accept entries with no signature |
+
+## 9. Tests
+
+```bash
+python3 -m pytest tests/test_task_signature.py -q
+```
+
+Covers canonicalization (key order, whitespace, nested payload escaping,
+non-ASCII), tampering with each signed field, wrong secret, the freshness
+window edges, replay, dedup by `task_id` rather than content, fail-closed
+without a secret, and the `allow_unsigned` escape hatch. One test recomputes a
+signature straight from the spec snippet in §4 rather than through the helper,
+so a drift in the canonicalization is caught.

--- a/docs/sessions/2026-08-21_moddy-tasks-signature.md
+++ b/docs/sessions/2026-08-21_moddy-tasks-signature.md
@@ -1,0 +1,63 @@
+# 2026-08-21 — `moddy:tasks` HMAC signature
+
+## What was done
+
+Implemented the bot side of the `moddy:tasks` signature contract. Every entry
+of the Redis stream is now HMAC-SHA256 verified before it is executed; unsigned,
+forged, stale or replayed entries are skipped and logged instead of running with
+the bot's Discord permissions.
+
+- New `utils/task_signature.py`: canonicalization identical to the backend
+  (double JSON serialization, `separators=(",", ":")`, `sort_keys=True`,
+  `ensure_ascii=True`, `signature` excluded), `hmac.compare_digest`, freshness
+  window (`REPLAY_WINDOW=300`, `CLOCK_SKEW=60`) and `SET NX EX 600` anti-replay
+  keyed on `task_id`.
+- `bot.py::_consume_task_stream` calls `verify_task()` before `_process_task`.
+- `config.py`: `TASK_STREAM_SECRET` + `TASK_STREAM_ALLOW_UNSIGNED`, with a boot
+  error when the secret is missing or shorter than 32 chars, and a warning while
+  the escape hatch is on.
+- `tests/test_task_signature.py`: 31 tests, all passing.
+- Docs: new `docs/TASK_SIGNATURE.md`, plus updates to `CLAUDE.md`,
+  `docs/RAILWAY.md`, `docs/BACKEND-INTEGRATION.md`, `docs/REDIS_COMMUNICATION.md`.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `utils/task_signature.py` | **new** — verification helpers (`verify_task`, `sign_fields`, `TaskRejected`) |
+| `bot.py` | Verification in the stream consumer + resume point always advances |
+| `config.py` | `TASK_STREAM_SECRET`, `TASK_STREAM_ALLOW_UNSIGNED`, boot diagnostics |
+| `tests/test_task_signature.py` | **new** — contract test suite |
+| `docs/TASK_SIGNATURE.md` | **new** — full contract |
+| `CLAUDE.md`, `docs/RAILWAY.md`, `docs/BACKEND-INTEGRATION.md`, `docs/REDIS_COMMUNICATION.md` | Cross-references, env vars, key inventory |
+
+## Decisions
+
+- **Fail closed without a secret.** `verify_task` raises `no_secret` rather than
+  falling back to executing tasks: an unverifiable task is exactly what the
+  contract exists to stop. The boot-time error in `config.py` makes the
+  misconfiguration loud.
+- **`TASK_STREAM_ALLOW_UNSIGNED` escape hatch.** The contract forbids tolerating
+  unsigned entries, but §6 describes a window where the bot ships before the
+  backend signs. The flag defaults to `false`, only covers *absent* signatures
+  (a wrong signature is always rejected), and warns at boot while enabled.
+- **The resume point now always advances.** The consumer previously left
+  `moddy:tasks:last_id` untouched when `_process_task` raised, so a failing
+  entry was re-read in a tight loop forever. That is also the behaviour the
+  contract requires for rejected entries (rule 3: skip and log, never replay),
+  so both paths now advance the cursor.
+- **The dedup marker is only burned for otherwise-valid entries** (signature and
+  freshness first), so an attacker cannot flood the `task:seen:*` keyspace with
+  garbage.
+- **Tests load the module by path** rather than through `utils/__init__.py`,
+  which imports discord.py — the suite stays runnable with stdlib + pytest only.
+  One test recomputes a signature straight from the spec snippet rather than via
+  the helper, so a drift in canonicalization is caught rather than mirrored.
+
+## Follow-ups
+
+- Deployment: set `TASK_STREAM_SECRET` (same value) on both Railway services
+  **before** deploying, ship the bot first, then the backend, then make sure
+  `TASK_STREAM_ALLOW_UNSIGNED` is off. See `docs/TASK_SIGNATURE.md` §6.
+- The backend must start signing; until it does, tasks are rejected unless the
+  escape hatch is enabled.

--- a/tests/test_task_signature.py
+++ b/tests/test_task_signature.py
@@ -1,0 +1,291 @@
+"""Tests for the ``moddy:tasks`` HMAC signature contract.
+
+Run with: python3 -m pytest tests/test_task_signature.py -q
+"""
+
+import hashlib
+import hmac
+import importlib.util
+import json
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+# Loaded by path: `utils/__init__.py` pulls in discord.py, and this module is
+# pure stdlib — the suite must stay runnable without a Discord install.
+_SPEC = importlib.util.spec_from_file_location(
+    "moddy_task_signature",
+    Path(__file__).resolve().parent.parent / "utils" / "task_signature.py",
+)
+task_signature = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(task_signature)
+
+CLOCK_SKEW = task_signature.CLOCK_SKEW
+DEDUP_TTL = task_signature.DEDUP_TTL
+REPLAY_WINDOW = task_signature.REPLAY_WINDOW
+SEEN_KEY_PREFIX = task_signature.SEEN_KEY_PREFIX
+TaskRejected = task_signature.TaskRejected
+canonical_string = task_signature.canonical_string
+check_freshness = task_signature.check_freshness
+check_signature = task_signature.check_signature
+compute_signature = task_signature.compute_signature
+sign_fields = task_signature.sign_fields
+verify_task = task_signature.verify_task
+
+SECRET = "x" * 48
+
+
+class FakeRedis:
+    """Minimal ``SET key value NX EX`` stand-in."""
+
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.expiries: dict[str, int] = {}
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        if ex is not None:
+            self.expiries[key] = ex
+        return True
+
+
+def make_fields(payload=None, task_type="send_announcement", guild_id=0, issued_at=None):
+    return sign_fields(
+        task_type,
+        guild_id,
+        {"message": "hello"} if payload is None else payload,
+        str(uuid.uuid4()),
+        int(time.time()) if issued_at is None else issued_at,
+        SECRET,
+    )
+
+
+# ── Canonicalization ────────────────────────────────────────────────────────
+
+def test_canonical_key_order_is_fixed():
+    fields = make_fields()
+    canonical = canonical_string(fields)
+    assert canonical.startswith('{"guild_id":')
+    assert list(json.loads(canonical).keys()) == [
+        "guild_id", "issued_at", "payload", "task_id", "type"
+    ]
+
+
+def test_canonical_excludes_signature():
+    fields = make_fields()
+    assert "signature" not in json.loads(canonical_string(fields))
+
+
+def test_canonical_has_no_whitespace():
+    canonical = canonical_string(make_fields())
+    assert ", " not in canonical and '": ' not in canonical
+
+
+def test_payload_is_a_nested_json_string():
+    """Double serialization: payload's quotes are escaped inside canonical."""
+    fields = make_fields(payload={"b": 2, "a": 1})
+    assert fields["payload"] == '{"a":1,"b":2}'
+    assert '\\"a\\":1' in canonical_string(fields)
+
+
+def test_payload_is_sorted_and_non_ascii_is_escaped():
+    fields = make_fields(payload={"z": "é", "a": "ü"})
+    assert fields["payload"] == '{"a":"\\u00fc","z":"\\u00e9"}'
+
+
+def test_signature_matches_the_reference_implementation():
+    """Recompute the way the backend does, straight from the spec."""
+    payload = {"module_id": "starboard", "n": 3}
+    task_id = str(uuid.uuid4())
+    issued_at = str(int(time.time()))
+    payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    reference_fields = {
+        "type": "update_panel",
+        "guild_id": "123456789",
+        "payload": payload_json,
+        "task_id": task_id,
+        "issued_at": issued_at,
+    }
+    canonical = json.dumps(reference_fields, separators=(",", ":"), sort_keys=True)
+    expected = hmac.new(
+        SECRET.encode(), canonical.encode(), hashlib.sha256
+    ).hexdigest()
+
+    fields = sign_fields(
+        "update_panel", 123456789, payload, task_id, issued_at, SECRET
+    )
+    assert fields["signature"] == expected
+    assert expected == expected.lower()
+
+
+def test_missing_signed_field_is_rejected():
+    fields = make_fields()
+    del fields["task_id"]
+    with pytest.raises(TaskRejected) as exc:
+        compute_signature(fields, SECRET)
+    assert exc.value.code == "missing_field"
+
+
+# ── Signature check ─────────────────────────────────────────────────────────
+
+def test_valid_signature_passes():
+    check_signature(make_fields(), SECRET)
+
+
+def test_unsigned_entry_is_rejected():
+    fields = make_fields()
+    del fields["signature"]
+    with pytest.raises(TaskRejected) as exc:
+        check_signature(fields, SECRET)
+    assert exc.value.code == "unsigned"
+
+
+def test_empty_signature_is_rejected():
+    fields = make_fields()
+    fields["signature"] = ""
+    with pytest.raises(TaskRejected) as exc:
+        check_signature(fields, SECRET)
+    assert exc.value.code == "unsigned"
+
+
+@pytest.mark.parametrize("field", ["type", "guild_id", "payload", "task_id", "issued_at"])
+def test_tampering_with_any_signed_field_breaks_the_signature(field):
+    fields = make_fields(guild_id=42)
+    fields[field] = fields[field] + "0"
+    with pytest.raises(TaskRejected) as exc:
+        check_signature(fields, SECRET)
+    assert exc.value.code == "bad_signature"
+
+
+def test_wrong_secret_is_rejected():
+    with pytest.raises(TaskRejected) as exc:
+        check_signature(make_fields(), "y" * 48)
+    assert exc.value.code == "bad_signature"
+
+
+def test_payload_reordering_breaks_the_signature():
+    """A re-serialized payload with different key order must not verify."""
+    fields = make_fields(payload={"a": 1, "b": 2})
+    fields["payload"] = '{"b":2,"a":1}'
+    with pytest.raises(TaskRejected) as exc:
+        check_signature(fields, SECRET)
+    assert exc.value.code == "bad_signature"
+
+
+# ── Freshness ───────────────────────────────────────────────────────────────
+
+def test_fresh_entry_passes():
+    now = int(time.time())
+    check_freshness(make_fields(issued_at=now), now=now)
+
+
+def test_entry_at_the_edge_of_the_window_passes():
+    now = int(time.time())
+    check_freshness(make_fields(issued_at=now - REPLAY_WINDOW), now=now)
+    check_freshness(make_fields(issued_at=now + CLOCK_SKEW), now=now)
+
+
+def test_too_old_entry_is_rejected():
+    now = int(time.time())
+    with pytest.raises(TaskRejected) as exc:
+        check_freshness(make_fields(issued_at=now - REPLAY_WINDOW - 1), now=now)
+    assert exc.value.code == "expired"
+
+
+def test_entry_from_the_future_is_rejected():
+    now = int(time.time())
+    with pytest.raises(TaskRejected) as exc:
+        check_freshness(make_fields(issued_at=now + CLOCK_SKEW + 1), now=now)
+    assert exc.value.code == "future"
+
+
+def test_non_numeric_issued_at_is_rejected():
+    fields = make_fields()
+    fields["issued_at"] = "not-a-number"
+    with pytest.raises(TaskRejected) as exc:
+        check_freshness(fields)
+    assert exc.value.code == "missing_field"
+
+
+def test_dedup_ttl_outlives_the_replay_window():
+    assert DEDUP_TTL > REPLAY_WINDOW + CLOCK_SKEW
+
+
+# ── Full verification ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_valid_task_is_accepted_once():
+    redis = FakeRedis()
+    fields = make_fields()
+    await verify_task(fields, SECRET, redis)
+    assert redis.expiries[f"{SEEN_KEY_PREFIX}{fields['task_id']}"] == DEDUP_TTL
+
+
+@pytest.mark.asyncio
+async def test_replaying_the_same_task_id_is_rejected():
+    redis = FakeRedis()
+    fields = make_fields()
+    await verify_task(fields, SECRET, redis)
+    with pytest.raises(TaskRejected) as exc:
+        await verify_task(fields, SECRET, redis)
+    assert exc.value.code == "replay"
+
+
+@pytest.mark.asyncio
+async def test_two_identical_payloads_with_distinct_task_ids_both_pass():
+    """Dedup is keyed on task_id, not content: two identical legitimate
+    announcements must be able to go out in a row."""
+    redis = FakeRedis()
+    await verify_task(make_fields(payload={"message": "same"}), SECRET, redis)
+    await verify_task(make_fields(payload={"message": "same"}), SECRET, redis)
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_does_not_burn_the_dedup_key():
+    redis = FakeRedis()
+    fields = make_fields()
+    fields["signature"] = "0" * 64
+    with pytest.raises(TaskRejected):
+        await verify_task(fields, SECRET, redis)
+    assert redis.store == {}
+
+
+@pytest.mark.asyncio
+async def test_missing_secret_fails_closed():
+    redis = FakeRedis()
+    with pytest.raises(TaskRejected) as exc:
+        await verify_task(make_fields(), "", redis)
+    assert exc.value.code == "no_secret"
+
+
+@pytest.mark.asyncio
+async def test_unsigned_task_is_rejected_by_default():
+    redis = FakeRedis()
+    fields = make_fields()
+    del fields["signature"]
+    with pytest.raises(TaskRejected) as exc:
+        await verify_task(fields, SECRET, redis)
+    assert exc.value.code == "unsigned"
+
+
+@pytest.mark.asyncio
+async def test_allow_unsigned_accepts_only_during_the_deployment_window():
+    redis = FakeRedis()
+    fields = make_fields()
+    del fields["signature"]
+    await verify_task(fields, SECRET, redis, allow_unsigned=True)
+
+
+@pytest.mark.asyncio
+async def test_allow_unsigned_still_rejects_a_forged_signature():
+    """The escape hatch covers *absent* signatures, never wrong ones."""
+    redis = FakeRedis()
+    fields = make_fields()
+    fields["signature"] = "0" * 64
+    with pytest.raises(TaskRejected) as exc:
+        await verify_task(fields, SECRET, redis, allow_unsigned=True)
+    assert exc.value.code == "bad_signature"

--- a/utils/task_signature.py
+++ b/utils/task_signature.py
@@ -1,0 +1,205 @@
+"""HMAC-SHA256 verification for the ``moddy:tasks`` Redis stream.
+
+The stream carries tasks with Discord side effects (bot avatar/bio changes,
+announcements, panel updates, guild sanctions). Anyone with write access to
+Redis could inject an arbitrary task and have the bot execute it with its own
+permissions. The backend therefore signs every entry, and the bot refuses
+anything it cannot verify.
+
+Wire contract (six string fields per entry):
+
+======== ======================================================================
+type      task type (``bot_customization_update``, ``send_announcement``, …)
+guild_id  decimal guild id, ``"0"`` when there is no guild
+payload   the business payload, JSON-serialized compact + sorted
+task_id   UUID v4, unique per task — the deduplication key
+issued_at Unix timestamp in seconds, UTC
+signature lowercase hex HMAC-SHA256 of the five fields above
+======== ======================================================================
+
+The canonical string is a *double* serialization: ``payload`` is itself a JSON
+string inside the canonical object, so its quotes are escaped. Both levels use
+``separators=(",", ":")``, ``sort_keys=True`` and ``ensure_ascii=True`` (the
+Python defaults for the last one). The ``signature`` field is excluded from the
+computation. See ``docs/TASK_SIGNATURE.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+from typing import Any, Mapping, Optional
+
+logger = logging.getLogger('moddy.tasks')
+
+# Fields covered by the signature, in contract order (sorting is applied by
+# json.dumps anyway, this tuple only defines *which* fields are signed).
+SIGNED_FIELDS = ("type", "guild_id", "payload", "task_id", "issued_at")
+
+# Maximum accepted age of an entry, in seconds.
+REPLAY_WINDOW = 300
+# Tolerance when the backend clock runs ahead of ours, in seconds.
+CLOCK_SKEW = 60
+# Lifetime of a dedup marker. MUST stay > REPLAY_WINDOW, otherwise a replay
+# becomes possible again while the entry is still considered fresh.
+DEDUP_TTL = 600
+
+# Redis key prefix for the anti-replay markers.
+SEEN_KEY_PREFIX = "task:seen:"
+
+# Minimum secret length accepted, mirroring the backend.
+MIN_SECRET_LENGTH = 32
+
+
+class TaskRejected(Exception):
+    """A stream entry failed verification.
+
+    ``code`` is a short machine-readable reason, used for logging and tests:
+    ``no_secret``, ``unsigned``, ``missing_field``, ``bad_signature``,
+    ``expired``, ``future``, ``replay``.
+    """
+
+    def __init__(self, code: str, detail: str = ""):
+        self.code = code
+        self.detail = detail
+        super().__init__(f"{code}: {detail}" if detail else code)
+
+
+def canonical_payload(payload: Any) -> str:
+    """Serialize a business payload the way the backend does before signing."""
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def canonical_string(fields: Mapping[str, str]) -> str:
+    """Build the canonical string that is fed to HMAC.
+
+    Raises ``TaskRejected('missing_field')`` when a signed field is absent: an
+    entry that does not carry the full contract cannot be verified, so it is
+    rejected rather than signed over a partial object.
+    """
+    signed: dict[str, str] = {}
+    for key in SIGNED_FIELDS:
+        value = fields.get(key)
+        if value is None:
+            raise TaskRejected("missing_field", key)
+        signed[key] = value if isinstance(value, str) else str(value)
+    return json.dumps(signed, separators=(",", ":"), sort_keys=True)
+
+
+def compute_signature(fields: Mapping[str, str], secret: str) -> str:
+    """Return the expected lowercase hex HMAC-SHA256 for ``fields``."""
+    canonical = canonical_string(fields)
+    return hmac.new(
+        secret.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def sign_fields(
+    task_type: str,
+    guild_id: int | str,
+    payload: Any,
+    task_id: str,
+    issued_at: int | str,
+    secret: str,
+) -> dict[str, str]:
+    """Build a fully signed set of stream fields.
+
+    The bot does not produce tasks in production — this exists so tests (and
+    any local tooling) can generate valid entries with the exact same code
+    path the verifier uses.
+    """
+    fields = {
+        "type": task_type,
+        "guild_id": str(guild_id),
+        "payload": canonical_payload(payload),
+        "task_id": str(task_id),
+        "issued_at": str(issued_at),
+    }
+    fields["signature"] = compute_signature(fields, secret)
+    return fields
+
+
+def check_signature(fields: Mapping[str, str], secret: str) -> None:
+    """Verify the HMAC of an entry. Raises ``TaskRejected`` on failure."""
+    signature = fields.get("signature")
+    if not signature:
+        # An unsigned entry is exactly the hole the signature closes: never
+        # tolerated "for compatibility".
+        raise TaskRejected("unsigned")
+
+    expected = compute_signature(fields, secret)
+    # compare_digest is mandatory: `==` leaks the signature through timing.
+    if not hmac.compare_digest(str(signature), expected):
+        raise TaskRejected("bad_signature")
+
+
+def check_freshness(fields: Mapping[str, str], now: Optional[int] = None) -> None:
+    """Verify ``issued_at`` sits inside the accepted window."""
+    raw = fields.get("issued_at")
+    try:
+        issued_at = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise TaskRejected("missing_field", "issued_at")
+
+    now = int(time.time()) if now is None else int(now)
+    if issued_at < now - REPLAY_WINDOW:
+        raise TaskRejected("expired", f"issued_at={issued_at} now={now}")
+    if issued_at > now + CLOCK_SKEW:
+        raise TaskRejected("future", f"issued_at={issued_at} now={now}")
+
+
+async def check_not_replayed(fields: Mapping[str, str], redis) -> None:
+    """Consume the entry's ``task_id`` once. Raises on a replay.
+
+    ``SET NX`` is atomic, so two bot instances racing on the same entry can
+    never both win. Deduplication is keyed on ``task_id``, not on the content:
+    two identical legitimate announcements must be able to go out in a row.
+    """
+    task_id = fields.get("task_id")
+    if not task_id:
+        raise TaskRejected("missing_field", "task_id")
+
+    fresh = await redis.set(f"{SEEN_KEY_PREFIX}{task_id}", "1", nx=True, ex=DEDUP_TTL)
+    if not fresh:
+        raise TaskRejected("replay", f"task_id={task_id}")
+
+
+async def verify_task(
+    fields: Mapping[str, str],
+    secret: Optional[str],
+    redis,
+    *,
+    allow_unsigned: bool = False,
+    now: Optional[int] = None,
+) -> None:
+    """Full verification of a ``moddy:tasks`` entry.
+
+    Returns ``None`` when the entry may be executed, raises ``TaskRejected``
+    otherwise. Order matters: signature first (cheap, local), then freshness,
+    then the anti-replay marker — the marker is only burned for an entry that
+    is otherwise valid, so garbage cannot flood the dedup keyspace.
+
+    ``allow_unsigned`` exists solely for the deployment window described in
+    ``docs/TASK_SIGNATURE.md`` §6, where the bot ships before the backend
+    starts signing. It defaults to off and must be turned back off as soon as
+    the backend is in production.
+    """
+    if not secret:
+        # Fail closed: without a secret nothing can be verified, so nothing is
+        # executed. The boot-time error in config.py says how to fix it.
+        raise TaskRejected("no_secret")
+
+    if not fields.get("signature") and allow_unsigned:
+        logger.warning(
+            "[Tasks] Unsigned task '%s' accepted because TASK_STREAM_ALLOW_UNSIGNED "
+            "is enabled — turn it off once the backend signs.",
+            fields.get("type"),
+        )
+        return
+
+    check_signature(fields, secret)
+    check_freshness(fields, now=now)
+    await check_not_replayed(fields, redis)


### PR DESCRIPTION
## Summary

Implements the bot-side of the `moddy:tasks` Redis stream signature contract. Every entry is now HMAC-SHA256 verified before execution; unsigned, forged, stale, or replayed entries are skipped and logged instead of running with the bot's Discord permissions.

## Key Changes

- **New `utils/task_signature.py`**: Complete signature verification implementation
  - Canonicalization identical to backend (double JSON serialization, `separators=(",", ":")`, `sort_keys=True`, `ensure_ascii=True`)
  - `hmac.compare_digest` for constant-time signature comparison
  - Freshness window validation (`REPLAY_WINDOW=300s`, `CLOCK_SKEW=60s`)
  - Anti-replay via `SET NX EX 600` keyed on `task_id`
  - `TaskRejected` exception with machine-readable error codes

- **`bot.py::_consume_task_stream`**: Verification before task execution
  - Calls `verify_task()` before `_process_task()`
  - Resume point (`moddy:tasks:last_id`) now always advances (prevents tight loops on failing entries)
  - Rejected entries logged at `warning` level, never retried
  - Execution errors also advance the cursor

- **`config.py`**: Configuration and boot diagnostics
  - `TASK_STREAM_SECRET`: shared HMAC secret (32 chars minimum)
  - `TASK_STREAM_ALLOW_UNSIGNED`: deployment window escape hatch (defaults to `false`)
  - Boot-time error if secret is missing or too short
  - Warning while `TASK_STREAM_ALLOW_UNSIGNED` is enabled

- **`tests/test_task_signature.py`**: 31-test contract suite
  - Canonicalization (key order, whitespace, nested payload escaping, non-ASCII)
  - Tampering detection for each signed field
  - Wrong secret rejection
  - Freshness window edges
  - Replay and dedup-by-`task_id` behavior
  - Fail-closed without secret
  - `allow_unsigned` escape hatch

- **Documentation**: New `docs/TASK_SIGNATURE.md` with full contract specification
  - Wire format (six string fields)
  - Canonicalization rules (double serialization, escaping)
  - Verification order and non-negotiable rules
  - Deployment order (bot first, then backend)
  - Environment variables and test invocation

## Implementation Details

- **Fail closed**: Without a secret, `verify_task` raises `no_secret` rather than executing unverifiable tasks
- **Dedup marker only burned for valid entries**: Signature and freshness checked first, so garbage cannot flood the `task:seen:*` keyspace
- **Tests load by path**: Module imported via `importlib.util` rather than through `utils/__init__.py` (which imports discord.py), keeping the test suite runnable with stdlib + pytest only
- **Reference implementation test**: One test recomputes a signature directly from the spec snippet to catch canonicalization drift

## Deployment Notes

Order matters:
1. Set `TASK_STREAM_SECRET` (same value) on both bot and backend **before** deploying code
2. Deploy bot first (already accepts signed entries; none exist yet)
3. Deploy backend next (starts signing)
4. Once backend is in production, disable `TASK_STREAM_ALLOW_UNSIGNED`

See `docs/TASK_SIGNATURE.md` §6 for full deployment order and rollback considerations.

https://claude.ai/code/session_01Pccn5v3mZgjYNbcBxnUA7h