### PR TITLE
Fix staff panel dynamic item dispatch + restore `/manage rank` command

### DIFF
--- a/docs/PERSISTENT_VIEWS.md
+++ b/docs/PERSISTENT_VIEWS.md
@@ -143,6 +143,19 @@ dedicated test for this
 (`test_no_duplicate_custom_ids_across_registered_views`) — it must pass
 before a new view is added to the registry.
 
+**`DynamicItem` templates must not overlap either.** discord.py keeps
+dynamic items in a dict keyed by the **compiled** pattern and dispatches to
+the first template that `fullmatch`es the clicked `custom_id`. Because
+`re.compile` caches, two `DynamicItem` classes declared with the *same*
+pattern string collapse into a **single** registry entry — the one
+registered last wins, and every click on the others dies with "This
+interaction failed". Give each class its own non-overlapping template
+(one action per template, or a disjoint `(?P<action>a|b)` alternation),
+never a shared "all actions" regex.
+`test_dynamic_item_templates_do_not_overlap` in
+`tests/test_persistent_views.py` enforces this — add new `DynamicItem`
+classes to `_dynamic_item_cases()` so they are covered.
+
 ### Never put in a `custom_id`
 - `locale` → fetch from interaction via `i18n.get_user_locale(interaction)`
 - Secrets, tokens, webhook URLs

--- a/docs/STAFF_SYSTEM.md
+++ b/docs/STAFF_SYSTEM.md
@@ -112,6 +112,7 @@ All available via `/manage` (slash) or `m.` (message).
 | Command | What it does |
 |---------|-------------|
 | `/manage staff @user` | Open the unified rank + setstaff panel |
+| `/manage rank @user <role>` | Give one staff role directly (fast path, no panel) |
 | `/manage unrank @user` | Remove all roles and the TEAM attribute |
 | `/manage staffinfo @user` | Show roles, permissions, join date |
 | `/manage list` | List all staff by role |
@@ -168,6 +169,8 @@ CREATE TABLE staff_permissions (
 | `staff/framework/context.py` | `StaffContext` — unified message/slash context |
 | `staff/framework/registry.py` | Discovery + slash group builder |
 | `staff/framework/design.py` | Components V2 panel helpers |
+| `staff/commands/manage/staff.py` | `/manage staff` panel (persistent DynamicItem controls) |
+| `staff/commands/manage/rank.py` | `/manage rank` — single role assignment |
 | `staff/base.py` | `StaffCommandsCog` base (auto-delete tracking for message commands) |
 | `utils/staff_permissions.py` | `StaffPermissionManager`, `CommandType`, `StaffRole` |
 | `utils/staff_role_permissions.py` | Node definitions per role |

--- a/docs/sessions/2026-08-21_staff-panel-roles-dispatch-and-rank.md
+++ b/docs/sessions/2026-08-21_staff-panel-roles-dispatch-and-rank.md
@@ -1,0 +1,54 @@
+# 2026-08-21 — `/manage staff` roles dropdown dispatch fix + `/manage rank`
+
+## What was done
+
+### 1. `m.staff` roles dropdown returned "This interaction failed"
+
+Root cause: `StaffPanelRolesSelect`, `StaffPanelScopeSelect` and
+`StaffPanelActionButton` were all declared with the **same** `DynamicItem`
+template (`_CID_TEMPLATE`, an `(?P<action>roles|scope|save|remove)`
+alternation). discord.py stores dynamic items in a dict keyed by the
+*compiled* pattern, and `re.compile` caches — so the three classes collapsed
+into one registry entry. The last one registered (`StaffPanelActionButton`)
+shadowed the other two, and every roles/scope select click was dispatched to
+a `ui.Button` item, blowing up before the callback ran.
+
+Fix: one non-overlapping template per class —
+`_CID_ROLES_TEMPLATE`, `_CID_SCOPE_TEMPLATE`, `_CID_ACTION_TEMPLATE`
+(`save|remove` only), `_CID_PERMS_TEMPLATE` unchanged. The emitted
+`custom_id`s are unchanged, so panels already posted in Discord keep working.
+
+### 2. `m.rank` is a real command again
+
+`rank` was only an alias of the `/manage staff` panel, so the documented
+`m.rank @user Manager` form silently ignored the role argument. Added
+`staff/commands/manage/rank.py`: `/manage rank <user> <role>` (slash choices)
+and `m.rank <@user|user_id> <role>` (role name accepted as the stored value,
+the display name, or a loose case/spacing variant). It reuses the panel's
+gates — hierarchy check on existing staff, `can_assign_role`, bot targets
+rejected — then `db.add_staff_role()` (which also sets the `TEAM` attribute).
+`rank` was removed from `StaffPanelCommand.aliases` so the registry routes it
+to the new command (`setstaff` still opens the panel).
+
+## Files modified
+
+- `staff/commands/manage/staff.py` — split templates, drop the `rank` alias
+- `staff/commands/manage/rank.py` — **new**
+- `locales/{fr,en-US,es-ES,pt-BR,de}.json` — `staff.manage.rank.*`
+- `tests/test_persistent_views.py` — `test_dynamic_item_templates_do_not_overlap`
+- `docs/PERSISTENT_VIEWS.md` — non-overlapping template rule
+- `docs/STAFF_SYSTEM.md` — `/manage rank` row + implementation files
+
+## Decisions
+
+- `rank` **adds** a role to whatever the member already has rather than
+  replacing the set; replacing is what the panel is for, and `m.unrank`
+  already covers full removal.
+- No `locales/commands/*.json` entries: staff commands are deliberately not
+  localized (see docs/COMMAND_LOCALIZATION.md).
+
+## Follow-ups
+
+- The panel still applies role/permission changes immediately (Save is only a
+  confirmation) — unchanged by this session, still flagged in
+  docs/PERSISTENT_VIEWS.md Step 15.

--- a/locales/de.json
+++ b/locales/de.json
@@ -2496,6 +2496,15 @@
         "done_title": "Staff-Mitglied entfernt",
         "done": "{user} wurde aus dem Staff-Team entfernt."
       },
+      "rank": {
+        "unknown_role_title": "Unbekannte Rolle",
+        "unknown_role": "Ungültige Rolle. Verfügbare Rollen: {roles}.",
+        "already_title": "Rolle bereits vergeben",
+        "already": "{user} hat die Rolle {role} bereits.",
+        "done_title": "Rolle vergeben",
+        "done": "Die Rolle {role} wurde {user} zugewiesen.",
+        "hint": "Nutze `m.staff` für die Berechtigungen und `m.unrank`, um jemanden aus dem Team zu entfernen."
+      },
       "staff": {
         "title": "Staff-Verwaltung",
         "subtitle": "Weise Rollen zu und konfiguriere Berechtigungen, dann speichern.",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -2496,6 +2496,15 @@
         "done_title": "Staff Member Removed",
         "done": "{user} has been removed from the staff team."
       },
+      "rank": {
+        "unknown_role_title": "Unknown role",
+        "unknown_role": "Invalid role. Available roles: {roles}.",
+        "already_title": "Role already assigned",
+        "already": "{user} already has the {role} role.",
+        "done_title": "Role assigned",
+        "done": "The {role} role has been assigned to {user}.",
+        "hint": "Use `m.staff` to configure permissions, `m.unrank` to remove from the team."
+      },
       "staff": {
         "title": "Staff Management",
         "subtitle": "Assign roles and configure permissions, then save.",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -2496,6 +2496,15 @@
         "done_title": "Miembro del staff eliminado",
         "done": "{user} ha sido eliminado del equipo de staff."
       },
+      "rank": {
+        "unknown_role_title": "Rol desconocido",
+        "unknown_role": "Rol no válido. Roles disponibles: {roles}.",
+        "already_title": "Rol ya asignado",
+        "already": "{user} ya tiene el rol {role}.",
+        "done_title": "Rol asignado",
+        "done": "El rol {role} se ha asignado a {user}.",
+        "hint": "Usa `m.staff` para configurar los permisos y `m.unrank` para quitar del equipo."
+      },
       "staff": {
         "title": "Gestión del staff",
         "subtitle": "Asigna roles y configura permisos, luego guarda.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2495,6 +2495,15 @@
         "done_title": "Membre retiré",
         "done": "{user} a été retiré de l'équipe staff."
       },
+      "rank": {
+        "unknown_role_title": "Rôle inconnu",
+        "unknown_role": "Rôle invalide. Rôles disponibles : {roles}.",
+        "already_title": "Rôle déjà attribué",
+        "already": "{user} possède déjà le rôle {role}.",
+        "done_title": "Rôle attribué",
+        "done": "Le rôle {role} a été attribué à {user}.",
+        "hint": "Utilise `m.staff` pour configurer les permissions, `m.unrank` pour retirer du staff."
+      },
       "staff": {
         "title": "Gestion du staff",
         "subtitle": "Attribue des rôles et configure les permissions, puis enregistre.",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -2496,6 +2496,15 @@
         "done_title": "Membro da Equipe Removido",
         "done": "{user} foi removido da equipe."
       },
+      "rank": {
+        "unknown_role_title": "Cargo desconhecido",
+        "unknown_role": "Cargo inválido. Cargos disponíveis: {roles}.",
+        "already_title": "Cargo já atribuído",
+        "already": "{user} já possui o cargo {role}.",
+        "done_title": "Cargo atribuído",
+        "done": "O cargo {role} foi atribuído a {user}.",
+        "hint": "Use `m.staff` para configurar as permissões e `m.unrank` para remover da equipe."
+      },
       "staff": {
         "title": "Gerenciamento de Equipe",
         "subtitle": "Atribua cargos e configure permissões, depois salve.",

--- a/staff/commands/manage/rank.py
+++ b/staff/commands/manage/rank.py
@@ -1,0 +1,147 @@
+"""`/manage rank` — give a member a single staff role.
+
+The full editor lives in ``/manage staff`` (roles + granular permissions).
+This command is the fast path: one member, one role, no panel — useful when
+onboarding someone or adding a second role to an existing staff member.
+Removing everything is ``/manage unrank``.
+"""
+
+import logging
+from typing import Optional
+
+import discord
+
+from staff.framework import StaffCommand, SlashOption, staff_command, design, CommandType, parse_user_id
+from staff.framework import badges
+from utils.i18n import t
+from utils.staff_permissions import staff_permissions, StaffRole
+from utils.staff_role_permissions import get_role_display_name
+from staff.commands.manage.staff import ASSIGNABLE_ROLES
+
+logger = logging.getLogger("moddy.staff.manage.rank")
+
+
+def resolve_role(raw: str) -> Optional[StaffRole]:
+    """Resolve a user-typed role name to an assignable :class:`StaffRole`.
+
+    Accepts the stored value (``Supervisor_Mod``), the display name
+    (``Moderation Supervisor``) and loose spacing/case variants of either,
+    so ``m.rank @user moderation supervisor`` works as well as the slash
+    choice list does.
+    """
+    key = " ".join((raw or "").split()).lower().replace("_", " ")
+    if not key:
+        return None
+    for role in ASSIGNABLE_ROLES:
+        candidates = {
+            role.value.lower().replace("_", " "),
+            get_role_display_name(role.value).lower(),
+        }
+        if key in candidates:
+            return role
+    return None
+
+
+@staff_command
+class RankCommand(StaffCommand):
+    command_type = CommandType.MANAGEMENT
+    name = "rank"
+    description = "Give a member a staff role."
+    options = [
+        SlashOption("user", "user", "Member to promote.", required=True),
+        SlashOption("role", "string", "Role to assign.", required=True,
+                    choices=[r.value for r in ASSIGNABLE_ROLES]),
+    ]
+
+    def parse_message(self, raw: str) -> dict:
+        """``m.rank <@user|user_id> <role>`` — the role is the remainder."""
+        parts = (raw or "").strip().split(None, 1)
+        return {
+            "user_id": parts[0] if parts else "",
+            "role": parts[1].strip() if len(parts) > 1 else "",
+        }
+
+    async def execute(self, ctx):
+        bot = ctx.bot
+        locale = ctx.locale
+        usage = "m.rank <@user|user_id> <role>"
+
+        target = ctx.opt("user")
+        uid = target.id if target else parse_user_id(ctx.opt("user_id") or "")
+        role = resolve_role(ctx.opt("role") or "")
+
+        if not uid:
+            await ctx.send(view=design.invalid_usage(locale, usage))
+            return
+
+        if role is None:
+            await ctx.send(view=design.error(
+                t("staff.manage.rank.unknown_role_title", locale=locale),
+                t("staff.manage.rank.unknown_role", locale=locale,
+                  roles=", ".join(f"`{r.value}`" for r in ASSIGNABLE_ROLES)),
+            ))
+            return
+
+        if target and target.bot:
+            await ctx.send(view=design.error(
+                t("staff.manage.staff.bot_title", locale=locale),
+                t("staff.manage.staff.bot", locale=locale),
+            ))
+            return
+
+        try:
+            user = await bot.fetch_user(uid)
+        except discord.NotFound:
+            await ctx.send(view=design.error(
+                t("staff.team.user_notfound_title", locale=locale),
+                t("staff.team.user_notfound", locale=locale, id=f"`{uid}`"),
+            ))
+            return
+
+        if user.bot:
+            await ctx.send(view=design.error(
+                t("staff.manage.staff.bot_title", locale=locale),
+                t("staff.manage.staff.bot", locale=locale),
+            ))
+            return
+
+        user_data = await bot.db.get_user(uid)
+        is_staff = bool(user_data["attributes"].get("TEAM"))
+
+        # Same hierarchy gate as /manage staff: an existing staff member (or a
+        # dev) may only be edited by someone above them.
+        if (is_staff or bot.is_developer(uid)) and not await staff_permissions.can_modify_user(ctx.author.id, uid):
+            await ctx.send(view=design.permission_denied(locale, t("staff.manage.hierarchy", locale=locale)))
+            return
+
+        if not await staff_permissions.can_assign_role(ctx.author.id, role):
+            await ctx.send(view=design.permission_denied(
+                locale,
+                t("staff.manage.staff.cannot_assign", locale=locale,
+                  roles=get_role_display_name(role.value)),
+            ))
+            return
+
+        perms = await bot.db.get_staff_permissions(uid)
+        if role.value in perms["roles"]:
+            await ctx.send(view=design.info(
+                t("staff.manage.rank.already_title", locale=locale),
+                t("staff.manage.rank.already", locale=locale, user=user.mention,
+                  role=f"{badges.role_badge(role.value)} {get_role_display_name(role.value)}"),
+            ))
+            return
+
+        # Adds the role and sets the TEAM attribute (see
+        # db/repositories/staff.py::set_staff_roles).
+        await bot.db.add_staff_role(uid, role.value, ctx.author.id)
+        logger.info("Staff %s granted role %s to %s", ctx.author.id, role.value, uid)
+
+        roles = [StaffRole(r) for r in (await bot.db.get_staff_permissions(uid))["roles"]]
+        await ctx.send(view=design.success(
+            t("staff.manage.rank.done_title", locale=locale),
+            t("staff.manage.rank.done", locale=locale, user=user.mention,
+              role=f"{badges.role_badge(role.value)} {get_role_display_name(role.value)}"),
+            fields=[{"name": t("staff.manage.staff.roles", locale=locale),
+                     "value": " ".join(f"{badges.role_badge(r.value)} {get_role_display_name(r.value)}" for r in roles)}],
+            footer=t("staff.manage.rank.hint", locale=locale),
+        ))

--- a/staff/commands/manage/staff.py
+++ b/staff/commands/manage/staff.py
@@ -4,6 +4,9 @@ Merges the old ``m.rank`` (add) and ``m.setstaff`` (roles + granular
 permissions) into a single intuitive panel: assign roles, configure the
 permissions for each role (and the shared "common" set), then save — or remove
 the member from the team. Works from both message and slash transports.
+
+``m.rank`` is a separate command again (``staff/commands/manage/rank.py``) for
+the one-member/one-role fast path; it no longer aliases this panel.
 """
 
 import json
@@ -46,7 +49,15 @@ ASSIGNABLE_ROLES = [
 # wrong id were ever trusted. See docs/PERSISTENT_VIEWS.md Migration log,
 # Step 15 — THIS VIEW REQUIRES HUMAN REVIEW BEFORE MERGE.
 # --------------------------------------------------------------------------- #
-_CID_TEMPLATE = r"moddy:staffpanel:(?P<action>roles|scope|save|remove):(?P<target>\d{1,20}):(?P<modifier>\d{1,20})"
+# One template PER DynamicItem class. They must not overlap: discord.py keys
+# its dynamic-item registry by compiled pattern and dispatches to the first
+# template that matches, so two classes sharing a pattern means one silently
+# shadows the other and every click on the shadowed control dies with
+# "This interaction failed" (this is exactly what happened to the roles
+# select, which was shadowed by the Save/Remove button).
+_CID_ROLES_TEMPLATE = r"moddy:staffpanel:roles:(?P<target>\d{1,20}):(?P<modifier>\d{1,20})"
+_CID_SCOPE_TEMPLATE = r"moddy:staffpanel:scope:(?P<target>\d{1,20}):(?P<modifier>\d{1,20})"
+_CID_ACTION_TEMPLATE = r"moddy:staffpanel:(?P<action>save|remove):(?P<target>\d{1,20}):(?P<modifier>\d{1,20})"
 
 # The perms select needs a 4th field: which scope ("common" or a role value)
 # its options belong to, since that isn't reconstructible from the
@@ -265,10 +276,10 @@ class StaffManagerPanel(BaseView):
 
 # --------------------------------------------------------------------------- #
 # Dynamic items (persistent). All four encode target_id + modifier_id — see
-# the module-level docstring on _CID_TEMPLATE for why both are required.
+# the module-level custom_id templates block for why both are required.
 # --------------------------------------------------------------------------- #
 
-class StaffPanelRolesSelect(ui.DynamicItem[ui.Select], template=_CID_TEMPLATE):
+class StaffPanelRolesSelect(ui.DynamicItem[ui.Select], template=_CID_ROLES_TEMPLATE):
     """Role-assignment select. Re-checks can_assign_role per role, unchanged
     from the pre-migration behaviour.
 
@@ -357,7 +368,7 @@ class StaffPanelRolesSelect(ui.DynamicItem[ui.Select], template=_CID_TEMPLATE):
         await interaction.response.edit_message(view=view)
 
 
-class StaffPanelScopeSelect(ui.DynamicItem[ui.Select], template=_CID_TEMPLATE):
+class StaffPanelScopeSelect(ui.DynamicItem[ui.Select], template=_CID_SCOPE_TEMPLATE):
     """Picks which role's (or "common") permission set the perms select edits."""
 
     def __init__(self, target_id: int, modifier_id: int, *, locale: str = "en-US",
@@ -462,7 +473,7 @@ class StaffPanelPermsSelect(ui.DynamicItem[ui.Select], template=_CID_PERMS_TEMPL
         await interaction.response.edit_message(view=view)
 
 
-class StaffPanelActionButton(ui.DynamicItem[ui.Button], template=_CID_TEMPLATE):
+class StaffPanelActionButton(ui.DynamicItem[ui.Button], template=_CID_ACTION_TEMPLATE):
     """Save / Remove button."""
 
     _STYLE = {"save": discord.ButtonStyle.success, "remove": discord.ButtonStyle.danger}
@@ -538,7 +549,7 @@ class StaffPanelActionButton(ui.DynamicItem[ui.Button], template=_CID_TEMPLATE):
 class StaffPanelCommand(StaffCommand):
     command_type = CommandType.MANAGEMENT
     name = "staff"
-    aliases = ("rank", "setstaff")
+    aliases = ("setstaff",)
     description = "Manage a member's staff roles and permissions."
     options = [
         SlashOption("user", "user", "Member to manage.", required=True),

--- a/tests/test_persistent_views.py
+++ b/tests/test_persistent_views.py
@@ -161,3 +161,27 @@ async def test_dynamic_item_template_matches_emitted_id(cls, args):
         f"{cls.__name__}: template does not match its own custom_id {cid!r}"
     )
     assert len(cid) <= 100, f"{cls.__name__}: custom_id exceeds 100 chars"
+
+
+async def test_dynamic_item_templates_do_not_overlap():
+    """Two DynamicItem classes must never share (or cross-match) a template.
+
+    discord.py stores dynamic items in a dict keyed by the *compiled* pattern
+    and dispatches to the first template that matches. ``re.compile`` caches,
+    so two classes declared with the same pattern string end up as a single
+    registry entry: the last one registered silently shadows the others and
+    every click on a shadowed control dies with "This interaction failed".
+    That is what the four /manage staff panel controls used to do.
+    """
+    cases = _dynamic_item_cases()
+    for cls, args in cases:
+        cid = cls(*args).item.custom_id
+        matching = [
+            other.__name__ for other, _ in cases
+            if other.__discord_ui_compiled_template__.fullmatch(cid)
+        ]
+        assert matching == [cls.__name__], (
+            f"custom_id {cid!r} emitted by {cls.__name__} also matches "
+            f"{[m for m in matching if m != cls.__name__]} — clicks dispatch "
+            "to only one of them"
+        )


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the staff management panel where role and scope selection dropdowns were silently failing with "This interaction failed", and restores `/manage rank` as a dedicated fast-path command for assigning a single role to a staff member.

## Changes

### 1. Fixed Dynamic Item Template Collision in Staff Panel

**Problem:** `StaffPanelRolesSelect`, `StaffPanelScopeSelect`, and `StaffPanelActionButton` were all declared with the same `DynamicItem` template regex (`_CID_TEMPLATE`). Since discord.py keys its dynamic-item registry by compiled pattern and `re.compile` caches, the three classes collapsed into a single registry entry. The last one registered (`StaffPanelActionButton`) shadowed the others, causing every click on roles/scope selects to dispatch to a `ui.Button` handler, resulting in "This interaction failed".

**Solution:** Split into three non-overlapping templates:
- `_CID_ROLES_TEMPLATE` for `StaffPanelRolesSelect`
- `_CID_SCOPE_TEMPLATE` for `StaffPanelScopeSelect`  
- `_CID_ACTION_TEMPLATE` for `StaffPanelActionButton` (save|remove only)

The emitted `custom_id`s remain unchanged, so existing panels in Discord continue to work.

### 2. Restored `/manage rank` as a Dedicated Command

**Problem:** `rank` was only an alias of the `/manage staff` panel, so the documented `m.rank @user Manager` form silently ignored the role argument.

**Solution:** Created `staff/commands/manage/rank.py` with:
- Slash command: `/manage rank <user> <role>` with role choices
- Message command: `m.rank <@user|user_id> <role>` with flexible role name parsing
- Role resolution accepts stored value (e.g., `Supervisor_Mod`), display name (e.g., `Moderation Supervisor`), or loose case/spacing variants
- Reuses panel's permission gates: hierarchy check on existing staff, `can_assign_role` validation, bot target rejection
- **Adds** a role to existing roles (doesn't replace); full replacement is the panel's job
- Removed `rank` from `StaffPanelCommand.aliases` so registry routes it to the new command

### 3. Added Test Coverage

Added `test_dynamic_item_templates_do_not_overlap()` in `tests/test_persistent_views.py` to enforce that no two `DynamicItem` classes share or cross-match templates, preventing this class of bug in the future.

### 4. Localization

Added `staff.manage.rank.*` message keys (unknown_role, already_assigned, done, hint) to all five locale files (en-US, fr, es-ES, pt-BR, de).

### 5. Documentation

- Updated `docs/PERSISTENT_VIEWS.md` with the non-overlapping template rule and test requirement
- Updated `docs/STAFF_SYSTEM.md` to document `/manage rank` as a separate command
- Added session notes in `docs/sessions/2026-08-21_staff-panel-roles-dispatch-and-rank.md`

## Implementation Details

- The rank command uses the same `db.add_staff_role()` call as the panel, which automatically sets the `TEAM` attribute
- Role resolution is case-insensitive and tolerates spacing variations, making both slash choices and message-form role names user-friendly
- Hierarchy and permission checks mirror the panel exactly, maintaining consistent access control

https://claude.ai/code/session_01GRZbgUepNmQu1ZfBFPTt1t