### PR TITLE
Add sanction expiration notifications (unban/unmute/unwarn DM)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,8 @@ moddy/
 │   ├── automod_render.py      #   Shared automod card helpers (barème breakdown, sanction name/accent)
 │   ├── transcription_views.py #   Voice transcription cards + persistent Transcribe button
 │   ├── appeal_views.py        #   Automod appeal UI (DM buttons + reviewer panels, persistent)
+│   ├── expiration_views.py    #   Sanction-expiration DM (unban/unmute/unwarn + invite)
+│   ├── invites.py             #   Shared guild invite creation (appeals, expirations)
 │   ├── moderation_cases.py    #   Cases domain model + enums + reference gen
 │   ├── global_sanctions.py    #   Global (Moddy-team) sanction levels: warn/limited/suspended
 │   ├── global_sanction_views.py #  Global sanction UI (notice DMs, staff panels, Modals V2)
@@ -186,6 +188,7 @@ moddy/
 │   ├── backend_client.py      #   Backend HTTP client
 │   ├── feeds_client.py        #   moddy-feeds Redis client (social notifications)
 │   ├── case_service.py        #   Scalable sanction→case entry point (source registry)
+│   ├── expiration_notifier.py #   Expired sanctions: lift the ban + DM the subject (invite)
 │   ├── global_sanction_service.py # Global sanctions: grouped cases, notice DM, 48h countdown, Redis
 │   ├── appeal_service.py      #   Automod sanction appeals (server / Moddy team, binding)
 │   ├── precedent_service.py   #   Automod server precedents (record + serve, RAG)
@@ -216,6 +219,7 @@ moddy/
     ├── test_global_sanctions.py   # Global sanction levels, cache TTL, user/guild context
     ├── test_global_sanction_flow.py # Groups, notices, countdown, Redis events, allowlists
     ├── test_bot_customization.py  # Bot customization validation (bio budget, styles)
+    ├── test_expiration_notifications.py # Expired sanctions: unban, invite, DM card
     ├── test_task_signature.py #   moddy:tasks HMAC contract (canonicalization, replay, dedup)
     └── test_transcription.py  #   Voice transcription helpers, guard rails, cards
 ```

--- a/bot.py
+++ b/bot.py
@@ -119,6 +119,9 @@ class ModdyBot(ModdyFrameworkBot):
         from services.global_sanction_service import GlobalSanctionService
         # Moddy-team global sanctions: grouped cases, one notice, one countdown
         self.global_sanctions = GlobalSanctionService(self)
+        from services.expiration_notifier import ExpirationNotifier
+        # Expired sanctions: lift the Discord action + notify the subject
+        self.expirations = ExpirationNotifier(self)
         from services.precedent_service import PrecedentService
         self.precedents = PrecedentService(self)  # automod server precedents (RAG)
         from services.transcription_service import TranscriptionService
@@ -2017,7 +2020,9 @@ class ModdyBot(ModdyFrameworkBot):
         """Expire temporary moderation sanctions whose deadline has passed.
 
         Flips each due sanction to ``expired``, logs the timeline event and
-        recomputes the parent case status (see db/repositories/moderation.py).
+        recomputes the parent case status (see db/repositories/moderation.py),
+        then hands the expired rows to ``self.expirations`` so the Discord
+        action is reversed and the subject is notified.
         """
         if not self.db:
             return
@@ -2027,32 +2032,11 @@ class ModdyBot(ModdyFrameworkBot):
             logger.error(f"Error expiring moderation sanctions: {e}", exc_info=True)
             return
 
-        # Reverse the Discord side of any expired guild ban (temporary bans):
-        # a timeout (mute) is auto-cleared by Discord, but a ban must be lifted
-        # explicitly when its case sanction expires.
-        for row in expired or []:
-            try:
-                # A temporary global sanction (limitation / suspension) has no
-                # Discord side to reverse — it only has to stop applying.
-                if row.get("case_type") == "global":
-                    subject_type = row.get("subject_type") or global_sanctions.SUBJECT_USER
-                    global_sanctions.invalidate(self, subject_type, row.get("subject_id"))
-                    continue
-                if row.get("action") != "ban" or row.get("case_type") != "guild":
-                    continue
-                if row.get("scope_type") != "discord_guild" or not row.get("scope_id"):
-                    continue
-                guild = self.get_guild(int(row["scope_id"]))
-                if guild is None or not guild.me.guild_permissions.ban_members:
-                    continue
-                await guild.unban(
-                    discord.Object(id=int(row["subject_id"])),
-                    reason="[Automod] temporary ban expired",
-                )
-            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
-                continue
-            except Exception as e:
-                logger.error(f"Error reversing expired sanction: {e}", exc_info=True)
+        # Reverse the Discord side of each expired sanction (a temporary ban has
+        # to be lifted explicitly; a timeout is auto-cleared by Discord) and DM
+        # the subject that it is over — with an invite back when it was a ban.
+        # See services/expiration_notifier.py.
+        await self.expirations.process(expired)
 
     @case_expiry.before_loop
     async def before_case_expiry(self):

--- a/db/repositories/moderation.py
+++ b/db/repositories/moderation.py
@@ -554,17 +554,18 @@ class ModerationRepository:
         """Expire temporary sanctions whose ``expires_at`` has passed.
 
         Returns the list of expired sanctions (each a dict with ``action``,
-        ``case_type``, ``subject_type``, ``subject_id``, ``scope_type`` and
-        ``scope_id``) so the caller can reverse the matching Discord action
-        (e.g. unban a temporary ban). Each expiry logs an event and recomputes
-        the parent case status.
+        ``expires_at``, ``case_type``, ``reference``, ``subject_type``,
+        ``subject_id``, ``scope_type`` and ``scope_id``) so the caller can
+        reverse the matching Discord action (e.g. unban a temporary ban) and
+        notify the subject. Each expiry logs an event and recomputes the parent
+        case status.
         """
         expired: List[Dict[str, Any]] = []
         async with self.pool.acquire() as conn:
             due = await conn.fetch(
                 """
-                SELECT s.id, s.case_id, s.action,
-                       c.type AS case_type, c.subject_type, c.subject_id,
+                SELECT s.id, s.case_id, s.action, s.expires_at,
+                       c.type AS case_type, c.reference, c.subject_type, c.subject_id,
                        c.scope_type, c.scope_id
                 FROM case_sanctions s
                 JOIN cases c ON c.id = s.case_id

--- a/docs/MODERATION_CASES.md
+++ b/docs/MODERATION_CASES.md
@@ -77,6 +77,8 @@ dependency.
 | Personal command `/mycases` | `cogs/cases_user.py` |
 | Server command `/cases` | `cogs/cases_server.py` |
 | Periodic expiry job | `bot.py::case_expiry` (every 2 min) |
+| **Expiration consequences + subject DM** | `services/expiration_notifier.py`, `utils/expiration_views.py` |
+| Shared invite creation | `utils/invites.py` |
 
 ---
 
@@ -292,6 +294,39 @@ the `/mycases` server filter).
 
 ---
 
+### 7bis. Expiration notifications
+
+Every two minutes `bot.py::case_expiry` flips due sanctions to `expired` and
+hands the rows to `bot.expirations`
+(`services/expiration_notifier.py::ExpirationNotifier`), which turns the DB
+change into what the subject actually experiences:
+
+| Expired sanction | Discord side | DM to the subject |
+|---|---|---|
+| `guild` / `ban` | the ban is **lifted** (`guild.unban`) | "your ban expired" + a **Rejoin the server** link button |
+| `guild` / `mute` | nothing — Discord clears the timeout itself | "your timeout is over" |
+| `guild` / `warn` | nothing | "your warning no longer counts" |
+| `global` / * | nothing — no Discord side | none (its own notice flow, see [GLOBAL_SANCTIONS.md](GLOBAL_SANCTIONS.md)) |
+
+The invite is **only** attached to an expired ban — the other actions never
+removed the member from the server — and only when the unban actually
+succeeded, so the DM never promises a way back that does not exist. It is
+built through `utils/invites.py::create_guild_invite` (first channel where
+Moddy holds *Create Invite*; rules → system → any text channel), single-use and
+valid for 7 days.
+
+The card (`utils/expiration_views.py::build_expiration_dm_view`) mirrors the
+sanction DM — same layout, same case link, same `sent by` footer — in green,
+and is written in the guild's `preferred_locale`. It holds only a **link**
+button, which carries no `custom_id` and triggers no interaction, so it stays
+valid forever without being registered as a persistent view.
+
+Nothing here is fatal: closed DMs, a member who left, a guild Moddy was removed
+from or one where it cannot create an invite each degrade to "no notification"
+while the expiry itself stands.
+
+---
+
 ## 8. Notes / open points
 
 - **Deletion**: FKs use `ON DELETE CASCADE`; no command deletes cases (moderation
@@ -337,7 +372,8 @@ they are recorded on that one case.
 computes the sanction and its `duree_heures`, so warns / mutes / bans can be
 temporary. A mute uses it as the timeout length; a ban becomes a *temp ban*
 whose `expires_at` is honoured by `bot.case_expiry`, which lifts the Discord ban
-when the sanction expires (mutes are auto-cleared by Discord).
+when the sanction expires (mutes are auto-cleared by Discord). The member is
+then DMed that the sanction is over — with an invite back for a ban (§7bis).
 
 A sanctioned member can **appeal** (see [AUTOMOD.md](AUTOMOD.md) §7):
 

--- a/docs/PERSISTENT_VIEWS.md
+++ b/docs/PERSISTENT_VIEWS.md
@@ -398,8 +398,9 @@ was easier not to" is not one.
   before deciding whether it needs migrating or removing.
 - **Every view with zero interactive children** (`AvatarView`, `BannerView`,
   `RollView`, `TextResultView`, static info/log cards, …) or whose only
-  children are `ButtonStyle.link` buttons (e.g. `SubscriptionView`) —
-  `bot.add_view()` on these is a no-op. Do not add `__persistent__`; there
+  children are `ButtonStyle.link` buttons (e.g. `SubscriptionView`, and
+  `utils/expiration_views.py::build_expiration_dm_view`, whose only control is
+  the *Rejoin the server* invite link) — `bot.add_view()` on these is a no-op. Do not add `__persistent__`; there
   is nothing to register.
 - **`utils/transcription_views.py::TranscribePromptView`** — the one-button
   message posted under a voice message. It is a `BaseView` with

--- a/docs/sessions/2026-08-21_sanction-expiration-notifications.md
+++ b/docs/sessions/2026-08-21_sanction-expiration-notifications.md
@@ -1,0 +1,68 @@
+# Sanction expiration notifications (unban / unmute / unwarn DM)
+
+## What was done
+
+A member whose temporary sanction expired was never told about it: the DB row
+flipped to `expired`, a temporary ban was silently lifted, and that was it. The
+member had no way to know they could come back — for a ban, not even a way to
+rejoin the server.
+
+Every expired **guild** sanction now sends the subject a DM:
+
+| Expired sanction | Discord side | DM |
+|---|---|---|
+| `ban` | ban lifted | "your ban expired" + **Rejoin the server** invite button |
+| `mute` | nothing (Discord clears the timeout) | "your timeout is over" |
+| `warn` | nothing | "your warning no longer counts" |
+
+The invite is attached to bans only (the other actions never removed the
+member) and only when the unban actually succeeded — the DM never offers a way
+back that does not exist. It is single-use and valid 7 days.
+
+Global (Moddy-team) sanctions keep their own notice flow: `case_expiry` still
+only drops their resolver cache, no DM from here.
+
+## Files modified
+
+- `services/expiration_notifier.py` **(new)** — `ExpirationNotifier`
+  (`bot.expirations`): reverses the Discord action of each expired row, then
+  notifies the subject. Absorbs the unban loop that lived inline in `bot.py`.
+- `utils/expiration_views.py` **(new)** — `build_expiration_dm_view`, the green
+  sibling of the sanction DM (same layout, case link, `sent by` footer) plus
+  the invite link button.
+- `utils/invites.py` **(new)** — `create_guild_invite`, the "first channel
+  where Moddy may invite" lookup, previously private to the appeal service.
+- `services/appeal_service.py` — `_make_invite` now delegates to it.
+- `db/repositories/moderation.py` — `expire_due_sanctions` also returns the
+  case `reference` and the sanction's `expires_at` (both are rendered in the DM).
+- `bot.py` — instantiates `ExpirationNotifier`; `case_expiry` hands it the
+  expired rows.
+- `locales/{fr,en-US,es-ES,pt-BR,de}.json` — `commands.moderation.expiry_dm.*`.
+- `tests/test_expiration_notifications.py` **(new)** — 16 offline tests.
+- Docs: `docs/MODERATION_CASES.md` §7bis, `docs/PERSISTENT_VIEWS.md`, `CLAUDE.md`.
+
+## Decisions
+
+- **A service, not inline in `bot.py`.** The expiry loop was already growing a
+  per-row Discord branch; moving it out makes the consequences of an expiry
+  testable without a gateway (the new suite drives it with duck-typed stubs).
+- **No persistent view registration.** The card's only control is a
+  `ButtonStyle.link` button: it carries no `custom_id`, triggers no
+  interaction, and stays valid across restarts by construction. This is the
+  documented "link-only view" exclusion, not a skipped persistence.
+- **Guild `preferred_locale` for the DM**, matching
+  `cogs/moderation_commands._guild_locale` — the sanction DM and its
+  expiration notice are then written in the same language.
+- **Failures degrade to silence**: closed DMs, a member who left, a guild
+  Moddy was removed from, or one without invite permission each mean "no
+  notification"; the expiry itself always stands.
+
+## Follow-ups
+
+- Revocations (an appeal accepted, a moderator lifting a sanction by hand) do
+  **not** send this DM — only expirations do. Appeal outcomes have their own
+  notice; a manual revocation still tells the member nothing, which may be
+  worth a follow-up.
+- The invite is created per expired ban. On a mass expiry in one guild this is
+  one API call per member; if that ever becomes a problem, cache one
+  multi-use invite per guild per sweep.

--- a/locales/de.json
+++ b/locales/de.json
@@ -785,6 +785,21 @@
         "case_id": "Fall-ID",
         "sent_by": "Gesendet von [**{guild}**]({guild_url}) (`{guild_id}`)"
       },
+      "expiry_dm": {
+        "title": "Deine Strafe ist abgelaufen",
+        "body": "Die gegen dich erfasste Strafe ist beendet.",
+        "ban_title": "Dein Bann ist abgelaufen",
+        "ban_body": "Dein temporärer Bann wurde aufgehoben — du kannst dem Server wieder beitreten.",
+        "mute_title": "Deine Auszeit ist abgelaufen",
+        "mute_body": "Deine Auszeit ist vorbei — du kannst wieder auf dem Server schreiben.",
+        "warn_title": "Deine Verwarnung ist abgelaufen",
+        "warn_body": "Deine Verwarnung ist abgelaufen und zählt nicht mehr gegen dich.",
+        "expired_at": "Abgelaufen",
+        "case_id": "Fallnummer",
+        "rejoin": "Server wieder beitreten",
+        "invite_note": "Diese Einladung ist einmalig nutzbar und läuft in 7 Tagen ab.",
+        "sent_by": "Gesendet von [**{guild}**]({guild_url}) (`{guild_id}`)"
+      },
       "errors": {
         "invalid_duration_title": "Ungültige Dauer",
         "invalid_duration": "Verwende Formate wie `7d`, `24h`, `30m`, oder lasse das Feld leer für dauerhaft.",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -785,6 +785,21 @@
         "case_id": "Case ID",
         "sent_by": "Sent by [**{guild}**]({guild_url}) (`{guild_id}`)"
       },
+      "expiry_dm": {
+        "title": "Your sanction has expired",
+        "body": "The sanction recorded against you has run out.",
+        "ban_title": "Your ban has expired",
+        "ban_body": "Your temporary ban has been lifted — you can join the server again.",
+        "mute_title": "Your timeout has expired",
+        "mute_body": "Your timeout is over — you can talk in the server again.",
+        "warn_title": "Your warning has expired",
+        "warn_body": "Your warning has expired and no longer counts against you.",
+        "expired_at": "Expired",
+        "case_id": "Case ID",
+        "rejoin": "Rejoin the server",
+        "invite_note": "This invite is single-use and expires in 7 days.",
+        "sent_by": "Sent by [**{guild}**]({guild_url}) (`{guild_id}`)"
+      },
       "errors": {
         "invalid_duration_title": "Invalid Duration",
         "invalid_duration": "Use formats like `7d`, `24h`, `30m`, or leave empty for permanent.",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -785,6 +785,21 @@
         "case_id": "ID de caso",
         "sent_by": "Enviado por [**{guild}**]({guild_url}) (`{guild_id}`)"
       },
+      "expiry_dm": {
+        "title": "Tu sanción ha expirado",
+        "body": "La sanción registrada en tu contra ha llegado a su fin.",
+        "ban_title": "Tu expulsión ha expirado",
+        "ban_body": "Tu expulsión temporal ha sido levantada — puedes volver a unirte al servidor.",
+        "mute_title": "Tu aislamiento ha expirado",
+        "mute_body": "Tu aislamiento ha terminado — puedes volver a hablar en el servidor.",
+        "warn_title": "Tu advertencia ha expirado",
+        "warn_body": "Tu advertencia ha expirado y ya no cuenta en tu contra.",
+        "expired_at": "Expirada",
+        "case_id": "N.º de caso",
+        "rejoin": "Volver al servidor",
+        "invite_note": "Esta invitación es de un solo uso y caduca en 7 días.",
+        "sent_by": "Enviado por [**{guild}**]({guild_url}) (`{guild_id}`)"
+      },
       "errors": {
         "invalid_duration_title": "Duración no válida",
         "invalid_duration": "Usa formatos como `7d`, `24h`, `30m`, o déjalo vacío para permanente.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -784,6 +784,21 @@
         "case_id": "ID du cas",
         "sent_by": "Envoyé par [**{guild}**]({guild_url}) (`{guild_id}`)"
       },
+      "expiry_dm": {
+        "title": "Votre sanction a expiré",
+        "body": "La sanction enregistrée contre vous est arrivée à son terme.",
+        "ban_title": "Votre bannissement a expiré",
+        "ban_body": "Votre bannissement temporaire a été levé — vous pouvez rejoindre le serveur.",
+        "mute_title": "Votre exclusion temporaire a expiré",
+        "mute_body": "Votre exclusion temporaire est terminée — vous pouvez à nouveau parler sur le serveur.",
+        "warn_title": "Votre avertissement a expiré",
+        "warn_body": "Votre avertissement a expiré et ne compte plus contre vous.",
+        "expired_at": "Expirée",
+        "case_id": "Numéro de dossier",
+        "rejoin": "Rejoindre le serveur",
+        "invite_note": "Cette invitation est à usage unique et expire dans 7 jours.",
+        "sent_by": "Envoyé par [**{guild}**]({guild_url}) (`{guild_id}`)"
+      },
       "errors": {
         "invalid_duration_title": "Durée invalide",
         "invalid_duration": "Utilise des formats comme `7d`, `24h`, `30m`, ou laisse vide pour permanent.",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -785,6 +785,21 @@
         "case_id": "ID do Caso",
         "sent_by": "Enviado por [**{guild}**]({guild_url}) (`{guild_id}`)"
       },
+      "expiry_dm": {
+        "title": "Sua sanção expirou",
+        "body": "A sanção registrada contra você chegou ao fim.",
+        "ban_title": "Seu banimento expirou",
+        "ban_body": "Seu banimento temporário foi removido — você pode entrar no servidor novamente.",
+        "mute_title": "Seu castigo expirou",
+        "mute_body": "Seu castigo terminou — você pode falar no servidor novamente.",
+        "warn_title": "Seu aviso expirou",
+        "warn_body": "Seu aviso expirou e não conta mais contra você.",
+        "expired_at": "Expirou",
+        "case_id": "N.º do caso",
+        "rejoin": "Entrar no servidor",
+        "invite_note": "Este convite é de uso único e expira em 7 dias.",
+        "sent_by": "Enviado por [**{guild}**]({guild_url}) (`{guild_id}`)"
+      },
       "errors": {
         "invalid_duration_title": "Duração Inválida",
         "invalid_duration": "Use formatos como `7d`, `24h`, `30m`, ou deixe em branco para permanente.",

--- a/services/appeal_service.py
+++ b/services/appeal_service.py
@@ -216,23 +216,11 @@ class AppealService:
             pass
 
     async def _make_invite(self, guild: discord.Guild) -> Optional[str]:
-        me = guild.me
-        candidates = [guild.rules_channel, guild.system_channel]
-        candidates += [c for c in guild.text_channels]
-        for ch in candidates:
-            if ch is None:
-                continue
-            try:
-                if not ch.permissions_for(me).create_instant_invite:
-                    continue
-                invite = await ch.create_invite(
-                    max_age=86400, max_uses=1, unique=True,
-                    reason="[Automod] appeal review — reviewer investigation",
-                )
-                return invite.url
-            except (discord.Forbidden, discord.HTTPException):
-                continue
-        return None
+        from utils.invites import create_guild_invite
+
+        return await create_guild_invite(
+            guild, reason="[Automod] appeal review — reviewer investigation",
+        )
 
     async def _rerender_pending_panel(self, interaction: discord.Interaction, appeal: dict):
         """Rebuild the (still-pending) reviewer panel in place after a claim."""

--- a/services/expiration_notifier.py
+++ b/services/expiration_notifier.py
@@ -1,0 +1,156 @@
+"""
+Sanction expiration handling — reverse the Discord action, then tell the subject.
+
+``bot.case_expiry`` flips due sanctions to ``expired`` in the database every two
+minutes; this service turns each of those rows into what the subject actually
+experiences:
+
+- **ban** (guild) — the Discord ban is lifted, then the member is DMed with a
+  fresh **invite** to the server, because an unban they cannot act on is
+  invisible to them.
+- **mute** (guild) — Discord clears the timeout on its own, so there is nothing
+  to reverse; the member is simply told the timeout is over.
+- **warn** (guild) — nothing to reverse either; the member is told the warning
+  no longer stands.
+- **global** (platform scope) — no Discord side and its own notice flow
+  (``services/global_sanction_service.py``); only the resolver cache is dropped.
+
+DM failures are never fatal: a closed DM, a member who left, a guild without
+invite permission — each degrades to "no notification" while the expiry itself
+stands.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, Optional
+
+import discord
+
+from utils import global_sanctions
+from utils.expiration_views import NOTIFIABLE_ACTIONS, build_expiration_dm_view
+from utils.invites import create_guild_invite
+
+logger = logging.getLogger('moddy.expiration_notifier')
+
+# Reason written to the Discord audit log when a temporary ban runs out.
+UNBAN_REASON = "[Moddy] temporary ban expired"
+
+# The invite handed to an unbanned member: long enough to be found in a DM they
+# may not read immediately, single-use so it cannot be passed around.
+INVITE_MAX_AGE = 7 * 86400  # 7 days
+INVITE_MAX_USES = 1
+
+
+class ExpirationNotifier:
+    """Applies the consequences of expired sanctions (``bot.expirations``)."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    # ------------------------------------------------------------------ entry
+    async def process(self, expired: Iterable[Dict[str, Any]]) -> int:
+        """Handle every expired sanction row. Returns the number of DMs sent."""
+        sent = 0
+        for row in expired or []:
+            try:
+                if await self.handle(row):
+                    sent += 1
+            except Exception as exc:  # never let one row break the sweep
+                logger.error("Error handling expired sanction: %s", exc, exc_info=True)
+        return sent
+
+    async def handle(self, row: Dict[str, Any]) -> bool:
+        """Handle one expired sanction. Returns whether the subject was DMed."""
+        # A temporary global sanction has no Discord side to reverse — it only
+        # has to stop applying (its own service owns the subject's notices).
+        if row.get("case_type") == "global":
+            subject_type = row.get("subject_type") or global_sanctions.SUBJECT_USER
+            global_sanctions.invalidate(self.bot, subject_type, row.get("subject_id"))
+            return False
+
+        action = row.get("action")
+        if row.get("case_type") != "guild" or action not in NOTIFIABLE_ACTIONS:
+            return False
+        if row.get("scope_type") != "discord_guild" or not row.get("scope_id"):
+            return False
+        # Only guild-scoped cases about a Discord user are notifiable.
+        if (row.get("subject_type") or "discord_user") != "discord_user":
+            return False
+
+        guild = self.bot.get_guild(int(row["scope_id"]))
+        if guild is None:
+            return False  # Moddy left the server — nothing it can say or do
+        try:
+            subject_id = int(row["subject_id"])
+        except (TypeError, ValueError):
+            return False
+
+        invite_url: Optional[str] = None
+        if action == "ban":
+            if not await self._lift_ban(guild, subject_id):
+                # The ban could not be lifted (missing permission, already
+                # gone): do not promise a way back that does not exist.
+                return False
+            invite_url = await create_guild_invite(
+                guild, reason=UNBAN_REASON,
+                max_age=INVITE_MAX_AGE, max_uses=INVITE_MAX_USES,
+            )
+
+        return await self._notify(guild, subject_id, row, invite_url)
+
+    # --------------------------------------------------------------- helpers
+    async def _lift_ban(self, guild: discord.Guild, subject_id: int) -> bool:
+        """Unban the subject. ``True`` when they are no longer banned."""
+        me = guild.me
+        if me is None or not me.guild_permissions.ban_members:
+            return False
+        try:
+            await guild.unban(discord.Object(id=subject_id), reason=UNBAN_REASON)
+            return True
+        except discord.NotFound:
+            # Already unbanned (manually, or by another Moddy path): the
+            # sanction is still over, so the member should still hear about it.
+            return True
+        except (discord.Forbidden, discord.HTTPException) as exc:
+            logger.warning(
+                "Could not lift expired ban of %s in guild %s: %s",
+                subject_id, guild.id, exc,
+            )
+            return False
+
+    async def _notify(self, guild: discord.Guild, subject_id: int,
+                      row: Dict[str, Any], invite_url: Optional[str]) -> bool:
+        """DM the subject that their sanction expired. Never raises."""
+        try:
+            user = self.bot.get_user(subject_id) or await self.bot.fetch_user(subject_id)
+        except discord.HTTPException:
+            return False
+        if user is None:
+            return False
+
+        view = build_expiration_dm_view(
+            locale=self.guild_locale(guild),
+            action=row.get("action"),
+            guild_name=guild.name,
+            guild_id=guild.id,
+            reference=row.get("reference"),
+            expired_at=row.get("expires_at"),
+            invite_url=invite_url,
+        )
+        try:
+            await user.send(view=view)
+            return True
+        except discord.Forbidden:
+            return False  # DMs closed — the case timeline still records it
+        except discord.HTTPException as exc:
+            logger.warning("Expiration DM to %s failed: %s", subject_id, exc)
+            return False
+
+    @staticmethod
+    def guild_locale(guild: Optional[discord.Guild]) -> str:
+        """The locale the guild's sanction DMs are written in."""
+        try:
+            return str(guild.preferred_locale) if guild and guild.preferred_locale else "en-US"
+        except Exception:
+            return "en-US"

--- a/tests/test_expiration_notifications.py
+++ b/tests/test_expiration_notifications.py
@@ -1,0 +1,277 @@
+"""Sanction expiration — Discord reversal + the DM the subject receives.
+
+Everything here is offline: Discord objects are duck-typed stubs, no gateway
+call and no database are involved.
+
+    pytest tests/test_expiration_notifications.py -q
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import discord
+import pytest
+from discord import ui
+
+from services.expiration_notifier import ExpirationNotifier
+from utils.expiration_views import build_expiration_dm_view
+from utils.invites import create_guild_invite
+
+
+# --------------------------------------------------------------------------- #
+# Stubs
+# --------------------------------------------------------------------------- #
+
+class FakeChannel:
+    def __init__(self, cid=1, can_invite=True, fails=False):
+        self.id = cid
+        self._can_invite = can_invite
+        self._fails = fails
+        self.invite_calls = []
+
+    def permissions_for(self, _me):
+        return SimpleNamespace(create_instant_invite=self._can_invite)
+
+    async def create_invite(self, **kwargs):
+        if self._fails:
+            raise discord.HTTPException(SimpleNamespace(status=403, reason=""), "nope")
+        self.invite_calls.append(kwargs)
+        return SimpleNamespace(url=f"https://discord.gg/inv{self.id}")
+
+
+class FakeGuild:
+    def __init__(self, gid=42, *, can_ban=True, channels=None, unban_error=None,
+                 preferred_locale="fr"):
+        self.id = gid
+        self.name = "Test Guild"
+        self.preferred_locale = preferred_locale
+        self.me = SimpleNamespace(guild_permissions=SimpleNamespace(ban_members=can_ban))
+        self.rules_channel = None
+        self.system_channel = None
+        self.text_channels = channels if channels is not None else [FakeChannel()]
+        self._unban_error = unban_error
+        self.unbanned = []
+
+    async def unban(self, obj, reason=None):
+        if self._unban_error is not None:
+            raise self._unban_error
+        self.unbanned.append((obj.id, reason))
+
+
+class FakeUser:
+    def __init__(self, uid=7, *, error=None):
+        self.id = uid
+        self._error = error
+        self.sent = []
+
+    async def send(self, **kwargs):
+        if self._error is not None:
+            raise self._error
+        self.sent.append(kwargs)
+
+
+class FakeBot:
+    def __init__(self, guild=None, user=None):
+        self._guild = guild
+        self._user = user
+
+    def get_guild(self, gid):
+        return self._guild if self._guild and self._guild.id == gid else None
+
+    def get_user(self, uid):
+        return self._user if self._user and self._user.id == uid else None
+
+    async def fetch_user(self, uid):
+        return self.get_user(uid)
+
+
+def row(action="ban", **over):
+    base = {
+        "action": action,
+        "case_type": "guild",
+        "reference": "A7F2K9",
+        "subject_type": "discord_user",
+        "subject_id": "7",
+        "scope_type": "discord_guild",
+        "scope_id": "42",
+        "expires_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+    }
+    base.update(over)
+    return base
+
+
+def rendered(view) -> str:
+    """Every bit of text the view renders, flattened."""
+    out = []
+
+    def walk(item):
+        if isinstance(item, ui.TextDisplay):
+            out.append(item.content)
+        for child in getattr(item, "children", []) or []:
+            walk(child)
+
+    for child in view.children:
+        walk(child)
+    return "\n".join(out)
+
+
+def buttons(view):
+    found = []
+
+    def walk(item):
+        if isinstance(item, ui.Button):
+            found.append(item)
+        for child in getattr(item, "children", []) or []:
+            walk(child)
+
+    for child in view.children:
+        walk(child)
+    return found
+
+
+# --------------------------------------------------------------------------- #
+# Invite helper
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_invite_uses_the_first_channel_moddy_may_invite_from():
+    blocked, ok = FakeChannel(1, can_invite=False), FakeChannel(2)
+    url = await create_guild_invite(FakeGuild(channels=[blocked, ok]), reason="r",
+                                    max_age=10, max_uses=1)
+    assert url == "https://discord.gg/inv2"
+    assert ok.invite_calls[0]["max_age"] == 10
+
+
+@pytest.mark.asyncio
+async def test_invite_returns_none_when_no_channel_works():
+    guild = FakeGuild(channels=[FakeChannel(1, can_invite=False), FakeChannel(2, fails=True)])
+    assert await create_guild_invite(guild, reason="r") is None
+
+
+@pytest.mark.asyncio
+async def test_invite_never_raises_without_a_guild():
+    assert await create_guild_invite(None, reason="r") is None
+
+
+# --------------------------------------------------------------------------- #
+# The DM view
+# --------------------------------------------------------------------------- #
+
+def test_expired_ban_dm_carries_the_invite_button():
+    view = build_expiration_dm_view(
+        locale="en-US", action="ban", guild_name="Test Guild", guild_id=42,
+        reference="A7F2K9", expired_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        invite_url="https://discord.gg/inv2",
+    )
+    link = [b for b in buttons(view) if b.style is discord.ButtonStyle.link]
+    assert [b.url for b in link] == ["https://discord.gg/inv2"]
+    text = rendered(view)
+    assert "A7F2K9" in text and "Test Guild" in text
+
+
+@pytest.mark.parametrize("action", ["mute", "warn"])
+def test_non_ban_expirations_get_no_invite(action):
+    view = build_expiration_dm_view(
+        locale="en-US", action=action, guild_name="Test Guild", guild_id=42,
+        reference="A7F2K9",
+    )
+    assert buttons(view) == []
+
+
+def test_unknown_action_falls_back_to_generic_wording():
+    view = build_expiration_dm_view(
+        locale="en-US", action="restrict", guild_name="G", guild_id=1,
+    )
+    text = rendered(view)
+    assert "[" not in text.split("\n")[0]  # no raw i18n key leaked as a title
+
+
+def test_the_dm_is_written_in_the_guild_locale():
+    fr = rendered(build_expiration_dm_view(
+        locale="fr", action="mute", guild_name="G", guild_id=1))
+    en = rendered(build_expiration_dm_view(
+        locale="en-US", action="mute", guild_name="G", guild_id=1))
+    assert fr != en
+
+
+# --------------------------------------------------------------------------- #
+# The notifier
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_expired_ban_is_lifted_then_the_member_is_dmed_with_an_invite():
+    guild, user = FakeGuild(), FakeUser()
+    notifier = ExpirationNotifier(FakeBot(guild, user))
+
+    assert await notifier.handle(row("ban")) is True
+    assert guild.unbanned and guild.unbanned[0][0] == 7
+    link = [b for b in buttons(user.sent[0]["view"]) if b.style is discord.ButtonStyle.link]
+    assert link and link[0].url.startswith("https://discord.gg/")
+
+
+@pytest.mark.asyncio
+async def test_expired_mute_dms_without_touching_the_ban_list():
+    guild, user = FakeGuild(), FakeUser()
+    notifier = ExpirationNotifier(FakeBot(guild, user))
+
+    assert await notifier.handle(row("mute")) is True
+    assert guild.unbanned == []
+    assert buttons(user.sent[0]["view"]) == []
+
+
+@pytest.mark.asyncio
+async def test_an_already_lifted_ban_still_notifies():
+    guild = FakeGuild(unban_error=discord.NotFound(SimpleNamespace(status=404, reason=""), "gone"))
+    user = FakeUser()
+    notifier = ExpirationNotifier(FakeBot(guild, user))
+
+    assert await notifier.handle(row("ban")) is True
+
+
+@pytest.mark.asyncio
+async def test_a_ban_that_cannot_be_lifted_promises_nothing():
+    guild, user = FakeGuild(can_ban=False), FakeUser()
+    notifier = ExpirationNotifier(FakeBot(guild, user))
+
+    assert await notifier.handle(row("ban")) is False
+    assert user.sent == []
+
+
+@pytest.mark.asyncio
+async def test_closed_dms_are_not_an_error():
+    guild = FakeGuild()
+    user = FakeUser(error=discord.Forbidden(SimpleNamespace(status=403, reason=""), "closed"))
+    notifier = ExpirationNotifier(FakeBot(guild, user))
+
+    assert await notifier.handle(row("mute")) is False
+
+
+@pytest.mark.asyncio
+async def test_a_guild_moddy_left_is_skipped():
+    notifier = ExpirationNotifier(FakeBot(None, FakeUser()))
+    assert await notifier.handle(row("ban")) is False
+
+
+@pytest.mark.asyncio
+async def test_global_sanctions_are_not_dmed_here():
+    guild, user = FakeGuild(), FakeUser()
+    notifier = ExpirationNotifier(FakeBot(guild, user))
+
+    assert await notifier.handle(row("ban", case_type="global",
+                                     scope_type="platform", scope_id=None)) is False
+    assert user.sent == []
+
+
+@pytest.mark.asyncio
+async def test_process_survives_a_failing_row_and_counts_the_dms():
+    guild, user = FakeGuild(), FakeUser()
+    notifier = ExpirationNotifier(FakeBot(guild, user))
+
+    sent = await notifier.process([
+        row("mute"),
+        row("mute", subject_id="not-an-id"),
+        row("warn"),
+    ])
+    assert sent == 2

--- a/utils/expiration_views.py
+++ b/utils/expiration_views.py
@@ -1,0 +1,110 @@
+"""
+Sanction expiration DM (Components V2).
+
+When a temporary sanction reaches its ``expires_at``, ``bot.case_expiry`` flips
+it to ``expired`` and :class:`services.expiration_notifier.ExpirationNotifier`
+tells the subject about it: the timeout is over, the warning no longer counts,
+the ban has been lifted.
+
+The panel mirrors the sanction DM (``cogs/moderation_commands._send_sanction_dm``)
+so the "good news" message is visually the sibling of the one that announced the
+sanction — same layout, same case link, same ``sent by`` footer — only in green.
+An expired **ban** additionally carries a *Rejoin the server* link button, since
+being unbanned is worthless without a way back in.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseView
+from utils import emojis
+from utils.i18n import t
+
+# Same public case URL as the sanction DM.
+CASE_URL = "https://moddy.app/cases?{ref}"
+
+# Green — an expiration is always good news for the subject.
+EXPIRY_ACCENT = 0x57F287
+
+# Sanction → title icon. The lift, not the sanction, so a check for the
+# reversible ones and the sanction's own icon otherwise.
+_EXPIRY_EMOJIS = {
+    "ban": emojis.LEGAL,
+    "mute": emojis.MIC_OFF,
+    "warn": emojis.WARNING,
+}
+
+#: Actions the subject is notified about when they expire.
+NOTIFIABLE_ACTIONS = ("ban", "mute", "warn")
+
+
+def _key(action: str, suffix: str) -> str:
+    return f"commands.moderation.expiry_dm.{action}_{suffix}"
+
+
+def build_expiration_dm_view(
+    *,
+    locale: str,
+    action: str,
+    guild_name: str,
+    guild_id: int,
+    reference: Optional[str] = None,
+    expired_at=None,
+    invite_url: Optional[str] = None,
+) -> BaseView:
+    """The DM a subject receives when one of their sanctions expires.
+
+    ``invite_url`` is only ever passed for an expired **ban** — the other
+    actions never removed the member from the server.
+    """
+    icon = _EXPIRY_EMOJIS.get(action, emojis.DONE)
+    guild_url = f"https://discord.com/channels/{guild_id}"
+
+    title = t(_key(action, "title"), locale=locale)
+    if title.startswith("["):  # unknown action → generic wording
+        title = t("commands.moderation.expiry_dm.title", locale=locale)
+    body = t(_key(action, "body"), locale=locale)
+    if body.startswith("["):
+        body = t("commands.moderation.expiry_dm.body", locale=locale)
+
+    lines = [f"### {icon} {title}", body]
+    if expired_at is not None:
+        lines.append(
+            f"> **{t('commands.moderation.expiry_dm.expired_at', locale=locale)}:** "
+            f"<t:{int(expired_at.timestamp())}:R>"
+        )
+    if reference:
+        lines.append(
+            f"> **{t('commands.moderation.expiry_dm.case_id', locale=locale)}:**"
+            f" [``{reference}``](<{CASE_URL.format(ref=reference)}>)"
+        )
+    lines.append(
+        f"-# {t('commands.moderation.expiry_dm.sent_by', locale=locale, guild=guild_name, guild_id=guild_id, guild_url=guild_url)}"
+    )
+
+    view = BaseView()
+    container = ui.Container(
+        ui.TextDisplay("\n".join(lines)),
+        accent_colour=discord.Colour(EXPIRY_ACCENT),
+    )
+    view.add_item(container)
+
+    # Link buttons carry no custom_id and trigger no interaction, so the view
+    # stays valid forever without being registered as persistent.
+    if invite_url:
+        row = ui.ActionRow()
+        row.add_item(ui.Button(
+            style=discord.ButtonStyle.link,
+            label=t("commands.moderation.expiry_dm.rejoin", locale=locale)[:80],
+            url=invite_url,
+        ))
+        container.add_item(row)
+        container.add_item(ui.TextDisplay(
+            f"-# {t('commands.moderation.expiry_dm.invite_note', locale=locale)}"
+        ))
+
+    return view

--- a/utils/invites.py
+++ b/utils/invites.py
@@ -1,0 +1,60 @@
+"""
+Shared invite creation.
+
+Several flows need to hand someone a working invite to a guild Moddy is in:
+an appeal reviewer investigating a case, a member whose temporary ban just
+expired… They all need the same thing — the first channel where Moddy may
+actually create an invite — so the lookup lives here instead of being
+re-implemented per feature.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import discord
+
+logger = logging.getLogger('moddy.invites')
+
+# Defaults for a reviewer-style, single-use invite.
+DEFAULT_MAX_AGE = 86400   # 24 h
+DEFAULT_MAX_USES = 1
+
+
+async def create_guild_invite(
+    guild: Optional[discord.Guild],
+    *,
+    reason: str,
+    max_age: int = DEFAULT_MAX_AGE,
+    max_uses: int = DEFAULT_MAX_USES,
+) -> Optional[str]:
+    """Return an invite URL for ``guild``, or ``None`` when none can be made.
+
+    Tries the rules channel first, then the system channel, then any text
+    channel — the first one where Moddy holds *Create Invite* wins. Never
+    raises: a guild where the bot cannot invite simply yields ``None``.
+    """
+    if guild is None:
+        return None
+    me = guild.me
+    if me is None:
+        return None
+
+    candidates = [guild.rules_channel, guild.system_channel]
+    candidates += list(guild.text_channels)
+    seen: set[int] = set()
+    for channel in candidates:
+        if channel is None or channel.id in seen:
+            continue
+        seen.add(channel.id)
+        try:
+            if not channel.permissions_for(me).create_instant_invite:
+                continue
+            invite = await channel.create_invite(
+                max_age=max_age, max_uses=max_uses, unique=True, reason=reason,
+            )
+            return invite.url
+        except (discord.Forbidden, discord.HTTPException):
+            continue
+    return None


### PR DESCRIPTION
## Summary

Members whose temporary sanctions expired were never notified—the database row flipped to `expired`, temporary bans were silently lifted, and that was it. This change sends subjects a DM when their guild sanctions expire, with action-specific messaging and a rejoin invite for unbanned members.

## Changes

- **New service: `services/expiration_notifier.py`** — `ExpirationNotifier` class that processes expired sanction rows from the database:
  - Lifts expired bans via `guild.unban()` (with graceful handling of already-unbanned cases)
  - Sends localized DMs to the subject with action-specific messaging
  - Attaches a single-use, 7-day invite link only for expired bans (other actions never removed the member)
  - Absorbs the inline unban loop that previously lived in `bot.py`

- **New view builder: `utils/expiration_views.py`** — `build_expiration_dm_view()` creates the expiration notification card:
  - Green accent (good news for the subject)
  - Mirrors the sanction DM layout (same case link, `sent by` footer)
  - Includes case reference, expiration timestamp, and action-specific title/body
  - Link-only button (no `custom_id`, no persistent view registration needed)

- **New invite helper: `utils/invites.py`** — `create_guild_invite()` shared utility:
  - Finds the first channel where Moddy can create an invite (rules → system → any text channel)
  - Extracted from appeal service's `_make_invite()` for reuse
  - Never raises; returns `None` if no suitable channel exists

- **Integration in `bot.py`**:
  - Instantiates `ExpirationNotifier` as `self.expirations`
  - `case_expiry()` task now hands expired rows to the notifier after database updates

- **Database: `db/repositories/moderation.py`**:
  - `expire_due_sanctions()` now returns `reference` and `expires_at` fields (needed for DM rendering)

- **Localization**: Added `commands.moderation.expiry_dm.*` keys to all 5 locale files (en-US, fr, es-ES, pt-BR, de)

- **Tests: `tests/test_expiration_notifications.py`** — 16 offline tests covering:
  - Invite creation logic (channel selection, fallback)
  - DM view rendering (action-specific text, locale switching, button presence)
  - Notifier behavior (ban lifting, mute/warn handling, error resilience)
  - Edge cases (missing guild, closed DMs, permission failures, global sanctions)

## Implementation Details

- **Failure resilience**: Closed DMs, missing guilds, permission errors, and already-unbanned members all degrade gracefully to "no notification" without breaking the expiry sweep
- **Locale-aware**: DMs are written in the guild's `preferred_locale`, matching the sanction DM behavior
- **No persistent view overhead**: The expiration card uses only link buttons, which carry no `custom_id` and require no registration
- **Global sanctions excluded**: Platform-scoped sanctions keep their own notice flow; only guild-scoped cases are handled here

## Related Documentation

- `docs/MODERATION_CASES.md` §7bis — expiration notification flow
- `docs/PERSISTENT_VIEWS.md` — link-only view exclusion rationale
- `CLAUDE.md` — updated file structure

https://claude.ai/code/session_01M4Sp6dvVJ4MXv983vK1oT5