### PR TITLE
Add MODULE_ORDER to fix /config module picker ordering

### DIFF
--- a/docs/MODULE_SYSTEM.md
+++ b/docs/MODULE_SYSTEM.md
@@ -215,6 +215,8 @@ class TicketModule(ModuleBase):
     MODULE_NAME = "Tickets"
     MODULE_DESCRIPTION = "Système de tickets pour le support utilisateur"
     MODULE_EMOJI = "🎫"
+    # Position dans le menu déroulant /config (voir MODULE_ORDER ci-dessous)
+    MODULE_ORDER = 130
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)
@@ -498,6 +500,11 @@ L'interface utilise les **Composants V2** pour une expérience moderne :
    - Description de bienvenue
    - Menu déroulant avec tous les modules disponibles
    - Chaque option affiche : emoji + nom + description
+   - L'ordre des options est fixe : `ModuleManager.get_available_modules()`
+     trie par `MODULE_ORDER` (du plus important au moins important), pas par
+     nom ni par ordre de découverte des fichiers. Un nouveau module doit
+     définir `MODULE_ORDER` (voir Étape 1) en le comparant aux autres
+     modules dans `modules/*.py` pour se placer au bon rang.
 
 2. **Page de configuration d'un module**
    - Titre et description du module

--- a/modules/adaptive_slowmode.py
+++ b/modules/adaptive_slowmode.py
@@ -92,6 +92,7 @@ class AdaptiveSlowmodeModule(ModuleBase):
     MODULE_NAME = "Adaptive Slowmode"
     MODULE_DESCRIPTION = "Ajuste automatiquement le slowmode selon l'activité"
     MODULE_EMOJI = TIME
+    MODULE_ORDER = 70
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)

--- a/modules/altguard.py
+++ b/modules/altguard.py
@@ -62,6 +62,7 @@ class AltGuardModule(ModuleBase):
     # The /config picker uses the shield (it is a protection module); the
     # animated AltGuard face is reserved for the panel message itself.
     MODULE_EMOJI = SHIELD
+    MODULE_ORDER = 20
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)

--- a/modules/auto_restore_roles.py
+++ b/modules/auto_restore_roles.py
@@ -25,6 +25,7 @@ class AutoRestoreRolesModule(ModuleBase):
     MODULE_NAME = "Auto Restore Roles"
     MODULE_DESCRIPTION = "Restaure automatiquement les rôles des utilisateurs qui reviennent"
     MODULE_EMOJI = HISTORY
+    MODULE_ORDER = 60
 
     # Modes de sauvegarde
     MODE_ALL = "all"  # Tous les rôles

--- a/modules/auto_role.py
+++ b/modules/auto_role.py
@@ -23,6 +23,7 @@ class AutoRoleModule(ModuleBase):
     MODULE_NAME = "Auto Role"
     MODULE_DESCRIPTION = "Attribue automatiquement des rôles aux nouveaux membres"
     MODULE_EMOJI = MANAGE_USER
+    MODULE_ORDER = 30
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)

--- a/modules/automod_ai.py
+++ b/modules/automod_ai.py
@@ -234,6 +234,7 @@ class AutomodModule(ModuleBase):
     MODULE_NAME = "Automod AI"
     MODULE_DESCRIPTION = "Modération automatique des messages problématiques (IA)"
     MODULE_EMOJI = "<:shield:1521471376815292498>"
+    MODULE_ORDER = 10
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)

--- a/modules/bot_customization.py
+++ b/modules/bot_customization.py
@@ -272,6 +272,7 @@ class BotCustomizationModule(ModuleBase):
     MODULE_NAME = "Bot Customization"
     MODULE_DESCRIPTION = "Personnalise l'identité de Moddy sur ce serveur"
     MODULE_EMOJI = MODDY_SQUARE
+    MODULE_ORDER = 120
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)

--- a/modules/interserver.py
+++ b/modules/interserver.py
@@ -35,6 +35,7 @@ class InterServerModule(ModuleBase):
     MODULE_NAME = "Inter-Server"
     MODULE_DESCRIPTION = "Connecte plusieurs serveurs via des salons dédiés"
     MODULE_EMOJI = GROUPS
+    MODULE_ORDER = 100
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)

--- a/modules/module_manager.py
+++ b/modules/module_manager.py
@@ -40,6 +40,11 @@ class ModuleBase(ABC):
     MODULE_NAME: str = "Base Module"  # Nom affiché du module
     MODULE_DESCRIPTION: str = "Base module description"  # Description du module
     MODULE_EMOJI: str = "⚙️"  # Emoji représentant le module
+    # Position dans le menu déroulant /config, du plus important (0) au moins
+    # important. Fixe et explicite — ne dépend ni de l'ordre de découverte
+    # des fichiers (non déterministe) ni du nom affiché (qui varie par
+    # module mais ne reflète pas son importance).
+    MODULE_ORDER: int = 100
 
     def __init__(self, bot, guild_id: int):
         """
@@ -204,8 +209,10 @@ class ModuleManager:
         Returns:
             Liste de dictionnaires avec les informations des modules
         """
-        # Sort by display name so the /config module picker is stable across
-        # restarts (filesystem glob discovery order is not deterministic).
+        # Sort by MODULE_ORDER (most important first) so the /config module
+        # picker has a fixed position per module — not the display name
+        # (which doesn't reflect importance) nor the filesystem discovery
+        # order (which is not deterministic across restarts).
         return [
             {
                 'id': module_class.MODULE_ID,
@@ -215,7 +222,7 @@ class ModuleManager:
             }
             for module_class in sorted(
                 self.registered_modules.values(),
-                key=lambda m: m.MODULE_NAME.lower(),
+                key=lambda m: (m.MODULE_ORDER, m.MODULE_NAME.lower()),
             )
         ]
 

--- a/modules/social_notifications.py
+++ b/modules/social_notifications.py
@@ -260,6 +260,7 @@ class SocialNotificationsModule(ModuleBase):
     MODULE_NAME = "Social Notifications"
     MODULE_DESCRIPTION = "Get notified when social accounts post new content"
     MODULE_EMOJI = SOCIAL
+    MODULE_ORDER = 80
 
     async def load_config(self, config_data: Dict[str, Any]) -> bool:
         # Configuration lives in the social_subscriptions table, not JSONB.

--- a/modules/starboard.py
+++ b/modules/starboard.py
@@ -273,6 +273,7 @@ class StarboardModule(ModuleBase):
     MODULE_NAME = "Starboard"
     MODULE_DESCRIPTION = "Tableau d'honneur des messages populaires"
     MODULE_EMOJI = STAR
+    MODULE_ORDER = 90
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)

--- a/modules/voice_transcription.py
+++ b/modules/voice_transcription.py
@@ -46,6 +46,7 @@ class VoiceTranscriptionModule(ModuleBase):
     MODULE_NAME = "Voice Transcription"
     MODULE_DESCRIPTION = "Transcrit les messages vocaux en texte"
     MODULE_EMOJI = VOICE_CHAT
+    MODULE_ORDER = 110
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)

--- a/modules/welcome_channel.py
+++ b/modules/welcome_channel.py
@@ -193,6 +193,7 @@ class WelcomeChannelModule(ModuleBase):
     MODULE_NAME = "Welcome Channel"
     MODULE_DESCRIPTION = "Welcome messages posted in public channels"
     MODULE_EMOJI = WAVING_HAND
+    MODULE_ORDER = 40
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)

--- a/modules/welcome_dm.py
+++ b/modules/welcome_dm.py
@@ -204,6 +204,7 @@ class WelcomeDmModule(ModuleBase):
     MODULE_NAME = "Welcome DM"
     MODULE_DESCRIPTION = "Welcome messages sent in private to new members"
     MODULE_EMOJI = WAVING_HAND
+    MODULE_ORDER = 50
 
     def __init__(self, bot, guild_id: int):
         super().__init__(bot, guild_id)


### PR DESCRIPTION
## Summary
Replaces non-deterministic module ordering in the `/config` command picker with an explicit `MODULE_ORDER` class attribute. Modules are now sorted by importance (lower values first) rather than by display name or filesystem discovery order.

## Changes
- **ModuleBase**: Added `MODULE_ORDER: int = 100` class attribute with documentation explaining its purpose (fixed, explicit positioning independent of discovery order or display name)
- **ModuleManager.get_available_modules()**: Updated sorting logic to use `(MODULE_ORDER, MODULE_NAME.lower())` tuple instead of just `MODULE_NAME.lower()`, ensuring stable and intentional module ordering
- **All 12 modules**: Added `MODULE_ORDER` values reflecting their importance:
  - Automod AI: 10 (highest priority)
  - AltGuard: 20
  - Auto Role: 30
  - Welcome Channel: 40
  - Welcome DM: 50
  - Auto Restore Roles: 60
  - Adaptive Slowmode: 70
  - Social Notifications: 80
  - Starboard: 90
  - Inter-Server & Base: 100
  - Voice Transcription: 110
  - Bot Customization: 120
  - Tickets (example in docs): 130
- **Documentation**: Updated `MODULE_SYSTEM.md` with explanation of the new ordering system and guidance for adding new modules

## Implementation Details
- The secondary sort by `MODULE_NAME.lower()` ensures deterministic ordering when multiple modules share the same `MODULE_ORDER` value
- Default value of 100 allows new modules to be inserted at any priority level without requiring updates to existing modules
- Ordering reflects security/core features first (Automod, AltGuard), then member management (roles, welcome), then engagement/utility features (starboard, social, customization)

https://claude.ai/code/session_013KS9gnJT9ixruJoCmpVNX9