### PR TITLE
Add the advanced server logs system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ moddy/
 │   ├── text_tools.py          #   /fix, /rephrase, /summarize (OpenAI, Modal V2 + context menus)
 │   ├── voice_transcription.py #   "Transcribe" context menu (Groq Whisper)
 │   ├── webhook.py             #   Webhook management
+│   ├── logs.py                #   Advanced server logs — Discord wiring only
 │   ├── social_notifications.py #  Social notifications dispatch + feeds service wiring
 │   ├── altguard.py            #   AltGuard verdicts, membership events, /altguard verify|unverify
 │   ├── interserver_commands.py #  Inter-server commands
@@ -76,6 +77,7 @@ moddy/
 │   ├── automod_ai.py          #   Automod AI (applies decisions, cases+evidence, scalable features)
 │   ├── bot_customization.py   #   Bot identity per guild (nick/avatar/banner/bio + name style)
 │   ├── voice_transcription.py #   Voice message transcription (button or automatic)
+│   ├── logs.py                #   Advanced server logs (config + routing, 163 events)
 │   └── configs/               #   Components V2 config UIs per module
 │       ├── adaptive_slowmode_config.py
 │       ├── altguard_config.py             # AltGuard gate (channel, roles, logs, language)
@@ -86,6 +88,18 @@ moddy/
 │       ├── welcome_dm_config.py           # Welcome DMs list + add/manage (Modal V2)
 │       ├── voice_transcription_config.py  # Voice transcription (status, mode, channels)
 │       ├── bot_customization_config.py    # Bot customization (identity Modal V2 + name style)
+│       ├── logs_config.py                 # Server logs (categories, events, options)
+│
+├── serverlogs/                # Advanced server logs (the log messages themselves)
+│   ├── registry.py            #   Single catalogue of categories + events (source of truth)
+│   ├── renderer.py            #   The only place deciding what a log looks like + formatters
+│   ├── dispatcher.py          #   Per-channel webhooks, 10-embed batching, bounded queues
+│   ├── audit.py               #   Gateway-fed audit-log cache ("who did this", no REST call)
+│   ├── service.py             #   Listener API: open() / submit() / executor()
+│   └── listeners/             #   One builder module per category + _diff.py (before/after)
+│                              #   members, messages, channels, roles, guild, threads, voice,
+│                              #   invites, assets, scheduled_events, stage, polls,
+│                              #   integrations, automod, moderation
 │
 ├── automod/                   # Automod AI DETECTION pipeline (decides only; no side effects)
 │   ├── engine.py              #   Shared per-bot orchestrator (funnel entry)
@@ -221,7 +235,9 @@ moddy/
     ├── test_bot_customization.py  # Bot customization validation (bio budget, styles)
     ├── test_expiration_notifications.py # Expired sanctions: unban, invite, DM card
     ├── test_task_signature.py #   moddy:tasks HMAC contract (canonicalization, replay, dedup)
-    └── test_transcription.py  #   Voice transcription helpers, guard rails, cards
+    ├── test_transcription.py  #   Voice transcription helpers, guard rails, cards
+    ├── test_logs.py           #   Server logs: registry, routing, rendering, delivery
+    └── test_logs_i18n.py      #   Server logs: i18n completeness on the 5 locales
 ```
 
 ---
@@ -384,6 +400,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/BOT_CUSTOMIZATION.md](docs/BOT_CUSTOMIZATION.md) | Bot Customization — per-guild nickname/avatar/banner/bio + name styles, Redis dashboard contract |
 | [docs/PREMIUM.md](docs/PREMIUM.md) | **Premium gating** — how to check whether a server (or a user) is premium |
 | [docs/STAFF_SYSTEM.md](docs/STAFF_SYSTEM.md) | Staff/dev commands, permissions, roles |
+| [docs/LOGS.md](docs/LOGS.md) | **Advanced server logs** — 163 events, registry, rendering, webhook delivery, stored config & dashboard contract |
 | [docs/MODERATION_CASES.md](docs/MODERATION_CASES.md) | Moderation cases/sanctions, the case service & sources, auto-sync |
 | [docs/GLOBAL_SANCTIONS.md](docs/GLOBAL_SANCTIONS.md) | **Global sanctions** — Moddy-team warn / limited / suspended, on users *and* servers |
 | [docs/TECHNICAL_LOGS.md](docs/TECHNICAL_LOGS.md) | Internal technical staff logs (webhook-based, per-event channels) |

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -265,6 +265,14 @@ class ConfigMainView(BaseView):
                 locale,
                 module_config
             )
+        elif module_id == 'logs':
+            from modules.configs.logs_config import LogsConfigView
+            config_view = await LogsConfigView.create(
+                bot,
+                guild_id,
+                user_id,
+                locale
+            )
         elif module_id == 'automod_ai':
             from modules.configs.automod_ai_config import AutomodAIConfigView
             config_view = AutomodAIConfigView(

--- a/cogs/logs.py
+++ b/cogs/logs.py
@@ -1,0 +1,435 @@
+"""Advanced server logs — Discord wiring.
+
+This cog is deliberately dumb: it owns the ``@commands.Cog.listener()``
+methods and forwards each one to a builder in :mod:`serverlogs.listeners`.
+Nothing here decides what a log says, where it goes or what it looks like —
+that lives in ``serverlogs/`` (see ``docs/LOGS.md``).
+
+Keeping the wiring separate is what makes the system editable: adding a
+field to a log means touching one small builder, and adding an event means
+touching the registry plus one builder — never this file's plumbing.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import List
+
+import discord
+from discord.ext import commands
+
+from serverlogs.listeners import (
+    automod as automod_listener,
+    assets as assets_listener,
+    channels as channels_listener,
+    guild as guild_listener,
+    integrations as integrations_listener,
+    invites as invites_listener,
+    members as members_listener,
+    messages as messages_listener,
+    polls as polls_listener,
+    roles as roles_listener,
+    scheduled_events as events_listener,
+    stage as stage_listener,
+    threads as threads_listener,
+    voice as voice_listener,
+)
+from serverlogs.service import LogService
+
+logger = logging.getLogger('moddy.cogs.logs')
+
+#: Discord invite links posted in a message (invites.invite_post).
+_INVITE_RE = re.compile(
+    r"(?:https?://)?(?:www\.)?(?:discord(?:app)?\.com/invite|discord\.gg|discord\.me)/"
+    r"([a-zA-Z0-9\-_]{2,32})",
+    re.IGNORECASE,
+)
+
+#: Audit-log action id for a voice channel status change. Discord ships no
+#: gateway event for it and discord.py has no enum member, so it is matched
+#: on the raw value — harmless if Discord ever removes it.
+_VOICE_STATUS_ACTION = 192
+
+
+class ServerLogs(commands.Cog):
+    """Forwards Discord events to the server-logs builders."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.service = LogService(bot)
+
+    async def cog_unload(self) -> None:
+        await self.service.close()
+
+    # ------------------------------------------------------------------ #
+    # Audit log — the source of "who did it" for every other listener
+    # ------------------------------------------------------------------ #
+
+    @commands.Cog.listener()
+    async def on_audit_log_entry_create(self, entry: discord.AuditLogEntry):
+        # Cache first: another listener may already be waiting on this entry.
+        self.service.audit.add(entry)
+
+        guild = entry.guild
+        if guild is None:
+            return
+
+        action = entry.action
+        try:
+            if action is discord.AuditLogAction.member_prune:
+                await members_listener.on_member_prune(self.service, guild, entry)
+            elif action is discord.AuditLogAction.member_move:
+                await voice_listener.on_voice_move(self.service, guild, entry)
+            elif action is discord.AuditLogAction.member_disconnect:
+                await voice_listener.on_voice_kick(self.service, guild, entry)
+            elif action in (discord.AuditLogAction.webhook_create,
+                            discord.AuditLogAction.webhook_update,
+                            discord.AuditLogAction.webhook_delete):
+                await integrations_listener.on_webhook_audit(self.service, guild, entry)
+            elif action in (discord.AuditLogAction.bot_add,
+                            discord.AuditLogAction.integration_create):
+                await integrations_listener.on_app_audit(self.service, guild, entry, "app_add")
+            elif action is discord.AuditLogAction.integration_delete:
+                await integrations_listener.on_app_audit(self.service, guild, entry, "app_remove")
+            elif action is discord.AuditLogAction.automod_rule_update:
+                await automod_listener.on_automod_rule_audit(self.service, guild, entry)
+            elif action is discord.AuditLogAction.onboarding_update:
+                await guild_listener.on_onboarding_update(self.service, guild, entry)
+            elif action is discord.AuditLogAction.onboarding_prompt_create:
+                await guild_listener.on_onboarding_prompt(
+                    self.service, guild, entry, "onboarding_question_add")
+            elif action is discord.AuditLogAction.onboarding_prompt_delete:
+                await guild_listener.on_onboarding_prompt(
+                    self.service, guild, entry, "onboarding_question_remove")
+            elif action is discord.AuditLogAction.onboarding_prompt_update:
+                await guild_listener.on_onboarding_prompt(
+                    self.service, guild, entry, "onboarding_question_update")
+            elif getattr(action, "value", None) == _VOICE_STATUS_ACTION:
+                await channels_listener.on_voice_status_update(self.service, guild, entry)
+        except Exception as e:
+            _report(f"audit entry {action}", e)
+
+    # ------------------------------------------------------------------ #
+    # Members
+    # ------------------------------------------------------------------ #
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member: discord.Member):
+        await _safe(members_listener.on_member_join(self.service, member), "member_join")
+
+    @commands.Cog.listener()
+    async def on_member_remove(self, member: discord.Member):
+        await _safe(members_listener.on_member_remove(self.service, member), "member_remove")
+
+    @commands.Cog.listener()
+    async def on_member_ban(self, guild: discord.Guild, user: discord.abc.User):
+        await _safe(members_listener.on_member_ban(self.service, guild, user), "member_ban")
+
+    @commands.Cog.listener()
+    async def on_member_unban(self, guild: discord.Guild, user: discord.abc.User):
+        await _safe(members_listener.on_member_unban(self.service, guild, user), "member_unban")
+
+    @commands.Cog.listener()
+    async def on_member_update(self, before: discord.Member, after: discord.Member):
+        await _safe(members_listener.on_member_update(self.service, before, after),
+                    "member_update")
+
+    @commands.Cog.listener()
+    async def on_user_update(self, before: discord.User, after: discord.User):
+        shared = [g for g in self.bot.guilds if g.get_member(after.id) is not None]
+        if not shared:
+            return
+        await _safe(members_listener.on_user_update(self.service, shared, before, after),
+                    "user_update")
+
+    # ------------------------------------------------------------------ #
+    # Messages
+    # ------------------------------------------------------------------ #
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.guild is None or message.author.id == self.bot.user.id:
+            return
+
+        codes = _INVITE_RE.findall(message.content or "")
+        if codes:
+            await _safe(invites_listener.on_invite_post(self.service, message, codes),
+                        "invite_post")
+
+        if message.poll is not None:
+            await _safe(polls_listener.on_poll_create(self.service, message), "poll_create")
+
+    @commands.Cog.listener()
+    async def on_message_delete(self, message: discord.Message):
+        if message.guild is None:
+            return
+        await _safe(messages_listener.on_message_delete(self.service, message),
+                    "message_delete")
+        if message.poll is not None:
+            await _safe(polls_listener.on_poll_delete(self.service, message), "poll_delete")
+
+    @commands.Cog.listener()
+    async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent):
+        # The cached path above already logged it, with its content.
+        if payload.cached_message is not None or payload.guild_id is None:
+            return
+        guild = self.bot.get_guild(payload.guild_id)
+        if guild is None:
+            return
+        await _safe(messages_listener.on_raw_message_delete(self.service, guild, payload),
+                    "raw_message_delete")
+
+    @commands.Cog.listener()
+    async def on_bulk_message_delete(self, messages: List[discord.Message]):
+        await _safe(messages_listener.on_bulk_message_delete(self.service, messages),
+                    "bulk_message_delete")
+
+    @commands.Cog.listener()
+    async def on_raw_bulk_message_delete(self, payload: discord.RawBulkMessageDeleteEvent):
+        if payload.guild_id is None:
+            return
+        guild = self.bot.get_guild(payload.guild_id)
+        if guild is None:
+            return
+        await _safe(
+            messages_listener.on_raw_bulk_message_delete(self.service, guild, payload),
+            "raw_bulk_message_delete")
+
+    @commands.Cog.listener()
+    async def on_message_edit(self, before: discord.Message, after: discord.Message):
+        if after.guild is None:
+            return
+
+        if before.content != after.content:
+            await _safe(messages_listener.on_message_edit(self.service, before, after),
+                        "message_edit")
+
+        # A crosspost is delivered as an edit setting the CROSSPOSTED flag.
+        if not before.flags.crossposted and after.flags.crossposted:
+            await _safe(messages_listener.on_message_publish(self.service, after),
+                        "message_publish")
+
+        if _poll_just_finalised(before, after):
+            await _safe(polls_listener.on_poll_finalize(self.service, after),
+                        "poll_finalize")
+
+    @commands.Cog.listener()
+    async def on_app_command_completion(self, interaction: discord.Interaction, command):
+        await _safe(messages_listener.on_command_used(self.service, interaction),
+                    "command_used")
+
+    # ------------------------------------------------------------------ #
+    # Channels and threads
+    # ------------------------------------------------------------------ #
+
+    @commands.Cog.listener()
+    async def on_guild_channel_create(self, channel: discord.abc.GuildChannel):
+        await _safe(channels_listener.on_channel_create(self.service, channel),
+                    "channel_create")
+
+    @commands.Cog.listener()
+    async def on_guild_channel_delete(self, channel: discord.abc.GuildChannel):
+        await _safe(channels_listener.on_channel_delete(self.service, channel),
+                    "channel_delete")
+
+    @commands.Cog.listener()
+    async def on_guild_channel_update(self, before: discord.abc.GuildChannel,
+                                      after: discord.abc.GuildChannel):
+        await _safe(channels_listener.on_channel_update(self.service, before, after),
+                    "channel_update")
+
+    @commands.Cog.listener()
+    async def on_guild_channel_pins_update(self, channel, last_pin):
+        await _safe(channels_listener.on_channel_pins_update(self.service, channel, last_pin),
+                    "channel_pins_update")
+
+    @commands.Cog.listener()
+    async def on_thread_create(self, thread: discord.Thread):
+        await _safe(threads_listener.on_thread_create(self.service, thread), "thread_create")
+
+    @commands.Cog.listener()
+    async def on_thread_delete(self, thread: discord.Thread):
+        await _safe(threads_listener.on_thread_delete(self.service, thread), "thread_delete")
+
+    @commands.Cog.listener()
+    async def on_thread_update(self, before: discord.Thread, after: discord.Thread):
+        await _safe(threads_listener.on_thread_update(self.service, before, after),
+                    "thread_update")
+
+    # ------------------------------------------------------------------ #
+    # Roles, server, voice
+    # ------------------------------------------------------------------ #
+
+    @commands.Cog.listener()
+    async def on_guild_role_create(self, role: discord.Role):
+        await _safe(roles_listener.on_role_create(self.service, role), "role_create")
+
+    @commands.Cog.listener()
+    async def on_guild_role_delete(self, role: discord.Role):
+        await _safe(roles_listener.on_role_delete(self.service, role), "role_delete")
+
+    @commands.Cog.listener()
+    async def on_guild_role_update(self, before: discord.Role, after: discord.Role):
+        await _safe(roles_listener.on_role_update(self.service, before, after), "role_update")
+
+    @commands.Cog.listener()
+    async def on_guild_update(self, before: discord.Guild, after: discord.Guild):
+        await _safe(guild_listener.on_guild_update(self.service, before, after),
+                    "guild_update")
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(self, member: discord.Member,
+                                    before: discord.VoiceState,
+                                    after: discord.VoiceState):
+        await _safe(voice_listener.on_voice_state_update(self.service, member, before, after),
+                    "voice_state_update")
+
+    # ------------------------------------------------------------------ #
+    # Invites, emojis, stickers, sounds
+    # ------------------------------------------------------------------ #
+
+    @commands.Cog.listener()
+    async def on_invite_create(self, invite: discord.Invite):
+        await _safe(invites_listener.on_invite_create(self.service, invite), "invite_create")
+
+    @commands.Cog.listener()
+    async def on_invite_delete(self, invite: discord.Invite):
+        await _safe(invites_listener.on_invite_delete(self.service, invite), "invite_delete")
+
+    @commands.Cog.listener()
+    async def on_guild_emojis_update(self, guild: discord.Guild, before, after):
+        await _safe(assets_listener.on_emojis_update(self.service, guild, before, after),
+                    "emojis_update")
+
+    @commands.Cog.listener()
+    async def on_guild_stickers_update(self, guild: discord.Guild, before, after):
+        await _safe(assets_listener.on_stickers_update(self.service, guild, before, after),
+                    "stickers_update")
+
+    @commands.Cog.listener()
+    async def on_soundboard_sound_create(self, sound):
+        await _safe(assets_listener.on_soundboard_sound_create(self.service, sound),
+                    "sound_create")
+
+    @commands.Cog.listener()
+    async def on_soundboard_sound_delete(self, sound):
+        await _safe(assets_listener.on_soundboard_sound_delete(self.service, sound),
+                    "sound_delete")
+
+    @commands.Cog.listener()
+    async def on_soundboard_sound_update(self, before, after):
+        await _safe(assets_listener.on_soundboard_sound_update(self.service, before, after),
+                    "sound_update")
+
+    # ------------------------------------------------------------------ #
+    # Scheduled events, stages, polls
+    # ------------------------------------------------------------------ #
+
+    @commands.Cog.listener()
+    async def on_scheduled_event_create(self, event):
+        await _safe(events_listener.on_event_create(self.service, event), "event_create")
+
+    @commands.Cog.listener()
+    async def on_scheduled_event_delete(self, event):
+        await _safe(events_listener.on_event_delete(self.service, event), "event_delete")
+
+    @commands.Cog.listener()
+    async def on_scheduled_event_update(self, before, after):
+        await _safe(events_listener.on_event_update(self.service, before, after),
+                    "event_update")
+
+    @commands.Cog.listener()
+    async def on_scheduled_event_user_add(self, event, user):
+        await _safe(events_listener.on_event_user_add(self.service, event, user),
+                    "event_user_add")
+
+    @commands.Cog.listener()
+    async def on_scheduled_event_user_remove(self, event, user):
+        await _safe(events_listener.on_event_user_remove(self.service, event, user),
+                    "event_user_remove")
+
+    @commands.Cog.listener()
+    async def on_stage_instance_create(self, stage):
+        await _safe(stage_listener.on_stage_create(self.service, stage), "stage_create")
+
+    @commands.Cog.listener()
+    async def on_stage_instance_delete(self, stage):
+        await _safe(stage_listener.on_stage_delete(self.service, stage), "stage_delete")
+
+    @commands.Cog.listener()
+    async def on_stage_instance_update(self, before, after):
+        await _safe(stage_listener.on_stage_update(self.service, before, after),
+                    "stage_update")
+
+    @commands.Cog.listener()
+    async def on_raw_poll_vote_add(self, payload):
+        guild = self.bot.get_guild(payload.guild_id) if payload.guild_id else None
+        if guild is None:
+            return
+        await _safe(polls_listener.on_poll_vote(self.service, guild, payload, True),
+                    "poll_vote_add")
+
+    @commands.Cog.listener()
+    async def on_raw_poll_vote_remove(self, payload):
+        guild = self.bot.get_guild(payload.guild_id) if payload.guild_id else None
+        if guild is None:
+            return
+        await _safe(polls_listener.on_poll_vote(self.service, guild, payload, False),
+                    "poll_vote_remove")
+
+    # ------------------------------------------------------------------ #
+    # Discord AutoMod and applications
+    # ------------------------------------------------------------------ #
+
+    @commands.Cog.listener()
+    async def on_automod_rule_create(self, rule):
+        await _safe(automod_listener.on_automod_rule_create(self.service, rule),
+                    "automod_rule_create")
+
+    @commands.Cog.listener()
+    async def on_automod_rule_delete(self, rule):
+        await _safe(automod_listener.on_automod_rule_delete(self.service, rule),
+                    "automod_rule_delete")
+
+    @commands.Cog.listener()
+    async def on_automod_action(self, execution):
+        await _safe(automod_listener.on_automod_action(self.service, execution),
+                    "automod_action")
+
+    @commands.Cog.listener()
+    async def on_raw_app_command_permissions_update(self, payload):
+        guild = getattr(payload, "guild", None)
+        if guild is None:
+            return
+        await _safe(
+            integrations_listener.on_app_command_permissions_update(
+                self.service, guild, payload),
+            "app_command_permissions_update")
+
+
+def _poll_just_finalised(before: discord.Message, after: discord.Message) -> bool:
+    if after.poll is None:
+        return False
+    try:
+        if not after.poll.is_finalised():
+            return False
+        return before.poll is None or not before.poll.is_finalised()
+    except AttributeError:
+        return False
+
+
+async def _safe(coro, label: str) -> None:
+    """Run a builder; a broken log must never take a gateway handler down."""
+    try:
+        await coro
+    except Exception as e:
+        _report(label, e)
+
+
+def _report(label: str, error: Exception) -> None:
+    logger.error(f"[Logs] Listener {label} failed: {error}", exc_info=True)
+
+
+async def setup(bot):
+    await bot.add_cog(ServerLogs(bot))

--- a/docs/LOGS.md
+++ b/docs/LOGS.md
@@ -1,0 +1,416 @@
+# Advanced Server Logs
+
+> Records **163 events across 18 categories** into the server's own log
+> channels — who did what, to whom, and what changed.
+>
+> Read this before touching `serverlogs/`, `modules/logs.py`,
+> `modules/configs/logs_config.py` or `cogs/logs.py`.
+
+| | |
+|---|---|
+| Module id | `logs` |
+| Module (config + routing) | [modules/logs.py](../modules/logs.py) |
+| Config UI | [modules/configs/logs_config.py](../modules/configs/logs_config.py) |
+| Discord wiring | [cogs/logs.py](../cogs/logs.py) |
+| Event catalogue | [serverlogs/registry.py](../serverlogs/registry.py) |
+| Rendering | [serverlogs/renderer.py](../serverlogs/renderer.py) |
+| Delivery | [serverlogs/dispatcher.py](../serverlogs/dispatcher.py) |
+| Audit correlation | [serverlogs/audit.py](../serverlogs/audit.py) |
+| Listener API | [serverlogs/service.py](../serverlogs/service.py) |
+| Builders | [serverlogs/listeners/](../serverlogs/listeners/) |
+| Tests | [tests/test_logs.py](../tests/test_logs.py), [tests/test_logs_i18n.py](../tests/test_logs_i18n.py) |
+
+---
+
+## What a server sees
+
+One embed per event, in the channel the category is bound to:
+
+```
+┌──────────────────────────────────────────────┐
+│ Role(s) added to a user                      │  title       = i18n event title
+│ > **User:** @dyvion_ (<@120…>)               │  description = "> **Label:** value"
+│ > **Added:** <@&966…>                        │
+│ > **Reason:** Join Roles                     │
+│                                     [avatar] │  thumbnail   = the subject
+│ Moddy#0001                       26/07 13:12 │  footer      = executor + timestamp
+└──────────────────────────────────────────────┘
+```
+
+The accent colour states the nature of the event at a glance:
+
+| Kind | Colour | Meaning |
+|---|---|---|
+| `create` | green `0x57F287` | something appeared |
+| `delete` | red `0xED4245` | something disappeared |
+| `update` | blurple `0x5865F2` | something changed |
+| `moderation` | orange `0xF28500` | a moderator acted |
+
+The kind is **inferred** from the event name (`*_create` → create, `*_delete`
+→ delete, everything else → update), with a small override table in
+`registry._KIND_OVERRIDES` for the names that would infer wrong (`ban_add`
+is moderation, not a creation).
+
+> **Components V2 exception.** These messages use a classic
+> `discord.Embed`, not `ui.Container`. Logs are posted through a channel
+> **webhook**, and Discord rejects the `IS_COMPONENTS_V2` flag on a webhook
+> message that carries a classic embed. This is the same documented
+> exception `modules/starboard.py` relies on, and it is the only place in
+> the logs system where CLAUDE.md rule 1 does not apply. Everything else —
+> the `/config` panel and its modals — is Components V2 as usual.
+
+---
+
+## Architecture
+
+```
+Discord gateway ──▶ cogs/logs.py ──▶ serverlogs/listeners/<category>.py
+                     (wiring only)      (builds the entry)
+                          │                    │
+                          │                    ▼
+                          │            serverlogs/service.py
+                          │             open() → is it logged?  ─── modules/logs.py
+                          │             submit() → where to?         (config + routing)
+                          ▼                    │
+              serverlogs/audit.py              ▼
+              ("who did this")        serverlogs/renderer.py  →  serverlogs/dispatcher.py
+                                        (the one renderer)        (webhook, batching)
+```
+
+Each layer has exactly one job:
+
+* **`cogs/logs.py`** — `@commands.Cog.listener()` methods, nothing else. It
+  never decides what a log says. Adding a field to a log never touches it.
+* **`serverlogs/listeners/<category>.py`** — one builder per event: what
+  lines the log carries. `channels.py` is the reference for style.
+* **`serverlogs/registry.py`** — the catalogue. Categories, events, colour
+  kinds, i18n key names. Everything else reads it instead of hardcoding.
+* **`modules/logs.py`** — the stored configuration and the routing
+  (`channels_for(event)`).
+* **`serverlogs/renderer.py`** — the **only** place that decides what a log
+  looks like, plus the value formatters every listener must use.
+* **`serverlogs/dispatcher.py`** — webhooks, batching, back-pressure.
+* **`serverlogs/audit.py`** — a short-lived audit-log cache so a gateway
+  event can be attributed to a moderator without a single REST call.
+
+### The listener contract
+
+```python
+entry = await service.open(member.guild, "user_join", subject=member)
+if entry is None:                     # not logged, muted channel, ignored actor
+    return
+entry.line("account_created", fmt_time(member.created_at))
+entry.line("member_count", fmt_number(member.guild.member_count))
+await service.submit(member.guild, entry)
+```
+
+`open()` returns `None` immediately when the server does not log the event.
+On a server that logs nothing, every listener costs one dict lookup — that
+is what makes 163 events affordable.
+
+**Every value goes through a formatter** (`fmt_user`, `fmt_channel`,
+`fmt_role`, `fmt_time`, `fmt_duration`, `fmt_bool`, `fmt_number`,
+`fmt_permissions`, `escape`). Never build a user-facing value with a bare
+f-string: markdown in a nickname or a channel topic would otherwise break
+the layout of every log around it.
+
+---
+
+## Categories
+
+| Id | Name (en-US) | Events |
+|---|---|---|
+| `server` | Server | 35 |
+| `messages` | Messages | 5 |
+| `users` | Users | 7 |
+| `moderation` | Moderation | 17 |
+| `channels` | Channels | 21 |
+| `roles` | Roles | 8 |
+| `threads` | Threads | 9 |
+| `voice` | Voice | 6 |
+| `invites` | Invites | 3 |
+| `automod` | Discord AutoMod | 9 |
+| `emojis` | Emojis | 4 |
+| `stickers` | Stickers | 5 |
+| `soundboard` | Soundboard | 5 |
+| `events` | Events | 12 |
+| `stage` | Stage | 4 |
+| `polls` | Polls | 5 |
+| `webhooks` | Webhooks | 5 |
+| `applications` | Applications | 3 |
+
+A **category is the unit a channel is bound to** — you cannot send two
+events of the same category to two different channels. That is deliberate:
+163 individual routes would be unusable in a config panel.
+
+The same real-world occurrence can live in **two** categories: a ban is both
+`server.ban_add` and `moderation.ban_add`. They are two distinct keys with
+two distinct destinations, so a server can send bans to `#server-logs`, to
+`#mod-logs`, or to both. Listeners emit the **bare** event name (`ban_add`)
+and `LogsModule.channels_for()` fans it out to every category that declares
+it and has not excluded it.
+
+---
+
+## Configuration (`/config` → Logs)
+
+Three screens, **no save button** — every change applies immediately:
+
+| Screen | What it does |
+|---|---|
+| **Root** | One line per configured category, a picker to open one, a "send everything to one channel" shortcut, and a "clear everything" button |
+| **Category** | The channels this category posts to (up to `MAX_CHANNELS_PER_CATEGORY = 3`) and a paginated checklist of its events (25 per page) |
+| **Options** | Ignored channels, ignored roles, ignore bots, attach transcripts, log language |
+
+Applying on the spot is not a style choice: the category screen is built
+from `DynamicItem`s (they carry the category and the page in their
+`custom_id`), and a dynamic item is rebuilt from scratch on *every* click —
+there is no `self` on which to stage pending edits. See
+[docs/PERSISTENT_VIEWS.md](PERSISTENT_VIEWS.md).
+
+### Stored schema — `guilds.data.modules.logs`
+
+```jsonc
+{
+  "categories": {
+    "server":   { "channel_ids": ["123456789012345678"], "disabled_events": ["user_kick"] },
+    "messages": { "channel_ids": ["456789012345678901"], "disabled_events": [] }
+  },
+  "ignored_channel_ids": ["789012345678901234"],
+  "ignored_role_ids": [],
+  "ignore_bots": false,
+  "attach_transcripts": true,
+  "locale": "auto"
+}
+```
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `categories` | object | `{}` | Only categories the admin actually configured. Unknown category ids are dropped on load. |
+| `categories.<id>.channel_ids` | array of snowflake **strings** | `[]` | Destinations, max **3**. Extra entries are truncated. A category with no channel logs nothing. |
+| `categories.<id>.disabled_events` | array of bare event names | `[]` | **Exclusions only.** Anything not listed is enabled. Names unknown to the registry are dropped. |
+| `ignored_channel_ids` | array of snowflake strings | `[]` | Max **25**. Matches the channel, its parent category, and a thread's parent. |
+| `ignored_role_ids` | array of snowflake strings | `[]` | Max **25**. A member holding one of these roles is never the subject of a log. |
+| `ignore_bots` | bool | `false` | Skip events whose subject/actor is a bot. |
+| `attach_transcripts` | bool | `true` | Attach `.txt` transcripts and overflow files. When `false`, files are dropped and only the embed is sent. |
+| `locale` | `"auto"` \| `fr` \| `en-US` \| `es-ES` \| `pt-BR` \| `de` | `"auto"` | Language of the log messages. `"auto"` follows `guild.preferred_locale`, falling back to `en-US`. |
+
+Two conventions matter here:
+
+* **Snowflakes are strings** in stored JSON (project-wide convention).
+  `modules/logs.py::_int_list()` accepts both and coerces to `int`, so an
+  integer written by an older client still loads.
+* **Only exclusions are persisted.** An event added to the registry later
+  therefore starts **enabled** on every server that already had its category
+  bound — which is what an admin expects from "log this category".
+
+The module has **no separate on/off switch**: `enabled` is computed as "at
+least one category has a channel". Removing the last channel disables the
+module.
+
+### Backend / dashboard contract
+
+The dashboard writes `guilds.data.modules.logs` directly and notifies the
+bot over Redis (see
+[docs/BACKEND-INTEGRATION.md](BACKEND-INTEGRATION.md) and
+[docs/MODULE_SYSTEM.md](MODULE_SYSTEM.md)). Three things to know:
+
+1. **`on_external_config_change()` is deliberately not implemented.** That
+   hook exists for modules whose configuration is *visible* in Discord — a
+   panel message to re-post, channel overwrites to re-apply, an external
+   service to notify (`modules/altguard.py` is the example). The logs module
+   posts no panel and holds no Discord-side state: reloading the config is
+   the whole of the change. This is a decision, **not an oversight** — if
+   the logs module ever grows something visible (a "logging started" notice,
+   a pinned summary), the hook has to be added at the same time.
+2. **Validation is not run on the dashboard's behalf.**
+   `LogsModule.validate_config()` (every bound channel exists and the bot
+   can `view_channel` + `send_messages` + `embed_links` there) is what
+   `/config` enforces. A dashboard write that skips it stores a channel the
+   bot cannot post in; delivery then fails silently per channel and only
+   logs a warning bot-side. The dashboard should mirror the same three
+   permission checks before saving.
+3. **Changing a channel leaves the old webhook behind.** Moddy creates a
+   webhook named `Moddy Logs` in each destination channel on first delivery
+   (see below). If a channel is unbound — from `/config` or from the
+   dashboard — that webhook is **not** deleted: it simply stops being used.
+   It is inert (Moddy holds no reference to it after a restart, and it is
+   never reused for another channel), but it stays visible in the channel's
+   integration settings until someone removes it. Deleting it automatically
+   was rejected: the bot cannot tell its own leftover webhook from one an
+   admin has since repurposed, and deleting a webhook is not reversible.
+
+---
+
+## Delivery
+
+Logs fire hardest exactly when a server is in trouble — a raid, a mass ban,
+a purge. Posting them with `channel.send` would burn the bot's own
+rate-limit buckets and slow every other command down, so:
+
+* every log goes out through a **channel webhook** named `Moddy Logs`,
+  created on demand (requires `manage_webhooks`), with its own rate-limit
+  bucket;
+* up to **10 embeds per request**, batched over a **0.75 s** window, so a
+  burst of 200 deletions collapses into a handful of calls;
+* **one worker task and one bounded queue per destination channel**
+  (`QUEUE_MAXSIZE = 500`). When the queue is full the **oldest** pending
+  entry is dropped and counted — a flood degrades into "the most recent
+  events", never into unbounded memory. A warning is logged every 100 drops.
+* an idle worker exits after 30 s and is restarted by the next `enqueue`.
+
+**Fallbacks.** No `manage_webhooks` permission, webhook creation refused, or
+a webhook deleted behind Moddy's back → delivery falls back to a plain
+`channel.send`. A misconfigured server still gets its logs, just slower. The
+cached webhook is invalidated on `NotFound` / `HTTPException` so the next
+delivery re-resolves it.
+
+**Threads** have no webhook of their own: the parent channel's webhook is
+used with `thread=`.
+
+**Entries carrying files** (transcripts, overflowing message bodies) are
+sent on their own — attachments are per-message and cannot be batched.
+
+### Size limits
+
+Individual values are capped in the renderer (`MAX_DESCRIPTION = 4000`,
+`MAX_FIELD_VALUE = 1000`), and a block longer than a field allows is moved
+to a `.txt` attachment rather than silently cut. On top of that,
+`LogEntry._fit()` enforces `MAX_EMBED_TOTAL = 5800` on the **whole** embed:
+Discord rejects an over-budget message entirely, so a log with many fields
+(a permission diff over a dozen roles) would otherwise never arrive.
+Trailing fields are dropped first, the description is shortened only if that
+is not enough, and the reader is always told the log was shortened
+(`modules.logs.values.size_limit`).
+
+---
+
+## Audit-log correlation — "who did this"
+
+The gateway says *that* a role was deleted; only the audit log says *who*
+deleted it. A naive `guild.audit_logs(limit=1)` is unreliable (the audit
+entry and the gateway event race, either can arrive first) and expensive
+during a raid.
+
+So `cogs/logs.py` feeds every `on_audit_log_entry_create` into
+`serverlogs/audit.py` — free, it comes over the gateway — and a listener
+that needs an executor calls:
+
+```python
+executor, reason = await service.executor(
+    guild, discord.AuditLogAction.channel_delete, channel.id)
+```
+
+which looks the cache up, then waits **up to 2 s** for a matching entry to
+arrive, then gives up. **No REST call is ever made.** Cached entries live
+`CACHE_TTL = 20 s`, 60 per guild.
+
+A log whose executor could not be resolved is still sent, without a footer:
+"we know it happened" beats "we said nothing".
+
+---
+
+## Adding an event
+
+Three steps, nothing else:
+
+1. **Registry** — add the bare event name to its category in
+   `_CATALOGUE` (`serverlogs/registry.py`). Add a `_KIND_OVERRIDES` entry
+   only if the name would infer the wrong colour.
+2. **i18n** — add two keys **in all five locales**
+   (`fr`, `en-US`, `es-ES`, `pt-BR`, `de`):
+   * `modules.logs.events.<category>.<event>` — the short name in `/config`
+   * `modules.logs.titles.<category>.<event>` — the embed title
+3. **Builder** — emit it from a listener in `serverlogs/listeners/`, and
+   wire the gateway event in `cogs/logs.py` if it is a new one.
+
+The `/config` panel paginates itself, the stored config validates the new
+key away on old servers, and the event starts **enabled** everywhere its
+category is bound.
+
+`tests/test_logs_i18n.py` reads the listener sources: a new
+`entry.line("something")` or `modules.logs.values.<key>` fails the suite
+until it is translated in all five locales. That is the point — a missing
+key does not crash, it renders as `[modules.logs.…]` in a production log
+channel.
+
+## Changing what a log says
+
+* **Wording** — edit `locales/<locale>.json` under `modules.logs`. No Python.
+* **A field of one log** — edit that one builder in
+  `serverlogs/listeners/`.
+* **The look of every log** — `serverlogs/renderer.py`, and only there.
+
+---
+
+## Known gaps and deliberate choices
+
+### `moderation` events with no source yet
+
+Wired today: `warn_add/remove`, `mute_add/remove`, `ban_add/remove` (via
+`services/case_service.py::_log_to_server` → `serverlogs/listeners/moderation.py`),
+`kick_add` (Discord audit log), `auto_moderation` (Discord AutoMod).
+
+These are declared in the registry, served by
+`serverlogs/listeners/moderation.py::log_case_event(...)`, and **nothing
+calls them**:
+
+| Event | Why |
+|---|---|
+| `case_delete`, `mass_case_delete` | Moddy cannot delete a case — there is no `delete_case` in `db/repositories/moderation.py` |
+| `case_update` | Only reached today by the `restrict` / `revoke_access` sanctions; a reason edit or a manual status change is not mirrored yet |
+| `kick_remove` | A kick cannot be "lifted" |
+| `report_create`, `reports_ignore`, `reports_accept` | Moddy has no report system |
+| `user_note_add`, `user_note_remove` | Notes are recorded as case events, and the case service does not mirror them |
+
+They are declared on purpose so they light up the day the feature lands,
+without touching the logs system. The natural hook-ups are
+`db.add_event` (notes), `db.update_case_reason` and `db.set_status_manual`
+(`case_update`) — but from **`CaseService`**, not from the DB repository:
+`_log_to_server` is where the guild-scope check and the "a log never breaks
+the moderation action" guarantee live.
+
+### `channel_voice_status_update`
+
+Discord ships no gateway event for a voice-channel status change and
+discord.py has no enum member for it, so it is matched on the **raw audit
+action id `192`** (`cogs/logs.py::_VOICE_STATUS_ACTION`). This has not been
+confirmed against a live server: if the id is wrong or Discord removes the
+action, the event is simply never emitted — harmless, but the config panel
+would advertise a log that never fires.
+
+### Not validated live
+
+The system is covered by 59 unit tests but **has never run against a real
+Discord server**. Worth checking on a test guild before it reaches
+production: webhook creation and reuse, the `manage_webhooks` fallback,
+batching under a burst of deletions, the 1–2 s audit-correlation windows
+(they may need widening), the raw action id above, and the rendering of at
+least one event per category.
+
+### Premium
+
+Logs are **not** premium-gated today — every server gets all 18 categories.
+If that changes, `utils/subscription.py::is_guild_premium` is the check (see
+[docs/PREMIUM.md](PREMIUM.md)); the natural knobs are the number of
+categories a free server may bind and `MAX_CHANNELS_PER_CATEGORY`.
+
+`MAX_CHANNELS_PER_CATEGORY = 3` and `MAX_IGNORED_CHANNELS` /
+`MAX_IGNORED_ROLES = 25` (the Discord select limit) are working values, not
+researched ones.
+
+---
+
+## Tests
+
+```bash
+python3 -m pytest tests/test_logs.py tests/test_logs_i18n.py -q
+python3 -m pytest tests/test_persistent_views.py -q
+```
+
+* `tests/test_logs.py` — registry consistency, routing and fan-out, stored
+  schema round-trip, ignore lists, rendering (escaping, truncation,
+  attachments, size budget), delivery and batching.
+* `tests/test_logs_i18n.py` — every event name, title, field label, standalone
+  value and Discord permission name exists in all five locales, and no stale
+  translation is left behind after a rename.

--- a/docs/PERSISTENT_VIEWS.md
+++ b/docs/PERSISTENT_VIEWS.md
@@ -442,6 +442,24 @@ was easier not to" is not one.
   with a classic embed. `_StarboardReactorsButton`'s callback is guarded
   with `report_component_error` instead of a live view's `on_error`, same
   as the appeal buttons.
+- **`modules/configs/logs_config.py::LogsCategoryView`** — the `/config` →
+  Logs *category* screen (its destinations and its paginated event
+  checklist). Every one of its children is a persistent `DynamicItem`
+  carrying the category — and, for the checklist, the page — in its
+  `custom_id` (`moddy:logs:catchan:<category>`,
+  `moddy:logs:catev:<category>:<page>`,
+  `moddy:logs:catbtn:<action>:<category>:<page>`), registered through
+  `LogsPersistence.register_persistent` (`bot.add_dynamic_items(...)`, same
+  marker-view pattern as `AppealPersistence` and `TranscriptionPersistence`).
+  Registering the wrapper as a shell would be meaningless: it cannot be
+  built without a category id, and there is nothing left for it to carry
+  once its three items reconstruct themselves from their custom_id on every
+  click. That is also why this screen applies every change immediately
+  instead of staging edits behind a Save button — same reasoning as
+  `StaffManagerPanel` below. The root and options screens
+  (`LogsConfigView`, `LogsOptionsView`) *are* registered normally: their
+  custom_ids are static and `interaction.guild_id` plus a Manage Server
+  check is the whole auth context they need.
 
 ---
 

--- a/docs/sessions/2026-08-23_advanced-server-logs.md
+++ b/docs/sessions/2026-08-23_advanced-server-logs.md
@@ -1,0 +1,114 @@
+# Advanced server logs: documentation, emoji cleanup and embed size guard
+
+Follow-up session on the advanced server logs system (previous commit
+`7171dc2 "Add the advanced server logs system"`, branch
+`claude/advanced-logging-system-jc4mjs`). The system itself — 163 events over
+18 categories, `serverlogs/`, `modules/logs.py`, `modules/configs/logs_config.py`,
+`cogs/logs.py` — already existed and was not reworked. This session closed the
+documentation gap and the three loose ends left behind in the code.
+
+## What was done
+
+### Documentation (the standing CLAUDE.md rule)
+
+- **`docs/LOGS.md` (new)** — the reference for the whole system: what a server
+  sees, the layer-by-layer architecture and who is allowed to decide what, the
+  18 categories, the `/config` panel, the **exact stored schema** of
+  `guilds.data.modules.logs` with the backend/dashboard contract, how to add an
+  event (registry + 2 i18n keys + 1 builder) and how to change what a log says
+  (locale JSON only), webhook delivery and behaviour under a raid, audit-log
+  correlation, and a *Known gaps* section that names every deliberate hole
+  rather than leaving it to be rediscovered.
+- **`CLAUDE.md`** — `serverlogs/` added to the project tree (with its six
+  modules and the `listeners/` package), plus `cogs/logs.py`,
+  `modules/logs.py`, `modules/configs/logs_config.py`, `tests/test_logs.py`
+  and `tests/test_logs_i18n.py`; `docs/LOGS.md` added to the documentation
+  index.
+- **`docs/PERSISTENT_VIEWS.md` → "Deliberate exclusions"** — `LogsCategoryView`
+  documented with its three `DynamicItem` templates, why the wrapper has
+  nothing to register, and why that is also the reason the category screen
+  applies changes immediately instead of behind a Save button.
+
+### Code
+
+- **`serverlogs/registry.py`** — the 18 category emojis were hardcoded strings;
+  they now come from `utils/emojis.py` (CLAUDE.md rule 3). `utils/emojis.py`
+  has no imports of its own, so pulling it into a module that is imported
+  during module discovery introduces no cycle. A new test asserts every
+  category emoji is one of the constants, so a hardcoded one cannot come back.
+- **`modules/logs.py` / `modules/configs/logs_config.py`** — the module icon was
+  `HISTORY`, already used by `modules/auto_restore_roles.py`: two modules with
+  the same icon in the `/config` picker. Switched to `NOTE`, which nothing else
+  uses, and the root config panel follows.
+- **`serverlogs/renderer.py`** — `MAX_EMBED_TOTAL` was declared and never used.
+  It is now enforced by `LogEntry._fit()`: past the budget, trailing fields are
+  dropped first, the description is shortened only if that is not enough, and
+  the reader is told the log was shortened
+  (`modules.logs.values.size_limit`, added to the five locales).
+
+## Decisions made and why
+
+- **Enforce `MAX_EMBED_TOTAL` rather than delete it.** Individual values were
+  already capped, but Discord rejects an over-budget message *as a whole* — a
+  permission diff spanning a dozen roles would simply never arrive, which is
+  the one failure mode a log system cannot afford. Fields are dropped before
+  the description because the description carries the facts and the fields
+  carry the detail.
+- **`on_external_config_change()` stays unimplemented** for the logs module,
+  and `docs/LOGS.md` says so explicitly. The hook exists for modules whose
+  configuration is *visible* in Discord (a panel to re-post, overwrites to
+  re-apply); the logs module posts nothing and holds no Discord-side state, so
+  the standard config reload is the whole of the change. Documented as a
+  decision so it does not read as an oversight — and with the condition that
+  would reverse it.
+- **An unbound channel's `Moddy Logs` webhook is left in place**, and that is
+  documented rather than automated. Moddy cannot distinguish its own leftover
+  webhook from one an admin has since repurposed, and deleting a webhook is not
+  reversible. The leftover is inert: it is never reused for another channel.
+- **The `moderation` events with no source are kept in the registry.**
+  `case_delete`, `mass_case_delete`, `kick_remove`, `report_create`,
+  `reports_ignore`, `reports_accept`, `user_note_add`, `user_note_remove` are
+  served by `log_case_event()` and called by nobody, because Moddy cannot
+  delete a case and has no report system. They were left declared (so they
+  light up the day the feature lands) and documented with their natural
+  hook-ups — from `CaseService`, never from the DB repository, since
+  `_log_to_server` is where the guild-scope check and the "a log never breaks
+  the moderation action" guarantee live. `case_update` is half-wired already
+  (the `restrict` / `revoke_access` sanctions reach it; a reason edit does not).
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `docs/LOGS.md` | **new** — full system reference |
+| `docs/sessions/2026-08-23_advanced-server-logs.md` | **new** — this file |
+| `CLAUDE.md` | project tree + documentation index |
+| `docs/PERSISTENT_VIEWS.md` | `LogsCategoryView` exclusion |
+| `serverlogs/registry.py` | category emojis from `utils/emojis.py` |
+| `serverlogs/renderer.py` | `LogEntry._fit()` enforces `MAX_EMBED_TOTAL` |
+| `modules/logs.py` | `MODULE_EMOJI = NOTE` |
+| `modules/configs/logs_config.py` | root panel icon follows |
+| `locales/{fr,en-US,es-ES,pt-BR,de}.json` | `modules.logs.values.size_limit` |
+| `tests/test_logs.py` | category-emoji test + two embed-budget tests |
+
+## Known issues / follow-ups
+
+- **Nothing has run against a real Discord server.** Still to check on a test
+  guild: webhook creation and reuse, the `manage_webhooks` fallback, batching
+  under a burst of deletions, the 1–2 s audit-correlation windows, and the
+  rendering of at least one event per category. Listed in `docs/LOGS.md`.
+- **`channel_voice_status_update`** is matched on the raw audit action id `192`
+  (`cogs/logs.py::_VOICE_STATUS_ACTION`) — Discord ships no gateway event and
+  discord.py has no enum member. Unconfirmed live; if the id is wrong the event
+  is inert while the config panel still advertises it.
+- **Premium is an open product decision.** Logs are not gated today; the
+  natural knobs (`is_guild_premium`, number of bindable categories,
+  `MAX_CHANNELS_PER_CATEGORY`) are documented, not chosen.
+- **`MAX_CHANNELS_PER_CATEGORY = 3`, `MAX_IGNORED_CHANNELS/ROLES = 25`** remain
+  working values rather than researched ones.
+
+## Tests
+
+`python3 -m pytest -q` → **1019 passed** (1016 before, +3 new in
+`tests/test_logs.py`); `python3 -m pytest tests/test_persistent_views.py -q`
+green.

--- a/locales/de.json
+++ b/locales/de.json
@@ -2049,6 +2049,748 @@
           "footer": "Bei Fragen wende dich an die Moderation des Servers."
         }
       }
+    },
+    "logs": {
+      "fields": {
+        "account_created": "Konto erstellt",
+        "action": "Aktion",
+        "added": "Hinzugefügt",
+        "after": "Nachher",
+        "after_channel": "Neuer Kanal",
+        "allow_list": "Positivliste",
+        "animated": "Animiert",
+        "answer_id": "Antwort-ID",
+        "answers": "Antworten",
+        "application": "Anwendung",
+        "attachments": "Anhänge",
+        "author": "Autor(in)",
+        "authors": "Betroffene Autoren",
+        "before": "Vorher",
+        "before_channel": "Vorheriger Kanal",
+        "case": "Fall",
+        "category": "Kategorie",
+        "channel": "Kanal",
+        "channel_created": "Kanal erstellt",
+        "colour": "Farbe",
+        "command": "Befehl",
+        "count": "Anzahl",
+        "created": "Erstellt",
+        "description": "Beschreibung",
+        "emoji": "Emoji",
+        "enabled": "Aktiviert",
+        "end_time": "Ende",
+        "event": "Event",
+        "expires": "Läuft ab",
+        "expires_at": "Läuft ab am",
+        "hoisted": "Separat angezeigt",
+        "id": "ID",
+        "inactive_days": "Tage ohne Aktivität",
+        "invite": "Einladung",
+        "inviter": "Erstellt von",
+        "invites": "Einladungen",
+        "joined_at": "Beigetreten am",
+        "keyword_filter": "Schlüsselwörter",
+        "last_pin": "Zuletzt angeheftete Nachricht",
+        "location": "Ort",
+        "matched": "Treffer",
+        "max_uses": "Maximale Nutzungen",
+        "member_count": "Anzahl der Mitglieder",
+        "members": "Mitglieder",
+        "members_removed": "Entfernte Mitglieder",
+        "mention_limit": "Erwähnungslimit",
+        "mentionable": "Erwähnbar",
+        "message": "Nachricht",
+        "message_created": "Nachricht erstellt",
+        "message_id": "Nachrichten-ID",
+        "moderator": "Moderator(in)",
+        "name": "Name",
+        "newest_message": "Neueste Nachricht",
+        "note": "Notiz",
+        "oldest_message": "Älteste Nachricht",
+        "options": "Optionen",
+        "owner": "Inhaber(in)",
+        "parent_channel": "Übergeordneter Kanal",
+        "permissions": "Berechtigungen",
+        "presets": "Vordefinierte Filter",
+        "privacy_level": "Privatsphäre",
+        "question": "Frage",
+        "reason": "Grund",
+        "regex_patterns": "Reguläre Ausdrücke",
+        "removed": "Entfernt",
+        "reply_to": "Antwort auf",
+        "role": "Rolle",
+        "role_created": "Rolle erstellt",
+        "roles": "Rollen",
+        "roles_added": "Hinzugefügt",
+        "roles_removed": "Entfernt",
+        "rule": "Regel",
+        "server": "Server",
+        "sound": "Sound",
+        "start_time": "Beginn",
+        "status": "Status",
+        "sticker": "Sticker",
+        "stickers": "Sticker",
+        "subscribers": "Interessierte",
+        "target": "Ziel",
+        "temporary": "Temporär",
+        "thread": "Thread",
+        "thread_created": "Thread erstellt",
+        "topic": "Thema",
+        "trigger": "Auslöser",
+        "type": "Typ",
+        "until": "Bis",
+        "user": "Nutzer(in)",
+        "user_id": "Nutzer-ID",
+        "user_limit": "Nutzerlimit",
+        "uses": "Nutzungen",
+        "volume": "Lautstärke",
+        "votes": "Stimmen",
+        "webhook": "Webhook"
+      },
+      "values": {
+        "yes": "Ja",
+        "no": "Nein",
+        "on": "An",
+        "off": "Aus",
+        "none": "Keine",
+        "unlimited": "Unbegrenzt",
+        "disabled": "Deaktiviert",
+        "automatic": "Automatisch",
+        "allowed": "Erlaubt",
+        "denied": "Verweigert",
+        "open_link": "Ansehen",
+        "default_colour": "Standardfarbe",
+        "boost_tier": "Stufe {tier}",
+        "empty_content": "*Kein Text*",
+        "uncached_message": "*Der Nachrichteninhalt war nicht mehr im Cache.*",
+        "uncached_messages": "*Keine dieser Nachrichten war im Cache, daher konnte kein Transkript erstellt werden.*",
+        "moved_to_file": "Inhalt gekürzt — der vollständige Text ist angehängt.",
+        "transcript_attached": "*Der vollständige Inhalt ist als `.txt`-Transkript angehängt.*",
+        "transcript_header": "Transkript gelöschter Nachrichten — Moddy",
+        "duration": {
+          "day": "{count} T",
+          "hour": "{count} Std.",
+          "minute": "{count} Min.",
+          "second": "{count} Sek."
+        }
+      },
+      "permissions": {
+        "add_reactions": "Reaktionen hinzufügen",
+        "administrator": "Administrator",
+        "attach_files": "Dateien anhängen",
+        "ban_members": "Mitglieder bannen",
+        "bypass_slowmode": "Slow-Modus umgehen",
+        "change_nickname": "Nickname ändern",
+        "connect": "Verbinden",
+        "create_events": "Events erstellen",
+        "create_expressions": "Ausdrücke erstellen",
+        "create_instant_invite": "Einladung erstellen",
+        "create_polls": "Umfragen erstellen",
+        "create_private_threads": "Private Threads erstellen",
+        "create_public_threads": "Öffentliche Threads erstellen",
+        "deafen_members": "Mitglieder taub schalten",
+        "embed_links": "Links einbetten",
+        "external_emojis": "Externe Emojis",
+        "external_stickers": "Externe Sticker",
+        "kick_members": "Mitglieder kicken",
+        "manage_channels": "Kanäle verwalten",
+        "manage_emojis": "Emojis verwalten",
+        "manage_emojis_and_stickers": "Emojis und Sticker verwalten",
+        "manage_events": "Events verwalten",
+        "manage_expressions": "Ausdrücke verwalten",
+        "manage_guild": "Server verwalten",
+        "manage_messages": "Nachrichten verwalten",
+        "manage_nicknames": "Nicknames verwalten",
+        "manage_permissions": "Berechtigungen verwalten",
+        "manage_roles": "Rollen verwalten",
+        "manage_threads": "Threads verwalten",
+        "manage_webhooks": "Webhooks verwalten",
+        "mention_everyone": "@everyone erwähnen",
+        "moderate_members": "Mitglieder in den Timeout versetzen",
+        "move_members": "Mitglieder verschieben",
+        "mute_members": "Mitglieder stummschalten",
+        "pin_messages": "Nachrichten anheften",
+        "priority_speaker": "Prioritäts-Sprecher",
+        "read_message_history": "Nachrichtenverlauf anzeigen",
+        "read_messages": "Kanäle ansehen",
+        "request_to_speak": "Redeerlaubnis anfragen",
+        "send_messages": "Nachrichten senden",
+        "send_messages_in_threads": "Nachrichten in Threads senden",
+        "send_polls": "Umfragen senden",
+        "send_tts_messages": "Text-zu-Sprache-Nachrichten senden",
+        "send_voice_messages": "Sprachnachrichten senden",
+        "set_voice_channel_status": "Status des Sprachkanals festlegen",
+        "speak": "Sprechen",
+        "stream": "Video",
+        "use_application_commands": "Anwendungsbefehle verwenden",
+        "use_embedded_activities": "Aktivitäten verwenden",
+        "use_external_apps": "Externe Apps verwenden",
+        "use_external_emojis": "Externe Emojis verwenden",
+        "use_external_sounds": "Externe Sounds verwenden",
+        "use_external_stickers": "Externe Sticker verwenden",
+        "use_soundboard": "Soundboard verwenden",
+        "use_voice_activation": "Sprachaktivierung verwenden",
+        "view_audit_log": "Audit-Log ansehen",
+        "view_channel": "Kanal ansehen",
+        "view_creator_monetization_analytics": "Monetarisierungsanalysen ansehen",
+        "view_guild_insights": "Server-Insights ansehen"
+      },
+      "description": "Detaillierte Logs zu allem, was auf dem Server passiert",
+      "config": {
+        "title": "Server-Logs",
+        "description": "Wähle eine Kategorie, lege den oder die Kanäle fest, die sie erhalten sollen, und entferne den Haken bei den Events, die dich nicht interessieren. Standardmäßig ist alles aktiviert.",
+        "summary": {
+          "empty": "Bisher ist keine Kategorie konfiguriert.",
+          "events": "{enabled}/{total} Events werden protokolliert"
+        },
+        "categories": {
+          "placeholder": "Kategorie konfigurieren…",
+          "bound": "{count} Kanal/Kanäle · {enabled}/{total} Events",
+          "unbound": "Nicht konfiguriert · {total} Events verfügbar"
+        },
+        "mass": {
+          "section_title": "Alles in einen einzigen Kanal senden",
+          "section_description": "Weist alle Kategorien auf einen Schlag dem gewählten Kanal zu.",
+          "placeholder": "Kanal für alle Logs wählen…"
+        },
+        "channels": {
+          "section_title": "Zielkanäle",
+          "section_description": "Bis zu {max} Kanäle für diese Kategorie.",
+          "placeholder": "Einen oder mehrere Kanäle wählen…"
+        },
+        "events": {
+          "section_title": "Protokollierte Events",
+          "section_description": "Angehakte Events werden protokolliert; entferne den Haken bei denen, die ignoriert werden sollen.",
+          "enabled_count": "{enabled}/{total} Events aktiv",
+          "placeholder": "Events zum Protokollieren anhaken…"
+        },
+        "buttons": {
+          "back": "Zurück",
+          "all": "Alle aktivieren",
+          "none": "Alle deaktivieren",
+          "prev": "Vorherige Seite",
+          "next": "Nächste Seite"
+        },
+        "clear": {
+          "button": "Alles löschen"
+        },
+        "options": {
+          "button": "Optionen",
+          "title": "Log-Optionen",
+          "description": "Einstellungen, die für alle Kategorien gelten.",
+          "channels": {
+            "section_title": "Ignorierte Kanäle",
+            "section_description": "Kein Event aus diesen Kanälen wird protokolliert.",
+            "placeholder": "Zu ignorierende Kanäle wählen…"
+          },
+          "roles": {
+            "section_title": "Ignorierte Rollen",
+            "section_description": "Mitglieder mit einer dieser Rollen werden nie protokolliert.",
+            "placeholder": "Zu ignorierende Rollen wählen…"
+          },
+          "locale": {
+            "section_title": "Sprache der Logs",
+            "section_description": "Standardmäßig folgen die Logs der Sprache des Servers.",
+            "placeholder": "Sprache der Logs wählen…",
+            "values": {
+              "auto": "Sprache des Servers",
+              "fr": "Français",
+              "en-US": "English",
+              "es-ES": "Español",
+              "pt-BR": "Português",
+              "de": "Deutsch"
+            }
+          },
+          "toggles": {
+            "section_title": "Einstellungen",
+            "bots": "Bots ignorieren",
+            "transcripts": "Transkripte als Anhang"
+          }
+        },
+        "errors": {
+          "title": "Speichern nicht möglich",
+          "invalid_config": "Ungültige Konfiguration.",
+          "unknown_category": "Unbekannte Kategorie: `{category}`.",
+          "channel_not_found": "Der Kanal `{channel_id}` wurde nicht gefunden.",
+          "missing_permissions": "Mir fehlen die Berechtigungen **Kanal ansehen**, **Nachrichten senden** oder **Links einbetten** in {channel}."
+        }
+      },
+      "categories": {
+        "server": {
+          "name": "Server",
+          "description": "Beitritte, Austritte, Sanktionen und Servereinstellungen."
+        },
+        "messages": {
+          "name": "Nachrichten",
+          "description": "Gelöschte, bearbeitete und veröffentlichte Nachrichten."
+        },
+        "users": {
+          "name": "Nutzer",
+          "description": "Nicknames, Avatare, Rollen und Timeouts."
+        },
+        "moderation": {
+          "name": "Moderation",
+          "description": "Moddy-Sanktionen und Moderationsaktionen."
+        },
+        "channels": {
+          "name": "Kanäle",
+          "description": "Erstellung, Löschung und Einstellungen von Kanälen."
+        },
+        "roles": {
+          "name": "Rollen",
+          "description": "Erstellung, Löschung und Einstellungen von Rollen."
+        },
+        "threads": {
+          "name": "Threads",
+          "description": "Erstellen, Archivieren und Sperren von Threads."
+        },
+        "voice": {
+          "name": "Sprache",
+          "description": "Verbindungen, Verschiebungen und Trennungen in Sprachkanälen."
+        },
+        "invites": {
+          "name": "Einladungen",
+          "description": "Erstellte, gelöschte oder geteilte Einladungen."
+        },
+        "automod": {
+          "name": "Discord AutoMod",
+          "description": "Native AutoMod-Regeln von Discord."
+        },
+        "emojis": {
+          "name": "Emojis",
+          "description": "Hinzugefügte, gelöschte oder umbenannte Emojis."
+        },
+        "stickers": {
+          "name": "Sticker",
+          "description": "Hinzugefügte, gelöschte oder geänderte Sticker."
+        },
+        "soundboard": {
+          "name": "Soundboard",
+          "description": "Hinzugefügte, geänderte oder gelöschte Sounds."
+        },
+        "events": {
+          "name": "Events",
+          "description": "Geplante Events des Servers."
+        },
+        "stage": {
+          "name": "Bühnen",
+          "description": "Gestartete oder beendete Bühnen (Bühnenkanäle)."
+        },
+        "polls": {
+          "name": "Umfragen",
+          "description": "Erstellte und beendete Umfragen sowie Stimmen."
+        },
+        "webhooks": {
+          "name": "Webhooks",
+          "description": "Erstellte, geänderte oder gelöschte Webhooks."
+        },
+        "applications": {
+          "name": "Anwendungen",
+          "description": "Hinzugefügte oder entfernte Bots und Anwendungen."
+        }
+      },
+      "events": {
+        "server": {
+          "ban_add": "Bann",
+          "ban_remove": "Entbannung",
+          "user_join": "Mitglied beigetreten",
+          "user_leave": "Mitglied verlassen",
+          "user_kick": "Kick",
+          "member_prune": "Inaktive Mitglieder entfernt",
+          "afk_channel_update": "AFK-Kanal",
+          "afk_timeout_update": "AFK-Timeout",
+          "server_banner_update": "Server-Banner",
+          "message_notifications_update": "Standard-Benachrichtigungen",
+          "server_discovery_splash_update": "Discovery-Bild",
+          "server_content_filter_update": "Inhaltsfilter",
+          "server_features_update": "Server-Funktionen",
+          "server_icon_update": "Server-Icon",
+          "mfa_level_update": "2FA-Stufe",
+          "server_name_update": "Servername",
+          "server_description_update": "Serverbeschreibung",
+          "server_owner_update": "Server-Inhaber",
+          "partnered_update": "Partner-Status",
+          "server_boost_level_update": "Boost-Stufe",
+          "boost_progress_bar_toggle": "Boost-Fortschrittsleiste",
+          "public_updates_channel_update": "Kanal für Discord-Ankündigungen",
+          "server_rules_channel_update": "Regelkanal",
+          "server_splash_update": "Einladungsbild",
+          "system_channel_update": "Systemkanal",
+          "server_vanity_update": "Eigene Einladung",
+          "verification_level_update": "Verifizierungsstufe",
+          "verified_update": "Verifiziert-Status",
+          "server_widget_update": "Server-Widget",
+          "server_preferred_locale_update": "Serversprache",
+          "onboarding_toggle": "Onboarding aktiviert",
+          "onboarding_channels_update": "Onboarding-Kanäle",
+          "onboarding_question_add": "Onboarding-Frage hinzugefügt",
+          "onboarding_question_remove": "Onboarding-Frage entfernt",
+          "onboarding_question_update": "Onboarding-Frage geändert"
+        },
+        "messages": {
+          "message_delete": "Nachricht gelöscht",
+          "message_bulk_delete": "Massenlöschung",
+          "message_edit": "Nachricht bearbeitet",
+          "message_publish": "Nachricht veröffentlicht",
+          "message_command_used": "Befehl verwendet"
+        },
+        "users": {
+          "user_name_update": "Nickname geändert",
+          "user_roles_update": "Rollen geändert",
+          "user_roles_add": "Rolle hinzugefügt",
+          "user_roles_remove": "Rolle entfernt",
+          "user_avatar_update": "Avatar geändert",
+          "user_timed_out": "Timeout",
+          "user_timeout_removed": "Timeout beendet"
+        },
+        "moderation": {
+          "auto_moderation": "Discord AutoMod",
+          "ban_add": "Bann",
+          "ban_remove": "Entbannung",
+          "case_delete": "Fall gelöscht",
+          "mass_case_delete": "Massenlöschung von Fällen",
+          "case_update": "Fall geändert",
+          "kick_add": "Kick",
+          "kick_remove": "Kick aufgehoben",
+          "mute_add": "Stummschaltung",
+          "mute_remove": "Stummschaltung aufgehoben",
+          "warn_add": "Verwarnung",
+          "warn_remove": "Verwarnung entfernt",
+          "report_create": "Meldung erstellt",
+          "reports_ignore": "Meldung ignoriert",
+          "reports_accept": "Meldung angenommen",
+          "user_note_add": "Notiz hinzugefügt",
+          "user_note_remove": "Notiz entfernt"
+        },
+        "channels": {
+          "channel_create": "Kanal erstellt",
+          "channel_delete": "Kanal gelöscht",
+          "channel_pins_update": "Angeheftete Nachrichten geändert",
+          "channel_name_update": "Kanalname",
+          "channel_topic_update": "Kanalthema",
+          "channel_nsfw_update": "NSFW des Kanals",
+          "channel_parent_update": "Kategorie des Kanals",
+          "channel_permissions_update": "Kanalberechtigungen",
+          "channel_type_update": "Kanaltyp",
+          "channel_bitrate_update": "Bitrate des Kanals",
+          "channel_user_limit_update": "Nutzerlimit",
+          "channel_slowmode_update": "Slow-Modus",
+          "channel_rtc_region_update": "Sprachregion",
+          "channel_video_quality_update": "Videoqualität",
+          "channel_default_archive_duration_update": "Standard-Archivierung",
+          "channel_default_thread_slowmode_update": "Slow-Modus für Threads",
+          "channel_default_reaction_emoji_update": "Standard-Reaktion",
+          "channel_default_sort_order_update": "Standard-Sortierung",
+          "channel_forum_tags_update": "Forum-Tags",
+          "channel_forum_layout_update": "Forum-Ansicht",
+          "channel_voice_status_update": "Status des Sprachkanals"
+        },
+        "roles": {
+          "role_create": "Rolle erstellt",
+          "role_delete": "Rolle gelöscht",
+          "role_color_update": "Rollenfarbe",
+          "role_hoist_update": "Separate Anzeige",
+          "role_mentionable_update": "Rolle erwähnbar",
+          "role_name_update": "Rollenname",
+          "role_permissions_update": "Rollenberechtigungen",
+          "role_icon_update": "Rollen-Icon"
+        },
+        "threads": {
+          "thread_create": "Thread erstellt",
+          "thread_delete": "Thread gelöscht",
+          "thread_name_update": "Thread-Name",
+          "thread_slowmode_update": "Slow-Modus des Threads",
+          "thread_archive_duration_update": "Archivierungsdauer",
+          "thread_archive": "Thread archiviert",
+          "thread_unarchive": "Thread wiederhergestellt",
+          "thread_lock": "Thread gesperrt",
+          "thread_unlock": "Thread entsperrt"
+        },
+        "voice": {
+          "voice_channel_full": "Sprachkanal voll",
+          "voice_user_join": "Sprachkanal betreten",
+          "voice_user_switch": "Sprachkanal gewechselt",
+          "voice_user_leave": "Sprachkanal verlassen",
+          "voice_user_move": "Zwangsverschiebung",
+          "voice_user_kick": "Zwangstrennung"
+        },
+        "invites": {
+          "invite_create": "Einladung erstellt",
+          "invite_delete": "Einladung gelöscht",
+          "invite_post": "Einladung geteilt"
+        },
+        "automod": {
+          "automod_rule_create": "Regel erstellt",
+          "automod_rule_delete": "Regel gelöscht",
+          "automod_rule_toggle": "Regel aktiviert/deaktiviert",
+          "automod_rule_name_update": "Name der Regel",
+          "automod_rule_actions_update": "Aktionen der Regel",
+          "automod_rule_content_update": "Gefilterte Inhalte",
+          "automod_rule_roles_update": "Ausgenommene Rollen",
+          "automod_rule_channels_update": "Ausgenommene Kanäle",
+          "automod_rule_whitelist_update": "Positivliste"
+        },
+        "emojis": {
+          "emoji_create": "Emoji hinzugefügt",
+          "emoji_delete": "Emoji gelöscht",
+          "emoji_name_update": "Name des Emojis",
+          "emoji_roles_update": "Rollen des Emojis"
+        },
+        "stickers": {
+          "sticker_create": "Sticker hinzugefügt",
+          "sticker_delete": "Sticker gelöscht",
+          "sticker_name_update": "Name des Stickers",
+          "sticker_description_update": "Beschreibung des Stickers",
+          "sticker_related_emoji_update": "Emoji des Stickers"
+        },
+        "soundboard": {
+          "sound_upload": "Sound hinzugefügt",
+          "sound_name_update": "Name des Sounds",
+          "sound_volume_update": "Lautstärke des Sounds",
+          "sound_emoji_update": "Emoji des Sounds",
+          "sound_delete": "Sound gelöscht"
+        },
+        "events": {
+          "event_create": "Event erstellt",
+          "event_delete": "Event gelöscht",
+          "event_name_update": "Name des Events",
+          "event_description_update": "Beschreibung des Events",
+          "event_location_update": "Ort des Events",
+          "event_privacy_level_update": "Privatsphäre des Events",
+          "event_start_time_update": "Beginn des Events",
+          "event_end_time_update": "Ende des Events",
+          "event_status_update": "Status des Events",
+          "event_image_update": "Bild des Events",
+          "event_user_subscribe": "Für Event angemeldet",
+          "event_user_unsubscribe": "Von Event abgemeldet"
+        },
+        "stage": {
+          "stage_start": "Bühne gestartet",
+          "stage_end": "Bühne beendet",
+          "stage_topic_update": "Thema der Bühne",
+          "stage_privacy_update": "Privatsphäre der Bühne"
+        },
+        "polls": {
+          "poll_create": "Umfrage erstellt",
+          "poll_delete": "Umfrage gelöscht",
+          "poll_finalize": "Umfrage beendet",
+          "poll_votes_add": "Stimme abgegeben",
+          "poll_votes_remove": "Stimme zurückgezogen"
+        },
+        "webhooks": {
+          "webhook_create": "Webhook erstellt",
+          "webhook_name_update": "Name des Webhooks",
+          "webhook_avatar_update": "Avatar des Webhooks",
+          "webhook_channel_update": "Kanal des Webhooks",
+          "webhook_delete": "Webhook gelöscht"
+        },
+        "applications": {
+          "app_add": "Anwendung hinzugefügt",
+          "app_remove": "Anwendung entfernt",
+          "app_command_permission_update": "Befehlsberechtigungen"
+        }
+      },
+      "titles": {
+        "server": {
+          "ban_add": "Ein Nutzer wurde gebannt",
+          "ban_remove": "Ein Nutzer wurde entbannt",
+          "user_join": "Ein Nutzer ist dem Server beigetreten",
+          "user_leave": "Ein Nutzer hat den Server verlassen",
+          "user_kick": "Ein Nutzer wurde gekickt",
+          "member_prune": "Inaktive Mitglieder wurden entfernt",
+          "afk_channel_update": "Der AFK-Kanal wurde geändert",
+          "afk_timeout_update": "Das AFK-Timeout wurde geändert",
+          "server_banner_update": "Das Server-Banner wurde geändert",
+          "message_notifications_update": "Die Standard-Benachrichtigungen wurden geändert",
+          "server_discovery_splash_update": "Das Discovery-Bild wurde geändert",
+          "server_content_filter_update": "Der Filter für anstößige Inhalte wurde geändert",
+          "server_features_update": "Die Server-Funktionen wurden geändert",
+          "server_icon_update": "Das Server-Icon wurde geändert",
+          "mfa_level_update": "Die Stufe der Zwei-Faktor-Authentifizierung wurde geändert",
+          "server_name_update": "Der Servername wurde geändert",
+          "server_description_update": "Die Serverbeschreibung wurde geändert",
+          "server_owner_update": "Der Server hat einen neuen Inhaber",
+          "partnered_update": "Der Partner-Status wurde geändert",
+          "server_boost_level_update": "Die Boost-Stufe wurde geändert",
+          "boost_progress_bar_toggle": "Die Boost-Fortschrittsleiste wurde geändert",
+          "public_updates_channel_update": "Der Kanal für Discord-Ankündigungen wurde geändert",
+          "server_rules_channel_update": "Der Regelkanal wurde geändert",
+          "server_splash_update": "Das Einladungsbild wurde geändert",
+          "system_channel_update": "Der Systemkanal wurde geändert",
+          "server_vanity_update": "Die eigene Einladung wurde geändert",
+          "verification_level_update": "Die Verifizierungsstufe wurde geändert",
+          "verified_update": "Der Verifiziert-Status wurde geändert",
+          "server_widget_update": "Das Server-Widget wurde geändert",
+          "server_preferred_locale_update": "Die Serversprache wurde geändert",
+          "onboarding_toggle": "Das Onboarding wurde aktiviert oder deaktiviert",
+          "onboarding_channels_update": "Die Standardkanäle des Onboardings wurden geändert",
+          "onboarding_question_add": "Eine Onboarding-Frage wurde hinzugefügt",
+          "onboarding_question_remove": "Eine Onboarding-Frage wurde entfernt",
+          "onboarding_question_update": "Eine Onboarding-Frage wurde geändert"
+        },
+        "messages": {
+          "message_delete": "Nachricht gelöscht",
+          "message_bulk_delete": "Mehrere Nachrichten wurden gelöscht",
+          "message_edit": "Nachricht bearbeitet",
+          "message_publish": "Nachricht in den abonnierten Servern veröffentlicht",
+          "message_command_used": "Ein Befehl wurde verwendet"
+        },
+        "users": {
+          "user_name_update": "Der Nickname eines Nutzers wurde geändert",
+          "user_roles_update": "Die Rollen eines Nutzers wurden geändert",
+          "user_roles_add": "Einem Nutzer wurden Rollen hinzugefügt",
+          "user_roles_remove": "Einem Nutzer wurden Rollen entfernt",
+          "user_avatar_update": "Der Avatar eines Nutzers wurde geändert",
+          "user_timed_out": "Ein Nutzer wurde in den Timeout versetzt",
+          "user_timeout_removed": "Der Timeout eines Nutzers wurde aufgehoben"
+        },
+        "moderation": {
+          "auto_moderation": "Discords AutoMod hat eingegriffen",
+          "ban_add": "Ein Nutzer wurde gebannt",
+          "ban_remove": "Ein Nutzer wurde entbannt",
+          "case_delete": "Ein Moderationsfall wurde gelöscht",
+          "mass_case_delete": "Mehrere Moderationsfälle wurden gelöscht",
+          "case_update": "Ein Moderationsfall wurde geändert",
+          "kick_add": "Ein Nutzer wurde gekickt",
+          "kick_remove": "Ein Kick wurde aufgehoben",
+          "mute_add": "Ein Nutzer wurde stummgeschaltet",
+          "mute_remove": "Ein Nutzer ist nicht mehr stummgeschaltet",
+          "warn_add": "Ein Nutzer hat eine Verwarnung erhalten",
+          "warn_remove": "Eine Verwarnung wurde entfernt",
+          "report_create": "Eine Meldung wurde erstellt",
+          "reports_ignore": "Eine Meldung wurde ignoriert",
+          "reports_accept": "Eine Meldung wurde angenommen",
+          "user_note_add": "Zu einem Nutzer wurde eine Notiz hinzugefügt",
+          "user_note_remove": "Von einem Nutzer wurde eine Notiz entfernt"
+        },
+        "channels": {
+          "channel_create": "Kanal erstellt",
+          "channel_delete": "Kanal gelöscht",
+          "channel_pins_update": "Die angehefteten Nachrichten eines Kanals wurden geändert",
+          "channel_name_update": "Der Name eines Kanals wurde geändert",
+          "channel_topic_update": "Das Thema eines Kanals wurde geändert",
+          "channel_nsfw_update": "Die NSFW-Einstellung eines Kanals wurde geändert",
+          "channel_parent_update": "Die Kategorie eines Kanals wurde geändert",
+          "channel_permissions_update": "Die Berechtigungen eines Kanals wurden geändert",
+          "channel_type_update": "Der Typ eines Kanals wurde geändert",
+          "channel_bitrate_update": "Die Bitrate eines Sprachkanals wurde geändert",
+          "channel_user_limit_update": "Das Nutzerlimit eines Sprachkanals wurde geändert",
+          "channel_slowmode_update": "Der Slow-Modus eines Kanals wurde geändert",
+          "channel_rtc_region_update": "Die Sprachregion eines Kanals wurde geändert",
+          "channel_video_quality_update": "Die Videoqualität eines Kanals wurde geändert",
+          "channel_default_archive_duration_update": "Die Standard-Archivierungsdauer wurde geändert",
+          "channel_default_thread_slowmode_update": "Der Standard-Slow-Modus für Threads wurde geändert",
+          "channel_default_reaction_emoji_update": "Das Standard-Reaktions-Emoji wurde geändert",
+          "channel_default_sort_order_update": "Die Standard-Sortierung eines Forums wurde geändert",
+          "channel_forum_tags_update": "Die Tags eines Forums wurden geändert",
+          "channel_forum_layout_update": "Die Ansicht eines Forums wurde geändert",
+          "channel_voice_status_update": "Der Status eines Sprachkanals wurde geändert"
+        },
+        "roles": {
+          "role_create": "Rolle erstellt",
+          "role_delete": "Rolle gelöscht",
+          "role_color_update": "Die Farbe einer Rolle wurde geändert",
+          "role_hoist_update": "Die separate Anzeige einer Rolle wurde geändert",
+          "role_mentionable_update": "Die Erwähnbarkeit einer Rolle wurde geändert",
+          "role_name_update": "Der Name einer Rolle wurde geändert",
+          "role_permissions_update": "Die Berechtigungen einer Rolle wurden geändert",
+          "role_icon_update": "Das Icon einer Rolle wurde geändert"
+        },
+        "threads": {
+          "thread_create": "Thread erstellt",
+          "thread_delete": "Thread gelöscht",
+          "thread_name_update": "Der Name eines Threads wurde geändert",
+          "thread_slowmode_update": "Der Slow-Modus eines Threads wurde geändert",
+          "thread_archive_duration_update": "Die Archivierungsdauer eines Threads wurde geändert",
+          "thread_archive": "Thread archiviert",
+          "thread_unarchive": "Thread wiederhergestellt",
+          "thread_lock": "Thread gesperrt",
+          "thread_unlock": "Thread entsperrt"
+        },
+        "voice": {
+          "voice_channel_full": "Ein Sprachkanal ist voll",
+          "voice_user_join": "Ein Nutzer hat einen Sprachkanal betreten",
+          "voice_user_switch": "Ein Nutzer hat den Sprachkanal gewechselt",
+          "voice_user_leave": "Ein Nutzer hat einen Sprachkanal verlassen",
+          "voice_user_move": "Ein Nutzer wurde in einen anderen Sprachkanal verschoben",
+          "voice_user_kick": "Ein Nutzer wurde aus dem Sprachkanal getrennt"
+        },
+        "invites": {
+          "invite_create": "Einladung erstellt",
+          "invite_delete": "Einladung gelöscht",
+          "invite_post": "Eine Einladung wurde in einem Kanal geteilt"
+        },
+        "automod": {
+          "automod_rule_create": "AutoMod-Regel erstellt",
+          "automod_rule_delete": "AutoMod-Regel gelöscht",
+          "automod_rule_toggle": "Eine AutoMod-Regel wurde aktiviert oder deaktiviert",
+          "automod_rule_name_update": "Der Name einer AutoMod-Regel wurde geändert",
+          "automod_rule_actions_update": "Die Aktionen einer AutoMod-Regel wurden geändert",
+          "automod_rule_content_update": "Die von einer AutoMod-Regel gefilterten Inhalte wurden geändert",
+          "automod_rule_roles_update": "Die ausgenommenen Rollen einer AutoMod-Regel wurden geändert",
+          "automod_rule_channels_update": "Die ausgenommenen Kanäle einer AutoMod-Regel wurden geändert",
+          "automod_rule_whitelist_update": "Die Positivliste einer AutoMod-Regel wurde geändert"
+        },
+        "emojis": {
+          "emoji_create": "Emoji hinzugefügt",
+          "emoji_delete": "Emoji gelöscht",
+          "emoji_name_update": "Der Name eines Emojis wurde geändert",
+          "emoji_roles_update": "Die berechtigten Rollen eines Emojis wurden geändert"
+        },
+        "stickers": {
+          "sticker_create": "Sticker hinzugefügt",
+          "sticker_delete": "Sticker gelöscht",
+          "sticker_name_update": "Der Name eines Stickers wurde geändert",
+          "sticker_description_update": "Die Beschreibung eines Stickers wurde geändert",
+          "sticker_related_emoji_update": "Das zugehörige Emoji eines Stickers wurde geändert"
+        },
+        "soundboard": {
+          "sound_upload": "Sound zum Soundboard hinzugefügt",
+          "sound_name_update": "Der Name eines Sounds wurde geändert",
+          "sound_volume_update": "Die Lautstärke eines Sounds wurde geändert",
+          "sound_emoji_update": "Das Emoji eines Sounds wurde geändert",
+          "sound_delete": "Sound aus dem Soundboard gelöscht"
+        },
+        "events": {
+          "event_create": "Event erstellt",
+          "event_delete": "Event gelöscht",
+          "event_name_update": "Der Name eines Events wurde geändert",
+          "event_description_update": "Die Beschreibung eines Events wurde geändert",
+          "event_location_update": "Der Ort eines Events wurde geändert",
+          "event_privacy_level_update": "Die Privatsphäre eines Events wurde geändert",
+          "event_start_time_update": "Die Startzeit eines Events wurde geändert",
+          "event_end_time_update": "Die Endzeit eines Events wurde geändert",
+          "event_status_update": "Der Status eines Events wurde geändert",
+          "event_image_update": "Das Bild eines Events wurde geändert",
+          "event_user_subscribe": "Ein Nutzer hat sich für ein Event angemeldet",
+          "event_user_unsubscribe": "Ein Nutzer hat sich von einem Event abgemeldet"
+        },
+        "stage": {
+          "stage_start": "Eine Bühne wurde gestartet",
+          "stage_end": "Eine Bühne wurde beendet",
+          "stage_topic_update": "Das Thema einer Bühne wurde geändert",
+          "stage_privacy_update": "Die Privatsphäre einer Bühne wurde geändert"
+        },
+        "polls": {
+          "poll_create": "Umfrage erstellt",
+          "poll_delete": "Umfrage gelöscht",
+          "poll_finalize": "Eine Umfrage wurde beendet",
+          "poll_votes_add": "Eine Stimme wurde zu einer Umfrage hinzugefügt",
+          "poll_votes_remove": "Eine Stimme wurde von einer Umfrage entfernt"
+        },
+        "webhooks": {
+          "webhook_create": "Webhook erstellt",
+          "webhook_name_update": "Der Name eines Webhooks wurde geändert",
+          "webhook_avatar_update": "Der Avatar eines Webhooks wurde geändert",
+          "webhook_channel_update": "Der Kanal eines Webhooks wurde geändert",
+          "webhook_delete": "Webhook gelöscht"
+        },
+        "applications": {
+          "app_add": "Eine Anwendung wurde dem Server hinzugefügt",
+          "app_remove": "Eine Anwendung wurde vom Server entfernt",
+          "app_command_permission_update": "Die Berechtigungen eines Befehls wurden geändert"
+        }
+      }
     }
   },
   "languages": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -2165,6 +2165,7 @@
         "uncached_message": "*Der Nachrichteninhalt war nicht mehr im Cache.*",
         "uncached_messages": "*Keine dieser Nachrichten war im Cache, daher konnte kein Transkript erstellt werden.*",
         "moved_to_file": "Inhalt gekürzt — der vollständige Text ist angehängt.",
+        "size_limit": "Log gekürzt — es überschritt die maximale Größe einer Discord-Nachricht.",
         "transcript_attached": "*Der vollständige Inhalt ist als `.txt`-Transkript angehängt.*",
         "transcript_header": "Transkript gelöschter Nachrichten — Moddy",
         "duration": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -2165,6 +2165,7 @@
         "uncached_message": "*The message content was no longer cached.*",
         "uncached_messages": "*None of these messages were cached, so no transcript could be built.*",
         "moved_to_file": "Content truncated — the full text is attached.",
+        "size_limit": "Log shortened — it exceeded the maximum size of a Discord message.",
         "transcript_attached": "*The full content is attached as a `.txt` transcript.*",
         "transcript_header": "Transcript of deleted messages — Moddy",
         "duration": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -2049,6 +2049,748 @@
           "footer": "For any question, contact the server's moderators."
         }
       }
+    },
+    "logs": {
+      "fields": {
+        "account_created": "Account created",
+        "action": "Action",
+        "added": "Added",
+        "after": "After",
+        "after_channel": "New channel",
+        "allow_list": "Allow list",
+        "animated": "Animated",
+        "answer_id": "Answer ID",
+        "answers": "Answers",
+        "application": "Application",
+        "attachments": "Attachments",
+        "author": "Author",
+        "authors": "Authors involved",
+        "before": "Before",
+        "before_channel": "Previous channel",
+        "case": "Case",
+        "category": "Category",
+        "channel": "Channel",
+        "channel_created": "Channel created",
+        "colour": "Colour",
+        "command": "Command",
+        "count": "Count",
+        "created": "Created",
+        "description": "Description",
+        "emoji": "Emoji",
+        "enabled": "Enabled",
+        "end_time": "End",
+        "event": "Event",
+        "expires": "Expires",
+        "expires_at": "Expires at",
+        "hoisted": "Displayed separately",
+        "id": "ID",
+        "inactive_days": "Inactive days",
+        "invite": "Invite",
+        "inviter": "Created by",
+        "invites": "Invites",
+        "joined_at": "Joined at",
+        "keyword_filter": "Keywords",
+        "last_pin": "Last pinned message",
+        "location": "Location",
+        "matched": "Match",
+        "max_uses": "Maximum uses",
+        "member_count": "Member count",
+        "members": "Members",
+        "members_removed": "Members removed",
+        "mention_limit": "Mention limit",
+        "mentionable": "Mentionable",
+        "message": "Message",
+        "message_created": "Message created",
+        "message_id": "Message ID",
+        "moderator": "Moderator",
+        "name": "Name",
+        "newest_message": "Newest message",
+        "note": "Note",
+        "oldest_message": "Oldest message",
+        "options": "Options",
+        "owner": "Owner",
+        "parent_channel": "Parent channel",
+        "permissions": "Permissions",
+        "presets": "Presets",
+        "privacy_level": "Privacy level",
+        "question": "Question",
+        "reason": "Reason",
+        "regex_patterns": "Regular expressions",
+        "removed": "Removed",
+        "reply_to": "Reply to",
+        "role": "Role",
+        "role_created": "Role created",
+        "roles": "Roles",
+        "roles_added": "Added",
+        "roles_removed": "Removed",
+        "rule": "Rule",
+        "server": "Server",
+        "sound": "Sound",
+        "start_time": "Start",
+        "status": "Status",
+        "sticker": "Sticker",
+        "stickers": "Stickers",
+        "subscribers": "Interested",
+        "target": "Target",
+        "temporary": "Temporary",
+        "thread": "Thread",
+        "thread_created": "Thread created",
+        "topic": "Topic",
+        "trigger": "Trigger",
+        "type": "Type",
+        "until": "Until",
+        "user": "User",
+        "user_id": "User ID",
+        "user_limit": "User limit",
+        "uses": "Uses",
+        "volume": "Volume",
+        "votes": "Votes",
+        "webhook": "Webhook"
+      },
+      "values": {
+        "yes": "Yes",
+        "no": "No",
+        "on": "On",
+        "off": "Off",
+        "none": "None",
+        "unlimited": "Unlimited",
+        "disabled": "Disabled",
+        "automatic": "Automatic",
+        "allowed": "Allowed",
+        "denied": "Denied",
+        "open_link": "View",
+        "default_colour": "Default colour",
+        "boost_tier": "Tier {tier}",
+        "empty_content": "*No text*",
+        "uncached_message": "*The message content was no longer cached.*",
+        "uncached_messages": "*None of these messages were cached, so no transcript could be built.*",
+        "moved_to_file": "Content truncated — the full text is attached.",
+        "transcript_attached": "*The full content is attached as a `.txt` transcript.*",
+        "transcript_header": "Transcript of deleted messages — Moddy",
+        "duration": {
+          "day": "{count}d",
+          "hour": "{count}h",
+          "minute": "{count}m",
+          "second": "{count}s"
+        }
+      },
+      "permissions": {
+        "add_reactions": "Add reactions",
+        "administrator": "Administrator",
+        "attach_files": "Attach files",
+        "ban_members": "Ban members",
+        "bypass_slowmode": "Bypass slowmode",
+        "change_nickname": "Change nickname",
+        "connect": "Connect",
+        "create_events": "Create events",
+        "create_expressions": "Create expressions",
+        "create_instant_invite": "Create invite",
+        "create_polls": "Create polls",
+        "create_private_threads": "Create private threads",
+        "create_public_threads": "Create public threads",
+        "deafen_members": "Deafen members",
+        "embed_links": "Embed links",
+        "external_emojis": "External emojis",
+        "external_stickers": "External stickers",
+        "kick_members": "Kick members",
+        "manage_channels": "Manage channels",
+        "manage_emojis": "Manage emojis",
+        "manage_emojis_and_stickers": "Manage emojis and stickers",
+        "manage_events": "Manage events",
+        "manage_expressions": "Manage expressions",
+        "manage_guild": "Manage server",
+        "manage_messages": "Manage messages",
+        "manage_nicknames": "Manage nicknames",
+        "manage_permissions": "Manage permissions",
+        "manage_roles": "Manage roles",
+        "manage_threads": "Manage threads",
+        "manage_webhooks": "Manage webhooks",
+        "mention_everyone": "Mention @everyone",
+        "moderate_members": "Timeout members",
+        "move_members": "Move members",
+        "mute_members": "Mute members",
+        "pin_messages": "Pin messages",
+        "priority_speaker": "Priority speaker",
+        "read_message_history": "Read message history",
+        "read_messages": "View channels",
+        "request_to_speak": "Request to speak",
+        "send_messages": "Send messages",
+        "send_messages_in_threads": "Send messages in threads",
+        "send_polls": "Send polls",
+        "send_tts_messages": "Send TTS messages",
+        "send_voice_messages": "Send voice messages",
+        "set_voice_channel_status": "Set voice channel status",
+        "speak": "Speak",
+        "stream": "Video",
+        "use_application_commands": "Use application commands",
+        "use_embedded_activities": "Use activities",
+        "use_external_apps": "Use external apps",
+        "use_external_emojis": "Use external emojis",
+        "use_external_sounds": "Use external sounds",
+        "use_external_stickers": "Use external stickers",
+        "use_soundboard": "Use soundboard",
+        "use_voice_activation": "Use voice activity",
+        "view_audit_log": "View audit log",
+        "view_channel": "View channel",
+        "view_creator_monetization_analytics": "View monetization analytics",
+        "view_guild_insights": "View server insights"
+      },
+      "description": "Detailed audit logs for everything that happens on the server",
+      "config": {
+        "title": "Server logs",
+        "description": "Pick a category, choose the channel(s) that should receive it, and untick the events you don't care about. Everything is on by default.",
+        "summary": {
+          "empty": "No category configured yet.",
+          "events": "{enabled}/{total} events logged"
+        },
+        "categories": {
+          "placeholder": "Configure a category…",
+          "bound": "{count} channel(s) · {enabled}/{total} events",
+          "unbound": "Not configured · {total} events available"
+        },
+        "mass": {
+          "section_title": "Send everything to one channel",
+          "section_description": "Binds every category to the chosen channel at once.",
+          "placeholder": "Pick the channel for all logs…"
+        },
+        "channels": {
+          "section_title": "Destination channels",
+          "section_description": "Up to {max} channels for this category.",
+          "placeholder": "Pick one or more channels…"
+        },
+        "events": {
+          "section_title": "Logged events",
+          "section_description": "Ticked events are logged; untick the ones to ignore.",
+          "enabled_count": "{enabled}/{total} events active",
+          "placeholder": "Tick the events to log…"
+        },
+        "buttons": {
+          "back": "Back",
+          "all": "Enable all",
+          "none": "Disable all",
+          "prev": "Previous page",
+          "next": "Next page"
+        },
+        "clear": {
+          "button": "Delete everything"
+        },
+        "options": {
+          "button": "Options",
+          "title": "Log options",
+          "description": "Settings that apply to every category.",
+          "channels": {
+            "section_title": "Ignored channels",
+            "section_description": "No event coming from these channels is logged.",
+            "placeholder": "Pick the channels to ignore…"
+          },
+          "roles": {
+            "section_title": "Ignored roles",
+            "section_description": "Members with any of these roles are never logged.",
+            "placeholder": "Pick the roles to ignore…"
+          },
+          "locale": {
+            "section_title": "Log language",
+            "section_description": "By default, logs follow the server's language.",
+            "placeholder": "Pick the log language…",
+            "values": {
+              "auto": "Server language",
+              "fr": "Français",
+              "en-US": "English",
+              "es-ES": "Español",
+              "pt-BR": "Português",
+              "de": "Deutsch"
+            }
+          },
+          "toggles": {
+            "section_title": "Settings",
+            "bots": "Ignore bots",
+            "transcripts": "Attach transcripts"
+          }
+        },
+        "errors": {
+          "title": "Cannot save",
+          "invalid_config": "Invalid configuration.",
+          "unknown_category": "Unknown category: `{category}`.",
+          "channel_not_found": "Channel `{channel_id}` could not be found.",
+          "missing_permissions": "I am missing **View Channel**, **Send Messages** or **Embed Links** in {channel}."
+        }
+      },
+      "categories": {
+        "server": {
+          "name": "Server",
+          "description": "Arrivals, departures, sanctions and server settings."
+        },
+        "messages": {
+          "name": "Messages",
+          "description": "Message deletions, edits and publishes."
+        },
+        "users": {
+          "name": "Users",
+          "description": "Nicknames, avatars, roles and timeouts."
+        },
+        "moderation": {
+          "name": "Moderation",
+          "description": "Moddy sanctions and moderation actions."
+        },
+        "channels": {
+          "name": "Channels",
+          "description": "Channel creation, deletion and settings."
+        },
+        "roles": {
+          "name": "Roles",
+          "description": "Role creation, deletion and settings."
+        },
+        "threads": {
+          "name": "Threads",
+          "description": "Thread creation, archiving and locking."
+        },
+        "voice": {
+          "name": "Voice",
+          "description": "Voice joins, moves and disconnects."
+        },
+        "invites": {
+          "name": "Invites",
+          "description": "Invites created, deleted or shared."
+        },
+        "automod": {
+          "name": "Discord AutoMod",
+          "description": "Discord's own AutoMod rules."
+        },
+        "emojis": {
+          "name": "Emojis",
+          "description": "Emojis added, deleted or renamed."
+        },
+        "stickers": {
+          "name": "Stickers",
+          "description": "Stickers added, deleted or updated."
+        },
+        "soundboard": {
+          "name": "Soundboard",
+          "description": "Sounds added, updated or deleted."
+        },
+        "events": {
+          "name": "Events",
+          "description": "The server's scheduled events."
+        },
+        "stage": {
+          "name": "Stage",
+          "description": "Stage channels started or ended."
+        },
+        "polls": {
+          "name": "Polls",
+          "description": "Polls created, finalised and voted on."
+        },
+        "webhooks": {
+          "name": "Webhooks",
+          "description": "Webhooks created, updated or deleted."
+        },
+        "applications": {
+          "name": "Applications",
+          "description": "Bots and applications added or removed."
+        }
+      },
+      "events": {
+        "server": {
+          "ban_add": "Ban added",
+          "ban_remove": "Ban removed",
+          "user_join": "User join",
+          "user_leave": "User leave",
+          "user_kick": "User kick",
+          "member_prune": "Member prune",
+          "afk_channel_update": "AFK channel",
+          "afk_timeout_update": "AFK timeout",
+          "server_banner_update": "Server banner",
+          "message_notifications_update": "Default notifications",
+          "server_discovery_splash_update": "Discovery splash",
+          "server_content_filter_update": "Content filter",
+          "server_features_update": "Server features",
+          "server_icon_update": "Server icon",
+          "mfa_level_update": "MFA level",
+          "server_name_update": "Server name",
+          "server_description_update": "Server description",
+          "server_owner_update": "Server owner",
+          "partnered_update": "Partnered status",
+          "server_boost_level_update": "Boost level",
+          "boost_progress_bar_toggle": "Boost progress bar",
+          "public_updates_channel_update": "Public updates channel",
+          "server_rules_channel_update": "Rules channel",
+          "server_splash_update": "Invite splash",
+          "system_channel_update": "System channel",
+          "server_vanity_update": "Vanity invite",
+          "verification_level_update": "Verification level",
+          "verified_update": "Verified status",
+          "server_widget_update": "Server widget",
+          "server_preferred_locale_update": "Server language",
+          "onboarding_toggle": "Onboarding toggle",
+          "onboarding_channels_update": "Onboarding channels",
+          "onboarding_question_add": "Onboarding question added",
+          "onboarding_question_remove": "Onboarding question removed",
+          "onboarding_question_update": "Onboarding question updated"
+        },
+        "messages": {
+          "message_delete": "Message delete",
+          "message_bulk_delete": "Bulk delete",
+          "message_edit": "Message edit",
+          "message_publish": "Message publish",
+          "message_command_used": "Command used"
+        },
+        "users": {
+          "user_name_update": "Name update",
+          "user_roles_update": "Roles update",
+          "user_roles_add": "Roles added",
+          "user_roles_remove": "Roles removed",
+          "user_avatar_update": "Avatar update",
+          "user_timed_out": "Timed out",
+          "user_timeout_removed": "Timeout removed"
+        },
+        "moderation": {
+          "auto_moderation": "Discord AutoMod",
+          "ban_add": "Ban added",
+          "ban_remove": "Ban removed",
+          "case_delete": "Case deleted",
+          "mass_case_delete": "Mass case delete",
+          "case_update": "Case updated",
+          "kick_add": "Kick added",
+          "kick_remove": "Kick removed",
+          "mute_add": "Mute added",
+          "mute_remove": "Mute removed",
+          "warn_add": "Warn added",
+          "warn_remove": "Warn removed",
+          "report_create": "Report created",
+          "reports_ignore": "Report ignored",
+          "reports_accept": "Report accepted",
+          "user_note_add": "Note added",
+          "user_note_remove": "Note removed"
+        },
+        "channels": {
+          "channel_create": "Channel create",
+          "channel_delete": "Channel delete",
+          "channel_pins_update": "Pins update",
+          "channel_name_update": "Channel name",
+          "channel_topic_update": "Channel topic",
+          "channel_nsfw_update": "Channel NSFW",
+          "channel_parent_update": "Channel category",
+          "channel_permissions_update": "Channel permissions",
+          "channel_type_update": "Channel type",
+          "channel_bitrate_update": "Channel bitrate",
+          "channel_user_limit_update": "User limit",
+          "channel_slowmode_update": "Slow mode",
+          "channel_rtc_region_update": "RTC region",
+          "channel_video_quality_update": "Video quality",
+          "channel_default_archive_duration_update": "Default archive duration",
+          "channel_default_thread_slowmode_update": "Default thread slow mode",
+          "channel_default_reaction_emoji_update": "Default reaction emoji",
+          "channel_default_sort_order_update": "Default sort order",
+          "channel_forum_tags_update": "Forum tags",
+          "channel_forum_layout_update": "Forum layout",
+          "channel_voice_status_update": "Voice status"
+        },
+        "roles": {
+          "role_create": "Role create",
+          "role_delete": "Role delete",
+          "role_color_update": "Role colour",
+          "role_hoist_update": "Role hoist",
+          "role_mentionable_update": "Role mentionable",
+          "role_name_update": "Role name",
+          "role_permissions_update": "Role permissions",
+          "role_icon_update": "Role icon"
+        },
+        "threads": {
+          "thread_create": "Thread create",
+          "thread_delete": "Thread delete",
+          "thread_name_update": "Thread name",
+          "thread_slowmode_update": "Thread slow mode",
+          "thread_archive_duration_update": "Archive duration",
+          "thread_archive": "Thread archived",
+          "thread_unarchive": "Thread unarchived",
+          "thread_lock": "Thread locked",
+          "thread_unlock": "Thread unlocked"
+        },
+        "voice": {
+          "voice_channel_full": "Voice channel full",
+          "voice_user_join": "Voice join",
+          "voice_user_switch": "Voice switch",
+          "voice_user_leave": "Voice leave",
+          "voice_user_move": "Voice move",
+          "voice_user_kick": "Voice kick"
+        },
+        "invites": {
+          "invite_create": "Invite create",
+          "invite_delete": "Invite delete",
+          "invite_post": "Invite posted"
+        },
+        "automod": {
+          "automod_rule_create": "Rule create",
+          "automod_rule_delete": "Rule delete",
+          "automod_rule_toggle": "Rule toggle",
+          "automod_rule_name_update": "Rule name",
+          "automod_rule_actions_update": "Rule actions",
+          "automod_rule_content_update": "Rule content",
+          "automod_rule_roles_update": "Exempt roles",
+          "automod_rule_channels_update": "Exempt channels",
+          "automod_rule_whitelist_update": "Allow list"
+        },
+        "emojis": {
+          "emoji_create": "Emoji create",
+          "emoji_delete": "Emoji delete",
+          "emoji_name_update": "Emoji name",
+          "emoji_roles_update": "Emoji roles"
+        },
+        "stickers": {
+          "sticker_create": "Sticker create",
+          "sticker_delete": "Sticker delete",
+          "sticker_name_update": "Sticker name",
+          "sticker_description_update": "Sticker description",
+          "sticker_related_emoji_update": "Sticker emoji"
+        },
+        "soundboard": {
+          "sound_upload": "Sound upload",
+          "sound_name_update": "Sound name",
+          "sound_volume_update": "Sound volume",
+          "sound_emoji_update": "Sound emoji",
+          "sound_delete": "Sound delete"
+        },
+        "events": {
+          "event_create": "Event create",
+          "event_delete": "Event delete",
+          "event_name_update": "Event name",
+          "event_description_update": "Event description",
+          "event_location_update": "Event location",
+          "event_privacy_level_update": "Event privacy",
+          "event_start_time_update": "Event start",
+          "event_end_time_update": "Event end",
+          "event_status_update": "Event status",
+          "event_image_update": "Event image",
+          "event_user_subscribe": "Event subscribe",
+          "event_user_unsubscribe": "Event unsubscribe"
+        },
+        "stage": {
+          "stage_start": "Stage start",
+          "stage_end": "Stage end",
+          "stage_topic_update": "Stage topic",
+          "stage_privacy_update": "Stage privacy"
+        },
+        "polls": {
+          "poll_create": "Poll create",
+          "poll_delete": "Poll delete",
+          "poll_finalize": "Poll finalize",
+          "poll_votes_add": "Vote added",
+          "poll_votes_remove": "Vote removed"
+        },
+        "webhooks": {
+          "webhook_create": "Webhook create",
+          "webhook_name_update": "Webhook name",
+          "webhook_avatar_update": "Webhook avatar",
+          "webhook_channel_update": "Webhook channel",
+          "webhook_delete": "Webhook delete"
+        },
+        "applications": {
+          "app_add": "App add",
+          "app_remove": "App remove",
+          "app_command_permission_update": "Command permissions"
+        }
+      },
+      "titles": {
+        "server": {
+          "ban_add": "A user was banned",
+          "ban_remove": "A user was unbanned",
+          "user_join": "A user joined the server",
+          "user_leave": "A user left the server",
+          "user_kick": "A user was kicked",
+          "member_prune": "Inactive members were pruned",
+          "afk_channel_update": "AFK channel updated",
+          "afk_timeout_update": "AFK timeout updated",
+          "server_banner_update": "Server banner updated",
+          "message_notifications_update": "Default notification setting updated",
+          "server_discovery_splash_update": "Discovery splash updated",
+          "server_content_filter_update": "Explicit content filter updated",
+          "server_features_update": "Server features updated",
+          "server_icon_update": "Server icon updated",
+          "mfa_level_update": "Two-factor requirement updated",
+          "server_name_update": "Server name updated",
+          "server_description_update": "Server description updated",
+          "server_owner_update": "Server ownership transferred",
+          "partnered_update": "Partnered status updated",
+          "server_boost_level_update": "Boost level updated",
+          "boost_progress_bar_toggle": "Boost progress bar toggled",
+          "public_updates_channel_update": "Public updates channel updated",
+          "server_rules_channel_update": "Rules channel updated",
+          "server_splash_update": "Invite splash updated",
+          "system_channel_update": "System channel updated",
+          "server_vanity_update": "Vanity invite updated",
+          "verification_level_update": "Verification level updated",
+          "verified_update": "Verified status updated",
+          "server_widget_update": "Server widget updated",
+          "server_preferred_locale_update": "Server language updated",
+          "onboarding_toggle": "Onboarding was enabled or disabled",
+          "onboarding_channels_update": "Onboarding default channels updated",
+          "onboarding_question_add": "An onboarding question was added",
+          "onboarding_question_remove": "An onboarding question was removed",
+          "onboarding_question_update": "An onboarding question was updated"
+        },
+        "messages": {
+          "message_delete": "Message deleted",
+          "message_bulk_delete": "Messages bulk deleted",
+          "message_edit": "Message edited",
+          "message_publish": "Message published",
+          "message_command_used": "A command was used"
+        },
+        "users": {
+          "user_name_update": "A user's name was changed",
+          "user_roles_update": "A user's roles were updated",
+          "user_roles_add": "Role(s) added to a user",
+          "user_roles_remove": "Role(s) removed from a user",
+          "user_avatar_update": "A user's avatar was changed",
+          "user_timed_out": "A user was timed out",
+          "user_timeout_removed": "A user's timeout was removed"
+        },
+        "moderation": {
+          "auto_moderation": "Discord AutoMod took action",
+          "ban_add": "A user was banned",
+          "ban_remove": "A user was unbanned",
+          "case_delete": "A moderation case was deleted",
+          "mass_case_delete": "Several moderation cases were deleted",
+          "case_update": "A moderation case was updated",
+          "kick_add": "A user was kicked",
+          "kick_remove": "A kick was reverted",
+          "mute_add": "A user was muted",
+          "mute_remove": "A user was unmuted",
+          "warn_add": "A user was warned",
+          "warn_remove": "A warning was removed",
+          "report_create": "A report was created",
+          "reports_ignore": "A report was ignored",
+          "reports_accept": "A report was accepted",
+          "user_note_add": "A note was added to a user",
+          "user_note_remove": "A note was removed from a user"
+        },
+        "channels": {
+          "channel_create": "Channel created",
+          "channel_delete": "Channel deleted",
+          "channel_pins_update": "A channel's pinned messages changed",
+          "channel_name_update": "A channel was renamed",
+          "channel_topic_update": "A channel topic was updated",
+          "channel_nsfw_update": "A channel's NSFW setting was updated",
+          "channel_parent_update": "A channel was moved to another category",
+          "channel_permissions_update": "A channel's permissions were updated",
+          "channel_type_update": "A channel's type was changed",
+          "channel_bitrate_update": "A voice channel's bitrate was updated",
+          "channel_user_limit_update": "A voice channel's user limit was updated",
+          "channel_slowmode_update": "A channel's slow mode was updated",
+          "channel_rtc_region_update": "A channel's voice region was updated",
+          "channel_video_quality_update": "A channel's video quality was updated",
+          "channel_default_archive_duration_update": "Default archive duration updated",
+          "channel_default_thread_slowmode_update": "Default thread slow mode updated",
+          "channel_default_reaction_emoji_update": "Default reaction emoji updated",
+          "channel_default_sort_order_update": "Forum default sort order updated",
+          "channel_forum_tags_update": "Forum tags updated",
+          "channel_forum_layout_update": "Forum layout updated",
+          "channel_voice_status_update": "A voice channel's status was updated"
+        },
+        "roles": {
+          "role_create": "Role created",
+          "role_delete": "Role deleted",
+          "role_color_update": "A role's colour was updated",
+          "role_hoist_update": "A role's separate display was updated",
+          "role_mentionable_update": "A role's mentionability was updated",
+          "role_name_update": "A role was renamed",
+          "role_permissions_update": "A role's permissions were updated",
+          "role_icon_update": "A role's icon was updated"
+        },
+        "threads": {
+          "thread_create": "Thread created",
+          "thread_delete": "Thread deleted",
+          "thread_name_update": "A thread was renamed",
+          "thread_slowmode_update": "A thread's slow mode was updated",
+          "thread_archive_duration_update": "A thread's archive duration was updated",
+          "thread_archive": "Thread archived",
+          "thread_unarchive": "Thread unarchived",
+          "thread_lock": "Thread locked",
+          "thread_unlock": "Thread unlocked"
+        },
+        "voice": {
+          "voice_channel_full": "A voice channel is full",
+          "voice_user_join": "A user joined a voice channel",
+          "voice_user_switch": "A user switched voice channel",
+          "voice_user_leave": "A user left a voice channel",
+          "voice_user_move": "A user was moved in voice",
+          "voice_user_kick": "A user was disconnected from voice"
+        },
+        "invites": {
+          "invite_create": "Invite created",
+          "invite_delete": "Invite deleted",
+          "invite_post": "An invite was posted in a channel"
+        },
+        "automod": {
+          "automod_rule_create": "AutoMod rule created",
+          "automod_rule_delete": "AutoMod rule deleted",
+          "automod_rule_toggle": "An AutoMod rule was enabled or disabled",
+          "automod_rule_name_update": "An AutoMod rule was renamed",
+          "automod_rule_actions_update": "An AutoMod rule's actions were updated",
+          "automod_rule_content_update": "An AutoMod rule's filters were updated",
+          "automod_rule_roles_update": "An AutoMod rule's exempt roles were updated",
+          "automod_rule_channels_update": "An AutoMod rule's exempt channels were updated",
+          "automod_rule_whitelist_update": "An AutoMod rule's allow list was updated"
+        },
+        "emojis": {
+          "emoji_create": "Emoji added",
+          "emoji_delete": "Emoji deleted",
+          "emoji_name_update": "An emoji was renamed",
+          "emoji_roles_update": "An emoji's allowed roles were updated"
+        },
+        "stickers": {
+          "sticker_create": "Sticker added",
+          "sticker_delete": "Sticker deleted",
+          "sticker_name_update": "A sticker was renamed",
+          "sticker_description_update": "A sticker's description was updated",
+          "sticker_related_emoji_update": "A sticker's related emoji was updated"
+        },
+        "soundboard": {
+          "sound_upload": "Soundboard sound uploaded",
+          "sound_name_update": "A soundboard sound was renamed",
+          "sound_volume_update": "A soundboard sound's volume was updated",
+          "sound_emoji_update": "A soundboard sound's emoji was updated",
+          "sound_delete": "Soundboard sound deleted"
+        },
+        "events": {
+          "event_create": "Event created",
+          "event_delete": "Event deleted",
+          "event_name_update": "An event was renamed",
+          "event_description_update": "An event's description was updated",
+          "event_location_update": "An event's location was updated",
+          "event_privacy_level_update": "An event's privacy level was updated",
+          "event_start_time_update": "An event's start time was updated",
+          "event_end_time_update": "An event's end time was updated",
+          "event_status_update": "An event's status was updated",
+          "event_image_update": "An event's image was updated",
+          "event_user_subscribe": "A user subscribed to an event",
+          "event_user_unsubscribe": "A user unsubscribed from an event"
+        },
+        "stage": {
+          "stage_start": "A stage started",
+          "stage_end": "A stage ended",
+          "stage_topic_update": "A stage's topic was updated",
+          "stage_privacy_update": "A stage's privacy level was updated"
+        },
+        "polls": {
+          "poll_create": "Poll created",
+          "poll_delete": "Poll deleted",
+          "poll_finalize": "A poll ended",
+          "poll_votes_add": "A vote was added to a poll",
+          "poll_votes_remove": "A vote was removed from a poll"
+        },
+        "webhooks": {
+          "webhook_create": "Webhook created",
+          "webhook_name_update": "A webhook was renamed",
+          "webhook_avatar_update": "A webhook's avatar was updated",
+          "webhook_channel_update": "A webhook's channel was updated",
+          "webhook_delete": "Webhook deleted"
+        },
+        "applications": {
+          "app_add": "An application was added to the server",
+          "app_remove": "An application was removed from the server",
+          "app_command_permission_update": "A command's permissions were updated"
+        }
+      }
     }
   },
   "languages": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -2049,6 +2049,748 @@
           "footer": "Para cualquier duda, contacta con la moderación del servidor."
         }
       }
+    },
+    "logs": {
+      "fields": {
+        "account_created": "Cuenta creada",
+        "action": "Acción",
+        "added": "Añadido(s)",
+        "after": "Después",
+        "after_channel": "Nuevo canal",
+        "allow_list": "Lista blanca",
+        "animated": "Animado",
+        "answer_id": "ID de la respuesta",
+        "answers": "Respuestas",
+        "application": "Aplicación",
+        "attachments": "Archivos adjuntos",
+        "author": "Autor(a)",
+        "authors": "Autores implicados",
+        "before": "Antes",
+        "before_channel": "Canal anterior",
+        "case": "Caso",
+        "category": "Categoría",
+        "channel": "Canal",
+        "channel_created": "Canal creado",
+        "colour": "Color",
+        "command": "Comando",
+        "count": "Cantidad",
+        "created": "Creación",
+        "description": "Descripción",
+        "emoji": "Emoji",
+        "enabled": "Activada",
+        "end_time": "Fin",
+        "event": "Evento",
+        "expires": "Caduca",
+        "expires_at": "Caduca el",
+        "hoisted": "Mostrado por separado",
+        "id": "ID",
+        "inactive_days": "Días de inactividad",
+        "invite": "Invitación",
+        "inviter": "Creada por",
+        "invites": "Invitaciones",
+        "joined_at": "Fecha de entrada",
+        "keyword_filter": "Palabras clave",
+        "last_pin": "Último mensaje anclado",
+        "location": "Ubicación",
+        "matched": "Coincidencia",
+        "max_uses": "Usos máximos",
+        "member_count": "Número de miembros",
+        "members": "Miembros",
+        "members_removed": "Miembros eliminados",
+        "mention_limit": "Límite de menciones",
+        "mentionable": "Mencionable",
+        "message": "Mensaje",
+        "message_created": "Mensaje creado",
+        "message_id": "ID del mensaje",
+        "moderator": "Moderador(a)",
+        "name": "Nombre",
+        "newest_message": "Mensaje más reciente",
+        "note": "Nota",
+        "oldest_message": "Mensaje más antiguo",
+        "options": "Opciones",
+        "owner": "Propietario(a)",
+        "parent_channel": "Canal principal",
+        "permissions": "Permisos",
+        "presets": "Filtros predefinidos",
+        "privacy_level": "Privacidad",
+        "question": "Pregunta",
+        "reason": "Motivo",
+        "regex_patterns": "Expresiones regulares",
+        "removed": "Eliminado(s)",
+        "reply_to": "En respuesta a",
+        "role": "Rol",
+        "role_created": "Rol creado",
+        "roles": "Roles",
+        "roles_added": "Añadido(s)",
+        "roles_removed": "Eliminado(s)",
+        "rule": "Regla",
+        "server": "Servidor",
+        "sound": "Sonido",
+        "start_time": "Inicio",
+        "status": "Estado",
+        "sticker": "Sticker",
+        "stickers": "Stickers",
+        "subscribers": "Interesados",
+        "target": "Objetivo",
+        "temporary": "Temporal",
+        "thread": "Hilo",
+        "thread_created": "Hilo creado",
+        "topic": "Tema",
+        "trigger": "Desencadenante",
+        "type": "Tipo",
+        "until": "Hasta el",
+        "user": "Usuario(a)",
+        "user_id": "ID del usuario(a)",
+        "user_limit": "Límite de usuarios",
+        "uses": "Usos",
+        "volume": "Volumen",
+        "votes": "Votos",
+        "webhook": "Webhook"
+      },
+      "values": {
+        "yes": "Sí",
+        "no": "No",
+        "on": "Activado",
+        "off": "Desactivado",
+        "none": "Ninguno",
+        "unlimited": "Ilimitado",
+        "disabled": "Desactivado",
+        "automatic": "Automático",
+        "allowed": "Permitido",
+        "denied": "Denegado",
+        "open_link": "Ver",
+        "default_colour": "Color predeterminado",
+        "boost_tier": "Nivel {tier}",
+        "empty_content": "*Sin texto*",
+        "uncached_message": "*El contenido del mensaje ya no estaba en caché.*",
+        "uncached_messages": "*Ninguno de estos mensajes estaba en caché: no se ha podido generar una transcripción.*",
+        "moved_to_file": "Contenido truncado — el texto completo está adjunto.",
+        "transcript_attached": "*El contenido completo está adjunto (transcripción `.txt`).*",
+        "transcript_header": "Transcripción de los mensajes eliminados — Moddy",
+        "duration": {
+          "day": "{count} d",
+          "hour": "{count} h",
+          "minute": "{count} min",
+          "second": "{count} s"
+        }
+      },
+      "permissions": {
+        "add_reactions": "Añadir reacciones",
+        "administrator": "Administrador",
+        "attach_files": "Adjuntar archivos",
+        "ban_members": "Banear miembros",
+        "bypass_slowmode": "Ignorar el modo lento",
+        "change_nickname": "Cambiar apodo",
+        "connect": "Conectar",
+        "create_events": "Crear eventos",
+        "create_expressions": "Crear expresiones",
+        "create_instant_invite": "Crear invitación",
+        "create_polls": "Crear encuestas",
+        "create_private_threads": "Crear hilos privados",
+        "create_public_threads": "Crear hilos públicos",
+        "deafen_members": "Ensordecer miembros",
+        "embed_links": "Insertar enlaces",
+        "external_emojis": "Emojis externos",
+        "external_stickers": "Stickers externos",
+        "kick_members": "Expulsar miembros",
+        "manage_channels": "Gestionar canales",
+        "manage_emojis": "Gestionar emojis",
+        "manage_emojis_and_stickers": "Gestionar emojis y stickers",
+        "manage_events": "Gestionar eventos",
+        "manage_expressions": "Gestionar expresiones",
+        "manage_guild": "Gestionar servidor",
+        "manage_messages": "Gestionar mensajes",
+        "manage_nicknames": "Gestionar apodos",
+        "manage_permissions": "Gestionar permisos",
+        "manage_roles": "Gestionar roles",
+        "manage_threads": "Gestionar hilos",
+        "manage_webhooks": "Gestionar webhooks",
+        "mention_everyone": "Mencionar a @everyone",
+        "moderate_members": "Aislar miembros",
+        "move_members": "Mover miembros",
+        "mute_members": "Silenciar miembros",
+        "pin_messages": "Anclar mensajes",
+        "priority_speaker": "Prioridad de intervención",
+        "read_message_history": "Leer el historial de mensajes",
+        "read_messages": "Ver canales",
+        "request_to_speak": "Pedir hablar",
+        "send_messages": "Enviar mensajes",
+        "send_messages_in_threads": "Enviar mensajes en hilos",
+        "send_polls": "Enviar encuestas",
+        "send_tts_messages": "Enviar mensajes de texto a voz",
+        "send_voice_messages": "Enviar mensajes de voz",
+        "set_voice_channel_status": "Definir el estado del canal de voz",
+        "speak": "Hablar",
+        "stream": "Compartir vídeo",
+        "use_application_commands": "Usar comandos",
+        "use_embedded_activities": "Usar actividades",
+        "use_external_apps": "Usar aplicaciones externas",
+        "use_external_emojis": "Usar emojis externos",
+        "use_external_sounds": "Usar sonidos externos",
+        "use_external_stickers": "Usar stickers externos",
+        "use_soundboard": "Usar la caja de sonidos",
+        "use_voice_activation": "Usar detección de voz",
+        "view_audit_log": "Ver el registro de auditoría",
+        "view_channel": "Ver canal",
+        "view_creator_monetization_analytics": "Ver estadísticas de monetización",
+        "view_guild_insights": "Ver estadísticas del servidor"
+      },
+      "description": "Registros detallados de todo lo que ocurre en el servidor",
+      "config": {
+        "title": "Registros del servidor",
+        "description": "Elige una categoría, indica el canal o los canales que deben recibirla y desmarca los eventos que no te interesen. Todo está activado de forma predeterminada.",
+        "summary": {
+          "empty": "Todavía no hay ninguna categoría configurada.",
+          "events": "{enabled}/{total} eventos registrados"
+        },
+        "categories": {
+          "placeholder": "Configurar una categoría…",
+          "bound": "{count} canal(es) · {enabled}/{total} eventos",
+          "unbound": "Sin configurar · {total} eventos disponibles"
+        },
+        "mass": {
+          "section_title": "Enviarlo todo a un solo canal",
+          "section_description": "Asigna todas las categorías al canal elegido de una vez.",
+          "placeholder": "Elegir el canal de todos los registros…"
+        },
+        "channels": {
+          "section_title": "Canales de destino",
+          "section_description": "Hasta {max} canales para esta categoría.",
+          "placeholder": "Elegir uno o varios canales…"
+        },
+        "events": {
+          "section_title": "Eventos registrados",
+          "section_description": "Los eventos marcados se registran; desmarca los que quieras ignorar.",
+          "enabled_count": "{enabled}/{total} eventos activos",
+          "placeholder": "Marcar los eventos que se deben registrar…"
+        },
+        "buttons": {
+          "back": "Volver",
+          "all": "Activar todo",
+          "none": "Desactivar todo",
+          "prev": "Página anterior",
+          "next": "Página siguiente"
+        },
+        "clear": {
+          "button": "Eliminar todo"
+        },
+        "options": {
+          "button": "Opciones",
+          "title": "Opciones de los registros",
+          "description": "Ajustes que se aplican a todas las categorías.",
+          "channels": {
+            "section_title": "Canales ignorados",
+            "section_description": "No se registrará ningún evento procedente de estos canales.",
+            "placeholder": "Elegir los canales que se deben ignorar…"
+          },
+          "roles": {
+            "section_title": "Roles ignorados",
+            "section_description": "Los miembros que tengan alguno de estos roles no se registrarán.",
+            "placeholder": "Elegir los roles que se deben ignorar…"
+          },
+          "locale": {
+            "section_title": "Idioma de los registros",
+            "section_description": "De forma predeterminada, los registros siguen el idioma del servidor.",
+            "placeholder": "Elegir el idioma de los registros…",
+            "values": {
+              "auto": "Idioma del servidor",
+              "fr": "Français",
+              "en-US": "English",
+              "es-ES": "Español",
+              "pt-BR": "Português",
+              "de": "Deutsch"
+            }
+          },
+          "toggles": {
+            "section_title": "Ajustes",
+            "bots": "Ignorar los bots",
+            "transcripts": "Transcripciones adjuntas"
+          }
+        },
+        "errors": {
+          "title": "No se ha podido configurar",
+          "invalid_config": "Configuración no válida.",
+          "unknown_category": "Categoría desconocida: `{category}`.",
+          "channel_not_found": "No se encuentra el canal `{channel_id}`.",
+          "missing_permissions": "Me faltan los permisos **Ver canal**, **Enviar mensajes** o **Insertar enlaces** en {channel}."
+        }
+      },
+      "categories": {
+        "server": {
+          "name": "Servidor",
+          "description": "Entradas, salidas, sanciones y ajustes del servidor."
+        },
+        "messages": {
+          "name": "Mensajes",
+          "description": "Eliminaciones, ediciones y publicaciones de mensajes."
+        },
+        "users": {
+          "name": "Usuarios",
+          "description": "Apodos, avatares, roles y aislamientos temporales."
+        },
+        "moderation": {
+          "name": "Moderación",
+          "description": "Sanciones de Moddy y acciones de moderación."
+        },
+        "channels": {
+          "name": "Canales",
+          "description": "Creación, eliminación y ajustes de los canales."
+        },
+        "roles": {
+          "name": "Roles",
+          "description": "Creación, eliminación y ajustes de los roles."
+        },
+        "threads": {
+          "name": "Hilos",
+          "description": "Creación, archivado y bloqueo de los hilos."
+        },
+        "voice": {
+          "name": "Voz",
+          "description": "Conexiones, movimientos y desconexiones en voz."
+        },
+        "invites": {
+          "name": "Invitaciones",
+          "description": "Invitaciones creadas, eliminadas o compartidas."
+        },
+        "automod": {
+          "name": "AutoMod de Discord",
+          "description": "Reglas de AutoMod nativas de Discord."
+        },
+        "emojis": {
+          "name": "Emojis",
+          "description": "Emojis añadidos, eliminados o renombrados."
+        },
+        "stickers": {
+          "name": "Stickers",
+          "description": "Stickers añadidos, eliminados o modificados."
+        },
+        "soundboard": {
+          "name": "Caja de sonidos",
+          "description": "Sonidos añadidos, modificados o eliminados."
+        },
+        "events": {
+          "name": "Eventos",
+          "description": "Eventos programados del servidor."
+        },
+        "stage": {
+          "name": "Escenarios",
+          "description": "Escenarios (canales de escenario) iniciados o finalizados."
+        },
+        "polls": {
+          "name": "Encuestas",
+          "description": "Encuestas creadas, finalizadas y votos."
+        },
+        "webhooks": {
+          "name": "Webhooks",
+          "description": "Webhooks creados, modificados o eliminados."
+        },
+        "applications": {
+          "name": "Aplicaciones",
+          "description": "Bots y aplicaciones añadidos o eliminados."
+        }
+      },
+      "events": {
+        "server": {
+          "ban_add": "Baneo",
+          "ban_remove": "Desbaneo",
+          "user_join": "Entrada de un miembro",
+          "user_leave": "Salida de un miembro",
+          "user_kick": "Expulsión",
+          "member_prune": "Purga de miembros inactivos",
+          "afk_channel_update": "Canal AFK",
+          "afk_timeout_update": "Tiempo de espera AFK",
+          "server_banner_update": "Banner del servidor",
+          "message_notifications_update": "Notificaciones predeterminadas",
+          "server_discovery_splash_update": "Imagen de descubrimiento",
+          "server_content_filter_update": "Filtro de contenido",
+          "server_features_update": "Funciones del servidor",
+          "server_icon_update": "Icono del servidor",
+          "mfa_level_update": "Nivel de A2F",
+          "server_name_update": "Nombre del servidor",
+          "server_description_update": "Descripción del servidor",
+          "server_owner_update": "Propietario del servidor",
+          "partnered_update": "Estado de partner",
+          "server_boost_level_update": "Nivel de mejora",
+          "boost_progress_bar_toggle": "Barra de progreso de mejoras",
+          "public_updates_channel_update": "Canal de anuncios de Discord",
+          "server_rules_channel_update": "Canal de reglas",
+          "server_splash_update": "Imagen de invitación",
+          "system_channel_update": "Canal del sistema",
+          "server_vanity_update": "Invitación personalizada",
+          "verification_level_update": "Nivel de verificación",
+          "verified_update": "Estado verificado",
+          "server_widget_update": "Widget del servidor",
+          "server_preferred_locale_update": "Idioma del servidor",
+          "onboarding_toggle": "Incorporación activada",
+          "onboarding_channels_update": "Canales de incorporación",
+          "onboarding_question_add": "Pregunta de incorporación añadida",
+          "onboarding_question_remove": "Pregunta de incorporación eliminada",
+          "onboarding_question_update": "Pregunta de incorporación modificada"
+        },
+        "messages": {
+          "message_delete": "Mensaje eliminado",
+          "message_bulk_delete": "Eliminación masiva",
+          "message_edit": "Mensaje editado",
+          "message_publish": "Mensaje publicado",
+          "message_command_used": "Comando utilizado"
+        },
+        "users": {
+          "user_name_update": "Cambio de apodo",
+          "user_roles_update": "Roles modificados",
+          "user_roles_add": "Rol añadido",
+          "user_roles_remove": "Rol eliminado",
+          "user_avatar_update": "Cambio de avatar",
+          "user_timed_out": "Aislamiento temporal",
+          "user_timeout_removed": "Fin del aislamiento temporal"
+        },
+        "moderation": {
+          "auto_moderation": "AutoMod de Discord",
+          "ban_add": "Baneo",
+          "ban_remove": "Desbaneo",
+          "case_delete": "Caso eliminado",
+          "mass_case_delete": "Eliminación masiva de casos",
+          "case_update": "Caso modificado",
+          "kick_add": "Expulsión",
+          "kick_remove": "Expulsión anulada",
+          "mute_add": "Silenciado",
+          "mute_remove": "Fin del silencio",
+          "warn_add": "Advertencia",
+          "warn_remove": "Advertencia retirada",
+          "report_create": "Denuncia creada",
+          "reports_ignore": "Denuncia ignorada",
+          "reports_accept": "Denuncia aceptada",
+          "user_note_add": "Nota añadida",
+          "user_note_remove": "Nota eliminada"
+        },
+        "channels": {
+          "channel_create": "Canal creado",
+          "channel_delete": "Canal eliminado",
+          "channel_pins_update": "Mensajes anclados modificados",
+          "channel_name_update": "Nombre del canal",
+          "channel_topic_update": "Tema del canal",
+          "channel_nsfw_update": "NSFW del canal",
+          "channel_parent_update": "Categoría del canal",
+          "channel_permissions_update": "Permisos del canal",
+          "channel_type_update": "Tipo de canal",
+          "channel_bitrate_update": "Bitrate del canal",
+          "channel_user_limit_update": "Límite de usuarios",
+          "channel_slowmode_update": "Modo lento",
+          "channel_rtc_region_update": "Región de voz",
+          "channel_video_quality_update": "Calidad de vídeo",
+          "channel_default_archive_duration_update": "Archivado predeterminado",
+          "channel_default_thread_slowmode_update": "Modo lento de los hilos",
+          "channel_default_reaction_emoji_update": "Reacción predeterminada",
+          "channel_default_sort_order_update": "Orden predeterminado",
+          "channel_forum_tags_update": "Etiquetas del foro",
+          "channel_forum_layout_update": "Vista del foro",
+          "channel_voice_status_update": "Estado del canal de voz"
+        },
+        "roles": {
+          "role_create": "Rol creado",
+          "role_delete": "Rol eliminado",
+          "role_color_update": "Color del rol",
+          "role_hoist_update": "Visualización por separado",
+          "role_mentionable_update": "Rol mencionable",
+          "role_name_update": "Nombre del rol",
+          "role_permissions_update": "Permisos del rol",
+          "role_icon_update": "Icono del rol"
+        },
+        "threads": {
+          "thread_create": "Hilo creado",
+          "thread_delete": "Hilo eliminado",
+          "thread_name_update": "Nombre del hilo",
+          "thread_slowmode_update": "Modo lento del hilo",
+          "thread_archive_duration_update": "Duración del archivado",
+          "thread_archive": "Hilo archivado",
+          "thread_unarchive": "Hilo desarchivado",
+          "thread_lock": "Hilo bloqueado",
+          "thread_unlock": "Hilo desbloqueado"
+        },
+        "voice": {
+          "voice_channel_full": "Canal de voz lleno",
+          "voice_user_join": "Conexión de voz",
+          "voice_user_switch": "Cambio de canal de voz",
+          "voice_user_leave": "Desconexión de voz",
+          "voice_user_move": "Movimiento forzado",
+          "voice_user_kick": "Desconexión forzada"
+        },
+        "invites": {
+          "invite_create": "Invitación creada",
+          "invite_delete": "Invitación eliminada",
+          "invite_post": "Invitación compartida"
+        },
+        "automod": {
+          "automod_rule_create": "Regla creada",
+          "automod_rule_delete": "Regla eliminada",
+          "automod_rule_toggle": "Regla activada/desactivada",
+          "automod_rule_name_update": "Nombre de la regla",
+          "automod_rule_actions_update": "Acciones de la regla",
+          "automod_rule_content_update": "Contenido filtrado",
+          "automod_rule_roles_update": "Roles exentos",
+          "automod_rule_channels_update": "Canales exentos",
+          "automod_rule_whitelist_update": "Lista blanca"
+        },
+        "emojis": {
+          "emoji_create": "Emoji añadido",
+          "emoji_delete": "Emoji eliminado",
+          "emoji_name_update": "Nombre del emoji",
+          "emoji_roles_update": "Roles del emoji"
+        },
+        "stickers": {
+          "sticker_create": "Sticker añadido",
+          "sticker_delete": "Sticker eliminado",
+          "sticker_name_update": "Nombre del sticker",
+          "sticker_description_update": "Descripción del sticker",
+          "sticker_related_emoji_update": "Emoji del sticker"
+        },
+        "soundboard": {
+          "sound_upload": "Sonido añadido",
+          "sound_name_update": "Nombre del sonido",
+          "sound_volume_update": "Volumen del sonido",
+          "sound_emoji_update": "Emoji del sonido",
+          "sound_delete": "Sonido eliminado"
+        },
+        "events": {
+          "event_create": "Evento creado",
+          "event_delete": "Evento eliminado",
+          "event_name_update": "Nombre del evento",
+          "event_description_update": "Descripción del evento",
+          "event_location_update": "Ubicación del evento",
+          "event_privacy_level_update": "Privacidad del evento",
+          "event_start_time_update": "Inicio del evento",
+          "event_end_time_update": "Fin del evento",
+          "event_status_update": "Estado del evento",
+          "event_image_update": "Imagen del evento",
+          "event_user_subscribe": "Inscripción a un evento",
+          "event_user_unsubscribe": "Baja de un evento"
+        },
+        "stage": {
+          "stage_start": "Escenario iniciado",
+          "stage_end": "Escenario finalizado",
+          "stage_topic_update": "Tema del escenario",
+          "stage_privacy_update": "Privacidad del escenario"
+        },
+        "polls": {
+          "poll_create": "Encuesta creada",
+          "poll_delete": "Encuesta eliminada",
+          "poll_finalize": "Encuesta finalizada",
+          "poll_votes_add": "Voto añadido",
+          "poll_votes_remove": "Voto retirado"
+        },
+        "webhooks": {
+          "webhook_create": "Webhook creado",
+          "webhook_name_update": "Nombre del webhook",
+          "webhook_avatar_update": "Avatar del webhook",
+          "webhook_channel_update": "Canal del webhook",
+          "webhook_delete": "Webhook eliminado"
+        },
+        "applications": {
+          "app_add": "Aplicación añadida",
+          "app_remove": "Aplicación eliminada",
+          "app_command_permission_update": "Permisos de comando"
+        }
+      },
+      "titles": {
+        "server": {
+          "ban_add": "Un usuario ha sido baneado",
+          "ban_remove": "Un usuario ha sido desbaneado",
+          "user_join": "Un usuario se ha unido al servidor",
+          "user_leave": "Un usuario ha salido del servidor",
+          "user_kick": "Un usuario ha sido expulsado",
+          "member_prune": "Se han purgado miembros inactivos",
+          "afk_channel_update": "Se ha modificado el canal AFK",
+          "afk_timeout_update": "Se ha modificado el tiempo de espera AFK",
+          "server_banner_update": "Se ha modificado el banner del servidor",
+          "message_notifications_update": "Se han modificado las notificaciones predeterminadas",
+          "server_discovery_splash_update": "Se ha modificado la imagen de descubrimiento",
+          "server_content_filter_update": "Se ha modificado el filtro de contenido explícito",
+          "server_features_update": "Se han modificado las funciones del servidor",
+          "server_icon_update": "Se ha modificado el icono del servidor",
+          "mfa_level_update": "Se ha modificado el nivel de autenticación en dos pasos",
+          "server_name_update": "Se ha modificado el nombre del servidor",
+          "server_description_update": "Se ha modificado la descripción del servidor",
+          "server_owner_update": "El servidor ha cambiado de propietario",
+          "partnered_update": "Se ha modificado el estado de partner",
+          "server_boost_level_update": "Se ha modificado el nivel de mejora",
+          "boost_progress_bar_toggle": "Se ha modificado la barra de progreso de mejoras",
+          "public_updates_channel_update": "Se ha modificado el canal de anuncios de Discord",
+          "server_rules_channel_update": "Se ha modificado el canal de reglas",
+          "server_splash_update": "Se ha modificado la imagen de invitación",
+          "system_channel_update": "Se ha modificado el canal del sistema",
+          "server_vanity_update": "Se ha modificado la invitación personalizada",
+          "verification_level_update": "Se ha modificado el nivel de verificación",
+          "verified_update": "Se ha modificado el estado verificado",
+          "server_widget_update": "Se ha modificado el widget del servidor",
+          "server_preferred_locale_update": "Se ha modificado el idioma del servidor",
+          "onboarding_toggle": "Se ha modificado la activación de la incorporación",
+          "onboarding_channels_update": "Se han modificado los canales predeterminados de la incorporación",
+          "onboarding_question_add": "Se ha añadido una pregunta de incorporación",
+          "onboarding_question_remove": "Se ha eliminado una pregunta de incorporación",
+          "onboarding_question_update": "Se ha modificado una pregunta de incorporación"
+        },
+        "messages": {
+          "message_delete": "Mensaje eliminado",
+          "message_bulk_delete": "Eliminación masiva de mensajes",
+          "message_edit": "Mensaje editado",
+          "message_publish": "Mensaje publicado en los servidores suscritos",
+          "message_command_used": "Se ha utilizado un comando"
+        },
+        "users": {
+          "user_name_update": "Se ha modificado el apodo de un usuario",
+          "user_roles_update": "Se han modificado los roles de un usuario",
+          "user_roles_add": "Se han añadido roles a un usuario",
+          "user_roles_remove": "Se han eliminado roles a un usuario",
+          "user_avatar_update": "Se ha modificado el avatar de un usuario",
+          "user_timed_out": "Un usuario ha sido aislado temporalmente",
+          "user_timeout_removed": "Se ha levantado el aislamiento temporal de un usuario"
+        },
+        "moderation": {
+          "auto_moderation": "El AutoMod de Discord ha intervenido",
+          "ban_add": "Un usuario ha sido baneado",
+          "ban_remove": "Un usuario ha sido desbaneado",
+          "case_delete": "Se ha eliminado un caso de moderación",
+          "mass_case_delete": "Se han eliminado varios casos de moderación",
+          "case_update": "Se ha modificado un caso de moderación",
+          "kick_add": "Un usuario ha sido expulsado",
+          "kick_remove": "Se ha anulado una expulsión",
+          "mute_add": "Un usuario ha sido silenciado",
+          "mute_remove": "Un usuario ya no está silenciado",
+          "warn_add": "Un usuario ha recibido una advertencia",
+          "warn_remove": "Se ha retirado una advertencia",
+          "report_create": "Se ha creado una denuncia",
+          "reports_ignore": "Se ha ignorado una denuncia",
+          "reports_accept": "Se ha aceptado una denuncia",
+          "user_note_add": "Se ha añadido una nota a un usuario",
+          "user_note_remove": "Se ha eliminado una nota de un usuario"
+        },
+        "channels": {
+          "channel_create": "Canal creado",
+          "channel_delete": "Canal eliminado",
+          "channel_pins_update": "Se han modificado los mensajes anclados de un canal",
+          "channel_name_update": "Se ha modificado el nombre de un canal",
+          "channel_topic_update": "Se ha modificado el tema de un canal",
+          "channel_nsfw_update": "Se ha modificado el ajuste NSFW de un canal",
+          "channel_parent_update": "Se ha modificado la categoría de un canal",
+          "channel_permissions_update": "Se han modificado los permisos de un canal",
+          "channel_type_update": "Se ha modificado el tipo de un canal",
+          "channel_bitrate_update": "Se ha modificado el bitrate de un canal de voz",
+          "channel_user_limit_update": "Se ha modificado el límite de usuarios de un canal de voz",
+          "channel_slowmode_update": "Se ha modificado el modo lento de un canal",
+          "channel_rtc_region_update": "Se ha modificado la región de voz de un canal",
+          "channel_video_quality_update": "Se ha modificado la calidad de vídeo de un canal",
+          "channel_default_archive_duration_update": "Se ha modificado la duración de archivado predeterminada",
+          "channel_default_thread_slowmode_update": "Se ha modificado el modo lento predeterminado de los hilos",
+          "channel_default_reaction_emoji_update": "Se ha modificado el emoji de reacción predeterminado",
+          "channel_default_sort_order_update": "Se ha modificado el orden predeterminado de un foro",
+          "channel_forum_tags_update": "Se han modificado las etiquetas de un foro",
+          "channel_forum_layout_update": "Se ha modificado la vista de un foro",
+          "channel_voice_status_update": "Se ha modificado el estado de un canal de voz"
+        },
+        "roles": {
+          "role_create": "Rol creado",
+          "role_delete": "Rol eliminado",
+          "role_color_update": "Se ha modificado el color de un rol",
+          "role_hoist_update": "Se ha modificado la visualización por separado de un rol",
+          "role_mentionable_update": "Se ha modificado si un rol se puede mencionar",
+          "role_name_update": "Se ha modificado el nombre de un rol",
+          "role_permissions_update": "Se han modificado los permisos de un rol",
+          "role_icon_update": "Se ha modificado el icono de un rol"
+        },
+        "threads": {
+          "thread_create": "Hilo creado",
+          "thread_delete": "Hilo eliminado",
+          "thread_name_update": "Se ha modificado el nombre de un hilo",
+          "thread_slowmode_update": "Se ha modificado el modo lento de un hilo",
+          "thread_archive_duration_update": "Se ha modificado la duración de archivado de un hilo",
+          "thread_archive": "Hilo archivado",
+          "thread_unarchive": "Hilo desarchivado",
+          "thread_lock": "Hilo bloqueado",
+          "thread_unlock": "Hilo desbloqueado"
+        },
+        "voice": {
+          "voice_channel_full": "Un canal de voz está lleno",
+          "voice_user_join": "Un usuario se ha unido a un canal de voz",
+          "voice_user_switch": "Un usuario ha cambiado de canal de voz",
+          "voice_user_leave": "Un usuario ha salido de un canal de voz",
+          "voice_user_move": "Un usuario ha sido movido en voz",
+          "voice_user_kick": "Un usuario ha sido desconectado de la voz"
+        },
+        "invites": {
+          "invite_create": "Invitación creada",
+          "invite_delete": "Invitación eliminada",
+          "invite_post": "Se ha compartido una invitación en un canal"
+        },
+        "automod": {
+          "automod_rule_create": "Regla de AutoMod creada",
+          "automod_rule_delete": "Regla de AutoMod eliminada",
+          "automod_rule_toggle": "Se ha activado o desactivado una regla de AutoMod",
+          "automod_rule_name_update": "Se ha modificado el nombre de una regla de AutoMod",
+          "automod_rule_actions_update": "Se han modificado las acciones de una regla de AutoMod",
+          "automod_rule_content_update": "Se ha modificado el contenido filtrado por una regla de AutoMod",
+          "automod_rule_roles_update": "Se han modificado los roles exentos de una regla de AutoMod",
+          "automod_rule_channels_update": "Se han modificado los canales exentos de una regla de AutoMod",
+          "automod_rule_whitelist_update": "Se ha modificado la lista blanca de una regla de AutoMod"
+        },
+        "emojis": {
+          "emoji_create": "Emoji añadido",
+          "emoji_delete": "Emoji eliminado",
+          "emoji_name_update": "Se ha modificado el nombre de un emoji",
+          "emoji_roles_update": "Se han modificado los roles autorizados de un emoji"
+        },
+        "stickers": {
+          "sticker_create": "Sticker añadido",
+          "sticker_delete": "Sticker eliminado",
+          "sticker_name_update": "Se ha modificado el nombre de un sticker",
+          "sticker_description_update": "Se ha modificado la descripción de un sticker",
+          "sticker_related_emoji_update": "Se ha modificado el emoji asociado a un sticker"
+        },
+        "soundboard": {
+          "sound_upload": "Sonido añadido a la caja de sonidos",
+          "sound_name_update": "Se ha modificado el nombre de un sonido",
+          "sound_volume_update": "Se ha modificado el volumen de un sonido",
+          "sound_emoji_update": "Se ha modificado el emoji de un sonido",
+          "sound_delete": "Sonido eliminado de la caja de sonidos"
+        },
+        "events": {
+          "event_create": "Evento creado",
+          "event_delete": "Evento eliminado",
+          "event_name_update": "Se ha modificado el nombre de un evento",
+          "event_description_update": "Se ha modificado la descripción de un evento",
+          "event_location_update": "Se ha modificado la ubicación de un evento",
+          "event_privacy_level_update": "Se ha modificado la privacidad de un evento",
+          "event_start_time_update": "Se ha modificado la hora de inicio de un evento",
+          "event_end_time_update": "Se ha modificado la hora de fin de un evento",
+          "event_status_update": "Se ha modificado el estado de un evento",
+          "event_image_update": "Se ha modificado la imagen de un evento",
+          "event_user_subscribe": "Un usuario se ha inscrito en un evento",
+          "event_user_unsubscribe": "Un usuario se ha dado de baja de un evento"
+        },
+        "stage": {
+          "stage_start": "Se ha iniciado un escenario",
+          "stage_end": "Se ha finalizado un escenario",
+          "stage_topic_update": "Se ha modificado el tema de un escenario",
+          "stage_privacy_update": "Se ha modificado la privacidad de un escenario"
+        },
+        "polls": {
+          "poll_create": "Encuesta creada",
+          "poll_delete": "Encuesta eliminada",
+          "poll_finalize": "Una encuesta ha finalizado",
+          "poll_votes_add": "Se ha añadido un voto a una encuesta",
+          "poll_votes_remove": "Se ha retirado un voto de una encuesta"
+        },
+        "webhooks": {
+          "webhook_create": "Webhook creado",
+          "webhook_name_update": "Se ha modificado el nombre de un webhook",
+          "webhook_avatar_update": "Se ha modificado el avatar de un webhook",
+          "webhook_channel_update": "Se ha modificado el canal de un webhook",
+          "webhook_delete": "Webhook eliminado"
+        },
+        "applications": {
+          "app_add": "Se ha añadido una aplicación al servidor",
+          "app_remove": "Se ha eliminado una aplicación del servidor",
+          "app_command_permission_update": "Se han modificado los permisos de un comando"
+        }
+      }
     }
   },
   "languages": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -2165,6 +2165,7 @@
         "uncached_message": "*El contenido del mensaje ya no estaba en caché.*",
         "uncached_messages": "*Ninguno de estos mensajes estaba en caché: no se ha podido generar una transcripción.*",
         "moved_to_file": "Contenido truncado — el texto completo está adjunto.",
+        "size_limit": "Registro acortado: superaba el tamaño máximo de un mensaje de Discord.",
         "transcript_attached": "*El contenido completo está adjunto (transcripción `.txt`).*",
         "transcript_header": "Transcripción de los mensajes eliminados — Moddy",
         "duration": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2164,6 +2164,7 @@
         "uncached_message": "*Le contenu du message n'était plus en cache.*",
         "uncached_messages": "*Aucun de ces messages n'était en cache : impossible d'en faire un transcript.*",
         "moved_to_file": "Contenu tronqué — le texte complet est en pièce jointe.",
+        "size_limit": "Log raccourci — il dépassait la taille maximale d'un message Discord.",
         "transcript_attached": "*Le contenu complet est en pièce jointe (transcript `.txt`).*",
         "transcript_header": "Transcript des messages supprimés — Moddy",
         "duration": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2048,6 +2048,748 @@
           "footer": "Pour toute question, contacte la modération du serveur."
         }
       }
+    },
+    "logs": {
+      "fields": {
+        "account_created": "Création du compte",
+        "action": "Action",
+        "added": "Ajouté(s)",
+        "after": "Après",
+        "after_channel": "Nouveau salon",
+        "allow_list": "Liste blanche",
+        "animated": "Animé",
+        "answer_id": "Identifiant de la réponse",
+        "answers": "Réponses",
+        "application": "Application",
+        "attachments": "Pièces jointes",
+        "author": "Auteur(rice)",
+        "authors": "Auteurs concernés",
+        "before": "Avant",
+        "before_channel": "Ancien salon",
+        "case": "Dossier",
+        "category": "Catégorie",
+        "channel": "Salon",
+        "channel_created": "Salon créé",
+        "colour": "Couleur",
+        "command": "Commande",
+        "count": "Nombre",
+        "created": "Création",
+        "description": "Description",
+        "emoji": "Émoji",
+        "enabled": "Activée",
+        "end_time": "Fin",
+        "event": "Événement",
+        "expires": "Expire",
+        "expires_at": "Expire le",
+        "hoisted": "Affiché séparément",
+        "id": "Identifiant",
+        "inactive_days": "Jours d'inactivité",
+        "invite": "Invitation",
+        "inviter": "Créée par",
+        "invites": "Invitations",
+        "joined_at": "Date d'arrivée",
+        "keyword_filter": "Mots-clés",
+        "last_pin": "Dernier message épinglé",
+        "location": "Lieu",
+        "matched": "Correspondance",
+        "max_uses": "Utilisations maximum",
+        "member_count": "Nombre de membres",
+        "members": "Membres",
+        "members_removed": "Membres retirés",
+        "mention_limit": "Limite de mentions",
+        "mentionable": "Mentionnable",
+        "message": "Message",
+        "message_created": "Message créé",
+        "message_id": "Identifiant du message",
+        "moderator": "Modérateur(rice)",
+        "name": "Nom",
+        "newest_message": "Message le plus récent",
+        "note": "Note",
+        "oldest_message": "Message le plus ancien",
+        "options": "Options",
+        "owner": "Propriétaire",
+        "parent_channel": "Salon parent",
+        "permissions": "Permissions",
+        "presets": "Filtres prédéfinis",
+        "privacy_level": "Confidentialité",
+        "question": "Question",
+        "reason": "Raison",
+        "regex_patterns": "Expressions régulières",
+        "removed": "Retiré(s)",
+        "reply_to": "En réponse à",
+        "role": "Rôle",
+        "role_created": "Rôle créé",
+        "roles": "Rôles",
+        "roles_added": "Ajouté(s)",
+        "roles_removed": "Retiré(s)",
+        "rule": "Règle",
+        "server": "Serveur",
+        "sound": "Son",
+        "start_time": "Début",
+        "status": "Statut",
+        "sticker": "Sticker",
+        "stickers": "Stickers",
+        "subscribers": "Intéressé(e)s",
+        "target": "Cible",
+        "temporary": "Temporaire",
+        "thread": "Fil",
+        "thread_created": "Fil créé",
+        "topic": "Sujet",
+        "trigger": "Déclencheur",
+        "type": "Type",
+        "until": "Jusqu'au",
+        "user": "Utilisateur(trice)",
+        "user_id": "Identifiant de l'utilisateur(trice)",
+        "user_limit": "Limite d'utilisateurs",
+        "uses": "Utilisations",
+        "volume": "Volume",
+        "votes": "Votes",
+        "webhook": "Webhook"
+      },
+      "values": {
+        "yes": "Oui",
+        "no": "Non",
+        "on": "Activé",
+        "off": "Désactivé",
+        "none": "Aucun",
+        "unlimited": "Illimité",
+        "disabled": "Désactivé",
+        "automatic": "Automatique",
+        "allowed": "Autorisé",
+        "denied": "Refusé",
+        "open_link": "Voir",
+        "default_colour": "Couleur par défaut",
+        "boost_tier": "Niveau {tier}",
+        "empty_content": "*Aucun texte*",
+        "uncached_message": "*Le contenu du message n'était plus en cache.*",
+        "uncached_messages": "*Aucun de ces messages n'était en cache : impossible d'en faire un transcript.*",
+        "moved_to_file": "Contenu tronqué — le texte complet est en pièce jointe.",
+        "transcript_attached": "*Le contenu complet est en pièce jointe (transcript `.txt`).*",
+        "transcript_header": "Transcript des messages supprimés — Moddy",
+        "duration": {
+          "day": "{count} j",
+          "hour": "{count} h",
+          "minute": "{count} min",
+          "second": "{count} s"
+        }
+      },
+      "permissions": {
+        "add_reactions": "Ajouter des réactions",
+        "administrator": "Administrateur",
+        "attach_files": "Joindre des fichiers",
+        "ban_members": "Bannir des membres",
+        "bypass_slowmode": "Ignorer le mode lent",
+        "change_nickname": "Changer de pseudo",
+        "connect": "Se connecter",
+        "create_events": "Créer des événements",
+        "create_expressions": "Créer des expressions",
+        "create_instant_invite": "Créer une invitation",
+        "create_polls": "Créer des sondages",
+        "create_private_threads": "Créer des fils privés",
+        "create_public_threads": "Créer des fils publics",
+        "deafen_members": "Rendre des membres sourds",
+        "embed_links": "Intégrer des liens",
+        "external_emojis": "Émojis externes",
+        "external_stickers": "Stickers externes",
+        "kick_members": "Expulser des membres",
+        "manage_channels": "Gérer les salons",
+        "manage_emojis": "Gérer les émojis",
+        "manage_emojis_and_stickers": "Gérer les émojis et stickers",
+        "manage_events": "Gérer les événements",
+        "manage_expressions": "Gérer les expressions",
+        "manage_guild": "Gérer le serveur",
+        "manage_messages": "Gérer les messages",
+        "manage_nicknames": "Gérer les pseudos",
+        "manage_permissions": "Gérer les permissions",
+        "manage_roles": "Gérer les rôles",
+        "manage_threads": "Gérer les fils",
+        "manage_webhooks": "Gérer les webhooks",
+        "mention_everyone": "Mentionner @everyone",
+        "moderate_members": "Exclure temporairement",
+        "move_members": "Déplacer des membres",
+        "mute_members": "Rendre des membres muets",
+        "pin_messages": "Épingler des messages",
+        "priority_speaker": "Voix prioritaire",
+        "read_message_history": "Voir les anciens messages",
+        "read_messages": "Voir les salons",
+        "request_to_speak": "Demander à parler",
+        "send_messages": "Envoyer des messages",
+        "send_messages_in_threads": "Envoyer des messages dans les fils",
+        "send_polls": "Envoyer des sondages",
+        "send_tts_messages": "Envoyer des messages TTS",
+        "send_voice_messages": "Envoyer des messages vocaux",
+        "set_voice_channel_status": "Définir le statut du salon vocal",
+        "speak": "Parler",
+        "stream": "Partager sa vidéo",
+        "use_application_commands": "Utiliser les commandes",
+        "use_embedded_activities": "Utiliser les activités",
+        "use_external_apps": "Utiliser des applications externes",
+        "use_external_emojis": "Utiliser des émojis externes",
+        "use_external_sounds": "Utiliser des sons externes",
+        "use_external_stickers": "Utiliser des stickers externes",
+        "use_soundboard": "Utiliser la soundboard",
+        "use_voice_activation": "Utiliser la détection de voix",
+        "view_audit_log": "Voir les logs d'audit",
+        "view_channel": "Voir le salon",
+        "view_creator_monetization_analytics": "Voir les statistiques de monétisation",
+        "view_guild_insights": "Voir les statistiques du serveur"
+      },
+      "description": "Logs détaillés de tout ce qui se passe sur le serveur",
+      "config": {
+        "title": "Logs du serveur",
+        "description": "Choisissez une catégorie, indiquez le ou les salons qui doivent la recevoir, et décochez les événements qui ne vous intéressent pas. Tout est activé par défaut.",
+        "summary": {
+          "empty": "Aucune catégorie configurée pour l'instant.",
+          "events": "{enabled}/{total} événements enregistrés"
+        },
+        "categories": {
+          "placeholder": "Configurer une catégorie…",
+          "bound": "{count} salon(s) · {enabled}/{total} événements",
+          "unbound": "Non configurée · {total} événements disponibles"
+        },
+        "mass": {
+          "section_title": "Tout envoyer dans un seul salon",
+          "section_description": "Attribue toutes les catégories au salon choisi, d'un coup.",
+          "placeholder": "Choisir le salon de tous les logs…"
+        },
+        "channels": {
+          "section_title": "Salons de destination",
+          "section_description": "Jusqu'à {max} salons pour cette catégorie.",
+          "placeholder": "Choisir un ou plusieurs salons…"
+        },
+        "events": {
+          "section_title": "Événements enregistrés",
+          "section_description": "Les événements cochés sont enregistrés ; décochez ceux à ignorer.",
+          "enabled_count": "{enabled}/{total} événements actifs",
+          "placeholder": "Cocher les événements à enregistrer…"
+        },
+        "buttons": {
+          "back": "Retour",
+          "all": "Tout activer",
+          "none": "Tout désactiver",
+          "prev": "Page précédente",
+          "next": "Page suivante"
+        },
+        "clear": {
+          "button": "Tout supprimer"
+        },
+        "options": {
+          "button": "Options",
+          "title": "Options des logs",
+          "description": "Réglages qui s'appliquent à toutes les catégories.",
+          "channels": {
+            "section_title": "Salons ignorés",
+            "section_description": "Aucun événement provenant de ces salons ne sera enregistré.",
+            "placeholder": "Choisir les salons à ignorer…"
+          },
+          "roles": {
+            "section_title": "Rôles ignorés",
+            "section_description": "Les membres portant un de ces rôles ne seront pas enregistrés.",
+            "placeholder": "Choisir les rôles à ignorer…"
+          },
+          "locale": {
+            "section_title": "Langue des logs",
+            "section_description": "Par défaut, les logs suivent la langue du serveur.",
+            "placeholder": "Choisir la langue des logs…",
+            "values": {
+              "auto": "Langue du serveur",
+              "fr": "Français",
+              "en-US": "English",
+              "es-ES": "Español",
+              "pt-BR": "Português",
+              "de": "Deutsch"
+            }
+          },
+          "toggles": {
+            "section_title": "Réglages",
+            "bots": "Ignorer les bots",
+            "transcripts": "Transcripts en pièce jointe"
+          }
+        },
+        "errors": {
+          "title": "Configuration impossible",
+          "invalid_config": "Configuration invalide.",
+          "unknown_category": "Catégorie inconnue : `{category}`.",
+          "channel_not_found": "Le salon `{channel_id}` est introuvable.",
+          "missing_permissions": "Il me manque les permissions **Voir le salon**, **Envoyer des messages** ou **Intégrer des liens** dans {channel}."
+        }
+      },
+      "categories": {
+        "server": {
+          "name": "Serveur",
+          "description": "Arrivées, départs, sanctions et réglages du serveur."
+        },
+        "messages": {
+          "name": "Messages",
+          "description": "Suppressions, modifications et publications de messages."
+        },
+        "users": {
+          "name": "Utilisateurs",
+          "description": "Pseudos, avatars, rôles et exclusions temporaires."
+        },
+        "moderation": {
+          "name": "Modération",
+          "description": "Sanctions Moddy et actions de modération."
+        },
+        "channels": {
+          "name": "Salons",
+          "description": "Création, suppression et réglages des salons."
+        },
+        "roles": {
+          "name": "Rôles",
+          "description": "Création, suppression et réglages des rôles."
+        },
+        "threads": {
+          "name": "Fils",
+          "description": "Création, archivage et verrouillage des fils."
+        },
+        "voice": {
+          "name": "Vocal",
+          "description": "Connexions, déplacements et déconnexions en vocal."
+        },
+        "invites": {
+          "name": "Invitations",
+          "description": "Invitations créées, supprimées ou partagées."
+        },
+        "automod": {
+          "name": "AutoMod Discord",
+          "description": "Règles d'AutoMod natives de Discord."
+        },
+        "emojis": {
+          "name": "Émojis",
+          "description": "Émojis ajoutés, supprimés ou renommés."
+        },
+        "stickers": {
+          "name": "Stickers",
+          "description": "Stickers ajoutés, supprimés ou modifiés."
+        },
+        "soundboard": {
+          "name": "Soundboard",
+          "description": "Sons ajoutés, modifiés ou supprimés."
+        },
+        "events": {
+          "name": "Événements",
+          "description": "Événements programmés du serveur."
+        },
+        "stage": {
+          "name": "Conférences",
+          "description": "Conférences (salons de scène) démarrées ou terminées."
+        },
+        "polls": {
+          "name": "Sondages",
+          "description": "Sondages créés, terminés et votes."
+        },
+        "webhooks": {
+          "name": "Webhooks",
+          "description": "Webhooks créés, modifiés ou supprimés."
+        },
+        "applications": {
+          "name": "Applications",
+          "description": "Bots et applications ajoutés ou retirés."
+        }
+      },
+      "events": {
+        "server": {
+          "ban_add": "Bannissement",
+          "ban_remove": "Débannissement",
+          "user_join": "Arrivée d'un membre",
+          "user_leave": "Départ d'un membre",
+          "user_kick": "Expulsion",
+          "member_prune": "Purge de membres inactifs",
+          "afk_channel_update": "Salon AFK",
+          "afk_timeout_update": "Délai AFK",
+          "server_banner_update": "Bannière du serveur",
+          "message_notifications_update": "Notifications par défaut",
+          "server_discovery_splash_update": "Image de découverte",
+          "server_content_filter_update": "Filtre de contenu",
+          "server_features_update": "Fonctionnalités du serveur",
+          "server_icon_update": "Icône du serveur",
+          "mfa_level_update": "Niveau A2F",
+          "server_name_update": "Nom du serveur",
+          "server_description_update": "Description du serveur",
+          "server_owner_update": "Propriétaire du serveur",
+          "partnered_update": "Statut partenaire",
+          "server_boost_level_update": "Niveau de boost",
+          "boost_progress_bar_toggle": "Barre de progression des boosts",
+          "public_updates_channel_update": "Salon des annonces Discord",
+          "server_rules_channel_update": "Salon des règles",
+          "server_splash_update": "Image d'invitation",
+          "system_channel_update": "Salon système",
+          "server_vanity_update": "Invitation personnalisée",
+          "verification_level_update": "Niveau de vérification",
+          "verified_update": "Statut vérifié",
+          "server_widget_update": "Widget du serveur",
+          "server_preferred_locale_update": "Langue du serveur",
+          "onboarding_toggle": "Intégration activée",
+          "onboarding_channels_update": "Salons d'intégration",
+          "onboarding_question_add": "Question d'intégration ajoutée",
+          "onboarding_question_remove": "Question d'intégration retirée",
+          "onboarding_question_update": "Question d'intégration modifiée"
+        },
+        "messages": {
+          "message_delete": "Message supprimé",
+          "message_bulk_delete": "Suppression en masse",
+          "message_edit": "Message modifié",
+          "message_publish": "Message publié",
+          "message_command_used": "Commande utilisée"
+        },
+        "users": {
+          "user_name_update": "Changement de pseudo",
+          "user_roles_update": "Rôles modifiés",
+          "user_roles_add": "Rôle ajouté",
+          "user_roles_remove": "Rôle retiré",
+          "user_avatar_update": "Changement d'avatar",
+          "user_timed_out": "Exclusion temporaire",
+          "user_timeout_removed": "Fin d'exclusion temporaire"
+        },
+        "moderation": {
+          "auto_moderation": "AutoMod Discord",
+          "ban_add": "Bannissement",
+          "ban_remove": "Débannissement",
+          "case_delete": "Dossier supprimé",
+          "mass_case_delete": "Suppression de dossiers en masse",
+          "case_update": "Dossier modifié",
+          "kick_add": "Expulsion",
+          "kick_remove": "Expulsion annulée",
+          "mute_add": "Mise en sourdine",
+          "mute_remove": "Fin de sourdine",
+          "warn_add": "Avertissement",
+          "warn_remove": "Avertissement retiré",
+          "report_create": "Signalement créé",
+          "reports_ignore": "Signalement ignoré",
+          "reports_accept": "Signalement accepté",
+          "user_note_add": "Note ajoutée",
+          "user_note_remove": "Note retirée"
+        },
+        "channels": {
+          "channel_create": "Salon créé",
+          "channel_delete": "Salon supprimé",
+          "channel_pins_update": "Épinglages modifiés",
+          "channel_name_update": "Nom du salon",
+          "channel_topic_update": "Sujet du salon",
+          "channel_nsfw_update": "NSFW du salon",
+          "channel_parent_update": "Catégorie du salon",
+          "channel_permissions_update": "Permissions du salon",
+          "channel_type_update": "Type du salon",
+          "channel_bitrate_update": "Débit du salon",
+          "channel_user_limit_update": "Limite d'utilisateurs",
+          "channel_slowmode_update": "Mode lent",
+          "channel_rtc_region_update": "Région vocale",
+          "channel_video_quality_update": "Qualité vidéo",
+          "channel_default_archive_duration_update": "Archivage par défaut",
+          "channel_default_thread_slowmode_update": "Mode lent des fils",
+          "channel_default_reaction_emoji_update": "Réaction par défaut",
+          "channel_default_sort_order_update": "Tri par défaut",
+          "channel_forum_tags_update": "Tags du forum",
+          "channel_forum_layout_update": "Affichage du forum",
+          "channel_voice_status_update": "Statut du salon vocal"
+        },
+        "roles": {
+          "role_create": "Rôle créé",
+          "role_delete": "Rôle supprimé",
+          "role_color_update": "Couleur du rôle",
+          "role_hoist_update": "Affichage séparé",
+          "role_mentionable_update": "Rôle mentionnable",
+          "role_name_update": "Nom du rôle",
+          "role_permissions_update": "Permissions du rôle",
+          "role_icon_update": "Icône du rôle"
+        },
+        "threads": {
+          "thread_create": "Fil créé",
+          "thread_delete": "Fil supprimé",
+          "thread_name_update": "Nom du fil",
+          "thread_slowmode_update": "Mode lent du fil",
+          "thread_archive_duration_update": "Durée d'archivage",
+          "thread_archive": "Fil archivé",
+          "thread_unarchive": "Fil désarchivé",
+          "thread_lock": "Fil verrouillé",
+          "thread_unlock": "Fil déverrouillé"
+        },
+        "voice": {
+          "voice_channel_full": "Salon vocal plein",
+          "voice_user_join": "Connexion vocale",
+          "voice_user_switch": "Changement de salon vocal",
+          "voice_user_leave": "Déconnexion vocale",
+          "voice_user_move": "Déplacement forcé",
+          "voice_user_kick": "Déconnexion forcée"
+        },
+        "invites": {
+          "invite_create": "Invitation créée",
+          "invite_delete": "Invitation supprimée",
+          "invite_post": "Invitation partagée"
+        },
+        "automod": {
+          "automod_rule_create": "Règle créée",
+          "automod_rule_delete": "Règle supprimée",
+          "automod_rule_toggle": "Règle activée/désactivée",
+          "automod_rule_name_update": "Nom de la règle",
+          "automod_rule_actions_update": "Actions de la règle",
+          "automod_rule_content_update": "Contenu filtré",
+          "automod_rule_roles_update": "Rôles exemptés",
+          "automod_rule_channels_update": "Salons exemptés",
+          "automod_rule_whitelist_update": "Liste blanche"
+        },
+        "emojis": {
+          "emoji_create": "Émoji ajouté",
+          "emoji_delete": "Émoji supprimé",
+          "emoji_name_update": "Nom de l'émoji",
+          "emoji_roles_update": "Rôles de l'émoji"
+        },
+        "stickers": {
+          "sticker_create": "Sticker ajouté",
+          "sticker_delete": "Sticker supprimé",
+          "sticker_name_update": "Nom du sticker",
+          "sticker_description_update": "Description du sticker",
+          "sticker_related_emoji_update": "Émoji du sticker"
+        },
+        "soundboard": {
+          "sound_upload": "Son ajouté",
+          "sound_name_update": "Nom du son",
+          "sound_volume_update": "Volume du son",
+          "sound_emoji_update": "Émoji du son",
+          "sound_delete": "Son supprimé"
+        },
+        "events": {
+          "event_create": "Événement créé",
+          "event_delete": "Événement supprimé",
+          "event_name_update": "Nom de l'événement",
+          "event_description_update": "Description de l'événement",
+          "event_location_update": "Lieu de l'événement",
+          "event_privacy_level_update": "Confidentialité de l'événement",
+          "event_start_time_update": "Début de l'événement",
+          "event_end_time_update": "Fin de l'événement",
+          "event_status_update": "Statut de l'événement",
+          "event_image_update": "Image de l'événement",
+          "event_user_subscribe": "Inscription à un événement",
+          "event_user_unsubscribe": "Désinscription d'un événement"
+        },
+        "stage": {
+          "stage_start": "Conférence démarrée",
+          "stage_end": "Conférence terminée",
+          "stage_topic_update": "Sujet de la conférence",
+          "stage_privacy_update": "Confidentialité de la conférence"
+        },
+        "polls": {
+          "poll_create": "Sondage créé",
+          "poll_delete": "Sondage supprimé",
+          "poll_finalize": "Sondage terminé",
+          "poll_votes_add": "Vote ajouté",
+          "poll_votes_remove": "Vote retiré"
+        },
+        "webhooks": {
+          "webhook_create": "Webhook créé",
+          "webhook_name_update": "Nom du webhook",
+          "webhook_avatar_update": "Avatar du webhook",
+          "webhook_channel_update": "Salon du webhook",
+          "webhook_delete": "Webhook supprimé"
+        },
+        "applications": {
+          "app_add": "Application ajoutée",
+          "app_remove": "Application retirée",
+          "app_command_permission_update": "Permissions de commande"
+        }
+      },
+      "titles": {
+        "server": {
+          "ban_add": "Un(e) utilisateur(trice) a été banni(e)",
+          "ban_remove": "Un(e) utilisateur(trice) a été débanni(e)",
+          "user_join": "Un(e) utilisateur(trice) a rejoint le serveur",
+          "user_leave": "Un(e) utilisateur(trice) a quitté le serveur",
+          "user_kick": "Un(e) utilisateur(trice) a été expulsé(e)",
+          "member_prune": "Des membres inactifs ont été purgés",
+          "afk_channel_update": "Modification du salon AFK",
+          "afk_timeout_update": "Modification du délai AFK",
+          "server_banner_update": "Modification de la bannière du serveur",
+          "message_notifications_update": "Modification des notifications par défaut",
+          "server_discovery_splash_update": "Modification de l'image de découverte",
+          "server_content_filter_update": "Modification du filtre de contenu explicite",
+          "server_features_update": "Modification des fonctionnalités du serveur",
+          "server_icon_update": "Modification de l'icône du serveur",
+          "mfa_level_update": "Modification du niveau d'authentification à deux facteurs",
+          "server_name_update": "Modification du nom du serveur",
+          "server_description_update": "Modification de la description du serveur",
+          "server_owner_update": "Changement de propriétaire du serveur",
+          "partnered_update": "Modification du statut de partenariat",
+          "server_boost_level_update": "Modification du niveau de boost",
+          "boost_progress_bar_toggle": "Modification de la barre de progression des boosts",
+          "public_updates_channel_update": "Modification du salon des annonces Discord",
+          "server_rules_channel_update": "Modification du salon des règles",
+          "server_splash_update": "Modification de l'image d'invitation",
+          "system_channel_update": "Modification du salon système",
+          "server_vanity_update": "Modification de l'invitation personnalisée",
+          "verification_level_update": "Modification du niveau de vérification",
+          "verified_update": "Modification du statut vérifié",
+          "server_widget_update": "Modification du widget du serveur",
+          "server_preferred_locale_update": "Modification de la langue du serveur",
+          "onboarding_toggle": "Modification de l'activation de l'intégration",
+          "onboarding_channels_update": "Modification des salons par défaut de l'intégration",
+          "onboarding_question_add": "Ajout d'une question d'intégration",
+          "onboarding_question_remove": "Suppression d'une question d'intégration",
+          "onboarding_question_update": "Modification d'une question d'intégration"
+        },
+        "messages": {
+          "message_delete": "Message supprimé",
+          "message_bulk_delete": "Suppression de messages en masse",
+          "message_edit": "Message modifié",
+          "message_publish": "Message publié dans les serveurs abonnés",
+          "message_command_used": "Une commande a été utilisée"
+        },
+        "users": {
+          "user_name_update": "Modification du pseudo d'un(e) utilisateur(trice)",
+          "user_roles_update": "Modification des rôles d'un(e) utilisateur(trice)",
+          "user_roles_add": "Rôle(s) ajouté(s) à un(e) utilisateur(trice)",
+          "user_roles_remove": "Rôle(s) retiré(s) à un(e) utilisateur(trice)",
+          "user_avatar_update": "Modification de l'avatar d'un(e) utilisateur(trice)",
+          "user_timed_out": "Un(e) utilisateur(trice) a été exclu(e) temporairement",
+          "user_timeout_removed": "L'exclusion temporaire d'un(e) utilisateur(trice) a été levée"
+        },
+        "moderation": {
+          "auto_moderation": "L'AutoMod de Discord est intervenu",
+          "ban_add": "Un(e) utilisateur(trice) a été banni(e)",
+          "ban_remove": "Un(e) utilisateur(trice) a été débanni(e)",
+          "case_delete": "Un dossier de modération a été supprimé",
+          "mass_case_delete": "Plusieurs dossiers de modération ont été supprimés",
+          "case_update": "Un dossier de modération a été modifié",
+          "kick_add": "Un(e) utilisateur(trice) a été expulsé(e)",
+          "kick_remove": "Une expulsion a été annulée",
+          "mute_add": "Un(e) utilisateur(trice) a été réduit(e) au silence",
+          "mute_remove": "Un(e) utilisateur(trice) n'est plus réduit(e) au silence",
+          "warn_add": "Un(e) utilisateur(trice) a reçu un avertissement",
+          "warn_remove": "Un avertissement a été retiré",
+          "report_create": "Un signalement a été créé",
+          "reports_ignore": "Un signalement a été ignoré",
+          "reports_accept": "Un signalement a été accepté",
+          "user_note_add": "Une note a été ajoutée à un(e) utilisateur(trice)",
+          "user_note_remove": "Une note a été retirée d'un(e) utilisateur(trice)"
+        },
+        "channels": {
+          "channel_create": "Salon créé",
+          "channel_delete": "Salon supprimé",
+          "channel_pins_update": "Modification des messages épinglés d'un salon",
+          "channel_name_update": "Modification du nom d'un salon",
+          "channel_topic_update": "Modification du sujet d'un salon",
+          "channel_nsfw_update": "Modification du réglage NSFW d'un salon",
+          "channel_parent_update": "Modification de la catégorie d'un salon",
+          "channel_permissions_update": "Modification des permissions d'un salon",
+          "channel_type_update": "Modification du type d'un salon",
+          "channel_bitrate_update": "Modification du débit d'un salon vocal",
+          "channel_user_limit_update": "Modification de la limite d'utilisateurs d'un salon vocal",
+          "channel_slowmode_update": "Modification du mode lent d'un salon",
+          "channel_rtc_region_update": "Modification de la région vocale d'un salon",
+          "channel_video_quality_update": "Modification de la qualité vidéo d'un salon",
+          "channel_default_archive_duration_update": "Modification de la durée d'archivage par défaut",
+          "channel_default_thread_slowmode_update": "Modification du mode lent par défaut des fils",
+          "channel_default_reaction_emoji_update": "Modification de l'émoji de réaction par défaut",
+          "channel_default_sort_order_update": "Modification du tri par défaut d'un forum",
+          "channel_forum_tags_update": "Modification des tags d'un forum",
+          "channel_forum_layout_update": "Modification de l'affichage d'un forum",
+          "channel_voice_status_update": "Modification du statut d'un salon vocal"
+        },
+        "roles": {
+          "role_create": "Rôle créé",
+          "role_delete": "Rôle supprimé",
+          "role_color_update": "Modification de la couleur d'un rôle",
+          "role_hoist_update": "Modification de l'affichage séparé d'un rôle",
+          "role_mentionable_update": "Modification de la mentionnabilité d'un rôle",
+          "role_name_update": "Modification du nom d'un rôle",
+          "role_permissions_update": "Modification des permissions d'un rôle",
+          "role_icon_update": "Modification de l'icône d'un rôle"
+        },
+        "threads": {
+          "thread_create": "Fil créé",
+          "thread_delete": "Fil supprimé",
+          "thread_name_update": "Modification du nom d'un fil",
+          "thread_slowmode_update": "Modification du mode lent d'un fil",
+          "thread_archive_duration_update": "Modification de la durée d'archivage d'un fil",
+          "thread_archive": "Fil archivé",
+          "thread_unarchive": "Fil désarchivé",
+          "thread_lock": "Fil verrouillé",
+          "thread_unlock": "Fil déverrouillé"
+        },
+        "voice": {
+          "voice_channel_full": "Un salon vocal est plein",
+          "voice_user_join": "Un(e) utilisateur(trice) a rejoint un salon vocal",
+          "voice_user_switch": "Un(e) utilisateur(trice) a changé de salon vocal",
+          "voice_user_leave": "Un(e) utilisateur(trice) a quitté un salon vocal",
+          "voice_user_move": "Un(e) utilisateur(trice) a été déplacé(e) en vocal",
+          "voice_user_kick": "Un(e) utilisateur(trice) a été déconnecté(e) du vocal"
+        },
+        "invites": {
+          "invite_create": "Invitation créée",
+          "invite_delete": "Invitation supprimée",
+          "invite_post": "Une invitation a été partagée dans un salon"
+        },
+        "automod": {
+          "automod_rule_create": "Règle d'AutoMod créée",
+          "automod_rule_delete": "Règle d'AutoMod supprimée",
+          "automod_rule_toggle": "Une règle d'AutoMod a été activée ou désactivée",
+          "automod_rule_name_update": "Modification du nom d'une règle d'AutoMod",
+          "automod_rule_actions_update": "Modification des actions d'une règle d'AutoMod",
+          "automod_rule_content_update": "Modification du contenu filtré par une règle d'AutoMod",
+          "automod_rule_roles_update": "Modification des rôles exemptés d'une règle d'AutoMod",
+          "automod_rule_channels_update": "Modification des salons exemptés d'une règle d'AutoMod",
+          "automod_rule_whitelist_update": "Modification de la liste blanche d'une règle d'AutoMod"
+        },
+        "emojis": {
+          "emoji_create": "Émoji ajouté",
+          "emoji_delete": "Émoji supprimé",
+          "emoji_name_update": "Modification du nom d'un émoji",
+          "emoji_roles_update": "Modification des rôles autorisés d'un émoji"
+        },
+        "stickers": {
+          "sticker_create": "Sticker ajouté",
+          "sticker_delete": "Sticker supprimé",
+          "sticker_name_update": "Modification du nom d'un sticker",
+          "sticker_description_update": "Modification de la description d'un sticker",
+          "sticker_related_emoji_update": "Modification de l'émoji associé à un sticker"
+        },
+        "soundboard": {
+          "sound_upload": "Son ajouté à la soundboard",
+          "sound_name_update": "Modification du nom d'un son",
+          "sound_volume_update": "Modification du volume d'un son",
+          "sound_emoji_update": "Modification de l'émoji d'un son",
+          "sound_delete": "Son supprimé de la soundboard"
+        },
+        "events": {
+          "event_create": "Événement créé",
+          "event_delete": "Événement supprimé",
+          "event_name_update": "Modification du nom d'un événement",
+          "event_description_update": "Modification de la description d'un événement",
+          "event_location_update": "Modification du lieu d'un événement",
+          "event_privacy_level_update": "Modification de la confidentialité d'un événement",
+          "event_start_time_update": "Modification de l'heure de début d'un événement",
+          "event_end_time_update": "Modification de l'heure de fin d'un événement",
+          "event_status_update": "Modification du statut d'un événement",
+          "event_image_update": "Modification de l'image d'un événement",
+          "event_user_subscribe": "Un(e) utilisateur(trice) s'est inscrit(e) à un événement",
+          "event_user_unsubscribe": "Un(e) utilisateur(trice) s'est désinscrit(e) d'un événement"
+        },
+        "stage": {
+          "stage_start": "Une conférence a démarré",
+          "stage_end": "Une conférence s'est terminée",
+          "stage_topic_update": "Modification du sujet d'une conférence",
+          "stage_privacy_update": "Modification de la confidentialité d'une conférence"
+        },
+        "polls": {
+          "poll_create": "Sondage créé",
+          "poll_delete": "Sondage supprimé",
+          "poll_finalize": "Un sondage s'est terminé",
+          "poll_votes_add": "Un vote a été ajouté à un sondage",
+          "poll_votes_remove": "Un vote a été retiré d'un sondage"
+        },
+        "webhooks": {
+          "webhook_create": "Webhook créé",
+          "webhook_name_update": "Modification du nom d'un webhook",
+          "webhook_avatar_update": "Modification de l'avatar d'un webhook",
+          "webhook_channel_update": "Modification du salon d'un webhook",
+          "webhook_delete": "Webhook supprimé"
+        },
+        "applications": {
+          "app_add": "Une application a été ajoutée au serveur",
+          "app_remove": "Une application a été retirée du serveur",
+          "app_command_permission_update": "Modification des permissions d'une commande"
+        }
+      }
     }
   },
   "languages": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -2165,6 +2165,7 @@
         "uncached_message": "*O conteúdo da mensagem não estava mais em cache.*",
         "uncached_messages": "*Nenhuma dessas mensagens estava em cache: não foi possível gerar uma transcrição.*",
         "moved_to_file": "Conteúdo truncado — o texto completo está em anexo.",
+        "size_limit": "Registro encurtado: excedia o tamanho máximo de uma mensagem do Discord.",
         "transcript_attached": "*O conteúdo completo está em anexo (transcrição `.txt`).*",
         "transcript_header": "Transcrição das mensagens excluídas — Moddy",
         "duration": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -2049,6 +2049,748 @@
           "footer": "Em caso de dúvida, fale com a moderação do servidor."
         }
       }
+    },
+    "logs": {
+      "fields": {
+        "account_created": "Criação da conta",
+        "action": "Ação",
+        "added": "Adicionado(s)",
+        "after": "Depois",
+        "after_channel": "Novo canal",
+        "allow_list": "Lista de permissões",
+        "animated": "Animado",
+        "answer_id": "Identificador da resposta",
+        "answers": "Respostas",
+        "application": "Aplicativo",
+        "attachments": "Anexos",
+        "author": "Autor(a)",
+        "authors": "Autores envolvidos",
+        "before": "Antes",
+        "before_channel": "Canal anterior",
+        "case": "Caso",
+        "category": "Categoria",
+        "channel": "Canal",
+        "channel_created": "Canal criado",
+        "colour": "Cor",
+        "command": "Comando",
+        "count": "Quantidade",
+        "created": "Criação",
+        "description": "Descrição",
+        "emoji": "Emoji",
+        "enabled": "Ativada",
+        "end_time": "Fim",
+        "event": "Evento",
+        "expires": "Expira",
+        "expires_at": "Expira em",
+        "hoisted": "Exibido separadamente",
+        "id": "Identificador",
+        "inactive_days": "Dias de inatividade",
+        "invite": "Convite",
+        "inviter": "Criado por",
+        "invites": "Convites",
+        "joined_at": "Data de entrada",
+        "keyword_filter": "Palavras-chave",
+        "last_pin": "Última mensagem fixada",
+        "location": "Local",
+        "matched": "Correspondência",
+        "max_uses": "Usos máximos",
+        "member_count": "Número de membros",
+        "members": "Membros",
+        "members_removed": "Membros removidos",
+        "mention_limit": "Limite de menções",
+        "mentionable": "Mencionável",
+        "message": "Mensagem",
+        "message_created": "Mensagem criada",
+        "message_id": "Identificador da mensagem",
+        "moderator": "Moderador(a)",
+        "name": "Nome",
+        "newest_message": "Mensagem mais recente",
+        "note": "Anotação",
+        "oldest_message": "Mensagem mais antiga",
+        "options": "Opções",
+        "owner": "Proprietário(a)",
+        "parent_channel": "Canal principal",
+        "permissions": "Permissões",
+        "presets": "Filtros predefinidos",
+        "privacy_level": "Privacidade",
+        "question": "Pergunta",
+        "reason": "Motivo",
+        "regex_patterns": "Expressões regulares",
+        "removed": "Removido(s)",
+        "reply_to": "Em resposta a",
+        "role": "Cargo",
+        "role_created": "Cargo criado",
+        "roles": "Cargos",
+        "roles_added": "Adicionado(s)",
+        "roles_removed": "Removido(s)",
+        "rule": "Regra",
+        "server": "Servidor",
+        "sound": "Som",
+        "start_time": "Início",
+        "status": "Status",
+        "sticker": "Figurinha",
+        "stickers": "Figurinhas",
+        "subscribers": "Interessados",
+        "target": "Alvo",
+        "temporary": "Temporário",
+        "thread": "Tópico",
+        "thread_created": "Tópico criado",
+        "topic": "Assunto",
+        "trigger": "Gatilho",
+        "type": "Tipo",
+        "until": "Até",
+        "user": "Usuário(a)",
+        "user_id": "Identificador do usuário",
+        "user_limit": "Limite de usuários",
+        "uses": "Usos",
+        "volume": "Volume",
+        "votes": "Votos",
+        "webhook": "Webhook"
+      },
+      "values": {
+        "yes": "Sim",
+        "no": "Não",
+        "on": "Ativado",
+        "off": "Desativado",
+        "none": "Nenhum",
+        "unlimited": "Ilimitado",
+        "disabled": "Desativado",
+        "automatic": "Automático",
+        "allowed": "Permitido",
+        "denied": "Negado",
+        "open_link": "Ver",
+        "default_colour": "Cor padrão",
+        "boost_tier": "Nível {tier}",
+        "empty_content": "*Nenhum texto*",
+        "uncached_message": "*O conteúdo da mensagem não estava mais em cache.*",
+        "uncached_messages": "*Nenhuma dessas mensagens estava em cache: não foi possível gerar uma transcrição.*",
+        "moved_to_file": "Conteúdo truncado — o texto completo está em anexo.",
+        "transcript_attached": "*O conteúdo completo está em anexo (transcrição `.txt`).*",
+        "transcript_header": "Transcrição das mensagens excluídas — Moddy",
+        "duration": {
+          "day": "{count} d",
+          "hour": "{count} h",
+          "minute": "{count} min",
+          "second": "{count} s"
+        }
+      },
+      "permissions": {
+        "add_reactions": "Adicionar reações",
+        "administrator": "Administrador",
+        "attach_files": "Anexar arquivos",
+        "ban_members": "Banir membros",
+        "bypass_slowmode": "Ignorar modo lento",
+        "change_nickname": "Alterar apelido",
+        "connect": "Conectar",
+        "create_events": "Criar eventos",
+        "create_expressions": "Criar expressões",
+        "create_instant_invite": "Criar convite",
+        "create_polls": "Criar enquetes",
+        "create_private_threads": "Criar tópicos privados",
+        "create_public_threads": "Criar tópicos públicos",
+        "deafen_members": "Ensurdecer membros",
+        "embed_links": "Inserir links",
+        "external_emojis": "Emojis externos",
+        "external_stickers": "Figurinhas externas",
+        "kick_members": "Expulsar membros",
+        "manage_channels": "Gerenciar canais",
+        "manage_emojis": "Gerenciar emojis",
+        "manage_emojis_and_stickers": "Gerenciar emojis e figurinhas",
+        "manage_events": "Gerenciar eventos",
+        "manage_expressions": "Gerenciar expressões",
+        "manage_guild": "Gerenciar servidor",
+        "manage_messages": "Gerenciar mensagens",
+        "manage_nicknames": "Gerenciar apelidos",
+        "manage_permissions": "Gerenciar permissões",
+        "manage_roles": "Gerenciar cargos",
+        "manage_threads": "Gerenciar tópicos",
+        "manage_webhooks": "Gerenciar webhooks",
+        "mention_everyone": "Mencionar @everyone",
+        "moderate_members": "Castigar membros",
+        "move_members": "Mover membros",
+        "mute_members": "Silenciar membros",
+        "pin_messages": "Fixar mensagens",
+        "priority_speaker": "Prioridade de fala",
+        "read_message_history": "Ver histórico de mensagens",
+        "read_messages": "Ver canais",
+        "request_to_speak": "Pedir para falar",
+        "send_messages": "Enviar mensagens",
+        "send_messages_in_threads": "Enviar mensagens em tópicos",
+        "send_polls": "Enviar enquetes",
+        "send_tts_messages": "Enviar mensagens em TTS",
+        "send_voice_messages": "Enviar mensagens de voz",
+        "set_voice_channel_status": "Definir status do canal de voz",
+        "speak": "Falar",
+        "stream": "Transmitir vídeo",
+        "use_application_commands": "Usar comandos de aplicativo",
+        "use_embedded_activities": "Usar atividades",
+        "use_external_apps": "Usar aplicativos externos",
+        "use_external_emojis": "Usar emojis externos",
+        "use_external_sounds": "Usar sons externos",
+        "use_external_stickers": "Usar figurinhas externas",
+        "use_soundboard": "Usar painel de sons",
+        "use_voice_activation": "Usar detecção de voz",
+        "view_audit_log": "Ver registro de auditoria",
+        "view_channel": "Ver canal",
+        "view_creator_monetization_analytics": "Ver análises de monetização",
+        "view_guild_insights": "Ver insights do servidor"
+      },
+      "description": "Registros detalhados de tudo o que acontece no servidor",
+      "config": {
+        "title": "Registros do servidor",
+        "description": "Escolha uma categoria, indique o canal ou os canais que devem recebê-la e desmarque os eventos que não lhe interessam. Tudo vem ativado por padrão.",
+        "summary": {
+          "empty": "Nenhuma categoria configurada por enquanto.",
+          "events": "{enabled}/{total} eventos registrados"
+        },
+        "categories": {
+          "placeholder": "Configurar uma categoria…",
+          "bound": "{count} canal(is) · {enabled}/{total} eventos",
+          "unbound": "Não configurada · {total} eventos disponíveis"
+        },
+        "mass": {
+          "section_title": "Enviar tudo para um único canal",
+          "section_description": "Atribui todas as categorias ao canal escolhido de uma só vez.",
+          "placeholder": "Escolher o canal de todos os registros…"
+        },
+        "channels": {
+          "section_title": "Canais de destino",
+          "section_description": "Até {max} canais para esta categoria.",
+          "placeholder": "Escolher um ou mais canais…"
+        },
+        "events": {
+          "section_title": "Eventos registrados",
+          "section_description": "Os eventos marcados são registrados; desmarque os que devem ser ignorados.",
+          "enabled_count": "{enabled}/{total} eventos ativos",
+          "placeholder": "Marcar os eventos a registrar…"
+        },
+        "buttons": {
+          "back": "Voltar",
+          "all": "Ativar tudo",
+          "none": "Desativar tudo",
+          "prev": "Página anterior",
+          "next": "Próxima página"
+        },
+        "clear": {
+          "button": "Excluir tudo"
+        },
+        "options": {
+          "button": "Opções",
+          "title": "Opções dos registros",
+          "description": "Configurações que se aplicam a todas as categorias.",
+          "channels": {
+            "section_title": "Canais ignorados",
+            "section_description": "Nenhum evento vindo desses canais será registrado.",
+            "placeholder": "Escolher os canais a ignorar…"
+          },
+          "roles": {
+            "section_title": "Cargos ignorados",
+            "section_description": "Membros com algum desses cargos nunca serão registrados.",
+            "placeholder": "Escolher os cargos a ignorar…"
+          },
+          "locale": {
+            "section_title": "Idioma dos registros",
+            "section_description": "Por padrão, os registros seguem o idioma do servidor.",
+            "placeholder": "Escolher o idioma dos registros…",
+            "values": {
+              "auto": "Idioma do servidor",
+              "fr": "Français",
+              "en-US": "English",
+              "es-ES": "Español",
+              "pt-BR": "Português",
+              "de": "Deutsch"
+            }
+          },
+          "toggles": {
+            "section_title": "Configurações",
+            "bots": "Ignorar bots",
+            "transcripts": "Transcrições em anexo"
+          }
+        },
+        "errors": {
+          "title": "Configuração impossível",
+          "invalid_config": "Configuração inválida.",
+          "unknown_category": "Categoria desconhecida: `{category}`.",
+          "channel_not_found": "O canal `{channel_id}` não foi encontrado.",
+          "missing_permissions": "Faltam-me as permissões **Ver canal**, **Enviar mensagens** ou **Inserir links** em {channel}."
+        }
+      },
+      "categories": {
+        "server": {
+          "name": "Servidor",
+          "description": "Entradas, saídas, punições e configurações do servidor."
+        },
+        "messages": {
+          "name": "Mensagens",
+          "description": "Exclusões, edições e publicações de mensagens."
+        },
+        "users": {
+          "name": "Usuários",
+          "description": "Apelidos, avatares, cargos e castigos."
+        },
+        "moderation": {
+          "name": "Moderação",
+          "description": "Punições do Moddy e ações de moderação."
+        },
+        "channels": {
+          "name": "Canais",
+          "description": "Criação, exclusão e configurações dos canais."
+        },
+        "roles": {
+          "name": "Cargos",
+          "description": "Criação, exclusão e configurações dos cargos."
+        },
+        "threads": {
+          "name": "Tópicos",
+          "description": "Criação, arquivamento e bloqueio de tópicos."
+        },
+        "voice": {
+          "name": "Voz",
+          "description": "Conexões, movimentações e desconexões em voz."
+        },
+        "invites": {
+          "name": "Convites",
+          "description": "Convites criados, excluídos ou compartilhados."
+        },
+        "automod": {
+          "name": "AutoMod do Discord",
+          "description": "Regras do AutoMod nativo do Discord."
+        },
+        "emojis": {
+          "name": "Emojis",
+          "description": "Emojis adicionados, excluídos ou renomeados."
+        },
+        "stickers": {
+          "name": "Figurinhas",
+          "description": "Figurinhas adicionadas, excluídas ou alteradas."
+        },
+        "soundboard": {
+          "name": "Painel de sons",
+          "description": "Sons adicionados, alterados ou excluídos."
+        },
+        "events": {
+          "name": "Eventos",
+          "description": "Eventos programados do servidor."
+        },
+        "stage": {
+          "name": "Palcos",
+          "description": "Palcos (canais de palco) iniciados ou encerrados."
+        },
+        "polls": {
+          "name": "Enquetes",
+          "description": "Enquetes criadas, encerradas e votos."
+        },
+        "webhooks": {
+          "name": "Webhooks",
+          "description": "Webhooks criados, alterados ou excluídos."
+        },
+        "applications": {
+          "name": "Aplicativos",
+          "description": "Bots e aplicativos adicionados ou removidos."
+        }
+      },
+      "events": {
+        "server": {
+          "ban_add": "Banimento",
+          "ban_remove": "Desbanimento",
+          "user_join": "Entrada de um membro",
+          "user_leave": "Saída de um membro",
+          "user_kick": "Expulsão",
+          "member_prune": "Remoção de membros inativos",
+          "afk_channel_update": "Canal AFK",
+          "afk_timeout_update": "Tempo limite de AFK",
+          "server_banner_update": "Banner do servidor",
+          "message_notifications_update": "Notificações padrão",
+          "server_discovery_splash_update": "Imagem de descoberta",
+          "server_content_filter_update": "Filtro de conteúdo",
+          "server_features_update": "Recursos do servidor",
+          "server_icon_update": "Ícone do servidor",
+          "mfa_level_update": "Nível de 2FA",
+          "server_name_update": "Nome do servidor",
+          "server_description_update": "Descrição do servidor",
+          "server_owner_update": "Proprietário do servidor",
+          "partnered_update": "Status de parceria",
+          "server_boost_level_update": "Nível de impulso",
+          "boost_progress_bar_toggle": "Barra de progresso dos impulsos",
+          "public_updates_channel_update": "Canal de avisos do Discord",
+          "server_rules_channel_update": "Canal de regras",
+          "server_splash_update": "Imagem de convite",
+          "system_channel_update": "Canal de sistema",
+          "server_vanity_update": "Convite personalizado",
+          "verification_level_update": "Nível de verificação",
+          "verified_update": "Status verificado",
+          "server_widget_update": "Widget do servidor",
+          "server_preferred_locale_update": "Idioma do servidor",
+          "onboarding_toggle": "Integração ativada",
+          "onboarding_channels_update": "Canais de integração",
+          "onboarding_question_add": "Pergunta de integração adicionada",
+          "onboarding_question_remove": "Pergunta de integração removida",
+          "onboarding_question_update": "Pergunta de integração alterada"
+        },
+        "messages": {
+          "message_delete": "Mensagem excluída",
+          "message_bulk_delete": "Exclusão em massa",
+          "message_edit": "Mensagem editada",
+          "message_publish": "Mensagem publicada",
+          "message_command_used": "Comando utilizado"
+        },
+        "users": {
+          "user_name_update": "Alteração de apelido",
+          "user_roles_update": "Cargos alterados",
+          "user_roles_add": "Cargo adicionado",
+          "user_roles_remove": "Cargo removido",
+          "user_avatar_update": "Alteração de avatar",
+          "user_timed_out": "Castigo aplicado",
+          "user_timeout_removed": "Fim do castigo"
+        },
+        "moderation": {
+          "auto_moderation": "AutoMod do Discord",
+          "ban_add": "Banimento",
+          "ban_remove": "Desbanimento",
+          "case_delete": "Caso excluído",
+          "mass_case_delete": "Exclusão de casos em massa",
+          "case_update": "Caso alterado",
+          "kick_add": "Expulsão",
+          "kick_remove": "Expulsão cancelada",
+          "mute_add": "Silenciamento",
+          "mute_remove": "Fim do silenciamento",
+          "warn_add": "Advertência",
+          "warn_remove": "Advertência removida",
+          "report_create": "Denúncia criada",
+          "reports_ignore": "Denúncia ignorada",
+          "reports_accept": "Denúncia aceita",
+          "user_note_add": "Anotação adicionada",
+          "user_note_remove": "Anotação removida"
+        },
+        "channels": {
+          "channel_create": "Canal criado",
+          "channel_delete": "Canal excluído",
+          "channel_pins_update": "Mensagens fixadas alteradas",
+          "channel_name_update": "Nome do canal",
+          "channel_topic_update": "Assunto do canal",
+          "channel_nsfw_update": "NSFW do canal",
+          "channel_parent_update": "Categoria do canal",
+          "channel_permissions_update": "Permissões do canal",
+          "channel_type_update": "Tipo do canal",
+          "channel_bitrate_update": "Taxa de bits do canal",
+          "channel_user_limit_update": "Limite de usuários",
+          "channel_slowmode_update": "Modo lento",
+          "channel_rtc_region_update": "Região de voz",
+          "channel_video_quality_update": "Qualidade de vídeo",
+          "channel_default_archive_duration_update": "Arquivamento padrão",
+          "channel_default_thread_slowmode_update": "Modo lento dos tópicos",
+          "channel_default_reaction_emoji_update": "Reação padrão",
+          "channel_default_sort_order_update": "Ordenação padrão",
+          "channel_forum_tags_update": "Tags do fórum",
+          "channel_forum_layout_update": "Exibição do fórum",
+          "channel_voice_status_update": "Status do canal de voz"
+        },
+        "roles": {
+          "role_create": "Cargo criado",
+          "role_delete": "Cargo excluído",
+          "role_color_update": "Cor do cargo",
+          "role_hoist_update": "Exibição separada",
+          "role_mentionable_update": "Cargo mencionável",
+          "role_name_update": "Nome do cargo",
+          "role_permissions_update": "Permissões do cargo",
+          "role_icon_update": "Ícone do cargo"
+        },
+        "threads": {
+          "thread_create": "Tópico criado",
+          "thread_delete": "Tópico excluído",
+          "thread_name_update": "Nome do tópico",
+          "thread_slowmode_update": "Modo lento do tópico",
+          "thread_archive_duration_update": "Duração do arquivamento",
+          "thread_archive": "Tópico arquivado",
+          "thread_unarchive": "Tópico desarquivado",
+          "thread_lock": "Tópico bloqueado",
+          "thread_unlock": "Tópico desbloqueado"
+        },
+        "voice": {
+          "voice_channel_full": "Canal de voz cheio",
+          "voice_user_join": "Conexão em voz",
+          "voice_user_switch": "Troca de canal de voz",
+          "voice_user_leave": "Desconexão de voz",
+          "voice_user_move": "Movimentação forçada",
+          "voice_user_kick": "Desconexão forçada"
+        },
+        "invites": {
+          "invite_create": "Convite criado",
+          "invite_delete": "Convite excluído",
+          "invite_post": "Convite compartilhado"
+        },
+        "automod": {
+          "automod_rule_create": "Regra criada",
+          "automod_rule_delete": "Regra excluída",
+          "automod_rule_toggle": "Regra ativada/desativada",
+          "automod_rule_name_update": "Nome da regra",
+          "automod_rule_actions_update": "Ações da regra",
+          "automod_rule_content_update": "Conteúdo filtrado",
+          "automod_rule_roles_update": "Cargos isentos",
+          "automod_rule_channels_update": "Canais isentos",
+          "automod_rule_whitelist_update": "Lista de permissões"
+        },
+        "emojis": {
+          "emoji_create": "Emoji adicionado",
+          "emoji_delete": "Emoji excluído",
+          "emoji_name_update": "Nome do emoji",
+          "emoji_roles_update": "Cargos do emoji"
+        },
+        "stickers": {
+          "sticker_create": "Figurinha adicionada",
+          "sticker_delete": "Figurinha excluída",
+          "sticker_name_update": "Nome da figurinha",
+          "sticker_description_update": "Descrição da figurinha",
+          "sticker_related_emoji_update": "Emoji da figurinha"
+        },
+        "soundboard": {
+          "sound_upload": "Som adicionado",
+          "sound_name_update": "Nome do som",
+          "sound_volume_update": "Volume do som",
+          "sound_emoji_update": "Emoji do som",
+          "sound_delete": "Som excluído"
+        },
+        "events": {
+          "event_create": "Evento criado",
+          "event_delete": "Evento excluído",
+          "event_name_update": "Nome do evento",
+          "event_description_update": "Descrição do evento",
+          "event_location_update": "Local do evento",
+          "event_privacy_level_update": "Privacidade do evento",
+          "event_start_time_update": "Início do evento",
+          "event_end_time_update": "Fim do evento",
+          "event_status_update": "Status do evento",
+          "event_image_update": "Imagem do evento",
+          "event_user_subscribe": "Interesse em um evento",
+          "event_user_unsubscribe": "Interesse retirado de um evento"
+        },
+        "stage": {
+          "stage_start": "Palco iniciado",
+          "stage_end": "Palco encerrado",
+          "stage_topic_update": "Assunto do palco",
+          "stage_privacy_update": "Privacidade do palco"
+        },
+        "polls": {
+          "poll_create": "Enquete criada",
+          "poll_delete": "Enquete excluída",
+          "poll_finalize": "Enquete encerrada",
+          "poll_votes_add": "Voto adicionado",
+          "poll_votes_remove": "Voto removido"
+        },
+        "webhooks": {
+          "webhook_create": "Webhook criado",
+          "webhook_name_update": "Nome do webhook",
+          "webhook_avatar_update": "Avatar do webhook",
+          "webhook_channel_update": "Canal do webhook",
+          "webhook_delete": "Webhook excluído"
+        },
+        "applications": {
+          "app_add": "Aplicativo adicionado",
+          "app_remove": "Aplicativo removido",
+          "app_command_permission_update": "Permissões de comando"
+        }
+      },
+      "titles": {
+        "server": {
+          "ban_add": "Um usuário foi banido",
+          "ban_remove": "Um usuário foi desbanido",
+          "user_join": "Um usuário entrou no servidor",
+          "user_leave": "Um usuário saiu do servidor",
+          "user_kick": "Um usuário foi expulso",
+          "member_prune": "Membros inativos foram removidos",
+          "afk_channel_update": "Alteração do canal AFK",
+          "afk_timeout_update": "Alteração do tempo limite de AFK",
+          "server_banner_update": "Alteração do banner do servidor",
+          "message_notifications_update": "Alteração das notificações padrão",
+          "server_discovery_splash_update": "Alteração da imagem de descoberta",
+          "server_content_filter_update": "Alteração do filtro de conteúdo explícito",
+          "server_features_update": "Alteração dos recursos do servidor",
+          "server_icon_update": "Alteração do ícone do servidor",
+          "mfa_level_update": "Alteração do nível de autenticação de dois fatores",
+          "server_name_update": "Alteração do nome do servidor",
+          "server_description_update": "Alteração da descrição do servidor",
+          "server_owner_update": "Troca de proprietário do servidor",
+          "partnered_update": "Alteração do status de parceria",
+          "server_boost_level_update": "Alteração do nível de impulso",
+          "boost_progress_bar_toggle": "Alteração da barra de progresso dos impulsos",
+          "public_updates_channel_update": "Alteração do canal de avisos do Discord",
+          "server_rules_channel_update": "Alteração do canal de regras",
+          "server_splash_update": "Alteração da imagem de convite",
+          "system_channel_update": "Alteração do canal de sistema",
+          "server_vanity_update": "Alteração do convite personalizado",
+          "verification_level_update": "Alteração do nível de verificação",
+          "verified_update": "Alteração do status verificado",
+          "server_widget_update": "Alteração do widget do servidor",
+          "server_preferred_locale_update": "Alteração do idioma do servidor",
+          "onboarding_toggle": "Alteração da ativação da integração",
+          "onboarding_channels_update": "Alteração dos canais padrão da integração",
+          "onboarding_question_add": "Adição de uma pergunta de integração",
+          "onboarding_question_remove": "Exclusão de uma pergunta de integração",
+          "onboarding_question_update": "Alteração de uma pergunta de integração"
+        },
+        "messages": {
+          "message_delete": "Mensagem excluída",
+          "message_bulk_delete": "Exclusão de mensagens em massa",
+          "message_edit": "Mensagem editada",
+          "message_publish": "Mensagem publicada nos servidores inscritos",
+          "message_command_used": "Um comando foi utilizado"
+        },
+        "users": {
+          "user_name_update": "Alteração do apelido de um usuário",
+          "user_roles_update": "Alteração dos cargos de um usuário",
+          "user_roles_add": "Cargo(s) adicionado(s) a um usuário",
+          "user_roles_remove": "Cargo(s) removido(s) de um usuário",
+          "user_avatar_update": "Alteração do avatar de um usuário",
+          "user_timed_out": "Um usuário foi colocado de castigo",
+          "user_timeout_removed": "O castigo de um usuário foi removido"
+        },
+        "moderation": {
+          "auto_moderation": "O AutoMod do Discord interveio",
+          "ban_add": "Um usuário foi banido",
+          "ban_remove": "Um usuário foi desbanido",
+          "case_delete": "Um caso de moderação foi excluído",
+          "mass_case_delete": "Vários casos de moderação foram excluídos",
+          "case_update": "Um caso de moderação foi alterado",
+          "kick_add": "Um usuário foi expulso",
+          "kick_remove": "Uma expulsão foi cancelada",
+          "mute_add": "Um usuário foi silenciado",
+          "mute_remove": "Um usuário deixou de estar silenciado",
+          "warn_add": "Um usuário recebeu uma advertência",
+          "warn_remove": "Uma advertência foi removida",
+          "report_create": "Uma denúncia foi criada",
+          "reports_ignore": "Uma denúncia foi ignorada",
+          "reports_accept": "Uma denúncia foi aceita",
+          "user_note_add": "Uma anotação foi adicionada a um usuário",
+          "user_note_remove": "Uma anotação foi removida de um usuário"
+        },
+        "channels": {
+          "channel_create": "Canal criado",
+          "channel_delete": "Canal excluído",
+          "channel_pins_update": "Alteração das mensagens fixadas de um canal",
+          "channel_name_update": "Alteração do nome de um canal",
+          "channel_topic_update": "Alteração do assunto de um canal",
+          "channel_nsfw_update": "Alteração da configuração NSFW de um canal",
+          "channel_parent_update": "Alteração da categoria de um canal",
+          "channel_permissions_update": "Alteração das permissões de um canal",
+          "channel_type_update": "Alteração do tipo de um canal",
+          "channel_bitrate_update": "Alteração da taxa de bits de um canal de voz",
+          "channel_user_limit_update": "Alteração do limite de usuários de um canal de voz",
+          "channel_slowmode_update": "Alteração do modo lento de um canal",
+          "channel_rtc_region_update": "Alteração da região de voz de um canal",
+          "channel_video_quality_update": "Alteração da qualidade de vídeo de um canal",
+          "channel_default_archive_duration_update": "Alteração da duração padrão do arquivamento",
+          "channel_default_thread_slowmode_update": "Alteração do modo lento padrão dos tópicos",
+          "channel_default_reaction_emoji_update": "Alteração do emoji de reação padrão",
+          "channel_default_sort_order_update": "Alteração da ordenação padrão de um fórum",
+          "channel_forum_tags_update": "Alteração das tags de um fórum",
+          "channel_forum_layout_update": "Alteração da exibição de um fórum",
+          "channel_voice_status_update": "Alteração do status de um canal de voz"
+        },
+        "roles": {
+          "role_create": "Cargo criado",
+          "role_delete": "Cargo excluído",
+          "role_color_update": "Alteração da cor de um cargo",
+          "role_hoist_update": "Alteração da exibição separada de um cargo",
+          "role_mentionable_update": "Alteração da possibilidade de mencionar um cargo",
+          "role_name_update": "Alteração do nome de um cargo",
+          "role_permissions_update": "Alteração das permissões de um cargo",
+          "role_icon_update": "Alteração do ícone de um cargo"
+        },
+        "threads": {
+          "thread_create": "Tópico criado",
+          "thread_delete": "Tópico excluído",
+          "thread_name_update": "Alteração do nome de um tópico",
+          "thread_slowmode_update": "Alteração do modo lento de um tópico",
+          "thread_archive_duration_update": "Alteração da duração do arquivamento de um tópico",
+          "thread_archive": "Tópico arquivado",
+          "thread_unarchive": "Tópico desarquivado",
+          "thread_lock": "Tópico bloqueado",
+          "thread_unlock": "Tópico desbloqueado"
+        },
+        "voice": {
+          "voice_channel_full": "Um canal de voz está cheio",
+          "voice_user_join": "Um usuário entrou em um canal de voz",
+          "voice_user_switch": "Um usuário trocou de canal de voz",
+          "voice_user_leave": "Um usuário saiu de um canal de voz",
+          "voice_user_move": "Um usuário foi movido na voz",
+          "voice_user_kick": "Um usuário foi desconectado da voz"
+        },
+        "invites": {
+          "invite_create": "Convite criado",
+          "invite_delete": "Convite excluído",
+          "invite_post": "Um convite foi compartilhado em um canal"
+        },
+        "automod": {
+          "automod_rule_create": "Regra do AutoMod criada",
+          "automod_rule_delete": "Regra do AutoMod excluída",
+          "automod_rule_toggle": "Uma regra do AutoMod foi ativada ou desativada",
+          "automod_rule_name_update": "Alteração do nome de uma regra do AutoMod",
+          "automod_rule_actions_update": "Alteração das ações de uma regra do AutoMod",
+          "automod_rule_content_update": "Alteração do conteúdo filtrado por uma regra do AutoMod",
+          "automod_rule_roles_update": "Alteração dos cargos isentos de uma regra do AutoMod",
+          "automod_rule_channels_update": "Alteração dos canais isentos de uma regra do AutoMod",
+          "automod_rule_whitelist_update": "Alteração da lista de permissões de uma regra do AutoMod"
+        },
+        "emojis": {
+          "emoji_create": "Emoji adicionado",
+          "emoji_delete": "Emoji excluído",
+          "emoji_name_update": "Alteração do nome de um emoji",
+          "emoji_roles_update": "Alteração dos cargos autorizados de um emoji"
+        },
+        "stickers": {
+          "sticker_create": "Figurinha adicionada",
+          "sticker_delete": "Figurinha excluída",
+          "sticker_name_update": "Alteração do nome de uma figurinha",
+          "sticker_description_update": "Alteração da descrição de uma figurinha",
+          "sticker_related_emoji_update": "Alteração do emoji associado a uma figurinha"
+        },
+        "soundboard": {
+          "sound_upload": "Som adicionado ao painel de sons",
+          "sound_name_update": "Alteração do nome de um som",
+          "sound_volume_update": "Alteração do volume de um som",
+          "sound_emoji_update": "Alteração do emoji de um som",
+          "sound_delete": "Som excluído do painel de sons"
+        },
+        "events": {
+          "event_create": "Evento criado",
+          "event_delete": "Evento excluído",
+          "event_name_update": "Alteração do nome de um evento",
+          "event_description_update": "Alteração da descrição de um evento",
+          "event_location_update": "Alteração do local de um evento",
+          "event_privacy_level_update": "Alteração da privacidade de um evento",
+          "event_start_time_update": "Alteração do horário de início de um evento",
+          "event_end_time_update": "Alteração do horário de término de um evento",
+          "event_status_update": "Alteração do status de um evento",
+          "event_image_update": "Alteração da imagem de um evento",
+          "event_user_subscribe": "Um usuário demonstrou interesse em um evento",
+          "event_user_unsubscribe": "Um usuário retirou o interesse em um evento"
+        },
+        "stage": {
+          "stage_start": "Um palco foi iniciado",
+          "stage_end": "Um palco foi encerrado",
+          "stage_topic_update": "Alteração do assunto de um palco",
+          "stage_privacy_update": "Alteração da privacidade de um palco"
+        },
+        "polls": {
+          "poll_create": "Enquete criada",
+          "poll_delete": "Enquete excluída",
+          "poll_finalize": "Uma enquete foi encerrada",
+          "poll_votes_add": "Um voto foi adicionado a uma enquete",
+          "poll_votes_remove": "Um voto foi removido de uma enquete"
+        },
+        "webhooks": {
+          "webhook_create": "Webhook criado",
+          "webhook_name_update": "Alteração do nome de um webhook",
+          "webhook_avatar_update": "Alteração do avatar de um webhook",
+          "webhook_channel_update": "Alteração do canal de um webhook",
+          "webhook_delete": "Webhook excluído"
+        },
+        "applications": {
+          "app_add": "Um aplicativo foi adicionado ao servidor",
+          "app_remove": "Um aplicativo foi removido do servidor",
+          "app_command_permission_update": "Alteração das permissões de um comando"
+        }
+      }
     }
   },
   "languages": {

--- a/modules/configs/logs_config.py
+++ b/modules/configs/logs_config.py
@@ -1,0 +1,841 @@
+"""Configuration UI for the advanced server logs.
+
+Three screens, no save button:
+
+* **root** — one line per configured category, a picker to open one, and a
+  "send everything to one channel" shortcut for the common case;
+* **category** — the channels this category posts to, and a paginated
+  checklist of its events (everything on by default, tick off what you don't
+  want);
+* **options** — server-wide ignore lists, bots, transcripts and language.
+
+Every change is applied immediately. That is deliberate: the category screen
+is built from ``DynamicItem``s (they carry the category and the page in
+their ``custom_id``), and a dynamic item is rebuilt from scratch on *every*
+click — there is no ``self`` to stage pending edits on. Applying on the spot
+is also what makes the panel simple: what you see is what is stored.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseView
+from modules.configs._common import check_guild_perms
+from modules.logs import (
+    MAX_CHANNELS_PER_CATEGORY, MAX_IGNORED_CHANNELS, MAX_IGNORED_ROLES,
+    LogsModule, config_from_raw,
+)
+from serverlogs import registry
+from utils.emojis import (
+    BACK, DELETE, FILTER, HISTORY, SETTINGS, TOGGLE_OFF, TOGGLE_ON, NEXT,
+)
+from utils.i18n import i18n, t
+
+logger = logging.getLogger('moddy.modules.logs_config')
+
+_MODULE_ID = "logs"
+
+#: Events shown per page in the category checklist (Discord's select limit).
+EVENTS_PER_PAGE = 25
+
+#: Languages a server can pin its logs to ("auto" follows the server locale).
+LOG_LOCALES = ("auto", "fr", "en-US", "es-ES", "pt-BR", "de")
+
+# Root panel — static custom_ids, guild-scoped authorization.
+_CID_CATEGORY = "moddy:logs:config:category"
+_CID_MASS_CHANNEL = "moddy:logs:config:mass_channel"
+_CID_OPTIONS = "moddy:logs:config:options"
+_CID_CLEAR = "moddy:logs:config:clear"
+_CID_BACK = "moddy:logs:config:back"
+
+# Options panel.
+_CID_OPT_CHANNELS = "moddy:logs:options:channels"
+_CID_OPT_ROLES = "moddy:logs:options:roles"
+_CID_OPT_BOTS = "moddy:logs:options:bots"
+_CID_OPT_TRANSCRIPTS = "moddy:logs:options:transcripts"
+_CID_OPT_LOCALE = "moddy:logs:options:locale"
+_CID_OPT_BACK = "moddy:logs:options:back"
+
+
+# --------------------------------------------------------------------------- #
+# Storage helpers — the panel edits a LogsModule, never a loose dict, so the
+# routing and validation rules live in exactly one place.
+# --------------------------------------------------------------------------- #
+
+async def _load(bot, guild_id: int) -> LogsModule:
+    raw = await bot.module_manager.get_module_config(guild_id, _MODULE_ID)
+    return config_from_raw(bot, guild_id, raw)
+
+
+async def _save(interaction: discord.Interaction, module: LogsModule) -> Optional[str]:
+    """Persist the edited module. Returns an error message, or ``None``."""
+    bot = interaction.client
+    success, error = await bot.module_manager.save_module_config(
+        interaction.guild_id, _MODULE_ID, module.to_config(),
+        actor_id=interaction.user.id,
+    )
+    return None if success else error
+
+
+async def _refuse(interaction: discord.Interaction, error: str) -> None:
+    from utils.components_v2 import create_error_message
+    locale = i18n.get_user_locale(interaction)
+    view = create_error_message(
+        t('modules.logs.config.errors.title', locale=locale), error)
+    if interaction.response.is_done():
+        await interaction.followup.send(view=view, ephemeral=True)
+    else:
+        await interaction.response.send_message(view=view, ephemeral=True)
+
+
+# --------------------------------------------------------------------------- #
+# Root panel
+# --------------------------------------------------------------------------- #
+
+class LogsConfigView(BaseView):
+    """Server logs — main panel.
+
+    Persistent: yes. Auth: Manage Server in the guild (re-checked on every
+    click via check_guild_perms — never a stored user_id, which cannot
+    survive a restarted shell).
+    """
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, guild_id: Optional[int] = None,
+                 user_id: Optional[int] = None, locale: str = "en-US",
+                 module: Optional[LogsModule] = None):
+        super().__init__()  # timeout=None
+        self.bot = bot
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.locale = locale
+        self.module = module if module is not None else config_from_raw(bot, guild_id or 0, None)
+        self._build_view()
+
+    @classmethod
+    async def create(cls, bot, guild_id: int, user_id: int, locale: str) -> "LogsConfigView":
+        return cls(bot, guild_id, user_id, locale, await _load(bot, guild_id))
+
+    # -- rendering -------------------------------------------------------- #
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container()
+
+        container.add_item(ui.TextDisplay(
+            f"### {HISTORY} {t('modules.logs.config.title', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            t('modules.logs.config.description', locale=self.locale)
+        ))
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+        container.add_item(ui.TextDisplay(self._summary()))
+
+        # Category picker.
+        picker_row = ui.ActionRow()
+        picker = ui.Select(
+            placeholder=t('modules.logs.config.categories.placeholder', locale=self.locale),
+            options=self._category_options(),
+            min_values=1, max_values=1,
+            custom_id=_CID_CATEGORY,
+        )
+        picker.callback = self.on_category_select
+        picker_row.add_item(picker)
+        container.add_item(picker_row)
+
+        # "Everything in one channel" — the setup most servers actually want.
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.logs.config.mass.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.logs.config.mass.section_description', locale=self.locale)}"
+        ))
+        mass_row = ui.ActionRow()
+        mass_select = ui.ChannelSelect(
+            placeholder=t('modules.logs.config.mass.placeholder', locale=self.locale),
+            channel_types=[discord.ChannelType.text, discord.ChannelType.news,
+                           discord.ChannelType.public_thread,
+                           discord.ChannelType.private_thread],
+            min_values=0, max_values=1,
+            custom_id=_CID_MASS_CHANNEL,
+        )
+        mass_select.callback = self.on_mass_channel
+        mass_row.add_item(mass_select)
+        container.add_item(mass_row)
+
+        self.add_item(container)
+        self._add_action_buttons()
+
+    def _summary(self) -> str:
+        bound = [c for c in registry.ordered_categories()
+                 if self.module.categories.get(c.id)
+                 and self.module.categories[c.id].is_bound]
+        if not bound:
+            return f"-# {t('modules.logs.config.summary.empty', locale=self.locale)}"
+
+        lines = []
+        for category in bound:
+            config = self.module.categories[category.id]
+            channels = " ".join(f"<#{cid}>" for cid in config.channel_ids)
+            total = len(category.events)
+            lines.append(
+                f"{category.emoji} **{t(category.name_key, locale=self.locale)}** → {channels}\n"
+                f"-# {t('modules.logs.config.summary.events', locale=self.locale, enabled=config.enabled_count, total=total)}"
+            )
+        return "\n".join(lines)
+
+    def _category_options(self) -> List[discord.SelectOption]:
+        options = []
+        for category in registry.ordered_categories():
+            config = self.module.categories.get(category.id)
+            bound = config.is_bound if config else False
+            description = (
+                t('modules.logs.config.categories.bound', locale=self.locale,
+                  count=len(config.channel_ids), enabled=config.enabled_count,
+                  total=len(category.events))
+                if bound else
+                t('modules.logs.config.categories.unbound', locale=self.locale,
+                  total=len(category.events))
+            )
+            options.append(discord.SelectOption(
+                label=t(category.name_key, locale=self.locale)[:100],
+                value=category.id,
+                description=description[:100],
+                emoji=discord.PartialEmoji.from_str(category.emoji),
+            ))
+        return options
+
+    def _add_action_buttons(self):
+        row = ui.ActionRow()
+
+        back = ui.Button(
+            emoji=discord.PartialEmoji.from_str(BACK),
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            custom_id=_CID_BACK,
+        )
+        back.callback = self.on_back
+        row.add_item(back)
+
+        options = ui.Button(
+            emoji=discord.PartialEmoji.from_str(SETTINGS),
+            label=t('modules.logs.config.options.button', locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            custom_id=_CID_OPTIONS,
+        )
+        options.callback = self.on_options
+        row.add_item(options)
+
+        # Rendered on the registration shell too, so its custom_id is known
+        # after a restart even when no guild has a configuration yet
+        # (docs/PERSISTENT_VIEWS.md, gotcha 2).
+        if self.bot is None or self.module.bound_categories:
+            clear = ui.Button(
+                emoji=discord.PartialEmoji.from_str(DELETE),
+                label=t('modules.logs.config.clear.button', locale=self.locale),
+                style=discord.ButtonStyle.danger,
+                custom_id=_CID_CLEAR,
+            )
+            clear.callback = self.on_clear
+            row.add_item(clear)
+
+        self.add_item(row)
+
+    # -- callbacks -------------------------------------------------------- #
+
+    async def on_category_select(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        values = interaction.data.get("values") or []
+        if not values or values[0] not in registry.CATEGORIES:
+            return
+        view = await LogsCategoryView.create(interaction, values[0], page=0)
+        await interaction.response.edit_message(view=view)
+
+    async def on_mass_channel(self, interaction: discord.Interaction):
+        """Bind every category to a single channel in one click."""
+        if not await check_guild_perms(interaction):
+            return
+        values = interaction.data.get("values") or []
+        if not values:
+            return
+
+        await interaction.response.defer()
+        channel_id = int(values[0])
+        module = await _load(interaction.client, interaction.guild_id)
+        for category_id in registry.CATEGORIES:
+            module.category(category_id).channel_ids = [channel_id]
+
+        error = await _save(interaction, module)
+        if error:
+            await _refuse(interaction, error)
+            return
+        await _rerender_root(interaction)
+
+    async def on_options(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        view = await LogsOptionsView.create(interaction)
+        await interaction.response.edit_message(view=view)
+
+    async def on_clear(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        await interaction.response.defer()
+
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        success = await bot.module_manager.delete_module_config(
+            interaction.guild_id, _MODULE_ID)
+        if not success:
+            await _refuse(interaction, t('modules.config.delete.error', locale=locale))
+            return
+        await _rerender_root(interaction)
+
+    async def on_back(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        from cogs.config import ConfigMainView
+        locale = i18n.get_user_locale(interaction)
+        await interaction.response.edit_message(view=ConfigMainView(
+            interaction.client, interaction.guild_id, interaction.user.id, locale))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_guild_perms(interaction)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: Manage Server in the guild (checked on every click)."""
+        bot.add_view(cls())
+
+
+async def _rerender_root(interaction: discord.Interaction) -> None:
+    """Rebuild the root panel from the DB — never resend a shared shell."""
+    bot = interaction.client
+    locale = i18n.get_user_locale(interaction)
+    view = await LogsConfigView.create(
+        bot, interaction.guild_id, interaction.user.id, locale)
+    await interaction.edit_original_response(view=view)
+
+
+# --------------------------------------------------------------------------- #
+# Category panel — built entirely from DynamicItems
+# --------------------------------------------------------------------------- #
+
+def _guarded(callback):
+    """Funnel a dynamic-item callback error to the central handler (no live view)."""
+    async def wrapper(self, interaction: discord.Interaction):
+        try:
+            await callback(self, interaction)
+        except Exception as e:  # noqa: BLE001
+            from cogs.error_handler import report_component_error
+            await report_component_error(interaction, e, self.__class__.__name__)
+    return wrapper
+
+
+class LogsCategoryView(BaseView):
+    """One category: its destinations and its event checklist.
+
+    Not registered as a persistent view: every one of its children is a
+    ``DynamicItem`` carrying the category (and page) in its ``custom_id`` and
+    registered through :class:`LogsPersistence` — the same arrangement as
+    ``utils/transcription_views.py::TranscribePromptView``. There is nothing
+    left for a shell instance to register.
+    """
+
+    def __init__(self, bot, guild_id: int, category_id: str, page: int,
+                 locale: str, module: LogsModule):
+        super().__init__()  # timeout=None
+        self.bot = bot
+        self.guild_id = guild_id
+        self.category_id = category_id
+        self.page = page
+        self.locale = locale
+        self.module = module
+        self._build_view()
+
+    @classmethod
+    async def create(cls, interaction: discord.Interaction, category_id: str,
+                     page: int) -> "LogsCategoryView":
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        module = await _load(bot, interaction.guild_id)
+        return cls(bot, interaction.guild_id, category_id, page, locale, module)
+
+    # -- rendering -------------------------------------------------------- #
+
+    @property
+    def spec(self) -> registry.LogCategorySpec:
+        return registry.CATEGORIES[self.category_id]
+
+    @property
+    def page_count(self) -> int:
+        return max(1, -(-len(self.spec.events) // EVENTS_PER_PAGE))
+
+    def _build_view(self):
+        self.clear_items()
+        spec = self.spec
+        config = self.module.category(self.category_id)
+        container = ui.Container()
+
+        container.add_item(ui.TextDisplay(
+            f"### {spec.emoji} {t(spec.name_key, locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(t(spec.description_key, locale=self.locale)))
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # --- destinations ------------------------------------------------ #
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.logs.config.channels.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.logs.config.channels.section_description', locale=self.locale, max=MAX_CHANNELS_PER_CATEGORY)}"
+        ))
+        channel_row = ui.ActionRow()
+        channel_row.add_item(LogsCategoryChannels(
+            self.category_id, self.locale, self._resolve_channels(config.channel_ids)))
+        container.add_item(channel_row)
+
+        # --- event checklist --------------------------------------------- #
+        page_label = t('modules.logs.config.events.section_title', locale=self.locale)
+        if self.page_count > 1:
+            page_label += f" ({self.page + 1}/{self.page_count})"
+        container.add_item(ui.TextDisplay(
+            f"**{page_label}**\n"
+            f"-# {t('modules.logs.config.events.section_description', locale=self.locale)}\n"
+            f"-# {t('modules.logs.config.events.enabled_count', locale=self.locale, enabled=config.enabled_count, total=len(spec.events))}"
+        ))
+        events_row = ui.ActionRow()
+        events_row.add_item(LogsCategoryEvents(
+            self.category_id, self.page, self.locale,
+            self._page_events(), config.disabled_events))
+        container.add_item(events_row)
+
+        self.add_item(container)
+
+        # --- controls ---------------------------------------------------- #
+        controls = ui.ActionRow()
+        controls.add_item(LogsCategoryButton("back", self.category_id, self.page, self.locale))
+        controls.add_item(LogsCategoryButton("all", self.category_id, self.page, self.locale))
+        controls.add_item(LogsCategoryButton("none", self.category_id, self.page, self.locale))
+        if self.page_count > 1:
+            controls.add_item(LogsCategoryButton("prev", self.category_id, self.page, self.locale))
+            controls.add_item(LogsCategoryButton("next", self.category_id, self.page, self.locale))
+        self.add_item(controls)
+
+    def _page_events(self) -> List[str]:
+        start = self.page * EVENTS_PER_PAGE
+        return list(self.spec.events[start:start + EVENTS_PER_PAGE])
+
+    def _resolve_channels(self, channel_ids: List[int]) -> List[discord.abc.GuildChannel]:
+        if self.bot is None:
+            return []
+        resolved = []
+        for channel_id in channel_ids:
+            channel = self.bot.get_channel(channel_id)
+            if channel is not None:
+                resolved.append(channel)
+        return resolved
+
+
+class LogsCategoryChannels(ui.DynamicItem[ui.ChannelSelect],
+                           template=r"moddy:logs:catchan:(?P<cat>[a-z_]+)"):
+    """Destination channels of one category."""
+
+    def __init__(self, category_id: str = "server", locale: str = "en-US",
+                 defaults: Optional[List[discord.abc.GuildChannel]] = None):
+        select = ui.ChannelSelect(
+            placeholder=t('modules.logs.config.channels.placeholder', locale=locale),
+            channel_types=[discord.ChannelType.text, discord.ChannelType.news,
+                           discord.ChannelType.public_thread,
+                           discord.ChannelType.private_thread],
+            min_values=0, max_values=MAX_CHANNELS_PER_CATEGORY,
+            custom_id=f"moddy:logs:catchan:{category_id}",
+        )
+        if defaults:
+            select.default_values = defaults
+        super().__init__(select)
+        self.category_id = category_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match, /):
+        return cls(match["cat"], i18n.get_user_locale(interaction))
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        await interaction.response.defer()
+
+        values = interaction.data.get("values") or []
+        module = await _load(interaction.client, interaction.guild_id)
+        module.category(self.category_id).channel_ids = [int(v) for v in values]
+
+        error = await _save(interaction, module)
+        if error:
+            await _refuse(interaction, error)
+            return
+        await _rerender_category(interaction, self.category_id, page=0)
+
+
+class LogsCategoryEvents(ui.DynamicItem[ui.Select],
+                         template=r"moddy:logs:catev:(?P<cat>[a-z_]+):(?P<page>\d+)"):
+    """Checklist of the events of one category, 25 per page.
+
+    Selected means "logged": the stored config only keeps the *excluded*
+    events, so a category the registry grows later starts enabled — new
+    events do not silently stay off.
+    """
+
+    def __init__(self, category_id: str = "server", page: int = 0,
+                 locale: str = "en-US", events: Optional[List[str]] = None,
+                 disabled: Optional[set] = None):
+        events = events if events is not None else list(
+            registry.CATEGORIES[category_id].events[:EVENTS_PER_PAGE])
+        disabled = disabled or set()
+        options = [
+            discord.SelectOption(
+                label=t(f"modules.logs.events.{category_id}.{event}", locale=locale)[:100],
+                value=event,
+                default=event not in disabled,
+            )
+            for event in events
+        ]
+        select = ui.Select(
+            placeholder=t('modules.logs.config.events.placeholder', locale=locale),
+            options=options or [discord.SelectOption(label="—", value="none")],
+            min_values=0, max_values=len(options) or 1,
+            custom_id=f"moddy:logs:catev:{category_id}:{page}",
+        )
+        super().__init__(select)
+        self.category_id = category_id
+        self.page = page
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match, /):
+        return cls(match["cat"], int(match["page"]), i18n.get_user_locale(interaction))
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        await interaction.response.defer()
+
+        kept = set(interaction.data.get("values") or [])
+        spec = registry.CATEGORIES[self.category_id]
+        start = self.page * EVENTS_PER_PAGE
+        page_events = set(spec.events[start:start + EVENTS_PER_PAGE])
+
+        module = await _load(interaction.client, interaction.guild_id)
+        config = module.category(self.category_id)
+        # Only this page's events are affected — the others keep their state.
+        config.disabled_events -= page_events
+        config.disabled_events |= (page_events - kept)
+
+        error = await _save(interaction, module)
+        if error:
+            await _refuse(interaction, error)
+            return
+        await _rerender_category(interaction, self.category_id, self.page)
+
+
+class LogsCategoryButton(ui.DynamicItem[ui.Button],
+                         template=r"moddy:logs:catbtn:(?P<action>back|all|none|prev|next):(?P<cat>[a-z_]+):(?P<page>\d+)"):
+    """Back / enable all / disable all / previous page / next page."""
+
+    _STYLES = {
+        "back": (discord.ButtonStyle.secondary, BACK),
+        "all": (discord.ButtonStyle.success, TOGGLE_ON),
+        "none": (discord.ButtonStyle.secondary, TOGGLE_OFF),
+        "prev": (discord.ButtonStyle.secondary, BACK),
+        "next": (discord.ButtonStyle.secondary, NEXT),
+    }
+
+    def __init__(self, action: str = "back", category_id: str = "server",
+                 page: int = 0, locale: str = "en-US"):
+        style, emoji = self._STYLES[action]
+        super().__init__(ui.Button(
+            label=t(f'modules.logs.config.buttons.{action}', locale=locale),
+            style=style,
+            emoji=discord.PartialEmoji.from_str(emoji),
+            custom_id=f"moddy:logs:catbtn:{action}:{category_id}:{page}",
+        ))
+        self.action = action
+        self.category_id = category_id
+        self.page = page
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match, /):
+        return cls(match["action"], match["cat"], int(match["page"]),
+                   i18n.get_user_locale(interaction))
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+
+        if self.action == "back":
+            view = await LogsConfigView.create(
+                interaction.client, interaction.guild_id, interaction.user.id,
+                i18n.get_user_locale(interaction))
+            await interaction.response.edit_message(view=view)
+            return
+
+        spec = registry.CATEGORIES[self.category_id]
+        page_count = max(1, -(-len(spec.events) // EVENTS_PER_PAGE))
+
+        if self.action in ("prev", "next"):
+            step = -1 if self.action == "prev" else 1
+            page = (self.page + step) % page_count
+            view = await LogsCategoryView.create(interaction, self.category_id, page)
+            await interaction.response.edit_message(view=view)
+            return
+
+        await interaction.response.defer()
+        module = await _load(interaction.client, interaction.guild_id)
+        config = module.category(self.category_id)
+        # "All"/"None" apply to the whole category, not just the visible page:
+        # ticking 35 boxes page by page is exactly what these buttons exist for.
+        config.disabled_events = set() if self.action == "all" else set(spec.events)
+
+        error = await _save(interaction, module)
+        if error:
+            await _refuse(interaction, error)
+            return
+        await _rerender_category(interaction, self.category_id, self.page)
+
+
+async def _rerender_category(interaction: discord.Interaction, category_id: str,
+                             page: int) -> None:
+    view = await LogsCategoryView.create(interaction, category_id, page)
+    await interaction.edit_original_response(view=view)
+
+
+# --------------------------------------------------------------------------- #
+# Options panel
+# --------------------------------------------------------------------------- #
+
+class LogsOptionsView(BaseView):
+    """Server-wide log options.
+
+    Persistent: yes. Auth: Manage Server in the guild.
+    """
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, guild_id: Optional[int] = None,
+                 locale: str = "en-US", module: Optional[LogsModule] = None):
+        super().__init__()  # timeout=None
+        self.bot = bot
+        self.guild_id = guild_id
+        self.locale = locale
+        self.module = module if module is not None else config_from_raw(bot, guild_id or 0, None)
+        self._build_view()
+
+    @classmethod
+    async def create(cls, interaction: discord.Interaction) -> "LogsOptionsView":
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        return cls(bot, interaction.guild_id, locale,
+                   await _load(bot, interaction.guild_id))
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container()
+
+        container.add_item(ui.TextDisplay(
+            f"### {FILTER} {t('modules.logs.config.options.title', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            t('modules.logs.config.options.description', locale=self.locale)
+        ))
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # Ignored channels.
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.logs.config.options.channels.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.logs.config.options.channels.section_description', locale=self.locale)}"
+        ))
+        channel_row = ui.ActionRow()
+        channel_select = ui.ChannelSelect(
+            placeholder=t('modules.logs.config.options.channels.placeholder', locale=self.locale),
+            min_values=0, max_values=MAX_IGNORED_CHANNELS,
+            custom_id=_CID_OPT_CHANNELS,
+        )
+        channel_select.default_values = self._resolve(self.module.ignored_channel_ids,
+                                                     kind="channel")
+        channel_select.callback = self.on_channels
+        channel_row.add_item(channel_select)
+        container.add_item(channel_row)
+
+        # Ignored roles.
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.logs.config.options.roles.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.logs.config.options.roles.section_description', locale=self.locale)}"
+        ))
+        role_row = ui.ActionRow()
+        role_select = ui.RoleSelect(
+            placeholder=t('modules.logs.config.options.roles.placeholder', locale=self.locale),
+            min_values=0, max_values=MAX_IGNORED_ROLES,
+            custom_id=_CID_OPT_ROLES,
+        )
+        role_select.default_values = self._resolve(self.module.ignored_role_ids, kind="role")
+        role_select.callback = self.on_roles
+        role_row.add_item(role_select)
+        container.add_item(role_row)
+
+        # Language.
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.logs.config.options.locale.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.logs.config.options.locale.section_description', locale=self.locale)}"
+        ))
+        locale_row = ui.ActionRow()
+        locale_select = ui.Select(
+            placeholder=t('modules.logs.config.options.locale.placeholder', locale=self.locale),
+            options=[
+                discord.SelectOption(
+                    label=t(f'modules.logs.config.options.locale.values.{code}',
+                            locale=self.locale),
+                    value=code,
+                    default=(code == (self.module.locale or "auto")),
+                )
+                for code in LOG_LOCALES
+            ],
+            min_values=1, max_values=1,
+            custom_id=_CID_OPT_LOCALE,
+        )
+        locale_select.callback = self.on_locale
+        locale_row.add_item(locale_select)
+        container.add_item(locale_row)
+
+        # Toggles.
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.logs.config.options.toggles.section_title', locale=self.locale)}**\n"
+            f"-# {t('modules.logs.config.options.toggles.bots', locale=self.locale)}: "
+            f"**{self._state(self.module.ignore_bots)}**\n"
+            f"-# {t('modules.logs.config.options.toggles.transcripts', locale=self.locale)}: "
+            f"**{self._state(self.module.attach_transcripts)}**"
+        ))
+
+        self.add_item(container)
+
+        row = ui.ActionRow()
+        back = ui.Button(
+            emoji=discord.PartialEmoji.from_str(BACK),
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            custom_id=_CID_OPT_BACK,
+        )
+        back.callback = self.on_back
+        row.add_item(back)
+
+        bots = ui.Button(
+            emoji=discord.PartialEmoji.from_str(
+                TOGGLE_ON if self.module.ignore_bots else TOGGLE_OFF),
+            label=t('modules.logs.config.options.toggles.bots', locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            custom_id=_CID_OPT_BOTS,
+        )
+        bots.callback = self.on_toggle_bots
+        row.add_item(bots)
+
+        transcripts = ui.Button(
+            emoji=discord.PartialEmoji.from_str(
+                TOGGLE_ON if self.module.attach_transcripts else TOGGLE_OFF),
+            label=t('modules.logs.config.options.toggles.transcripts', locale=self.locale),
+            style=discord.ButtonStyle.secondary,
+            custom_id=_CID_OPT_TRANSCRIPTS,
+        )
+        transcripts.callback = self.on_toggle_transcripts
+        row.add_item(transcripts)
+
+        self.add_item(row)
+
+    def _state(self, value: bool) -> str:
+        return t(f"modules.logs.values.{'on' if value else 'off'}", locale=self.locale)
+
+    def _resolve(self, ids: List[int], *, kind: str) -> List[discord.Object]:
+        if self.bot is None or not ids:
+            return []
+        object_type = discord.Role if kind == "role" else discord.abc.GuildChannel
+        return [discord.Object(id=item_id, type=object_type) for item_id in ids]
+
+    # -- callbacks -------------------------------------------------------- #
+
+    async def _apply(self, interaction: discord.Interaction, mutate) -> None:
+        await interaction.response.defer()
+        module = await _load(interaction.client, interaction.guild_id)
+        mutate(module)
+        error = await _save(interaction, module)
+        if error:
+            await _refuse(interaction, error)
+            return
+        view = await LogsOptionsView.create(interaction)
+        await interaction.edit_original_response(view=view)
+
+    async def on_channels(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        values = [int(v) for v in (interaction.data.get("values") or [])]
+        await self._apply(interaction,
+                          lambda module: setattr(module, "ignored_channel_ids", values))
+
+    async def on_roles(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        values = [int(v) for v in (interaction.data.get("values") or [])]
+        await self._apply(interaction,
+                          lambda module: setattr(module, "ignored_role_ids", values))
+
+    async def on_locale(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        values = interaction.data.get("values") or ["auto"]
+        code = values[0] if values[0] in LOG_LOCALES else "auto"
+        await self._apply(interaction, lambda module: setattr(module, "locale", code))
+
+    async def on_toggle_bots(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        await self._apply(interaction, lambda module: setattr(
+            module, "ignore_bots", not module.ignore_bots))
+
+    async def on_toggle_transcripts(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        await self._apply(interaction, lambda module: setattr(
+            module, "attach_transcripts", not module.attach_transcripts))
+
+    async def on_back(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        view = await LogsConfigView.create(
+            interaction.client, interaction.guild_id, interaction.user.id,
+            i18n.get_user_locale(interaction))
+        await interaction.response.edit_message(view=view)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_guild_perms(interaction)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: Manage Server in the guild (checked on every click)."""
+        bot.add_view(cls())
+
+
+class LogsPersistence(BaseView):
+    """Marker registering the category panel's dynamic items.
+
+    The panel itself has no shell worth registering (see
+    :class:`LogsCategoryView`); its three item classes carry all the state.
+    """
+
+    __persistent__ = True
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: Manage Server in the guild (checked on every click)."""
+        bot.add_dynamic_items(LogsCategoryChannels, LogsCategoryEvents,
+                              LogsCategoryButton)

--- a/modules/configs/logs_config.py
+++ b/modules/configs/logs_config.py
@@ -32,7 +32,7 @@ from modules.logs import (
 )
 from serverlogs import registry
 from utils.emojis import (
-    BACK, DELETE, FILTER, HISTORY, SETTINGS, TOGGLE_OFF, TOGGLE_ON, NEXT,
+    BACK, DELETE, FILTER, NOTE, SETTINGS, TOGGLE_OFF, TOGGLE_ON, NEXT,
 )
 from utils.i18n import i18n, t
 
@@ -129,7 +129,7 @@ class LogsConfigView(BaseView):
         container = ui.Container()
 
         container.add_item(ui.TextDisplay(
-            f"### {HISTORY} {t('modules.logs.config.title', locale=self.locale)}"
+            f"### {NOTE} {t('modules.logs.config.title', locale=self.locale)}"
         ))
         container.add_item(ui.TextDisplay(
             t('modules.logs.config.description', locale=self.locale)

--- a/modules/logs.py
+++ b/modules/logs.py
@@ -1,0 +1,305 @@
+"""Advanced server logs — module (configuration + routing).
+
+The module owns the *configuration*: which channel receives which category of
+events, which events are excluded inside a category, and the server-wide
+ignore lists. It deliberately owns no Discord listener — those live in
+``cogs/logs.py`` (wiring) and :mod:`serverlogs.listeners` (one file per
+category, where the log messages are built).
+
+Stored configuration (``guilds.data.modules.logs``)::
+
+    {
+      "categories": {
+        "server":   {"channel_ids": [123], "disabled_events": ["user_kick"]},
+        "messages": {"channel_ids": [456], "disabled_events": []}
+      },
+      "ignored_channel_ids": [789],
+      "ignored_role_ids": [],
+      "ignore_bots": false,
+      "attach_transcripts": true,
+      "locale": "auto"
+    }
+
+Only categories the admin actually bound to a channel are stored, so the
+config stays small however many events the registry grows to.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+import discord
+
+from modules.module_manager import ModuleBase
+from serverlogs import registry
+
+logger = logging.getLogger('moddy.modules.logs')
+
+MODULE_ID = "logs"
+
+#: How many channels a single category may fan out to.
+MAX_CHANNELS_PER_CATEGORY = 3
+#: How many channels/roles the server-wide ignore lists accept.
+MAX_IGNORED_CHANNELS = 25
+MAX_IGNORED_ROLES = 25
+
+
+def _int_list(values: Any, limit: int) -> List[int]:
+    """Coerce a stored JSON list into de-duplicated ints (snowflakes may be str)."""
+    if not isinstance(values, (list, tuple)):
+        return []
+    out: List[int] = []
+    for value in values:
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            continue
+        if number not in out:
+            out.append(number)
+    return out[:limit]
+
+
+class CategoryConfig:
+    """Configuration of one category: its channels and its excluded events."""
+
+    __slots__ = ("category_id", "channel_ids", "disabled_events")
+
+    def __init__(self, category_id: str, channel_ids: Sequence[int],
+                 disabled_events: Sequence[str]):
+        self.category_id = category_id
+        self.channel_ids: List[int] = list(channel_ids)
+        self.disabled_events: Set[str] = set(disabled_events)
+
+    @classmethod
+    def from_raw(cls, category_id: str, raw: Any) -> "CategoryConfig":
+        raw = raw if isinstance(raw, dict) else {}
+        known = set(registry.CATEGORIES[category_id].events)
+        disabled = [
+            event for event in (raw.get("disabled_events") or [])
+            if isinstance(event, str) and event in known
+        ]
+        return cls(
+            category_id,
+            _int_list(raw.get("channel_ids"), MAX_CHANNELS_PER_CATEGORY),
+            disabled,
+        )
+
+    def to_raw(self) -> Dict[str, Any]:
+        return {
+            "channel_ids": list(self.channel_ids),
+            "disabled_events": sorted(self.disabled_events),
+        }
+
+    def is_event_enabled(self, event: str) -> bool:
+        return event not in self.disabled_events
+
+    @property
+    def enabled_count(self) -> int:
+        total = len(registry.CATEGORIES[self.category_id].events)
+        return total - len(self.disabled_events)
+
+    @property
+    def is_bound(self) -> bool:
+        return bool(self.channel_ids)
+
+
+class LogsModule(ModuleBase):
+    """Server logs configuration holder and event router."""
+
+    MODULE_ID = MODULE_ID
+    MODULE_NAME = "Logs"
+    MODULE_DESCRIPTION = "Detailed audit logs for everything that happens on the server"
+    MODULE_EMOJI = "<:history:1519796822963392755>"
+    MODULE_ORDER = 25
+
+    def __init__(self, bot, guild_id: int):
+        super().__init__(bot, guild_id)
+        self.categories: Dict[str, CategoryConfig] = {}
+        self.ignored_channel_ids: List[int] = []
+        self.ignored_role_ids: List[int] = []
+        self.ignore_bots: bool = False
+        self.attach_transcripts: bool = True
+        # "auto" follows the server's own language (guild.preferred_locale).
+        self.locale: str = "auto"
+
+    # ------------------------------------------------------------------ #
+    # ModuleBase contract
+    # ------------------------------------------------------------------ #
+
+    def get_default_config(self) -> Dict[str, Any]:
+        return {
+            "categories": {},
+            "ignored_channel_ids": [],
+            "ignored_role_ids": [],
+            "ignore_bots": False,
+            "attach_transcripts": True,
+            "locale": "auto",
+        }
+
+    async def load_config(self, config_data: Dict[str, Any]) -> bool:
+        try:
+            self.config = config_data or {}
+            raw_categories = self.config.get("categories")
+            raw_categories = raw_categories if isinstance(raw_categories, dict) else {}
+
+            self.categories = {
+                category_id: CategoryConfig.from_raw(category_id, raw)
+                for category_id, raw in raw_categories.items()
+                if category_id in registry.CATEGORIES
+            }
+            self.ignored_channel_ids = _int_list(
+                self.config.get("ignored_channel_ids"), MAX_IGNORED_CHANNELS)
+            self.ignored_role_ids = _int_list(
+                self.config.get("ignored_role_ids"), MAX_IGNORED_ROLES)
+            self.ignore_bots = bool(self.config.get("ignore_bots", False))
+            self.attach_transcripts = bool(self.config.get("attach_transcripts", True))
+            self.locale = str(self.config.get("locale") or "auto")
+
+            # A logs configuration is "on" as soon as one category has a
+            # destination — there is no separate on/off switch to forget.
+            self.enabled = any(cat.is_bound for cat in self.categories.values())
+            return True
+        except Exception as e:
+            logger.error(f"Error loading logs config for guild {self.guild_id}: {e}",
+                         exc_info=True)
+            return False
+
+    async def validate_config(self, config_data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
+        """Check every bound channel exists and is writable by the bot."""
+        from utils.i18n import t
+
+        guild = self.bot.get_guild(self.guild_id) if self.bot else None
+        locale = str(guild.preferred_locale) if guild and guild.preferred_locale else 'en-US'
+
+        raw_categories = config_data.get("categories")
+        if raw_categories is not None and not isinstance(raw_categories, dict):
+            return False, t('modules.logs.config.errors.invalid_config', locale=locale)
+
+        for category_id, raw in (raw_categories or {}).items():
+            if category_id not in registry.CATEGORIES:
+                return False, t('modules.logs.config.errors.unknown_category',
+                                locale=locale, category=category_id)
+            if not guild:
+                continue
+            for channel_id in _int_list((raw or {}).get("channel_ids"),
+                                        MAX_CHANNELS_PER_CATEGORY):
+                channel = guild.get_channel_or_thread(channel_id)
+                if channel is None:
+                    return False, t('modules.logs.config.errors.channel_not_found',
+                                    locale=locale, channel_id=channel_id)
+                permissions = channel.permissions_for(guild.me)
+                if not (permissions.view_channel and permissions.send_messages
+                        and permissions.embed_links):
+                    return False, t('modules.logs.config.errors.missing_permissions',
+                                    locale=locale, channel=channel.mention)
+        return True, None
+
+    # ------------------------------------------------------------------ #
+    # Routing — read by the dispatcher on every event
+    # ------------------------------------------------------------------ #
+
+    def channels_for(self, event: str) -> List[int]:
+        """Channel ids that should receive one *bare* event name.
+
+        The same occurrence can belong to several categories (a ban is both a
+        ``server`` and a ``moderation`` event); each bound category that
+        declares the event and has not excluded it contributes its channels.
+        """
+        channel_ids: List[int] = []
+        for key in registry.keys_for(event):
+            spec = registry.EVENTS[key]
+            category = self.categories.get(spec.category)
+            if not category or not category.is_bound:
+                continue
+            if not category.is_event_enabled(spec.event):
+                continue
+            for channel_id in category.channel_ids:
+                if channel_id not in channel_ids:
+                    channel_ids.append(channel_id)
+        return channel_ids
+
+    def is_event_logged(self, event: str) -> bool:
+        return bool(self.channels_for(event))
+
+    def is_ignored_channel(self, channel: Optional[discord.abc.GuildChannel]) -> bool:
+        """True when a channel — or its parent category/thread parent — is muted."""
+        if channel is None or not self.ignored_channel_ids:
+            return False
+        candidates = {getattr(channel, "id", None)}
+        parent = getattr(channel, "parent", None)
+        if parent is not None:
+            candidates.add(parent.id)
+            candidates.add(getattr(getattr(parent, "category", None), "id", None))
+        candidates.add(getattr(getattr(channel, "category", None), "id", None))
+        return any(cid in self.ignored_channel_ids for cid in candidates if cid)
+
+    def is_ignored_actor(self, user: Optional[discord.abc.User]) -> bool:
+        """True when the subject/author of an event should never be logged."""
+        if user is None:
+            return False
+        if self.ignore_bots and getattr(user, "bot", False):
+            return True
+        if self.ignored_role_ids:
+            role_ids = {role.id for role in getattr(user, "roles", [])}
+            if role_ids & set(self.ignored_role_ids):
+                return True
+        return False
+
+    # ------------------------------------------------------------------ #
+    # Config edition helpers (used by the /config panel)
+    # ------------------------------------------------------------------ #
+
+    def to_config(self) -> Dict[str, Any]:
+        """Serialise the in-memory state back to the stored schema."""
+        return {
+            "categories": {
+                category_id: category.to_raw()
+                for category_id, category in self.categories.items()
+                # A category with no channel left carries no information.
+                if category.is_bound or category.disabled_events
+            },
+            "ignored_channel_ids": list(self.ignored_channel_ids),
+            "ignored_role_ids": list(self.ignored_role_ids),
+            "ignore_bots": self.ignore_bots,
+            "attach_transcripts": self.attach_transcripts,
+            "locale": self.locale,
+        }
+
+    def category(self, category_id: str) -> CategoryConfig:
+        """Category config, created empty on first access."""
+        if category_id not in self.categories:
+            self.categories[category_id] = CategoryConfig(category_id, [], [])
+        return self.categories[category_id]
+
+    @property
+    def bound_categories(self) -> List[str]:
+        return [cid for cid, cat in self.categories.items() if cat.is_bound]
+
+
+def config_from_raw(bot, guild_id: int, raw: Optional[Dict[str, Any]]) -> LogsModule:
+    """Build a detached :class:`LogsModule` from a stored config (no DB write).
+
+    Used by the ``/config`` panel, which edits a module instance rather than a
+    loose dict so validation and routing rules live in exactly one place.
+    """
+    module = LogsModule(bot, guild_id)
+    raw = raw if isinstance(raw, dict) and raw else module.get_default_config()
+    # load_config is intentionally not awaited here: the panel is sync-built.
+    # Mirror it manually — same normalisation, no side effect.
+    module.config = raw
+    raw_categories = raw.get("categories")
+    raw_categories = raw_categories if isinstance(raw_categories, dict) else {}
+    module.categories = {
+        category_id: CategoryConfig.from_raw(category_id, value)
+        for category_id, value in raw_categories.items()
+        if category_id in registry.CATEGORIES
+    }
+    module.ignored_channel_ids = _int_list(raw.get("ignored_channel_ids"),
+                                           MAX_IGNORED_CHANNELS)
+    module.ignored_role_ids = _int_list(raw.get("ignored_role_ids"), MAX_IGNORED_ROLES)
+    module.ignore_bots = bool(raw.get("ignore_bots", False))
+    module.attach_transcripts = bool(raw.get("attach_transcripts", True))
+    module.locale = str(raw.get("locale") or "auto")
+    module.enabled = any(cat.is_bound for cat in module.categories.values())
+    return module

--- a/modules/logs.py
+++ b/modules/logs.py
@@ -33,6 +33,7 @@ import discord
 
 from modules.module_manager import ModuleBase
 from serverlogs import registry
+from utils.emojis import NOTE
 
 logger = logging.getLogger('moddy.modules.logs')
 
@@ -110,7 +111,7 @@ class LogsModule(ModuleBase):
     MODULE_ID = MODULE_ID
     MODULE_NAME = "Logs"
     MODULE_DESCRIPTION = "Detailed audit logs for everything that happens on the server"
-    MODULE_EMOJI = "<:history:1519796822963392755>"
+    MODULE_EMOJI = NOTE
     MODULE_ORDER = 25
 
     def __init__(self, bot, guild_id: int):

--- a/serverlogs/__init__.py
+++ b/serverlogs/__init__.py
@@ -1,0 +1,26 @@
+"""Moddy's advanced server logs.
+
+Layout of the system::
+
+    serverlogs/registry.py    what can be logged (categories + events)
+    serverlogs/renderer.py    what a log looks like (the embed, the labels)
+    serverlogs/dispatcher.py  how it gets there (webhooks, batching, queues)
+    serverlogs/audit.py       who did it (audit-log correlation)
+    serverlogs/service.py     the API listeners use (open / submit)
+    serverlogs/listeners/     one module per category — the events themselves
+
+    modules/logs.py                    the configuration (what goes where)
+    modules/configs/logs_config.py     the /config panel
+    cogs/logs.py                       the Discord wiring
+
+Documentation: ``docs/LOGS.md``.
+
+The submodules are intentionally *not* imported here: ``modules/logs.py``
+imports :mod:`serverlogs.registry` at module-discovery time, long before
+``discord`` clients or cogs exist, so this package must stay importable
+without side effects.
+"""
+
+from __future__ import annotations
+
+__all__ = ["registry", "renderer", "dispatcher", "audit", "service"]

--- a/serverlogs/audit.py
+++ b/serverlogs/audit.py
@@ -1,0 +1,112 @@
+"""Audit-log correlation — putting a name on "who did this".
+
+The gateway tells us *that* a role was deleted; only the audit log tells us
+*who* deleted it and why. Two problems make a naive
+``guild.audit_logs(limit=1)`` call unreliable:
+
+* the audit entry and the gateway event race — either can arrive first;
+* polling the audit log on every event burns REST calls during a raid.
+
+So the cog feeds every ``on_audit_log_entry_create`` into this cache
+(free, it comes over the gateway), and a listener that needs an executor
+looks the cache up first, then waits a short moment for a matching entry to
+arrive, and only then gives up. No REST call is ever made.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import defaultdict, deque
+from typing import Callable, Deque, Dict, Optional
+
+import discord
+
+logger = logging.getLogger('moddy.serverlogs.audit')
+
+#: Entries kept per guild.
+CACHE_SIZE = 60
+#: How long a cached entry may still be matched to a gateway event.
+CACHE_TTL = 20.0
+#: How long a listener waits for an entry that has not arrived yet.
+DEFAULT_WAIT = 2.0
+
+
+class AuditCache:
+    """Short-lived, per-guild cache of incoming audit-log entries."""
+
+    def __init__(self):
+        self._entries: Dict[int, Deque] = defaultdict(lambda: deque(maxlen=CACHE_SIZE))
+        self._waiters: Dict[int, list] = defaultdict(list)
+
+    def add(self, entry: discord.AuditLogEntry) -> None:
+        guild = getattr(entry, "guild", None)
+        if guild is None:
+            return
+        self._entries[guild.id].append((time.monotonic(), entry))
+
+        # Wake anything waiting for this exact entry.
+        for future, check in list(self._waiters[guild.id]):
+            if future.done():
+                self._waiters[guild.id].remove((future, check))
+                continue
+            try:
+                matched = check(entry)
+            except Exception:
+                matched = False
+            if matched:
+                future.set_result(entry)
+                self._waiters[guild.id].remove((future, check))
+
+    def find(self, guild_id: int, check: Callable[[discord.AuditLogEntry], bool]
+             ) -> Optional[discord.AuditLogEntry]:
+        """Most recent cached entry matching ``check``, if still fresh."""
+        now = time.monotonic()
+        for stamp, entry in reversed(self._entries.get(guild_id, ())):
+            if now - stamp > CACHE_TTL:
+                break
+            try:
+                if check(entry):
+                    return entry
+            except Exception:
+                continue
+        return None
+
+    async def wait_for(self, guild_id: int,
+                       check: Callable[[discord.AuditLogEntry], bool],
+                       timeout: float = DEFAULT_WAIT) -> Optional[discord.AuditLogEntry]:
+        """Cached match, or the first one to arrive within ``timeout``."""
+        cached = self.find(guild_id, check)
+        if cached is not None:
+            return cached
+
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._waiters[guild_id].append((future, check))
+        try:
+            return await asyncio.wait_for(future, timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+        finally:
+            if not future.done():
+                future.cancel()
+            self._waiters[guild_id] = [
+                (f, c) for f, c in self._waiters[guild_id] if f is not future
+            ]
+
+
+def target_matcher(action: discord.AuditLogAction, target_id: Optional[int] = None,
+                   extra: Optional[Callable[[discord.AuditLogEntry], bool]] = None
+                   ) -> Callable[[discord.AuditLogEntry], bool]:
+    """Build a ``check`` for :meth:`AuditCache.wait_for`."""
+
+    def _check(entry: discord.AuditLogEntry) -> bool:
+        if entry.action != action:
+            return False
+        if target_id is not None:
+            entry_target_id = getattr(entry.target, "id", None) or entry.target_id
+            if entry_target_id != target_id:
+                return False
+        return extra(entry) if extra else True
+
+    return _check

--- a/serverlogs/dispatcher.py
+++ b/serverlogs/dispatcher.py
@@ -1,0 +1,271 @@
+"""Delivery of rendered logs — webhooks, batching and back-pressure.
+
+Logs are the one feature that fires hardest exactly when a server is in
+trouble (a raid, a mass ban, a purge). Posting them with ``channel.send``
+would burn the bot's own rate-limit buckets and slow every other command
+down, so every log goes out through a **channel webhook** instead:
+
+* webhooks have their own rate-limit bucket, separate from the bot user;
+* one webhook call can carry **10 embeds**, so a burst collapses into a
+  handful of requests;
+* if the webhook is missing or unusable, delivery falls back to a plain
+  ``channel.send`` so a misconfigured server still gets its logs.
+
+Each destination channel owns one worker task with a bounded queue. When the
+queue is full (a genuine flood) the oldest pending entry is dropped and
+counted rather than letting memory grow without bound.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import discord
+
+logger = logging.getLogger('moddy.serverlogs.dispatcher')
+
+#: Name of the webhook Moddy creates in each log channel.
+WEBHOOK_NAME = "Moddy Logs"
+#: Discord's own limit for embeds in a single message.
+MAX_EMBEDS_PER_MESSAGE = 10
+#: How long a worker waits for more entries before flushing a batch.
+BATCH_WINDOW = 0.75
+#: Pending entries kept per channel before the oldest are dropped.
+QUEUE_MAXSIZE = 500
+
+
+class _Payload:
+    """One queued log message: its embed and any attachments."""
+
+    __slots__ = ("embed", "files")
+
+    def __init__(self, embed: discord.Embed, files: List[discord.File]):
+        self.embed = embed
+        self.files = files
+
+    @property
+    def batchable(self) -> bool:
+        # Files are per-message, so an entry carrying a transcript is sent on
+        # its own rather than merged into a batch.
+        return not self.files
+
+
+class LogDispatcher:
+    """Owns the webhooks, the per-channel queues and their worker tasks."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self._queues: Dict[int, asyncio.Queue] = {}
+        self._workers: Dict[int, asyncio.Task] = {}
+        self._webhooks: Dict[int, Optional[discord.Webhook]] = {}
+        self._webhook_locks: Dict[int, asyncio.Lock] = {}
+        self._dropped: Dict[int, int] = {}
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    def enqueue(self, channel_id: int, embed: discord.Embed,
+                files: Optional[List[discord.File]] = None) -> None:
+        """Hand one rendered log to the channel's worker. Never blocks."""
+        queue = self._queues.get(channel_id)
+        if queue is None:
+            queue = asyncio.Queue(maxsize=QUEUE_MAXSIZE)
+            self._queues[channel_id] = queue
+
+        payload = _Payload(embed, files or [])
+        try:
+            queue.put_nowait(payload)
+        except asyncio.QueueFull:
+            # Under a flood, keep the most recent events: drop the oldest.
+            try:
+                queue.get_nowait()
+                queue.task_done()
+                queue.put_nowait(payload)
+            except (asyncio.QueueEmpty, asyncio.QueueFull):
+                pass
+            self._dropped[channel_id] = self._dropped.get(channel_id, 0) + 1
+            if self._dropped[channel_id] % 100 == 1:
+                logger.warning(
+                    f"[Logs] Channel {channel_id} is flooding: "
+                    f"{self._dropped[channel_id]} log entries dropped"
+                )
+
+        worker = self._workers.get(channel_id)
+        if worker is None or worker.done():
+            self._workers[channel_id] = asyncio.create_task(
+                self._run_worker(channel_id), name=f"moddy-logs-{channel_id}")
+
+    def invalidate_webhook(self, channel_id: int) -> None:
+        """Forget a cached webhook (deleted in Discord, permissions changed…)."""
+        self._webhooks.pop(channel_id, None)
+
+    async def close(self) -> None:
+        """Cancel every worker — called when the cog is unloaded."""
+        for task in self._workers.values():
+            task.cancel()
+        self._workers.clear()
+        self._queues.clear()
+        self._webhooks.clear()
+
+    # ------------------------------------------------------------------ #
+    # Worker
+    # ------------------------------------------------------------------ #
+
+    async def _run_worker(self, channel_id: int) -> None:
+        queue = self._queues.get(channel_id)
+        if queue is None:
+            return
+        try:
+            while True:
+                try:
+                    first: _Payload = await asyncio.wait_for(queue.get(), timeout=30)
+                except asyncio.TimeoutError:
+                    # Idle channel: let the task die, `enqueue` restarts one.
+                    return
+
+                batch = [first]
+                if first.batchable:
+                    batch.extend(await self._drain(queue))
+
+                try:
+                    await self._deliver(channel_id, batch)
+                except Exception as e:
+                    logger.error(f"[Logs] Delivery failed for channel {channel_id}: {e}",
+                                 exc_info=True)
+                finally:
+                    for _ in batch:
+                        queue.task_done()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"[Logs] Worker crashed for channel {channel_id}: {e}",
+                         exc_info=True)
+
+    async def _drain(self, queue: asyncio.Queue) -> List[_Payload]:
+        """Collect further batchable entries within the batching window."""
+        collected: List[_Payload] = []
+        deadline = asyncio.get_running_loop().time() + BATCH_WINDOW
+        while len(collected) < MAX_EMBEDS_PER_MESSAGE - 1:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                break
+            try:
+                payload: _Payload = await asyncio.wait_for(queue.get(), timeout=remaining)
+            except asyncio.TimeoutError:
+                break
+            if not payload.batchable:
+                # Not mergeable: put it back at the head by sending it next.
+                collected.append(payload)
+                break
+            collected.append(payload)
+        return collected
+
+    async def _deliver(self, channel_id: int, batch: List[_Payload]) -> None:
+        channel = self.bot.get_channel(channel_id)
+        if channel is None:
+            return
+
+        # Entries carrying files go out one by one; the rest are merged.
+        mergeable = [p for p in batch if p.batchable]
+        standalone = [p for p in batch if not p.batchable]
+
+        for chunk_start in range(0, len(mergeable), MAX_EMBEDS_PER_MESSAGE):
+            chunk = mergeable[chunk_start:chunk_start + MAX_EMBEDS_PER_MESSAGE]
+            await self._send(channel, [p.embed for p in chunk], [])
+
+        for payload in standalone:
+            await self._send(channel, [payload.embed], payload.files)
+
+    async def _send(self, channel, embeds: List[discord.Embed],
+                    files: List[discord.File]) -> None:
+        if not embeds:
+            return
+
+        webhook, thread = await self._get_webhook(channel)
+        if webhook is not None:
+            try:
+                kwargs = {"embeds": embeds, "files": files} if files else {"embeds": embeds}
+                if thread is not None:
+                    kwargs["thread"] = thread
+                await webhook.send(wait=False, **kwargs)
+                return
+            except discord.NotFound:
+                # Webhook deleted behind our back — drop it and fall through.
+                self.invalidate_webhook(channel.id)
+            except discord.HTTPException as e:
+                logger.warning(f"[Logs] Webhook send failed in {channel.id}: {e}")
+                self.invalidate_webhook(channel.id)
+
+        try:
+            await channel.send(embeds=embeds, files=files or discord.utils.MISSING)
+        except discord.HTTPException as e:
+            logger.warning(f"[Logs] Fallback send failed in {channel.id}: {e}")
+
+    # ------------------------------------------------------------------ #
+    # Webhooks
+    # ------------------------------------------------------------------ #
+
+    async def _get_webhook(self, channel) -> Tuple[Optional[discord.Webhook], Optional[discord.abc.Snowflake]]:
+        """Return ``(webhook, thread)`` for a destination channel.
+
+        Threads have no webhook of their own: the parent's webhook is used
+        with ``thread=``. ``None`` means "no usable webhook" — the caller
+        falls back to ``channel.send``.
+        """
+        thread = None
+        target = channel
+        if isinstance(channel, discord.Thread):
+            thread = channel
+            target = channel.parent
+            if target is None:
+                return None, None
+
+        cached = self._webhooks.get(target.id)
+        if cached is not None:
+            return cached, thread
+        if target.id in self._webhooks:  # cached negative result
+            return None, thread
+
+        lock = self._webhook_locks.setdefault(target.id, asyncio.Lock())
+        async with lock:
+            if target.id in self._webhooks:
+                return self._webhooks[target.id], thread
+
+            webhook = await self._resolve_webhook(target)
+            self._webhooks[target.id] = webhook
+            return webhook, thread
+
+    async def _resolve_webhook(self, channel) -> Optional[discord.Webhook]:
+        me = channel.guild.me if channel.guild else None
+        if me is None or not channel.permissions_for(me).manage_webhooks:
+            return None
+
+        try:
+            existing = await channel.webhooks()
+        except discord.HTTPException as e:
+            logger.debug(f"[Logs] Could not list webhooks in {channel.id}: {e}")
+            return None
+
+        for webhook in existing:
+            if webhook.token and webhook.name == WEBHOOK_NAME:
+                return webhook
+
+        avatar_bytes = None
+        try:
+            if self.bot.user and self.bot.user.display_avatar:
+                avatar_bytes = await self.bot.user.display_avatar.read()
+        except Exception:
+            avatar_bytes = None
+
+        try:
+            return await channel.create_webhook(
+                name=WEBHOOK_NAME,
+                avatar=avatar_bytes,
+                reason="Moddy server logs",
+            )
+        except discord.HTTPException as e:
+            logger.warning(f"[Logs] Could not create a webhook in {channel.id}: {e}")
+            return None

--- a/serverlogs/listeners/__init__.py
+++ b/serverlogs/listeners/__init__.py
@@ -1,0 +1,23 @@
+"""Log builders, one module per category.
+
+Every function here has the same shape::
+
+    async def on_something(service: LogService, ...discord objects...) -> None:
+        entry = await service.open(guild, "<event>", ...)
+        if entry is None:
+            return
+        entry.line("<field>", <formatted value>)
+        await service.submit(guild, entry)
+
+* ``service.open`` returns ``None`` when the server does not log the event,
+  so the very first line of every builder is also its cost on a server that
+  has logs turned off.
+* Values are always formatted through :mod:`serverlogs.renderer` helpers
+  (``fmt_user``, ``fmt_channel``, ``fmt_time``…) — never with f-strings — so
+  a user or a channel reads identically in all 163 events.
+* Labels and titles are i18n keys, never literals.
+
+``cogs/logs.py`` owns the ``@commands.Cog.listener()`` methods and does
+nothing but forward to these functions: the Discord wiring and the content
+of the logs stay separate.
+"""

--- a/serverlogs/listeners/_diff.py
+++ b/serverlogs/listeners/_diff.py
@@ -1,0 +1,118 @@
+"""Declarative before/after logging.
+
+Discord collapses a dozen distinct settings into a single ``*_update``
+gateway event, while the registry exposes one event per setting (so an admin
+can log renames without logging every permission tweak). Rather than writing
+the same ``if before.x != after.x`` block sixty times, each listener declares
+a table of :class:`DiffRule` and lets :func:`emit_diffs` do the comparison,
+the formatting and the audit-log lookup.
+
+Adding "log the new X setting" is then one line in a table.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Optional, Sequence
+
+import discord
+
+from serverlogs.renderer import escape
+
+#: Signature of a value renderer: ``(value, locale) -> str``.
+Renderer = Callable[[Any, str], str]
+
+
+def default_render(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    if value is None or value == "":
+        return t("modules.logs.values.none", locale=locale)
+    if isinstance(value, bool):
+        return t(f"modules.logs.values.{'yes' if value else 'no'}", locale=locale)
+    return escape(str(value))
+
+
+@dataclass(frozen=True)
+class DiffRule:
+    """One tracked setting: which event it emits and how it reads."""
+
+    event: str
+    attr: str
+    render: Renderer = default_render
+    #: Some settings only exist on certain channel types.
+    applies: Optional[Callable[[Any], bool]] = None
+    #: Extra lines added to the entry, ``(entry, before, after) -> None``.
+    decorate: Optional[Callable[[Any, Any, Any], None]] = None
+    #: Long values (topics, descriptions) go to a field instead of a line.
+    as_block: bool = False
+
+
+def _get(obj: Any, attr: str) -> Any:
+    value = obj
+    for part in attr.split("."):
+        value = getattr(value, part, None)
+        if value is None:
+            return None
+    return value
+
+
+async def emit_diffs(service, guild: discord.Guild, rules: Sequence[DiffRule],
+                     before: Any, after: Any, *,
+                     header: Optional[Callable[[Any], None]] = None,
+                     audit_action: Optional[discord.AuditLogAction] = None,
+                     audit_target_id: Optional[int] = None,
+                     thumbnail: Optional[str] = None) -> None:
+    """Emit one log per rule whose value actually changed.
+
+    ``header`` receives each entry and adds the identity lines shared by
+    every event of the family (the channel, the role, the server…).
+    """
+    changed = []
+    for rule in rules:
+        if rule.applies is not None and not rule.applies(after):
+            continue
+        old, new = _get(before, rule.attr), _get(after, rule.attr)
+        if old == new:
+            continue
+        changed.append((rule, old, new))
+
+    if not changed:
+        return
+
+    who = reason = None
+    if audit_action is not None:
+        who, reason = await service.executor(
+            guild, audit_action, audit_target_id, wait=1.5)
+
+    for rule, old, new in changed:
+        entry = await service.open(guild, rule.event, actor=who)
+        if entry is None:
+            continue
+        if header is not None:
+            header(entry)
+        if thumbnail:
+            entry.thumbnail(thumbnail)
+
+        before_text = rule.render(old, entry.locale)
+        after_text = rule.render(new, entry.locale)
+        if rule.as_block:
+            entry.block("before", before_text)
+            entry.block("after", after_text)
+        else:
+            entry.line("before", before_text)
+            entry.line("after", after_text)
+
+        if rule.decorate is not None:
+            rule.decorate(entry, old, new)
+        entry.actor(who, reason)
+        await service.submit(guild, entry)
+
+
+def diff_sets(before: Iterable[Any], after: Iterable[Any]):
+    """``(added, removed)`` between two iterables of hashable-by-id objects."""
+    before_list, after_list = list(before or []), list(after or [])
+    before_ids = {getattr(item, "id", item) for item in before_list}
+    after_ids = {getattr(item, "id", item) for item in after_list}
+    added = [item for item in after_list if getattr(item, "id", item) not in before_ids]
+    removed = [item for item in before_list if getattr(item, "id", item) not in after_ids]
+    return added, removed

--- a/serverlogs/listeners/assets.py
+++ b/serverlogs/listeners/assets.py
@@ -1,0 +1,305 @@
+"""Server assets: custom emojis, stickers and soundboard sounds.
+
+Discord does not tell us *what* changed in these three families: it sends the
+**whole collection** on ``on_guild_emojis_update`` and
+``on_guild_stickers_update``. Each builder therefore reconstructs the delta
+itself — :func:`~serverlogs.listeners._diff.diff_sets` isolates the additions
+and the removals, and the entries present on both sides are compared property
+by property so a rename never reads as "deleted then created".
+
+Soundboard sounds do get proper per-object gateway events, so they follow the
+usual declarative :class:`~serverlogs.listeners._diff.DiffRule` table.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import discord
+
+from serverlogs.listeners._diff import DiffRule, default_render, diff_sets, emit_diffs
+from serverlogs.renderer import escape, fmt_bool, fmt_roles, fmt_time
+
+
+# --------------------------------------------------------------------------- #
+# Value renderers
+# --------------------------------------------------------------------------- #
+
+def _render_emoji(value: Any, locale: str) -> str:
+    """A soundboard emoji (renderable) or a sticker's related emoji (a name)."""
+    if value in (None, ""):
+        return default_render(None, locale)
+    if isinstance(value, str):
+        return f"`{escape(value)}`"
+    return str(value)
+
+
+def _render_volume(value: Any, locale: str) -> str:
+    if value is None:
+        return default_render(value, locale)
+    return f"`{int(float(value) * 100)}%`"
+
+
+def _render_link(asset: Any, locale: str) -> str:
+    """A playable/viewable asset, rendered as a single "open" markdown link."""
+    from utils.i18n import t
+    url = getattr(asset, "url", None)
+    if not url:
+        return escape(getattr(asset, "name", "")) or default_render(None, locale)
+    return f"[{t('modules.logs.values.open_link', locale=locale)}]({url})"
+
+
+#: Tracked soundboard properties — one line here is one loggable event.
+SOUND_RULES = (
+    DiffRule("sound_name_update", "name"),
+    DiffRule("sound_volume_update", "volume", render=_render_volume),
+    DiffRule("sound_emoji_update", "emoji", render=_render_emoji),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Emojis
+# --------------------------------------------------------------------------- #
+
+async def on_emojis_update(service, guild: discord.Guild, before: list,
+                           after: list) -> None:
+    """Fan the whole-collection gateway event out into per-emoji logs."""
+    added, removed = diff_sets(before, after)
+
+    for emoji in added:
+        await _log_emoji_created(service, guild, emoji)
+    for emoji in removed:
+        await _log_emoji_deleted(service, guild, emoji)
+
+    for old, new in _pairs(before, after):
+        if old.name != new.name:
+            await _log_emoji_name(service, guild, old, new)
+        if list(getattr(old, "roles", []) or []) != list(getattr(new, "roles", []) or []):
+            await _log_emoji_roles(service, guild, old, new)
+
+
+async def _log_emoji_created(service, guild: discord.Guild,
+                             emoji: discord.Emoji) -> None:
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.emoji_create, emoji.id)
+
+    entry = await service.open(guild, "emoji_create", actor=who)
+    if entry is None:
+        return
+    _emoji_header(entry, emoji)
+    if getattr(emoji, "roles", None):
+        entry.line("roles", fmt_roles(emoji.roles))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def _log_emoji_deleted(service, guild: discord.Guild,
+                             emoji: discord.Emoji) -> None:
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.emoji_delete, emoji.id)
+
+    entry = await service.open(guild, "emoji_delete", actor=who)
+    if entry is None:
+        return
+    _emoji_header(entry, emoji)
+    entry.line("created", fmt_time(emoji.created_at))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def _log_emoji_name(service, guild: discord.Guild, old: discord.Emoji,
+                          new: discord.Emoji) -> None:
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.emoji_update, new.id, wait=1.5)
+
+    entry = await service.open(guild, "emoji_name_update", actor=who)
+    if entry is None:
+        return
+    _emoji_header(entry, new)
+    entry.line("before", escape(old.name))
+    entry.line("after", escape(new.name))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def _log_emoji_roles(service, guild: discord.Guild, old: discord.Emoji,
+                           new: discord.Emoji) -> None:
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.emoji_update, new.id, wait=1.5)
+
+    entry = await service.open(guild, "emoji_roles_update", actor=who)
+    if entry is None:
+        return
+    _emoji_header(entry, new)
+
+    added, removed = diff_sets(getattr(old, "roles", []), getattr(new, "roles", []))
+    if added:
+        entry.line("added", fmt_roles(added))
+    if removed:
+        entry.line("removed", fmt_roles(removed))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+def _emoji_header(entry, emoji: discord.Emoji) -> None:
+    """Identity lines shared by every emoji event."""
+    entry.line("emoji", str(emoji))
+    entry.line("name", escape(emoji.name))
+    entry.line("id", f"`{emoji.id}`")
+    entry.line("animated", fmt_bool(bool(emoji.animated), entry.locale))
+    entry.thumbnail(getattr(emoji, "url", None))
+
+
+# --------------------------------------------------------------------------- #
+# Stickers
+# --------------------------------------------------------------------------- #
+
+async def on_stickers_update(service, guild: discord.Guild, before: list,
+                             after: list) -> None:
+    """Same whole-collection treatment as emojis, for guild stickers."""
+    added, removed = diff_sets(before, after)
+
+    for sticker in added:
+        await _log_sticker_created(service, guild, sticker)
+    for sticker in removed:
+        await _log_sticker_deleted(service, guild, sticker)
+
+    for old, new in _pairs(before, after):
+        if old.name != new.name:
+            await _log_sticker_change(service, guild, new, "sticker_name_update",
+                                      old.name, new.name)
+        if (old.description or "") != (new.description or ""):
+            await _log_sticker_change(service, guild, new,
+                                      "sticker_description_update",
+                                      old.description, new.description,
+                                      as_block=True)
+        if (old.emoji or "") != (new.emoji or ""):
+            await _log_sticker_change(service, guild, new,
+                                      "sticker_related_emoji_update",
+                                      old.emoji, new.emoji,
+                                      render=_render_emoji)
+
+
+async def _log_sticker_created(service, guild: discord.Guild,
+                               sticker: discord.GuildSticker) -> None:
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.sticker_create, sticker.id)
+
+    entry = await service.open(guild, "sticker_create", actor=who)
+    if entry is None:
+        return
+    _sticker_header(entry, sticker)
+    entry.block("description", escape(sticker.description))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def _log_sticker_deleted(service, guild: discord.Guild,
+                               sticker: discord.GuildSticker) -> None:
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.sticker_delete, sticker.id)
+
+    entry = await service.open(guild, "sticker_delete", actor=who)
+    if entry is None:
+        return
+    _sticker_header(entry, sticker)
+    entry.line("created", fmt_time(sticker.created_at))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def _log_sticker_change(service, guild: discord.Guild,
+                              sticker: discord.GuildSticker, event: str,
+                              old: Any, new: Any, *,
+                              render=default_render,
+                              as_block: bool = False) -> None:
+    """One before/after log for a single sticker property."""
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.sticker_update, sticker.id, wait=1.5)
+
+    entry = await service.open(guild, event, actor=who)
+    if entry is None:
+        return
+    _sticker_header(entry, sticker)
+    add = entry.block if as_block else entry.line
+    add("before", render(old, entry.locale))
+    add("after", render(new, entry.locale))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+def _sticker_header(entry, sticker: discord.GuildSticker) -> None:
+    """Identity lines shared by every sticker event."""
+    entry.line("sticker", _render_link(sticker, entry.locale))
+    entry.line("name", escape(sticker.name))
+    entry.line("id", f"`{sticker.id}`")
+    entry.thumbnail(getattr(sticker, "url", None))
+
+
+# --------------------------------------------------------------------------- #
+# Soundboard
+# --------------------------------------------------------------------------- #
+
+async def on_soundboard_sound_create(service, sound) -> None:
+    guild = sound.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.soundboard_sound_create, sound.id)
+
+    entry = await service.open(guild, "sound_upload", actor=who)
+    if entry is None:
+        return
+    _sound_header(entry, sound)
+    entry.line("volume", _render_volume(sound.volume, entry.locale))
+    entry.line("emoji", _render_emoji(sound.emoji, entry.locale))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_soundboard_sound_delete(service, sound) -> None:
+    guild = sound.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.soundboard_sound_delete, sound.id)
+
+    entry = await service.open(guild, "sound_delete", actor=who)
+    if entry is None:
+        return
+    _sound_header(entry, sound)
+    entry.line("created", fmt_time(sound.created_at))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_soundboard_sound_update(service, before, after) -> None:
+    guild = after.guild
+    await emit_diffs(
+        service, guild, SOUND_RULES, before, after,
+        header=lambda entry: _sound_header(entry, after),
+        audit_action=discord.AuditLogAction.soundboard_sound_update,
+        audit_target_id=after.id,
+    )
+
+
+def _sound_header(entry, sound) -> None:
+    """Identity lines shared by every soundboard event."""
+    entry.line("sound", _render_link(sound, entry.locale))
+    entry.line("name", escape(sound.name))
+    entry.line("id", f"`{sound.id}`")
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _pairs(before: Optional[list], after: Optional[list]) -> List[tuple]:
+    """``(old, new)`` for every entry present in both collections.
+
+    Matching is done on the object id, which is what makes a rename readable
+    as a rename instead of a delete followed by a create.
+    """
+    old_by_id: Dict[int, Any] = {item.id: item for item in (before or [])}
+    matched: List[tuple] = []
+    for item in after or []:
+        old = old_by_id.get(item.id)
+        if old is not None:
+            matched.append((old, item))
+    return matched

--- a/serverlogs/listeners/automod.py
+++ b/serverlogs/listeners/automod.py
@@ -1,0 +1,353 @@
+"""Discord's own AutoMod: rules and executions.
+
+This is **Discord AutoMod** (``Server Settings → AutoMod``), not Moddy's own
+``automod_ai`` module — the two are unrelated and this file never touches the
+latter.
+
+The rule events are split in two halves for a reason:
+
+* creations and deletions arrive as real gateway events
+  (``on_automod_rule_create`` / ``on_automod_rule_delete``) and only need the
+  audit log to name the moderator;
+* updates do **not**: ``on_automod_rule_update`` hands over the *new* rule
+  with no "before" at all, so every per-property update event
+  (toggled, renamed, keywords changed…) is built from the changes carried by
+  the ``automod_rule_update`` audit entry, which the cog forwards to
+  :func:`on_automod_rule_audit`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import discord
+
+from serverlogs.listeners._diff import diff_sets
+from serverlogs.renderer import (
+    escape, fmt_bool, fmt_channel, fmt_code, fmt_number, fmt_role, fmt_user_id,
+)
+
+#: Trigger sub-properties that describe *what* a rule matches. Everything here
+#: feeds ``automod_rule_content_update`` — except ``allow_list``, which is the
+#: opposite (what the rule must ignore) and gets its own event.
+_CONTENT_ATTRIBUTES: Tuple[str, ...] = (
+    "keyword_filter", "regex_patterns", "presets",
+)
+_WHITELIST_ATTRIBUTE = "allow_list"
+
+
+# --------------------------------------------------------------------------- #
+# Rule lifecycle
+# --------------------------------------------------------------------------- #
+
+async def on_automod_rule_create(service, rule: discord.AutoModRule) -> None:
+    guild = getattr(rule, "guild", None)
+    if guild is None:
+        return
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.automod_rule_create, rule.id)
+
+    entry = await service.open(guild, "automod_rule_create", actor=who)
+    if entry is None:
+        return
+    _header(entry, rule=rule)
+    entry.line("enabled", fmt_bool(getattr(rule, "enabled", None), entry.locale))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_automod_rule_delete(service, rule: discord.AutoModRule) -> None:
+    guild = getattr(rule, "guild", None)
+    if guild is None:
+        return
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.automod_rule_delete, rule.id)
+
+    entry = await service.open(guild, "automod_rule_delete", actor=who)
+    if entry is None:
+        return
+    _header(entry, rule=rule)
+    entry.line("enabled", fmt_bool(getattr(rule, "enabled", None), entry.locale))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_automod_rule_audit(service, guild: discord.Guild,
+                                audit_entry: discord.AuditLogEntry) -> None:
+    """Every ``automod_rule_update`` property, one log per property.
+
+    discord.py's ``on_automod_rule_update`` only carries the new rule, so the
+    before/after values can only come from this audit entry.
+    """
+    changes = _changes(audit_entry)
+    if not changes:
+        return
+
+    rule = getattr(audit_entry, "target", None)
+    who = getattr(audit_entry, "user", None)
+    reason = getattr(audit_entry, "reason", None)
+
+    async def start(event: str):
+        """Open an entry already carrying the shared rule header."""
+        entry = await service.open(guild, event, actor=who)
+        if entry is None:
+            return None
+        _header(entry, rule=rule, audit_entry=audit_entry, changes=changes)
+        return entry
+
+    if "enabled" in changes:
+        before, after = changes["enabled"]
+        if before != after:
+            entry = await start("automod_rule_toggle")
+            if entry is not None:
+                entry.line("before", fmt_bool(bool(before), entry.locale))
+                entry.line("after", fmt_bool(bool(after), entry.locale))
+                entry.actor(who, reason)
+                await service.submit(guild, entry)
+
+    if "name" in changes:
+        before, after = changes["name"]
+        if before != after:
+            entry = await start("automod_rule_name_update")
+            if entry is not None:
+                entry.line("before", escape(before) or _value(entry, "none"))
+                entry.line("after", escape(after) or _value(entry, "none"))
+                entry.actor(who, reason)
+                await service.submit(guild, entry)
+
+    if "actions" in changes:
+        before, after = changes["actions"]
+        entry = await start("automod_rule_actions_update")
+        if entry is not None:
+            entry.line("before", _render_actions(before, entry.locale))
+            entry.line("after", _render_actions(after, entry.locale))
+            entry.actor(who, reason)
+            await service.submit(guild, entry)
+
+    for attribute, event, render in (
+        ("exempt_roles", "automod_rule_roles_update", fmt_role),
+        ("exempt_channels", "automod_rule_channels_update", fmt_channel),
+    ):
+        if attribute not in changes:
+            continue
+        before, after = changes[attribute]
+        added, removed = diff_sets(before or [], after or [])
+        if not added and not removed:
+            continue
+        entry = await start(event)
+        if entry is None:
+            continue
+        if added:
+            entry.line("added", ", ".join(render(item) for item in added))
+        if removed:
+            entry.line("removed", ", ".join(render(item) for item in removed))
+        entry.actor(who, reason)
+        await service.submit(guild, entry)
+
+    await _log_trigger_changes(service, guild, audit_entry, changes, start)
+
+
+async def _log_trigger_changes(service, guild: discord.Guild,
+                               audit_entry: discord.AuditLogEntry,
+                               changes: Dict[str, Tuple[Any, Any]], start) -> None:
+    """Split the trigger metadata into "what it matches" and "what it ignores"."""
+    before, after = _trigger_pair(changes)
+    if before is None and after is None:
+        return
+
+    who = getattr(audit_entry, "user", None)
+    reason = getattr(audit_entry, "reason", None)
+
+    # What the rule matches on — keywords, regexes, Discord's own presets.
+    content_changed = [
+        (attribute, getattr(before, attribute, None), getattr(after, attribute, None))
+        for attribute in _CONTENT_ATTRIBUTES
+        if getattr(before, attribute, None) != getattr(after, attribute, None)
+    ]
+    mention_before = getattr(before, "mention_limit", None)
+    mention_after = getattr(after, "mention_limit", None)
+
+    if content_changed or mention_before != mention_after:
+        entry = await start("automod_rule_content_update")
+        if entry is not None:
+            for attribute, old, new in content_changed:
+                entry.block(attribute, _render_list_delta(old, new, entry.locale))
+            if mention_before != mention_after:
+                entry.line("mention_limit",
+                           f"{fmt_number(mention_before)} → {fmt_number(mention_after)}")
+            entry.actor(who, reason)
+            await service.submit(guild, entry)
+
+    # What the rule deliberately ignores.
+    allow_before = getattr(before, _WHITELIST_ATTRIBUTE, None)
+    allow_after = getattr(after, _WHITELIST_ATTRIBUTE, None)
+    if allow_before != allow_after:
+        entry = await start("automod_rule_whitelist_update")
+        if entry is not None:
+            entry.block(_WHITELIST_ATTRIBUTE,
+                        _render_list_delta(allow_before, allow_after, entry.locale))
+            entry.actor(who, reason)
+            await service.submit(guild, entry)
+
+
+# --------------------------------------------------------------------------- #
+# Executions
+# --------------------------------------------------------------------------- #
+
+async def on_automod_action(service, execution: discord.AutoModAction) -> None:
+    """A rule actually fired on a message."""
+    guild = getattr(execution, "guild", None)
+    if guild is None:
+        return
+
+    channel = getattr(execution, "channel", None)
+    member = getattr(execution, "member", None)
+
+    entry = await service.open(guild, "auto_moderation", channel=channel,
+                               subject=member)
+    if entry is None:
+        return
+
+    entry.line("rule", _execution_rule(execution))
+    if member is None:
+        entry.line("user", fmt_user_id(getattr(execution, "user_id", None)))
+    if channel is not None:
+        entry.line("channel", fmt_channel(channel))
+    entry.line("action", _render_action_type(getattr(execution, "action", None)))
+
+    matched = (getattr(execution, "matched_keyword", None)
+               or getattr(execution, "matched_content", None))
+    if matched:
+        entry.line("matched", escape(str(matched)))
+
+    # The offending message can be very long — `block` offloads anything that
+    # does not fit an embed field to a .txt attachment.
+    entry.block("message", getattr(execution, "content", None) or None,
+                filename=f"automod-{getattr(execution, 'message_id', 0)}.txt")
+
+    await service.submit(guild, entry)
+
+
+def _execution_rule(execution: discord.AutoModAction) -> str:
+    """The trigger type name, falling back to the raw rule id."""
+    trigger_type = getattr(execution, "rule_trigger_type", None)
+    name = getattr(trigger_type, "name", None)
+    if name:
+        return fmt_code(name)
+    return fmt_number(getattr(execution, "rule_id", None))
+
+
+# --------------------------------------------------------------------------- #
+# Rendering helpers
+# --------------------------------------------------------------------------- #
+
+def _header(entry, *, rule: Any = None,
+            audit_entry: Optional[discord.AuditLogEntry] = None,
+            changes: Optional[Dict[str, Tuple[Any, Any]]] = None) -> None:
+    """Identity lines shared by every AutoMod rule event."""
+    name = getattr(rule, "name", None)
+    if not name and changes:
+        before, after = changes.get("name", (None, None))
+        name = after or before
+    if name:
+        entry.line("rule", escape(str(name)))
+
+    rule_id = getattr(rule, "id", None)
+    if rule_id is None and audit_entry is not None:
+        rule_id = getattr(audit_entry, "target_id", None)
+    if rule_id is not None:
+        entry.line("id", fmt_number(rule_id))
+
+    trigger_name = _trigger_type_name(rule, changes)
+    if trigger_name:
+        entry.line("trigger", fmt_code(trigger_name))
+
+
+def _trigger_type_name(rule: Any,
+                       changes: Optional[Dict[str, Tuple[Any, Any]]]) -> Optional[str]:
+    trigger = getattr(rule, "trigger", None)
+    name = getattr(getattr(trigger, "type", None), "name", None)
+    if name:
+        return str(name)
+    if changes:
+        before, after = changes.get("trigger_type", (None, None))
+        value = after if after is not None else before
+        name = getattr(value, "name", None)
+        if name:
+            return str(name)
+        trigger_before, trigger_after = _trigger_pair(changes)
+        for candidate in (trigger_after, trigger_before):
+            name = getattr(getattr(candidate, "type", None), "name", None)
+            if name:
+                return str(name)
+    return None
+
+
+def _trigger_pair(changes: Dict[str, Tuple[Any, Any]]) -> Tuple[Any, Any]:
+    """``(before, after)`` trigger objects, whichever key Discord used."""
+    for attribute in ("trigger", "trigger_metadata"):
+        if attribute in changes:
+            return changes[attribute]
+    return None, None
+
+
+def _render_list_delta(before: Any, after: Any, locale: str) -> str:
+    """``✚``/``✖`` listing of the entries added to and removed from a list."""
+    added, removed = diff_sets(_as_text_list(before), _as_text_list(after))
+    lines: List[str] = []
+    lines.extend(f"✚ {fmt_code(item)}" for item in added)
+    lines.extend(f"✖ {fmt_code(item)}" for item in removed)
+    if not lines:
+        from utils.i18n import t
+        return t("modules.logs.values.none", locale=locale)
+    return "\n".join(lines)
+
+
+def _as_text_list(value: Any) -> List[str]:
+    """Normalise keyword/regex/preset lists (presets are enums) to strings."""
+    if not value:
+        return []
+    if isinstance(value, (str, bytes)):
+        return [str(value)]
+    try:
+        items = list(value)
+    except TypeError:
+        return [str(value)]
+    return [str(getattr(item, "name", item)) for item in items]
+
+
+def _render_actions(actions: Any, locale: str) -> str:
+    """Comma-separated action types (``block_message``, ``timeout``…)."""
+    from utils.i18n import t
+    rendered = [
+        fmt_code(getattr(getattr(action, "type", None), "name", None) or action)
+        for action in (actions or [])
+    ]
+    if not rendered:
+        return t("modules.logs.values.none", locale=locale)
+    return ", ".join(rendered)
+
+
+def _render_action_type(action: Any) -> Optional[str]:
+    name = getattr(getattr(action, "type", None), "name", None)
+    return fmt_code(name) if name else None
+
+
+def _changes(audit_entry: discord.AuditLogEntry) -> Dict[str, Tuple[Any, Any]]:
+    """``{attribute: (before, after)}`` for an audit entry, defensively."""
+    result: Dict[str, Tuple[Any, Any]] = {}
+    try:
+        before, after = audit_entry.changes.before, audit_entry.changes.after
+    except Exception:
+        return result
+    attributes = (set(getattr(before, "_dict", {}) or {})
+                  | set(getattr(after, "_dict", {}) or {}))
+    for attribute in attributes:
+        result[attribute] = (getattr(before, attribute, None),
+                             getattr(after, attribute, None))
+    return result
+
+
+def _value(entry, key: str) -> str:
+    from utils.i18n import t
+    return t(f"modules.logs.values.{key}", locale=entry.locale)

--- a/serverlogs/listeners/channels.py
+++ b/serverlogs/listeners/channels.py
@@ -1,0 +1,301 @@
+"""Channels: creation, deletion, pins and every tracked setting.
+
+The twenty-one channel events are declared as a diff table (see
+:mod:`serverlogs.listeners._diff`): Discord sends one ``channel_update`` for
+all of them, and each rule turns into its own log so a server can follow
+renames without drowning in permission changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import discord
+
+from serverlogs.listeners._diff import DiffRule, default_render, diff_sets, emit_diffs
+from serverlogs.renderer import (
+    escape, fmt_channel, fmt_duration, fmt_permissions, fmt_role, fmt_time,
+    fmt_user,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Value renderers
+# --------------------------------------------------------------------------- #
+
+def _render_category(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    if value is None:
+        return t("modules.logs.values.none", locale=locale)
+    return fmt_channel(value)
+
+
+def _render_duration(value: Any, locale: str) -> str:
+    return fmt_duration(int(value) if value is not None else None, locale)
+
+
+def _render_minutes(value: Any, locale: str) -> str:
+    return fmt_duration(int(value) * 60 if value is not None else None, locale)
+
+
+def _render_bitrate(value: Any, locale: str) -> str:
+    if value is None:
+        return default_render(value, locale)
+    return f"`{int(value) // 1000} kbps`"
+
+
+def _render_user_limit(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    if not value:
+        return t("modules.logs.values.unlimited", locale=locale)
+    return f"`{value}`"
+
+
+def _render_region(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    if value is None:
+        return t("modules.logs.values.automatic", locale=locale)
+    return f"`{escape(str(value))}`"
+
+
+def _render_enum(value: Any, locale: str) -> str:
+    if value is None:
+        return default_render(value, locale)
+    return f"`{escape(getattr(value, 'name', str(value)))}`"
+
+
+def _render_emoji(value: Any, locale: str) -> str:
+    if value is None:
+        return default_render(value, locale)
+    return str(value)
+
+
+def _is_voice(channel: Any) -> bool:
+    return isinstance(channel, (discord.VoiceChannel, discord.StageChannel))
+
+
+def _is_forum(channel: Any) -> bool:
+    return isinstance(channel, discord.ForumChannel)
+
+
+#: One line per tracked setting — this table *is* the channel log catalogue.
+CHANNEL_RULES = (
+    DiffRule("channel_name_update", "name"),
+    DiffRule("channel_topic_update", "topic", as_block=True),
+    DiffRule("channel_nsfw_update", "nsfw"),
+    DiffRule("channel_parent_update", "category", render=_render_category),
+    DiffRule("channel_bitrate_update", "bitrate", render=_render_bitrate,
+             applies=_is_voice),
+    DiffRule("channel_user_limit_update", "user_limit", render=_render_user_limit,
+             applies=lambda c: isinstance(c, discord.VoiceChannel)),
+    DiffRule("channel_slowmode_update", "slowmode_delay", render=_render_duration),
+    DiffRule("channel_rtc_region_update", "rtc_region", render=_render_region,
+             applies=_is_voice),
+    DiffRule("channel_video_quality_update", "video_quality_mode", render=_render_enum,
+             applies=lambda c: isinstance(c, discord.VoiceChannel)),
+    DiffRule("channel_default_archive_duration_update", "default_auto_archive_duration",
+             render=_render_minutes),
+    DiffRule("channel_default_thread_slowmode_update", "default_thread_slowmode_delay",
+             render=_render_duration),
+    DiffRule("channel_default_reaction_emoji_update", "default_reaction_emoji",
+             render=_render_emoji, applies=_is_forum),
+    DiffRule("channel_default_sort_order_update", "default_sort_order",
+             render=_render_enum, applies=_is_forum),
+    DiffRule("channel_forum_layout_update", "default_layout", render=_render_enum,
+             applies=_is_forum),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Listeners
+# --------------------------------------------------------------------------- #
+
+async def on_channel_create(service, channel: discord.abc.GuildChannel) -> None:
+    guild = channel.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.channel_create, channel.id)
+
+    entry = await service.open(guild, "channel_create", channel=channel, actor=who)
+    if entry is None:
+        return
+    _header(entry, channel)
+    if getattr(channel, "category", None):
+        entry.line("category", fmt_channel(channel.category))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_channel_delete(service, channel: discord.abc.GuildChannel) -> None:
+    guild = channel.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.channel_delete, channel.id)
+
+    entry = await service.open(guild, "channel_delete", channel=channel, actor=who)
+    if entry is None:
+        return
+    _header(entry, channel)
+    if getattr(channel, "category", None):
+        entry.line("category", fmt_channel(channel.category))
+    entry.line("channel_created", fmt_time(channel.created_at))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_channel_update(service, before: discord.abc.GuildChannel,
+                            after: discord.abc.GuildChannel) -> None:
+    guild = after.guild
+
+    await emit_diffs(
+        service, guild, CHANNEL_RULES, before, after,
+        header=lambda entry: _header(entry, after),
+        audit_action=discord.AuditLogAction.channel_update,
+        audit_target_id=after.id,
+    )
+
+    if type(before) is not type(after):
+        await _log_type_change(service, guild, before, after)
+    if before.overwrites != after.overwrites:
+        await _log_permission_change(service, guild, before, after)
+    if _is_forum(after) and getattr(before, "available_tags", None) != getattr(after, "available_tags", None):
+        await _log_forum_tags(service, guild, before, after)
+
+
+async def on_channel_pins_update(service, channel: discord.abc.GuildChannel,
+                                 last_pin) -> None:
+    guild = getattr(channel, "guild", None)
+    if guild is None:
+        return
+    entry = await service.open(guild, "channel_pins_update", channel=channel)
+    if entry is None:
+        return
+    _header(entry, channel)
+    entry.line("last_pin", fmt_time(last_pin))
+
+    who = reason = None
+    for action in (discord.AuditLogAction.message_pin,
+                   discord.AuditLogAction.message_unpin):
+        who, reason = await service.executor(guild, action, wait=1.0)
+        if who is not None:
+            break
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_voice_status_update(service, guild: discord.Guild,
+                                 audit_entry: discord.AuditLogEntry) -> None:
+    """Voice channel "status" text.
+
+    Discord has no gateway event for it, and discord.py has no enum member
+    either — the cog matches the raw audit-log action id and forwards here.
+    """
+    channel = guild.get_channel(getattr(audit_entry, "target_id", None) or 0)
+    entry = await service.open(guild, "channel_voice_status_update",
+                               channel=channel, actor=audit_entry.user)
+    if entry is None:
+        return
+    if channel is not None:
+        _header(entry, channel)
+    status = getattr(getattr(audit_entry, "extra", None), "status", None)
+    entry.line("status", escape(status) if status else None)
+    entry.actor(audit_entry.user, audit_entry.reason)
+    await service.submit(guild, entry)
+
+
+# --------------------------------------------------------------------------- #
+# Special cases
+# --------------------------------------------------------------------------- #
+
+async def _log_type_change(service, guild, before, after) -> None:
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.channel_update, after.id, wait=1.5)
+    entry = await service.open(guild, "channel_type_update", channel=after, actor=who)
+    if entry is None:
+        return
+    _header(entry, after)
+    entry.line("before", f"`{before.type.name}`")
+    entry.line("after", f"`{after.type.name}`")
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def _log_permission_change(service, guild, before, after) -> None:
+    who = reason = None
+    for action in (discord.AuditLogAction.overwrite_update,
+                   discord.AuditLogAction.overwrite_create,
+                   discord.AuditLogAction.overwrite_delete):
+        who, reason = await service.executor(guild, action, after.id, wait=1.0)
+        if who is not None:
+            break
+
+    entry = await service.open(guild, "channel_permissions_update", channel=after,
+                               actor=who)
+    if entry is None:
+        return
+    _header(entry, after)
+
+    for target in set(before.overwrites) | set(after.overwrites):
+        old = before.overwrites.get(target)
+        new = after.overwrites.get(target)
+        if old == new:
+            continue
+        label = fmt_role(target) if isinstance(target, discord.Role) else fmt_user(target)
+        allowed, denied, reset = _overwrite_delta(old, new)
+        details: List[str] = []
+        if allowed:
+            details.append(f"✚ {fmt_permissions(allowed, entry.locale)}")
+        if denied:
+            details.append(f"✖ {fmt_permissions(denied, entry.locale)}")
+        if reset:
+            details.append(f"↺ {fmt_permissions(reset, entry.locale)}")
+        entry.block("target", f"{label}\n" + "\n".join(details) if details else label)
+
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+def _overwrite_delta(old: Optional[discord.PermissionOverwrite],
+                     new: Optional[discord.PermissionOverwrite]):
+    """``(allowed, denied, reset)`` permission names between two overwrites."""
+    old_pairs = dict(old) if old is not None else {}
+    new_pairs = dict(new) if new is not None else {}
+    allowed, denied, reset = [], [], []
+    for name in set(old_pairs) | set(new_pairs):
+        before_value = old_pairs.get(name)
+        after_value = new_pairs.get(name)
+        if before_value == after_value:
+            continue
+        if after_value is True:
+            allowed.append(name)
+        elif after_value is False:
+            denied.append(name)
+        else:
+            reset.append(name)
+    return sorted(allowed), sorted(denied), sorted(reset)
+
+
+async def _log_forum_tags(service, guild, before, after) -> None:
+    added, removed = diff_sets(getattr(before, "available_tags", []),
+                               getattr(after, "available_tags", []))
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.channel_update, after.id, wait=1.5)
+
+    entry = await service.open(guild, "channel_forum_tags_update", channel=after,
+                               actor=who)
+    if entry is None:
+        return
+    _header(entry, after)
+    if added:
+        entry.line("added", ", ".join(f"`{escape(tag.name)}`" for tag in added))
+    if removed:
+        entry.line("removed", ", ".join(f"`{escape(tag.name)}`" for tag in removed))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+def _header(entry, channel) -> None:
+    """Identity lines shared by every channel event."""
+    entry.line("channel", fmt_channel(channel))
+    entry.line("id", f"`{channel.id}`")
+    channel_type = getattr(channel, "type", None)
+    if channel_type is not None:
+        entry.line("type", f"`{channel_type.name}`")

--- a/serverlogs/listeners/guild.py
+++ b/serverlogs/listeners/guild.py
@@ -1,0 +1,202 @@
+"""Server settings: every ``guild_update`` property plus onboarding.
+
+Twenty-four of these come from a single ``guild_update`` gateway event and
+are declared as a diff table; the five onboarding events exist only in the
+audit log and are forwarded by the cog.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+from serverlogs.listeners._diff import DiffRule, default_render, diff_sets, emit_diffs
+from serverlogs.renderer import escape, fmt_channel, fmt_duration, fmt_user
+
+
+# --------------------------------------------------------------------------- #
+# Renderers
+# --------------------------------------------------------------------------- #
+
+def _render_channel(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    if value is None:
+        return t("modules.logs.values.none", locale=locale)
+    return fmt_channel(value)
+
+
+def _render_asset(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    if value is None:
+        return t("modules.logs.values.none", locale=locale)
+    return f"[{t('modules.logs.values.open_link', locale=locale)}]({value.url})"
+
+
+def _render_enum(value: Any, locale: str) -> str:
+    if value is None:
+        return default_render(value, locale)
+    return f"`{escape(getattr(value, 'name', str(value)))}`"
+
+
+def _render_seconds(value: Any, locale: str) -> str:
+    return fmt_duration(int(value) if value is not None else None, locale)
+
+
+def _render_owner(value: Any, locale: str) -> str:
+    return fmt_user(value)
+
+
+def _render_vanity(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    if not value:
+        return t("modules.logs.values.none", locale=locale)
+    return f"`discord.gg/{escape(str(value))}`"
+
+
+def _render_tier(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    return t("modules.logs.values.boost_tier", locale=locale, tier=value or 0)
+
+
+def _has_feature(guild: discord.Guild, feature: str) -> bool:
+    return feature in (guild.features or [])
+
+
+GUILD_RULES = (
+    DiffRule("server_name_update", "name"),
+    DiffRule("server_description_update", "description", as_block=True),
+    DiffRule("server_icon_update", "icon", render=_render_asset),
+    DiffRule("server_banner_update", "banner", render=_render_asset),
+    DiffRule("server_splash_update", "splash", render=_render_asset),
+    DiffRule("server_discovery_splash_update", "discovery_splash", render=_render_asset),
+    DiffRule("afk_channel_update", "afk_channel", render=_render_channel),
+    DiffRule("afk_timeout_update", "afk_timeout", render=_render_seconds),
+    DiffRule("system_channel_update", "system_channel", render=_render_channel),
+    DiffRule("server_rules_channel_update", "rules_channel", render=_render_channel),
+    DiffRule("public_updates_channel_update", "public_updates_channel",
+             render=_render_channel),
+    DiffRule("message_notifications_update", "default_notifications", render=_render_enum),
+    DiffRule("server_content_filter_update", "explicit_content_filter", render=_render_enum),
+    DiffRule("verification_level_update", "verification_level", render=_render_enum),
+    DiffRule("mfa_level_update", "mfa_level", render=_render_enum),
+    DiffRule("server_owner_update", "owner", render=_render_owner),
+    DiffRule("server_vanity_update", "vanity_url_code", render=_render_vanity),
+    DiffRule("server_boost_level_update", "premium_tier", render=_render_tier),
+    DiffRule("boost_progress_bar_toggle", "premium_progress_bar_enabled"),
+    DiffRule("server_preferred_locale_update", "preferred_locale"),
+    DiffRule("server_widget_update", "widget_enabled"),
+)
+
+
+async def on_guild_update(service, before: discord.Guild,
+                          after: discord.Guild) -> None:
+    await emit_diffs(
+        service, after, GUILD_RULES, before, after,
+        header=lambda entry: _header(entry, after),
+        audit_action=discord.AuditLogAction.guild_update,
+        audit_target_id=after.id,
+        thumbnail=after.icon.url if after.icon else None,
+    )
+
+    if set(before.features or []) != set(after.features or []):
+        await _log_features(service, before, after)
+
+
+async def _log_features(service, before: discord.Guild, after: discord.Guild) -> None:
+    added, removed = diff_sets(before.features or [], after.features or [])
+    who, reason = await service.executor(
+        after, discord.AuditLogAction.guild_update, after.id, wait=1.5)
+
+    entry = await service.open(after, "server_features_update", actor=who)
+    if entry is not None:
+        _header(entry, after)
+        if added:
+            entry.line("added", ", ".join(f"`{escape(f)}`" for f in added))
+        if removed:
+            entry.line("removed", ", ".join(f"`{escape(f)}`" for f in removed))
+        entry.actor(who, reason)
+        await service.submit(after, entry)
+
+    # "Partnered" and "Verified" are features, but servers care about them
+    # enough that the registry gives each its own event.
+    for feature, event in (("PARTNERED", "partnered_update"),
+                           ("VERIFIED", "verified_update")):
+        was, now = _has_feature(before, feature), _has_feature(after, feature)
+        if was == now:
+            continue
+        flag_entry = await service.open(after, event)
+        if flag_entry is None:
+            continue
+        _header(flag_entry, after)
+        flag_entry.line("before", was)
+        flag_entry.line("after", now)
+        await service.submit(after, flag_entry)
+
+
+# --------------------------------------------------------------------------- #
+# Onboarding — audit-log only
+# --------------------------------------------------------------------------- #
+
+async def on_onboarding_update(service, guild: discord.Guild,
+                               audit_entry: discord.AuditLogEntry) -> None:
+    """``onboarding_update``: the toggle and the default channels live here."""
+    changes = _changes(audit_entry)
+
+    if "enabled" in changes:
+        entry = await service.open(guild, "onboarding_toggle", actor=audit_entry.user)
+        if entry is not None:
+            _header(entry, guild)
+            before, after = changes["enabled"]
+            entry.line("before", bool(before))
+            entry.line("after", bool(after))
+            entry.actor(audit_entry.user, audit_entry.reason)
+            await service.submit(guild, entry)
+
+    if "default_channel_ids" in changes:
+        entry = await service.open(guild, "onboarding_channels_update",
+                                   actor=audit_entry.user)
+        if entry is not None:
+            _header(entry, guild)
+            before, after = changes["default_channel_ids"]
+            added, removed = diff_sets(before or [], after or [])
+            if added:
+                entry.line("added", ", ".join(f"<#{cid}>" for cid in added))
+            if removed:
+                entry.line("removed", ", ".join(f"<#{cid}>" for cid in removed))
+            entry.actor(audit_entry.user, audit_entry.reason)
+            await service.submit(guild, entry)
+
+
+async def on_onboarding_prompt(service, guild: discord.Guild,
+                               audit_entry: discord.AuditLogEntry,
+                               event: str) -> None:
+    """``onboarding_question_add`` / ``_remove`` / ``_update``."""
+    entry = await service.open(guild, event, actor=audit_entry.user)
+    if entry is None:
+        return
+    _header(entry, guild)
+    changes = _changes(audit_entry)
+    title = changes.get("title")
+    if title:
+        entry.line("question", escape(str(title[1] or title[0])))
+    entry.actor(audit_entry.user, audit_entry.reason)
+    await service.submit(guild, entry)
+
+
+def _changes(audit_entry: discord.AuditLogEntry) -> dict:
+    """``{attribute: (before, after)}`` for an audit entry, defensively."""
+    result = {}
+    try:
+        before, after = audit_entry.changes.before, audit_entry.changes.after
+    except Exception:
+        return result
+    for attribute in set(getattr(before, "_dict", {}) or {}) | set(getattr(after, "_dict", {}) or {}):
+        result[attribute] = (getattr(before, attribute, None),
+                             getattr(after, attribute, None))
+    return result
+
+
+def _header(entry, guild: discord.Guild) -> None:
+    entry.line("server", escape(guild.name))
+    entry.line("id", f"`{guild.id}`")

--- a/serverlogs/listeners/integrations.py
+++ b/serverlogs/listeners/integrations.py
@@ -1,0 +1,326 @@
+"""Webhooks and applications — the two families that only exist in the audit log.
+
+Discord's gateway is unusually poor here:
+
+* ``webhooks_update`` carries **no detail at all** — not the webhook, not the
+  channel, not even whether it was a create, an edit or a delete. Everything
+  in :func:`on_webhook_audit` therefore comes from the audit-log entry the
+  cog forwards, which is why this file never receives a ``discord.Webhook``.
+* bots and integrations have no gateway event either: an application being
+  added or removed is only ever visible as ``bot_add`` /
+  ``integration_create`` / ``integration_delete`` audit entries.
+
+The one exception is :func:`on_app_command_permissions_update`, which is a
+real gateway event (``on_raw_app_command_permissions_update``) and carries
+its own payload.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import discord
+
+from serverlogs.renderer import (
+    escape, fmt_channel, fmt_code, fmt_number, fmt_role, fmt_user, fmt_user_id,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Webhooks
+# --------------------------------------------------------------------------- #
+
+#: ``audit change attribute -> event`` for ``webhook_update``. Discord names
+#: the channel ``channel_id`` and the avatar ``avatar_hash`` depending on the
+#: API version, so both spellings map to the same event.
+_WEBHOOK_UPDATE_EVENTS: Tuple[Tuple[str, str], ...] = (
+    ("name", "webhook_name_update"),
+    ("avatar", "webhook_avatar_update"),
+    ("avatar_hash", "webhook_avatar_update"),
+    ("channel", "webhook_channel_update"),
+    ("channel_id", "webhook_channel_update"),
+)
+
+
+async def on_webhook_audit(service, guild: discord.Guild,
+                           audit_entry: discord.AuditLogEntry) -> None:
+    """``webhook_create`` / ``webhook_update`` / ``webhook_delete`` entries.
+
+    The cog filters on the action and forwards; the split between "created",
+    "edited" and "deleted" is done here so the three webhook lifecycles share
+    the same header and channel-ignore handling.
+    """
+    action = getattr(audit_entry, "action", None)
+    changes = _changes(audit_entry)
+    channel = _webhook_channel(guild, audit_entry, changes)
+
+    if action == discord.AuditLogAction.webhook_update:
+        await _log_webhook_update(service, guild, audit_entry, changes, channel)
+        return
+
+    if action == discord.AuditLogAction.webhook_create:
+        event = "webhook_create"
+    elif action == discord.AuditLogAction.webhook_delete:
+        event = "webhook_delete"
+    else:
+        return
+
+    entry = await service.open(guild, event, channel=channel,
+                               actor=getattr(audit_entry, "user", None))
+    if entry is None:
+        return
+    _webhook_header(entry, audit_entry, changes)
+    if channel is not None:
+        entry.line("channel", fmt_channel(channel))
+    entry.line("type", _webhook_type(changes, audit_entry))
+    entry.actor(getattr(audit_entry, "user", None), getattr(audit_entry, "reason", None))
+    await service.submit(guild, entry)
+
+
+async def _log_webhook_update(service, guild: discord.Guild,
+                              audit_entry: discord.AuditLogEntry,
+                              changes: Dict[str, Tuple[Any, Any]],
+                              channel: Any) -> None:
+    """One log per property the edit actually touched."""
+    seen: List[str] = []
+    for attribute, event in _WEBHOOK_UPDATE_EVENTS:
+        if attribute not in changes or event in seen:
+            continue
+        before, after = changes[attribute]
+        if before == after:
+            continue
+        seen.append(event)
+
+        entry = await service.open(guild, event, channel=channel,
+                                   actor=getattr(audit_entry, "user", None))
+        if entry is None:
+            continue
+        _webhook_header(entry, audit_entry, changes)
+
+        if event == "webhook_channel_update":
+            entry.line("before", fmt_channel(_resolve_channel(guild, before)))
+            entry.line("after", fmt_channel(_resolve_channel(guild, after)))
+        elif event == "webhook_avatar_update":
+            entry.line("before", _render_avatar(before, entry.locale))
+            entry.line("after", _render_avatar(after, entry.locale))
+        else:
+            entry.line("before", escape(before) or _none(entry))
+            entry.line("after", escape(after) or _none(entry))
+
+        entry.actor(getattr(audit_entry, "user", None),
+                    getattr(audit_entry, "reason", None))
+        await service.submit(guild, entry)
+
+
+def _webhook_header(entry, audit_entry: discord.AuditLogEntry,
+                    changes: Dict[str, Tuple[Any, Any]]) -> None:
+    """Identity lines shared by every webhook event."""
+    entry.line("webhook", escape(_webhook_name(audit_entry, changes)))
+    webhook_id = _target_id(audit_entry)
+    if webhook_id is not None:
+        entry.line("id", fmt_number(webhook_id))
+
+
+def _webhook_name(audit_entry: discord.AuditLogEntry,
+                  changes: Dict[str, Tuple[Any, Any]]) -> Optional[str]:
+    """Best available name: the target, else whichever side of the diff has one."""
+    name = getattr(getattr(audit_entry, "target", None), "name", None)
+    if name:
+        return str(name)
+    before, after = changes.get("name", (None, None))
+    for candidate in (after, before):
+        if candidate:
+            return str(candidate)
+    return None
+
+
+def _webhook_type(changes: Dict[str, Tuple[Any, Any]],
+                  audit_entry: discord.AuditLogEntry) -> Optional[str]:
+    """The webhook type, rendered as code — from the diff or from the target."""
+    before, after = changes.get("type", (None, None))
+    value = after if after is not None else before
+    if value is None:
+        value = getattr(getattr(audit_entry, "target", None), "type", None)
+    if value is None:
+        return None
+    return fmt_code(getattr(value, "name", None) or value)
+
+
+def _webhook_channel(guild: discord.Guild, audit_entry: discord.AuditLogEntry,
+                     changes: Dict[str, Tuple[Any, Any]]) -> Any:
+    """The channel a webhook lives in, from the diff or from ``entry.extra``."""
+    candidates: List[Any] = []
+    for attribute in ("channel", "channel_id"):
+        before, after = changes.get(attribute, (None, None))
+        candidates.extend((after, before))
+
+    extra = getattr(audit_entry, "extra", None)
+    candidates.append(getattr(extra, "channel", None))
+    candidates.append(getattr(extra, "channel_id", None))
+    candidates.append(getattr(getattr(audit_entry, "target", None), "channel", None))
+    candidates.append(getattr(getattr(audit_entry, "target", None), "channel_id", None))
+
+    for candidate in candidates:
+        resolved = _resolve_channel(guild, candidate)
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def _resolve_channel(guild: discord.Guild, value: Any) -> Any:
+    """Turn a channel id (or an already-resolved channel) into something printable."""
+    if value is None:
+        return None
+    if isinstance(value, (int, str)):
+        try:
+            channel_id = int(value)
+        except (TypeError, ValueError):
+            return None
+        resolved = guild.get_channel_or_thread(channel_id) if guild else None
+        return resolved if resolved is not None else discord.Object(id=channel_id)
+    return value
+
+
+def _render_avatar(value: Any, locale: str) -> str:
+    """Avatars arrive either as an :class:`~discord.Asset` or as a bare hash."""
+    from utils.i18n import t
+    if not value:
+        return t("modules.logs.values.none", locale=locale)
+    url = getattr(value, "url", None)
+    if url:
+        return f"[{t('modules.logs.values.open_link', locale=locale)}]({url})"
+    return fmt_code(value)
+
+
+# --------------------------------------------------------------------------- #
+# Applications
+# --------------------------------------------------------------------------- #
+
+async def on_app_audit(service, guild: discord.Guild,
+                       audit_entry: discord.AuditLogEntry, event: str) -> None:
+    """``app_add`` (``bot_add`` / ``integration_create``) or ``app_remove``.
+
+    Discord files three different audit actions for what a server owner reads
+    as one thing — "an app was added" — so the cog decides which of the two
+    events it is and passes it in.
+    """
+    entry = await service.open(guild, event, actor=getattr(audit_entry, "user", None))
+    if entry is None:
+        return
+
+    target = getattr(audit_entry, "target", None)
+    entry.line("application", _application_label(target, audit_entry))
+    application_id = _target_id(audit_entry)
+    if application_id is not None:
+        entry.line("id", fmt_number(application_id))
+
+    avatar = getattr(target, "display_avatar", None)
+    if avatar is not None:
+        entry.thumbnail(getattr(avatar, "url", None))
+
+    entry.actor(getattr(audit_entry, "user", None), getattr(audit_entry, "reason", None))
+    await service.submit(guild, entry)
+
+
+def _application_label(target: Any, audit_entry: discord.AuditLogEntry) -> Optional[str]:
+    """The app as a mention when it is a real user, else its name, else its id."""
+    if isinstance(target, (discord.User, discord.Member, discord.ClientUser)):
+        return fmt_user(target)
+    name = getattr(target, "name", None)
+    if name:
+        return escape(str(name))
+    application_id = _target_id(audit_entry)
+    return fmt_number(application_id) if application_id is not None else None
+
+
+async def on_app_command_permissions_update(
+        service, guild: discord.Guild,
+        payload: discord.RawAppCommandPermissionsUpdateEvent) -> None:
+    """A server changed who may use an application command.
+
+    The payload's ``target_id`` is either a command id or the application id
+    itself — in the latter case the overwrites apply to every command of that
+    app that has no explicit rule of its own.
+    """
+    entry = await service.open(guild, "app_command_permission_update")
+    if entry is None:
+        return
+
+    entry.line("application", fmt_number(getattr(payload, "application_id", None)))
+    entry.line("command", fmt_number(getattr(payload, "target_id", None)))
+
+    rendered = [
+        f"• {_permission_target(permission)} — {_permission_word(permission, entry.locale)}"
+        for permission in (getattr(payload, "permissions", None) or [])
+    ]
+    if rendered:
+        entry.block("permissions", "\n".join(rendered))
+
+    await service.submit(guild, entry)
+
+
+def _permission_target(permission: Any) -> str:
+    """Render a permission target as a mention whenever Discord resolved it."""
+    target = getattr(permission, "target", None)
+    if isinstance(target, discord.Role):
+        return fmt_role(target)
+    if isinstance(target, (discord.User, discord.Member, discord.ClientUser)):
+        return fmt_user(target)
+    if isinstance(target, (discord.abc.GuildChannel, discord.Thread)):
+        return fmt_channel(target)
+
+    target_id = (getattr(target, "id", None)
+                 or getattr(permission, "target_id", None)
+                 or getattr(permission, "id", None))
+    if target_id is None:
+        return "—"
+
+    # Unresolved target: fall back to the declared type so the reader still
+    # gets a clickable mention instead of a naked snowflake.
+    type_name = getattr(getattr(permission, "type", None), "name", "")
+    if type_name == "role":
+        return fmt_role(discord.Object(id=target_id))
+    if type_name == "user":
+        return fmt_user_id(target_id)
+    if type_name == "channel":
+        return fmt_channel(discord.Object(id=target_id))
+    return fmt_number(target_id)
+
+
+def _permission_word(permission: Any, locale: str) -> str:
+    from utils.i18n import t
+    key = "allowed" if getattr(permission, "permission", False) else "denied"
+    return t(f"modules.logs.values.{key}", locale=locale)
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers
+# --------------------------------------------------------------------------- #
+
+def _changes(audit_entry: discord.AuditLogEntry) -> Dict[str, Tuple[Any, Any]]:
+    """``{attribute: (before, after)}`` for an audit entry, defensively.
+
+    Audit change payloads differ between API versions, so nothing here may
+    assume an attribute exists.
+    """
+    result: Dict[str, Tuple[Any, Any]] = {}
+    try:
+        before, after = audit_entry.changes.before, audit_entry.changes.after
+    except Exception:
+        return result
+    attributes = (set(getattr(before, "_dict", {}) or {})
+                  | set(getattr(after, "_dict", {}) or {}))
+    for attribute in attributes:
+        result[attribute] = (getattr(before, attribute, None),
+                             getattr(after, attribute, None))
+    return result
+
+
+def _target_id(audit_entry: discord.AuditLogEntry) -> Optional[int]:
+    return (getattr(getattr(audit_entry, "target", None), "id", None)
+            or getattr(audit_entry, "target_id", None))
+
+
+def _none(entry) -> str:
+    from utils.i18n import t
+    return t("modules.logs.values.none", locale=entry.locale)

--- a/serverlogs/listeners/invites.py
+++ b/serverlogs/listeners/invites.py
@@ -1,0 +1,103 @@
+"""Invites: created, revoked, and posted in a channel.
+
+The first two mirror Discord's own gateway events. The third has nothing to
+do with the invite API: ``invite_post`` is a *message* event — someone
+dropped a ``discord.gg/…`` link in a channel — which is why servers use it to
+catch advertising, and why it is opened against the message's channel and
+author so the usual ignore lists apply.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import discord
+
+from serverlogs.renderer import (
+    fmt_bool, fmt_channel, fmt_code, fmt_number, fmt_time, fmt_user,
+)
+
+
+def _invite_link(code: Optional[str]) -> str:
+    """The shareable form of a code, as inline code so it stays unclickable."""
+    if not code:
+        return "—"
+    return fmt_code(f"discord.gg/{code}")
+
+
+def _guild_of(invite: discord.Invite) -> Optional[discord.Guild]:
+    """The real guild behind an invite.
+
+    ``Invite.guild`` may be a partial object outside of gateway events, so the
+    channel's guild — always a full one when it exists — comes first.
+    """
+    guild = getattr(invite.channel, "guild", None)
+    if isinstance(guild, discord.Guild):
+        return guild
+    return invite.guild if isinstance(invite.guild, discord.Guild) else None
+
+
+# --------------------------------------------------------------------------- #
+# Listeners
+# --------------------------------------------------------------------------- #
+
+async def on_invite_create(service, invite: discord.Invite) -> None:
+    from utils.i18n import t
+
+    guild = _guild_of(invite)
+    if guild is None:
+        return
+
+    entry = await service.open(guild, "invite_create", channel=invite.channel,
+                               actor=invite.inviter)
+    if entry is None:
+        return
+    entry.line("invite", _invite_link(invite.code))
+    entry.line("channel", fmt_channel(invite.channel))
+    entry.line("inviter", fmt_user(invite.inviter))
+    entry.line("expires", fmt_time(invite.expires_at))
+    # max_uses == 0 means "no cap", which fmt_number would render as a bare 0.
+    entry.line("max_uses",
+               fmt_number(invite.max_uses) if invite.max_uses
+               else t("modules.logs.values.unlimited", locale=entry.locale))
+    entry.line("temporary", fmt_bool(bool(invite.temporary), entry.locale))
+    entry.actor(invite.inviter)
+    await service.submit(guild, entry)
+
+
+async def on_invite_delete(service, invite: discord.Invite) -> None:
+    guild = _guild_of(invite)
+    if guild is None:
+        return
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.invite_delete)
+
+    entry = await service.open(guild, "invite_delete", channel=invite.channel,
+                               actor=who)
+    if entry is None:
+        return
+    entry.line("invite", _invite_link(invite.code))
+    entry.line("channel", fmt_channel(invite.channel))
+    entry.line("uses", fmt_number(invite.uses))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_invite_post(service, message: discord.Message,
+                         codes: List[str]) -> None:
+    """Someone posted one or more invite links in a channel."""
+    guild = message.guild
+    if guild is None or not codes:
+        return
+
+    entry = await service.open(guild, "invite_post", channel=message.channel,
+                               actor=message.author)
+    if entry is None:
+        return
+    entry.line("channel", fmt_channel(message.channel))
+    entry.line("author", fmt_user(message.author))
+    entry.line("message_id", f"`{message.id}`")
+    entry.line("invites", ", ".join(_invite_link(code) for code in codes))
+    entry.url(message.jump_url)
+    entry.actor(message.author)
+    await service.submit(guild, entry)

--- a/serverlogs/listeners/members.py
+++ b/serverlogs/listeners/members.py
@@ -1,0 +1,247 @@
+"""Members: joins, leaves, kicks, bans, timeouts, profile and role changes.
+
+Covers the ``server`` events about people (join / leave / kick / ban /
+prune) and the whole ``users`` category (name, avatar, roles, timeout).
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import discord
+
+from serverlogs.renderer import escape, fmt_number, fmt_roles, fmt_time
+
+
+# --------------------------------------------------------------------------- #
+# Arrivals and departures
+# --------------------------------------------------------------------------- #
+
+async def on_member_join(service, member: discord.Member) -> None:
+    entry = await service.open(member.guild, "user_join", subject=member)
+    if entry is None:
+        return
+    entry.line("account_created", fmt_time(member.created_at))
+    entry.line("member_count", fmt_number(member.guild.member_count))
+    if member.bot:
+        who, reason = await service.executor(
+            member.guild, discord.AuditLogAction.bot_add, member.id, wait=1.0)
+        entry.actor(who, reason)
+    await service.submit(member.guild, entry)
+
+
+async def on_member_remove(service, member: discord.Member) -> None:
+    """A departure is a leave, a kick or a ban — the audit log decides which.
+
+    Discord sends the same GUILD_MEMBER_REMOVE for all three, so we give the
+    audit log a moment to tell us which one it was before settling on
+    "left on their own".
+    """
+    guild = member.guild
+
+    kick = await service.audit.wait_for(
+        guild.id,
+        _member_action_matcher(discord.AuditLogAction.kick, member.id),
+        timeout=2.0,
+    )
+    if kick is not None:
+        entry = await service.open(guild, "user_kick", subject=member, actor=kick.user)
+        if entry is not None:
+            entry.line("joined_at", fmt_time(member.joined_at))
+            entry.line("member_count", fmt_number(guild.member_count))
+            entry.actor(kick.user, kick.reason)
+            await service.submit(guild, entry)
+        # The moderation category carries the same fact for mod teams.
+        await _mirror_kick(service, guild, member, kick)
+        return
+
+    # A ban also removes the member; on_member_ban already logged it.
+    ban = service.audit.find(
+        guild.id, _member_action_matcher(discord.AuditLogAction.ban, member.id))
+    if ban is not None:
+        return
+
+    entry = await service.open(guild, "user_leave", subject=member)
+    if entry is None:
+        return
+    entry.line("joined_at", fmt_time(member.joined_at))
+    entry.line("member_count", fmt_number(guild.member_count))
+    entry.line("roles", fmt_roles([r for r in member.roles if not r.is_default()]))
+    await service.submit(guild, entry)
+
+
+async def _mirror_kick(service, guild, member, audit_entry) -> None:
+    entry = await service.open(guild, "kick_add", subject=member,
+                               actor=audit_entry.user)
+    if entry is None:
+        return
+    entry.actor(audit_entry.user, audit_entry.reason)
+    await service.submit(guild, entry)
+
+
+async def on_member_ban(service, guild: discord.Guild,
+                        user: discord.abc.User) -> None:
+    # "ban_add" lives in both the server and the moderation categories; the
+    # dispatcher fans the single entry out to whichever are configured.
+    who, reason = await service.executor(guild, discord.AuditLogAction.ban, user.id)
+    entry = await service.open(guild, "ban_add", subject=user, actor=who)
+    if entry is None:
+        return
+    entry.line("account_created", fmt_time(user.created_at))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_member_unban(service, guild: discord.Guild,
+                          user: discord.abc.User) -> None:
+    who, reason = await service.executor(guild, discord.AuditLogAction.unban, user.id)
+    entry = await service.open(guild, "ban_remove", subject=user, actor=who)
+    if entry is None:
+        return
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_member_prune(service, guild: discord.Guild,
+                          audit_entry: discord.AuditLogEntry) -> None:
+    """Emitted from the audit-log listener: pruning has no gateway event."""
+    entry = await service.open(guild, "member_prune", actor=audit_entry.user)
+    if entry is None:
+        return
+    extra = audit_entry.extra or {}
+    entry.line("members_removed", fmt_number(getattr(extra, "members_removed", None)))
+    entry.line("inactive_days", fmt_number(getattr(extra, "delete_member_days", None)))
+    entry.line("member_count", fmt_number(guild.member_count))
+    entry.actor(audit_entry.user, audit_entry.reason)
+    await service.submit(guild, entry)
+
+
+# --------------------------------------------------------------------------- #
+# Profile and roles
+# --------------------------------------------------------------------------- #
+
+async def on_member_update(service, before: discord.Member,
+                           after: discord.Member) -> None:
+    guild = after.guild
+
+    if before.nick != after.nick or before.display_name != after.display_name:
+        await _log_name_change(service, guild, before, after)
+
+    if set(before.roles) != set(after.roles):
+        await _log_role_change(service, guild, before, after)
+
+    if before.timed_out_until != after.timed_out_until:
+        await _log_timeout(service, guild, before, after)
+
+    if before.display_avatar != after.display_avatar:
+        entry = await service.open(guild, "user_avatar_update", subject=after)
+        if entry is not None:
+            entry.line("before", f"[{_link_label(entry)}]({before.display_avatar.url})")
+            entry.image(after.display_avatar.url)
+            await service.submit(guild, entry)
+
+
+def _link_label(entry) -> str:
+    from utils.i18n import t
+    return t("modules.logs.values.open_link", locale=entry.locale)
+
+
+async def _log_name_change(service, guild, before: discord.Member,
+                           after: discord.Member) -> None:
+    entry = await service.open(guild, "user_name_update", subject=after)
+    if entry is None:
+        return
+    entry.line("before", escape(before.nick or before.name))
+    entry.line("after", escape(after.nick or after.name))
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.member_update, after.id, wait=1.5)
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def _log_role_change(service, guild, before: discord.Member,
+                           after: discord.Member) -> None:
+    added = [role for role in after.roles if role not in before.roles]
+    removed = [role for role in before.roles if role not in after.roles]
+
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.member_role_update, after.id, wait=1.5)
+
+    # One combined entry (what changed) plus the two focused ones, exactly
+    # like the categories in the registry promise.
+    combined = await service.open(guild, "user_roles_update", subject=after,
+                                  actor=who)
+    if combined is not None:
+        if added:
+            combined.line("roles_added", fmt_roles(added))
+        if removed:
+            combined.line("roles_removed", fmt_roles(removed))
+        combined.actor(who, reason)
+        await service.submit(guild, combined)
+
+    if added:
+        entry = await service.open(guild, "user_roles_add", subject=after, actor=who)
+        if entry is not None:
+            entry.line("roles_added", fmt_roles(added))
+            entry.actor(who, reason)
+            await service.submit(guild, entry)
+
+    if removed:
+        entry = await service.open(guild, "user_roles_remove", subject=after, actor=who)
+        if entry is not None:
+            entry.line("roles_removed", fmt_roles(removed))
+            entry.actor(who, reason)
+            await service.submit(guild, entry)
+
+
+async def _log_timeout(service, guild, before: discord.Member,
+                       after: discord.Member) -> None:
+    timed_out = after.timed_out_until is not None
+    event = "user_timed_out" if timed_out else "user_timeout_removed"
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.member_update, after.id, wait=1.5)
+
+    entry = await service.open(guild, event, subject=after, actor=who)
+    if entry is not None:
+        if timed_out:
+            entry.line("until", fmt_time(after.timed_out_until, "F"))
+            entry.line("expires", fmt_time(after.timed_out_until))
+        entry.actor(who, reason)
+        await service.submit(guild, entry)
+
+    # Mirror into the moderation category (mute add / remove).
+    mirror = await service.open(guild, "mute_add" if timed_out else "mute_remove",
+                                subject=after, actor=who)
+    if mirror is not None:
+        if timed_out:
+            mirror.line("until", fmt_time(after.timed_out_until, "F"))
+        mirror.actor(who, reason)
+        await service.submit(guild, mirror)
+
+
+async def on_user_update(service, guilds: List[discord.Guild],
+                         before: discord.User, after: discord.User) -> None:
+    """Global username/avatar changes, logged in every shared server."""
+    for guild in guilds:
+        if before.name != after.name or before.global_name != after.global_name:
+            entry = await service.open(guild, "user_name_update", subject=after)
+            if entry is not None:
+                entry.line("before", escape(before.global_name or before.name))
+                entry.line("after", escape(after.global_name or after.name))
+                await service.submit(guild, entry)
+
+        if before.display_avatar != after.display_avatar:
+            entry = await service.open(guild, "user_avatar_update", subject=after)
+            if entry is not None:
+                entry.line("before", f"[{_link_label(entry)}]({before.display_avatar.url})")
+                entry.image(after.display_avatar.url)
+                await service.submit(guild, entry)
+
+
+def _member_action_matcher(action: discord.AuditLogAction, member_id: int):
+    def _check(entry: discord.AuditLogEntry) -> bool:
+        if entry.action != action:
+            return False
+        target_id = getattr(entry.target, "id", None) or entry.target_id
+        return target_id == member_id
+    return _check

--- a/serverlogs/listeners/messages.py
+++ b/serverlogs/listeners/messages.py
@@ -1,0 +1,243 @@
+"""Messages: deletions, bulk deletions, edits, publishes and command uses.
+
+Two things make this category the noisiest one, and both are handled here
+rather than in the renderer:
+
+* **Bulk deletions** (a purge, an anti-raid sweep) produce one entry with a
+  full ``.txt`` transcript attached instead of one embed per message.
+* **Long messages** never get silently cut: anything that does not fit in an
+  embed field is moved to a ``.txt`` attachment by
+  :meth:`~serverlogs.renderer.LogEntry.block`.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+import discord
+
+from serverlogs.renderer import (
+    build_transcript, escape, fmt_channel, fmt_number, fmt_time, fmt_user,
+    truncate,
+)
+
+async def on_message_delete(service, message: discord.Message) -> None:
+    guild = message.guild
+    if guild is None:
+        return
+
+    entry = await service.open(guild, "message_delete", channel=message.channel,
+                               subject=None, actor=message.author)
+    if entry is None:
+        return
+
+    entry.line("channel", fmt_channel(message.channel))
+    entry.line("message_id", f"`{message.id}`")
+    entry.line("author", fmt_user(message.author))
+    entry.line("message_created", fmt_time(message.created_at))
+    entry.thumbnail(message.author.display_avatar.url if message.author else None)
+
+    _add_content(entry, message)
+
+    # Discord only files a MESSAGE_DELETE audit entry when someone deleted
+    # *someone else's* message; a self-delete leaves no trace, which is the
+    # normal case and simply means no footer.
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.message_delete,
+        getattr(message.author, "id", None), wait=1.5)
+    entry.actor(who, reason)
+
+    await service.submit(guild, entry)
+
+
+async def on_raw_message_delete(service, guild: discord.Guild,
+                                payload: discord.RawMessageDeleteEvent) -> None:
+    """Fallback for a message Discord no longer had in cache."""
+    channel = guild.get_channel_or_thread(payload.channel_id)
+    entry = await service.open(guild, "message_delete", channel=channel)
+    if entry is None:
+        return
+    entry.line("channel", fmt_channel(channel) if channel else f"<#{payload.channel_id}>")
+    entry.line("message_id", f"`{payload.message_id}`")
+    entry.raw_line(_note(entry, "uncached_message"))
+    await service.submit(guild, entry)
+
+
+async def on_bulk_message_delete(service, messages: Sequence[discord.Message]) -> None:
+    if not messages:
+        return
+    first = messages[0]
+    guild = first.guild
+    if guild is None:
+        return
+
+    entry = await service.open(guild, "message_bulk_delete", channel=first.channel)
+    if entry is None:
+        return
+
+    ordered = sorted(messages, key=lambda m: m.created_at or first.created_at)
+    authors = {m.author.id for m in ordered if m.author}
+
+    entry.line("channel", fmt_channel(first.channel))
+    entry.line("count", fmt_number(len(ordered)))
+    entry.line("authors", fmt_number(len(authors)))
+    entry.line("oldest_message", fmt_time(ordered[0].created_at))
+    entry.line("newest_message", fmt_time(ordered[-1].created_at))
+    entry.raw_line(_note(entry, "transcript_attached"))
+
+    entry.attach_file(build_transcript(
+        ordered,
+        guild_name=guild.name,
+        channel_name=getattr(first.channel, "name", str(first.channel.id)),
+        header=_note(entry, "transcript_header"),
+    ))
+
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.message_bulk_delete,
+        getattr(first.channel, "id", None), wait=2.0)
+    entry.actor(who, reason)
+
+    await service.submit(guild, entry)
+
+
+async def on_raw_bulk_message_delete(service, guild: discord.Guild,
+                                     payload: discord.RawBulkMessageDeleteEvent) -> None:
+    """Bulk deletion where none of the messages were cached."""
+    if payload.cached_messages:
+        return  # the cached path already logged it
+    channel = guild.get_channel_or_thread(payload.channel_id)
+    entry = await service.open(guild, "message_bulk_delete", channel=channel)
+    if entry is None:
+        return
+    entry.line("channel", fmt_channel(channel) if channel else f"<#{payload.channel_id}>")
+    entry.line("count", fmt_number(len(payload.message_ids)))
+    entry.raw_line(_note(entry, "uncached_messages"))
+    await service.submit(guild, entry)
+
+
+async def on_message_edit(service, before: discord.Message,
+                          after: discord.Message) -> None:
+    guild = after.guild
+    if guild is None or before.content == after.content:
+        return
+
+    entry = await service.open(guild, "message_edit", channel=after.channel,
+                               actor=after.author)
+    if entry is None:
+        return
+
+    entry.line("channel", fmt_channel(after.channel))
+    entry.line("message_id", f"`{after.id}`")
+    entry.line("author", fmt_user(after.author))
+    entry.line("message_created", fmt_time(after.created_at))
+    entry.thumbnail(after.author.display_avatar.url if after.author else None)
+    entry.url(after.jump_url)
+
+    entry.block("before", before.content or _note(entry, "empty_content"),
+                filename=f"before-{after.id}.txt")
+    entry.block("after", after.content or _note(entry, "empty_content"),
+                filename=f"after-{after.id}.txt")
+
+    await service.submit(guild, entry)
+
+
+async def on_message_publish(service, message: discord.Message) -> None:
+    """A message crossposted from an announcement channel."""
+    guild = message.guild
+    if guild is None:
+        return
+    entry = await service.open(guild, "message_publish", channel=message.channel,
+                               actor=message.author)
+    if entry is None:
+        return
+    entry.line("channel", fmt_channel(message.channel))
+    entry.line("message_id", f"`{message.id}`")
+    entry.line("author", fmt_user(message.author))
+    entry.url(message.jump_url)
+    _add_content(entry, message)
+    entry.actor(message.author)
+    await service.submit(guild, entry)
+
+
+async def on_command_used(service, interaction: discord.Interaction) -> None:
+    """An application command invoked in the server."""
+    guild = interaction.guild
+    if guild is None or interaction.command is None:
+        return
+    entry = await service.open(guild, "message_command_used",
+                               channel=interaction.channel,
+                               subject=interaction.user)
+    if entry is None:
+        return
+    entry.line("channel", fmt_channel(interaction.channel))
+    entry.line("command", f"`/{interaction.command.qualified_name}`")
+
+    options = _format_options(interaction)
+    if options:
+        entry.block("options", options)
+    entry.actor(interaction.user)
+    await service.submit(guild, entry)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _add_content(entry, message: discord.Message) -> None:
+    """Message body, attachments, stickers — the parts worth keeping."""
+    content = message.content or ""
+    if content:
+        entry.block("message", content, filename=f"message-{message.id}.txt")
+    elif not message.attachments and not message.stickers and not message.embeds:
+        entry.raw_line(_note(entry, "empty_content"))
+
+    if message.attachments:
+        listing = "\n".join(
+            f"• [{escape(a.filename)}]({a.url}) — `{_human_size(a.size)}`"
+            for a in message.attachments[:10]
+        )
+        entry.block("attachments", truncate(listing, 1000))
+        image = next((a for a in message.attachments
+                      if (a.content_type or "").startswith("image/")), None)
+        if image is not None:
+            entry.image(image.url)
+
+    if message.stickers:
+        entry.line("stickers", ", ".join(f"`{escape(s.name)}`" for s in message.stickers))
+
+    if message.reference and message.reference.message_id:
+        entry.line("reply_to", f"`{message.reference.message_id}`")
+
+
+def _format_options(interaction: discord.Interaction) -> Optional[str]:
+    data = interaction.data or {}
+    options = data.get("options") or []
+    rendered: List[str] = []
+
+    def walk(items, prefix=""):
+        for option in items:
+            name = f"{prefix}{option.get('name', '?')}"
+            if option.get("options"):
+                walk(option["options"], prefix=f"{name} ")
+            elif "value" in option:
+                rendered.append(f"• `{name}`: {escape(truncate(str(option['value']), 200))}")
+
+    walk(options)
+    return "\n".join(rendered) if rendered else None
+
+
+def _human_size(size: Optional[int]) -> str:
+    if not size:
+        return "0 B"
+    units = ("B", "KB", "MB", "GB")
+    value = float(size)
+    for unit in units:
+        if value < 1024 or unit == units[-1]:
+            return f"{value:.0f} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} GB"
+
+
+def _note(entry, key: str) -> str:
+    from utils.i18n import t
+    return t(f"modules.logs.values.{key}", locale=entry.locale)

--- a/serverlogs/listeners/moderation.py
+++ b/serverlogs/listeners/moderation.py
@@ -1,0 +1,127 @@
+"""Moderation: Moddy's own cases and sanctions.
+
+Unlike every other listener module, this one is not driven by a Discord
+gateway event: it is called by :mod:`services.case_service` whenever a
+sanction is recorded or lifted, so a server's mod-log shows Moddy's actions
+(automod sanctions, staff sanctions, expirations) next to the native Discord
+ones.
+
+Discord-side moderation — bans, kicks and timeouts applied with Discord's
+own tools — is logged by :mod:`serverlogs.listeners.members`, which mirrors
+those into this category too.
+
+Some events in the ``moderation`` category have no source in Moddy yet
+(cases cannot be deleted, and there is no report system): ``case_delete``,
+``mass_case_delete``, ``report_create``, ``reports_ignore`` and
+``reports_accept`` are declared in the registry and served by
+:func:`log_case_event`, so they start working the day those features land,
+without touching the logs system.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, Optional
+
+import discord
+
+from serverlogs.renderer import escape, fmt_number, fmt_time, fmt_user, truncate
+
+logger = logging.getLogger('moddy.serverlogs.moderation')
+
+#: Sanction action (utils.moderation_cases.SanctionAction) -> (added, removed).
+SANCTION_EVENTS: Mapping[str, tuple] = {
+    "warn": ("warn_add", "warn_remove"),
+    "mute": ("mute_add", "mute_remove"),
+    "ban": ("ban_add", "ban_remove"),
+    "restrict": ("case_update", "case_update"),
+    "revoke_access": ("case_update", "case_update"),
+}
+
+
+def event_for(action: str, *, revoked: bool = False) -> Optional[str]:
+    """Registry event name for a sanction action, or ``None`` if untracked."""
+    pair = SANCTION_EVENTS.get(str(action))
+    if pair is None:
+        return None
+    return pair[1] if revoked else pair[0]
+
+
+async def log_case_event(service, guild: discord.Guild, event: str, *,
+                         subject: Optional[discord.abc.User] = None,
+                         subject_id: Optional[int] = None,
+                         actor: Optional[discord.abc.User] = None,
+                         reference: Optional[str] = None,
+                         reason: Optional[str] = None,
+                         expires_at=None,
+                         note: Optional[str] = None,
+                         count: Optional[int] = None) -> None:
+    """Emit one moderation log. Safe to call from anywhere, never raises."""
+    try:
+        entry = await service.open(guild, event, subject=subject, actor=actor)
+        if entry is None:
+            return
+
+        if subject is None and subject_id:
+            entry.line("user", f"<@{subject_id}>")
+            entry.line("id", f"`{subject_id}`")
+        if reference:
+            entry.line("case", f"`{escape(reference)}`")
+        if count is not None:
+            entry.line("count", fmt_number(count))
+        if actor is not None:
+            entry.line("moderator", fmt_user(actor))
+        if expires_at is not None:
+            entry.line("expires", fmt_time(expires_at, "F"))
+        if note:
+            entry.block("note", escape(truncate(note, 900)))
+        entry.actor(actor, reason)
+        await service.submit(guild, entry)
+    except Exception as e:
+        # A log must never break the moderation action that produced it.
+        logger.debug(f"[Logs] Could not log moderation event {event}: {e}")
+
+
+async def log_sanction(bot, *, guild_id: Any, action: str, subject_id: Any,
+                       issuer_id: Optional[Any] = None,
+                       reason: Optional[str] = None, expires_at=None,
+                       reference: Optional[str] = None,
+                       revoked: bool = False) -> None:
+    """Entry point used by :class:`services.case_service.CaseService`.
+
+    Takes ids rather than objects because the case service works with raw
+    ids, and resolves them against the bot's cache here.
+    """
+    event = event_for(action, revoked=revoked)
+    if event is None:
+        return
+
+    cog = bot.get_cog("ServerLogs") if bot else None
+    if cog is None or not getattr(cog, "service", None):
+        return
+
+    try:
+        guild = bot.get_guild(int(guild_id))
+    except (TypeError, ValueError):
+        guild = None
+    if guild is None:
+        return
+
+    subject = None
+    try:
+        subject = guild.get_member(int(subject_id)) or bot.get_user(int(subject_id))
+    except (TypeError, ValueError):
+        pass
+
+    actor = None
+    if issuer_id:
+        try:
+            actor = guild.get_member(int(issuer_id)) or bot.get_user(int(issuer_id))
+        except (TypeError, ValueError):
+            actor = None
+
+    await log_case_event(
+        cog.service, guild, event,
+        subject=subject, subject_id=subject_id, actor=actor,
+        reference=reference, reason=reason, expires_at=expires_at,
+    )

--- a/serverlogs/listeners/polls.py
+++ b/serverlogs/listeners/polls.py
@@ -1,0 +1,109 @@
+"""Polls: creation, deletion, final results and individual votes.
+
+A poll lives inside a message, so every builder here starts from a
+:class:`discord.Message` and bails out when ``message.poll`` is ``None`` —
+Discord happily sends message events for messages that never carried a poll,
+and a message can also lose its poll after the fact.
+
+Votes arrive as raw payloads (``on_raw_poll_vote_add``/``_remove``), so the
+voter is resolved from the guild cache when possible and falls back to a bare
+id line when the member is not cached.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import discord
+
+from serverlogs.renderer import (
+    escape, fmt_channel, fmt_number, fmt_time, fmt_user,
+)
+
+#: Answers listed inline before the block would overflow into a file.
+MAX_LISTED_ANSWERS = 10
+
+
+async def on_poll_create(service, message: discord.Message) -> None:
+    await _log_poll(service, message, "poll_create")
+
+
+async def on_poll_delete(service, message: discord.Message) -> None:
+    await _log_poll(service, message, "poll_delete")
+
+
+async def on_poll_finalize(service, message: discord.Message) -> None:
+    """The poll closed: the vote counts are now exact rather than approximate."""
+    await _log_poll(service, message, "poll_finalize", with_expiry=False)
+
+
+async def _log_poll(service, message: discord.Message, event: str, *,
+                    with_expiry: bool = True) -> None:
+    """Shared body of the three message-level poll events."""
+    guild = message.guild
+    if guild is None or message.poll is None:
+        return
+
+    entry = await service.open(guild, event, channel=message.channel,
+                               actor=message.author)
+    if entry is None:
+        return
+
+    poll = message.poll
+    entry.line("channel", fmt_channel(message.channel))
+    entry.line("author", fmt_user(message.author))
+    entry.line("message_id", f"`{message.id}`")
+    entry.line("question", escape(poll.question))
+    if with_expiry:
+        entry.line("expires_at", fmt_time(poll.expires_at))
+    entry.line("votes", fmt_number(poll.total_votes))
+    entry.block("answers", _format_answers(poll))
+    entry.url(message.jump_url)
+    entry.thumbnail(message.author.display_avatar.url if message.author else None)
+    await service.submit(guild, entry)
+
+
+async def on_poll_vote(service, guild: discord.Guild,
+                       payload: discord.RawPollVoteActionEvent,
+                       added: bool) -> None:
+    """One member adding or removing one vote on one answer."""
+    channel = guild.get_channel_or_thread(payload.channel_id)
+    member = guild.get_member(payload.user_id)
+    event = "poll_votes_add" if added else "poll_votes_remove"
+
+    entry = await service.open(guild, event, channel=channel, subject=member,
+                               actor=member)
+    if entry is None:
+        return
+
+    entry.line("channel",
+               fmt_channel(channel) if channel else f"<#{payload.channel_id}>")
+    entry.line("message_id", f"`{payload.message_id}`")
+    entry.line("answer_id", fmt_number(payload.answer_id))
+    if member is None:
+        entry.line("user_id", f"`{payload.user_id}`")
+    await service.submit(guild, entry)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _format_answers(poll: discord.Poll) -> Optional[str]:
+    """The answers as a bulleted list, with their counts when they exist.
+
+    Counts are only meaningful once Discord has sent results — before that
+    they are absent, and a missing count reads better than a wrong ``0``.
+    """
+    lines: List[str] = []
+    for answer in list(poll.answers)[:MAX_LISTED_ANSWERS]:
+        label = escape(answer.text) or ""
+        emoji = getattr(answer, "emoji", None)
+        if emoji is not None:
+            label = f"{emoji} {label}".strip()
+        count = getattr(answer, "vote_count", None)
+        if count is None:
+            lines.append(f"• {label}")
+        else:
+            lines.append(f"• {label} — {fmt_number(count)}")
+    return "\n".join(lines) if lines else None

--- a/serverlogs/listeners/roles.py
+++ b/serverlogs/listeners/roles.py
@@ -1,0 +1,112 @@
+"""Roles: creation, deletion and every tracked property."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+from serverlogs.listeners._diff import DiffRule, emit_diffs
+from serverlogs.renderer import (
+    escape, fmt_number, fmt_permissions, fmt_role, fmt_time,
+)
+
+
+def _render_colour(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    if value is None or (isinstance(value, discord.Colour) and value.value == 0):
+        return t("modules.logs.values.default_colour", locale=locale)
+    return f"`{value}`"
+
+
+def _render_icon(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    if value is None:
+        return t("modules.logs.values.none", locale=locale)
+    url = getattr(value, "url", None)
+    if url:
+        return f"[{t('modules.logs.values.open_link', locale=locale)}]({url})"
+    return escape(str(value))
+
+
+ROLE_RULES = (
+    DiffRule("role_name_update", "name"),
+    DiffRule("role_color_update", "colour", render=_render_colour),
+    DiffRule("role_hoist_update", "hoist"),
+    DiffRule("role_mentionable_update", "mentionable"),
+    DiffRule("role_icon_update", "display_icon", render=_render_icon),
+)
+
+
+async def on_role_create(service, role: discord.Role) -> None:
+    guild = role.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.role_create, role.id)
+
+    entry = await service.open(guild, "role_create", actor=who)
+    if entry is None:
+        return
+    _header(entry, role)
+    entry.line("colour", _render_colour(role.colour, entry.locale))
+    entry.line("hoisted", role.hoist)
+    entry.line("mentionable", role.mentionable)
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_role_delete(service, role: discord.Role) -> None:
+    guild = role.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.role_delete, role.id)
+
+    entry = await service.open(guild, "role_delete", actor=who)
+    if entry is None:
+        return
+    _header(entry, role)
+    entry.line("members", fmt_number(len(role.members)))
+    entry.line("role_created", fmt_time(role.created_at))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_role_update(service, before: discord.Role, after: discord.Role) -> None:
+    guild = after.guild
+
+    await emit_diffs(
+        service, guild, ROLE_RULES, before, after,
+        header=lambda entry: _header(entry, after),
+        audit_action=discord.AuditLogAction.role_update,
+        audit_target_id=after.id,
+        thumbnail=getattr(after.display_icon, "url", None)
+        if not isinstance(after.display_icon, str) else None,
+    )
+
+    if before.permissions != after.permissions:
+        await _log_permissions(service, guild, before, after)
+
+
+async def _log_permissions(service, guild, before: discord.Role,
+                           after: discord.Role) -> None:
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.role_update, after.id, wait=1.5)
+
+    entry = await service.open(guild, "role_permissions_update", actor=who)
+    if entry is None:
+        return
+    _header(entry, after)
+
+    before_set = {name for name, value in before.permissions if value}
+    after_set = {name for name, value in after.permissions if value}
+    added = sorted(after_set - before_set)
+    removed = sorted(before_set - after_set)
+    if added:
+        entry.line("added", fmt_permissions(added, entry.locale))
+    if removed:
+        entry.line("removed", fmt_permissions(removed, entry.locale))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+def _header(entry, role: discord.Role) -> None:
+    entry.line("role", f"{escape(role.name)} ({fmt_role(role)})")
+    entry.line("id", f"`{role.id}`")

--- a/serverlogs/listeners/scheduled_events.py
+++ b/serverlogs/listeners/scheduled_events.py
@@ -1,0 +1,153 @@
+"""Discord scheduled events: lifecycle, settings and subscriptions.
+
+Discord collapses every property of a scheduled event into a single
+``on_scheduled_event_update``, so the eight tracked settings are declared as a
+:class:`~serverlogs.listeners._diff.DiffRule` table and
+:func:`~serverlogs.listeners._diff.emit_diffs` turns each real change into its
+own log — a server can follow start-time changes without also logging every
+description tweak.
+
+The two subscription events (a member pressing "Interested", or dropping it)
+come from their own gateway events and are logged with the member as subject.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+from serverlogs.listeners._diff import DiffRule, default_render, emit_diffs
+from serverlogs.renderer import escape, fmt_channel, fmt_number, fmt_time
+
+
+# --------------------------------------------------------------------------- #
+# Value renderers
+# --------------------------------------------------------------------------- #
+
+def _render_enum(value: Any, locale: str) -> str:
+    if value is None:
+        return default_render(value, locale)
+    return f"`{value.name}`"
+
+
+def _render_datetime(value: Any, locale: str) -> str:
+    if value is None:
+        return default_render(value, locale)
+    return fmt_time(value, "F")
+
+
+def _render_image(value: Any, locale: str) -> str:
+    from utils.i18n import t
+    url = getattr(value, "url", None)
+    if not url:
+        return default_render(None, locale)
+    return f"[{t('modules.logs.values.open_link', locale=locale)}]({url})"
+
+
+def _render_location(value: Any, locale: str) -> str:
+    """External events carry a free-text location; voice/stage ones a channel."""
+    if value is None:
+        return default_render(value, locale)
+    if isinstance(value, str):
+        return escape(value)
+    return fmt_channel(value)
+
+
+#: Tracked scheduled-event settings — one line here is one loggable event.
+EVENT_RULES = (
+    DiffRule("event_name_update", "name"),
+    DiffRule("event_description_update", "description", as_block=True),
+    DiffRule("event_location_update", "location", render=_render_location),
+    DiffRule("event_privacy_level_update", "privacy_level", render=_render_enum),
+    DiffRule("event_start_time_update", "start_time", render=_render_datetime),
+    DiffRule("event_end_time_update", "end_time", render=_render_datetime),
+    DiffRule("event_status_update", "status", render=_render_enum),
+    DiffRule("event_image_update", "cover_image", render=_render_image),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Listeners
+# --------------------------------------------------------------------------- #
+
+async def on_event_create(service, event: discord.ScheduledEvent) -> None:
+    guild = event.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.scheduled_event_create, event.id)
+
+    entry = await service.open(guild, "event_create", actor=who)
+    if entry is None:
+        return
+    _header(entry, event)
+    entry.line("location", _render_location(event.location or event.channel,
+                                            entry.locale))
+    entry.line("start_time", _render_datetime(event.start_time, entry.locale))
+    entry.line("end_time", _render_datetime(event.end_time, entry.locale))
+    entry.line("privacy_level", _render_enum(event.privacy_level, entry.locale))
+    entry.block("description", escape(event.description))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_event_delete(service, event: discord.ScheduledEvent) -> None:
+    guild = event.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.scheduled_event_delete, event.id)
+
+    entry = await service.open(guild, "event_delete", actor=who)
+    if entry is None:
+        return
+    _header(entry, event)
+    entry.line("start_time", _render_datetime(event.start_time, entry.locale))
+    entry.line("status", _render_enum(event.status, entry.locale))
+    entry.line("subscribers", fmt_number(event.user_count))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_event_update(service, before: discord.ScheduledEvent,
+                          after: discord.ScheduledEvent) -> None:
+    guild = after.guild
+    await emit_diffs(
+        service, guild, EVENT_RULES, before, after,
+        header=lambda entry: _header(entry, after),
+        audit_action=discord.AuditLogAction.scheduled_event_update,
+        audit_target_id=after.id,
+    )
+
+
+async def on_event_user_add(service, event: discord.ScheduledEvent,
+                            user: discord.User) -> None:
+    await _log_subscription(service, event, user, "event_user_subscribe")
+
+
+async def on_event_user_remove(service, event: discord.ScheduledEvent,
+                               user: discord.User) -> None:
+    await _log_subscription(service, event, user, "event_user_unsubscribe")
+
+
+async def _log_subscription(service, event: discord.ScheduledEvent,
+                            user: discord.User, log_event: str) -> None:
+    """A member marking themselves interested in an event, or dropping it."""
+    guild = event.guild
+    entry = await service.open(guild, log_event, subject=user)
+    if entry is None:
+        return
+    entry.line("event", escape(event.name))
+    entry.line("subscribers", fmt_number(event.user_count))
+    entry.url(getattr(event, "url", None))
+    await service.submit(guild, entry)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _header(entry, event: discord.ScheduledEvent) -> None:
+    """Identity lines shared by every scheduled-event log."""
+    entry.line("event", escape(event.name))
+    entry.line("id", f"`{event.id}`")
+    entry.url(getattr(event, "url", None))
+    if event.cover_image is not None:
+        entry.image(event.cover_image.url)

--- a/serverlogs/listeners/stage.py
+++ b/serverlogs/listeners/stage.py
@@ -1,0 +1,77 @@
+"""Stage instances: a stage channel going live, changing, and closing.
+
+A "stage instance" is the live session itself, not the channel: it appears
+when someone starts a stage and disappears when the last speaker ends it, so
+``stage_start``/``stage_end`` are the honest names for the two lifecycle
+events. The channel is passed to :meth:`~serverlogs.service.LogService.open`
+so a stage happening in an ignored channel is never logged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+from serverlogs.listeners._diff import DiffRule, default_render, emit_diffs
+from serverlogs.renderer import escape, fmt_channel
+
+
+def _render_enum(value: Any, locale: str) -> str:
+    if value is None:
+        return default_render(value, locale)
+    return f"`{value.name}`"
+
+
+#: Tracked stage-instance settings — one line here is one loggable event.
+STAGE_RULES = (
+    DiffRule("stage_topic_update", "topic", as_block=True),
+    DiffRule("stage_privacy_update", "privacy_level", render=_render_enum),
+)
+
+
+async def on_stage_create(service, stage: discord.StageInstance) -> None:
+    guild = stage.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.stage_instance_create, stage.id)
+
+    entry = await service.open(guild, "stage_start", channel=stage.channel,
+                               actor=who)
+    if entry is None:
+        return
+    _header(entry, stage)
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_stage_delete(service, stage: discord.StageInstance) -> None:
+    guild = stage.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.stage_instance_delete, stage.id)
+
+    entry = await service.open(guild, "stage_end", channel=stage.channel,
+                               actor=who)
+    if entry is None:
+        return
+    _header(entry, stage)
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_stage_update(service, before: discord.StageInstance,
+                          after: discord.StageInstance) -> None:
+    guild = after.guild
+    await emit_diffs(
+        service, guild, STAGE_RULES, before, after,
+        header=lambda entry: _header(entry, after),
+        audit_action=discord.AuditLogAction.stage_instance_update,
+        audit_target_id=after.id,
+    )
+
+
+def _header(entry, stage: discord.StageInstance) -> None:
+    """Identity lines shared by every stage log."""
+    entry.line("channel", fmt_channel(stage.channel))
+    entry.line("id", f"`{stage.id}`")
+    entry.line("topic", escape(stage.topic))
+    entry.line("privacy_level", _render_enum(stage.privacy_level, entry.locale))

--- a/serverlogs/listeners/threads.py
+++ b/serverlogs/listeners/threads.py
@@ -1,0 +1,121 @@
+"""Threads: creation, deletion, settings, archiving and locking.
+
+Discord sends a single ``thread_update`` for everything a thread carries, so
+the renamed/slowmode/auto-archive settings go through a diff table (see
+:mod:`serverlogs.listeners._diff`) exactly like channels do.
+
+``archived`` and ``locked`` are two independent booleans on the same object —
+closing a thread flips the first, a moderator locking it flips the second —
+so they are handled outside the table, as four distinct events, which lets a
+server log lock/unlock (a moderation signal) without logging the archive
+churn every busy forum produces.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+from serverlogs.listeners._diff import DiffRule, emit_diffs
+from serverlogs.renderer import fmt_channel, fmt_duration, fmt_time, fmt_user
+
+
+# --------------------------------------------------------------------------- #
+# Value renderers
+# --------------------------------------------------------------------------- #
+
+def _render_duration(value: Any, locale: str) -> str:
+    return fmt_duration(int(value) if value is not None else None, locale)
+
+
+def _render_minutes(value: Any, locale: str) -> str:
+    """``auto_archive_duration`` is expressed in minutes, not seconds."""
+    return fmt_duration(int(value) * 60 if value is not None else None, locale)
+
+
+#: One line per tracked setting — this table *is* the thread log catalogue.
+THREAD_RULES = (
+    DiffRule("thread_name_update", "name"),
+    DiffRule("thread_slowmode_update", "slowmode_delay", render=_render_duration),
+    DiffRule("thread_archive_duration_update", "auto_archive_duration",
+             render=_render_minutes),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Listeners
+# --------------------------------------------------------------------------- #
+
+async def on_thread_create(service, thread: discord.Thread) -> None:
+    guild = thread.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.thread_create, thread.id)
+
+    entry = await service.open(guild, "thread_create", channel=thread, actor=who)
+    if entry is None:
+        return
+    _header(entry, thread)
+    # The owner is only in cache when the creator is a known member.
+    owner = thread.owner
+    if owner is not None:
+        entry.line("owner", fmt_user(owner))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_thread_delete(service, thread: discord.Thread) -> None:
+    guild = thread.guild
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.thread_delete, thread.id)
+
+    entry = await service.open(guild, "thread_delete", channel=thread, actor=who)
+    if entry is None:
+        return
+    _header(entry, thread)
+    entry.line("thread_created", fmt_time(thread.created_at))
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+async def on_thread_update(service, before: discord.Thread,
+                           after: discord.Thread) -> None:
+    guild = after.guild
+
+    await emit_diffs(
+        service, guild, THREAD_RULES, before, after,
+        header=lambda entry: _header(entry, after),
+        audit_action=discord.AuditLogAction.thread_update,
+        audit_target_id=after.id,
+    )
+
+    if before.archived != after.archived:
+        await _log_state(service, guild, after,
+                         "thread_archive" if after.archived else "thread_unarchive")
+    if before.locked != after.locked:
+        await _log_state(service, guild, after,
+                         "thread_lock" if after.locked else "thread_unlock")
+
+
+# --------------------------------------------------------------------------- #
+# Special cases
+# --------------------------------------------------------------------------- #
+
+async def _log_state(service, guild, thread: discord.Thread, event: str) -> None:
+    """Archive/unarchive and lock/unlock share the same one-fact shape."""
+    who, reason = await service.executor(
+        guild, discord.AuditLogAction.thread_update, thread.id, wait=1.5)
+
+    entry = await service.open(guild, event, channel=thread, actor=who)
+    if entry is None:
+        return
+    _header(entry, thread)
+    entry.actor(who, reason)
+    await service.submit(guild, entry)
+
+
+def _header(entry, thread: discord.Thread) -> None:
+    """Identity lines shared by every thread event."""
+    entry.line("thread", fmt_channel(thread))
+    entry.line("id", f"`{thread.id}`")
+    entry.line("parent_channel", fmt_channel(thread.parent))

--- a/serverlogs/listeners/voice.py
+++ b/serverlogs/listeners/voice.py
@@ -1,0 +1,128 @@
+"""Voice: who joined, left, moved between channels, or was disconnected.
+
+Discord folds joins, leaves and switches into a single ``voice_state_update``
+whose only reliable signal is ``before.channel`` vs ``after.channel`` — the
+same event also fires for mute/deafen/stream changes, which this module
+deliberately ignores.
+
+Moves and forced disconnects have **no** gateway event at all: only the audit
+log knows a moderator dragged someone out of a channel, so those two arrive
+from the audit-log listener instead of from a voice state.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import discord
+
+from serverlogs.renderer import fmt_channel, fmt_number
+
+
+# --------------------------------------------------------------------------- #
+# Gateway: joins, leaves, switches
+# --------------------------------------------------------------------------- #
+
+async def on_voice_state_update(service, member: discord.Member,
+                                before: discord.VoiceState,
+                                after: discord.VoiceState) -> None:
+    guild = member.guild
+    old, new = before.channel, after.channel
+    if old == new:
+        # Mute, deafen, stream, camera… — not a movement, nothing to log.
+        return
+
+    if old is None and new is not None:
+        entry = await service.open(guild, "voice_user_join", channel=new,
+                                   subject=member)
+        if entry is not None:
+            entry.line("channel", fmt_channel(new))
+            entry.line("members", fmt_number(len(new.members)))
+            await service.submit(guild, entry)
+        await _log_channel_full(service, guild, member, new)
+        return
+
+    if new is None and old is not None:
+        entry = await service.open(guild, "voice_user_leave", channel=old,
+                                   subject=member)
+        if entry is not None:
+            entry.line("channel", fmt_channel(old))
+            entry.line("members", fmt_number(len(old.members)))
+            await service.submit(guild, entry)
+        return
+
+    # Both sides set and different: the user hopped channels on their own.
+    entry = await service.open(guild, "voice_user_switch", channel=new,
+                               subject=member)
+    if entry is None:
+        return
+    entry.line("before_channel", fmt_channel(old))
+    entry.line("after_channel", fmt_channel(new))
+    await service.submit(guild, entry)
+    await _log_channel_full(service, guild, member, new)
+
+
+async def _log_channel_full(service, guild, member: discord.Member,
+                            channel: Optional[discord.abc.GuildChannel]) -> None:
+    """Emit once, for the join that made the channel reach its user limit."""
+    limit = getattr(channel, "user_limit", 0) or 0
+    if not limit or len(channel.members) < limit:
+        return
+
+    entry = await service.open(guild, "voice_channel_full", channel=channel,
+                               subject=member)
+    if entry is None:
+        return
+    entry.line("channel", fmt_channel(channel))
+    entry.line("user_limit", fmt_number(limit))
+    entry.line("members", fmt_number(len(channel.members)))
+    await service.submit(guild, entry)
+
+
+# --------------------------------------------------------------------------- #
+# Audit log: moves and forced disconnects
+# --------------------------------------------------------------------------- #
+
+async def on_voice_move(service, guild: discord.Guild,
+                        audit_entry: discord.AuditLogEntry) -> None:
+    """``member_move`` — a moderator dragged users into another channel.
+
+    Discord reports the operation as a whole (a channel and a count), not one
+    entry per user, so the log describes the batch rather than the members.
+    """
+    channel = getattr(audit_entry.extra, "channel", None)
+    entry = await service.open(guild, "voice_user_move", channel=channel,
+                               actor=audit_entry.user)
+    if entry is None:
+        return
+    entry.line("channel", fmt_channel(channel))
+    entry.line("count", fmt_number(_count(audit_entry)))
+    entry.actor(audit_entry.user, audit_entry.reason)
+    await service.submit(guild, entry)
+
+
+async def on_voice_kick(service, guild: discord.Guild,
+                        audit_entry: discord.AuditLogEntry) -> None:
+    """``member_disconnect`` — users forcibly removed from voice."""
+    target = audit_entry.target
+    subject = target if isinstance(target, (discord.Member, discord.User)) else None
+    channel = getattr(audit_entry.extra, "channel", None)
+
+    entry = await service.open(guild, "voice_user_kick", channel=channel,
+                               subject=subject, actor=audit_entry.user)
+    if entry is None:
+        return
+    if channel is not None:
+        entry.line("channel", fmt_channel(channel))
+    entry.line("count", fmt_number(_count(audit_entry)))
+    entry.actor(audit_entry.user, audit_entry.reason)
+    await service.submit(guild, entry)
+
+
+def _count(audit_entry: discord.AuditLogEntry) -> Optional[int]:
+    """Discord sometimes sends audit-log counts as strings."""
+    raw = getattr(getattr(audit_entry, "extra", None), "count", None)
+    try:
+        return int(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None

--- a/serverlogs/registry.py
+++ b/serverlogs/registry.py
@@ -27,6 +27,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
+from utils.emojis import (
+    BALANCE, COMMANDS, EMOJI, FILTER, FOLDERS, GROUPS, IMAGE, LINK,
+    MANAGE_USER, MESSAGE, MIC_OFF, PLAY, SHIELD, TEXT, TIME, USER,
+    VOICE_CHAT, WEBHOOK,
+)
+
 # ---------------------------------------------------------------------------
 # Colour "kind" of an event — drives the embed accent so a log channel reads
 # at a glance: green = something appeared, red = something disappeared,
@@ -132,7 +138,7 @@ class LogCategorySpec:
 
 _CATALOGUE: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
     (
-        "server", "<:groups:1519789805456724049>",
+        "server", GROUPS,
         (
             "ban_add", "ban_remove", "user_join", "user_leave", "user_kick",
             "member_prune", "afk_channel_update", "afk_timeout_update",
@@ -152,14 +158,14 @@ _CATALOGUE: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "messages", "<:message:1519790643784843416>",
+        "messages", MESSAGE,
         (
             "message_delete", "message_bulk_delete", "message_edit",
             "message_publish", "message_command_used",
         ),
     ),
     (
-        "users", "<:user:1519798911517196511>",
+        "users", USER,
         (
             "user_name_update", "user_roles_update", "user_roles_add",
             "user_roles_remove", "user_avatar_update", "user_timed_out",
@@ -167,7 +173,7 @@ _CATALOGUE: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "moderation", "<:shield:1521471376815292498>",
+        "moderation", SHIELD,
         (
             "auto_moderation", "ban_add", "ban_remove", "case_delete",
             "mass_case_delete", "case_update", "kick_add", "kick_remove",
@@ -177,7 +183,7 @@ _CATALOGUE: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "channels", "<:text:1519791921462120601>",
+        "channels", TEXT,
         (
             "channel_create", "channel_delete", "channel_pins_update",
             "channel_name_update", "channel_topic_update",
@@ -194,7 +200,7 @@ _CATALOGUE: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "roles", "<:manageuser:1519798563880698066>",
+        "roles", MANAGE_USER,
         (
             "role_create", "role_delete", "role_color_update",
             "role_hoist_update", "role_mentionable_update", "role_name_update",
@@ -202,7 +208,7 @@ _CATALOGUE: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "threads", "<:folders:1520590403533934713>",
+        "threads", FOLDERS,
         (
             "thread_create", "thread_delete", "thread_name_update",
             "thread_slowmode_update", "thread_archive_duration_update",
@@ -211,18 +217,18 @@ _CATALOGUE: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "voice", "<:voice_chat:1535700758601666672>",
+        "voice", VOICE_CHAT,
         (
             "voice_channel_full", "voice_user_join", "voice_user_switch",
             "voice_user_leave", "voice_user_move", "voice_user_kick",
         ),
     ),
     (
-        "invites", "<:link:1521517863607734385>",
+        "invites", LINK,
         ("invite_create", "invite_delete", "invite_post"),
     ),
     (
-        "automod", "<:filter:1520586655180783666>",
+        "automod", FILTER,
         (
             "automod_rule_create", "automod_rule_delete",
             "automod_rule_toggle", "automod_rule_name_update",
@@ -232,28 +238,28 @@ _CATALOGUE: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "emojis", "<:emoji:1519800926636867675>",
+        "emojis", EMOJI,
         (
             "emoji_create", "emoji_delete", "emoji_name_update",
             "emoji_roles_update",
         ),
     ),
     (
-        "stickers", "<:image:1520593192892764260>",
+        "stickers", IMAGE,
         (
             "sticker_create", "sticker_delete", "sticker_name_update",
             "sticker_description_update", "sticker_related_emoji_update",
         ),
     ),
     (
-        "soundboard", "<:play:1519787501789773996>",
+        "soundboard", PLAY,
         (
             "sound_upload", "sound_name_update", "sound_volume_update",
             "sound_emoji_update", "sound_delete",
         ),
     ),
     (
-        "events", "<:time:1519798202990330087>",
+        "events", TIME,
         (
             "event_create", "event_delete", "event_name_update",
             "event_description_update", "event_location_update",
@@ -264,25 +270,25 @@ _CATALOGUE: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "stage", "<:mic_off:1520555496665255936>",
+        "stage", MIC_OFF,
         ("stage_start", "stage_end", "stage_topic_update", "stage_privacy_update"),
     ),
     (
-        "polls", "<:balance:1519801728961351730>",
+        "polls", BALANCE,
         (
             "poll_create", "poll_delete", "poll_finalize", "poll_votes_add",
             "poll_votes_remove",
         ),
     ),
     (
-        "webhooks", "<:webhook:1519793325329219675>",
+        "webhooks", WEBHOOK,
         (
             "webhook_create", "webhook_name_update", "webhook_avatar_update",
             "webhook_channel_update", "webhook_delete",
         ),
     ),
     (
-        "applications", "<:commands:1519794878933106830>",
+        "applications", COMMANDS,
         ("app_add", "app_remove", "app_command_permission_update"),
     ),
 )

--- a/serverlogs/registry.py
+++ b/serverlogs/registry.py
@@ -1,0 +1,340 @@
+"""Single source of truth for the advanced server logs.
+
+Every loggable event in Moddy is declared **once**, here. Everything else —
+the ``/config`` panel, the stored configuration, the dispatcher and the
+listeners — reads this registry instead of hardcoding its own list.
+
+Adding a new event is therefore a three-step change:
+
+1. add its key to the relevant :data:`CATEGORIES` entry,
+2. add the two i18n strings (``modules.logs.events.<cat>.<event>`` for the
+   short name shown in ``/config`` and ``modules.logs.titles.<cat>.<event>``
+   for the embed title),
+3. emit it from a listener in :mod:`serverlogs.listeners`.
+
+Nothing else has to be touched: the configuration UI paginates itself, the
+module validates unknown keys away, and the dispatcher routes on the key.
+
+Event keys are namespaced ``"<category>.<event>"``. The same real-world
+occurrence may legitimately exist in two categories (a ban is both a
+``server`` event and a ``moderation`` event) — they are two distinct keys
+with two distinct destinations, exactly like Sapphire and Dyno do it, so a
+server can send bans to #server-logs, to #mod-logs, or to both.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Colour "kind" of an event — drives the embed accent so a log channel reads
+# at a glance: green = something appeared, red = something disappeared,
+# blurple = something changed, orange = a moderator acted.
+# ---------------------------------------------------------------------------
+
+KIND_CREATE = "create"
+KIND_DELETE = "delete"
+KIND_UPDATE = "update"
+KIND_MODERATION = "moderation"
+
+# Suffix/prefix inference so 160+ events don't each need a hand-written kind.
+# Checked in order, on the event key (without its category prefix).
+_KIND_TOKENS: Tuple[Tuple[Tuple[str, ...], str], ...] = (
+    (("create", "add", "join", "start", "upload", "subscribe", "post", "publish"), KIND_CREATE),
+    (("delete", "remove", "leave", "end", "kick", "unsubscribe", "prune"), KIND_DELETE),
+)
+
+# Events whose name would infer the wrong colour, or that belong to the
+# moderation palette regardless of what they do.
+_KIND_OVERRIDES: Dict[str, str] = {
+    "server.ban_add": KIND_MODERATION,
+    "server.ban_remove": KIND_MODERATION,
+    "server.user_kick": KIND_MODERATION,
+    "server.member_prune": KIND_MODERATION,
+    "users.user_timed_out": KIND_MODERATION,
+    "users.user_timeout_removed": KIND_MODERATION,
+    "voice.voice_user_kick": KIND_MODERATION,
+    "messages.message_delete": KIND_DELETE,
+    "messages.message_bulk_delete": KIND_DELETE,
+    "threads.thread_archive": KIND_UPDATE,
+    "threads.thread_unarchive": KIND_UPDATE,
+    "threads.thread_lock": KIND_UPDATE,
+    "threads.thread_unlock": KIND_UPDATE,
+    "polls.poll_finalize": KIND_UPDATE,
+    "voice.voice_channel_full": KIND_UPDATE,
+    "voice.voice_user_switch": KIND_UPDATE,
+    "voice.voice_user_move": KIND_MODERATION,
+    "invites.invite_post": KIND_UPDATE,
+    "automod.automod_rule_toggle": KIND_UPDATE,
+    "server.onboarding_toggle": KIND_UPDATE,
+}
+
+
+def _infer_kind(key: str, event: str) -> str:
+    override = _KIND_OVERRIDES.get(key)
+    if override:
+        return override
+    if key.split(".", 1)[0] == "moderation":
+        return KIND_MODERATION
+    for tokens, kind in _KIND_TOKENS:
+        for token in tokens:
+            if event.endswith(f"_{token}") or event.startswith(f"{token}_") or event == token:
+                return kind
+    return KIND_UPDATE
+
+
+@dataclass(frozen=True)
+class LogEventSpec:
+    """One loggable event."""
+
+    key: str          # "server.user_join"
+    category: str     # "server"
+    event: str        # "user_join"
+    kind: str         # KIND_* — the embed accent colour
+
+    @property
+    def name_key(self) -> str:
+        """i18n key of the short name shown in the /config picker."""
+        return f"modules.logs.events.{self.category}.{self.event}"
+
+    @property
+    def title_key(self) -> str:
+        """i18n key of the sentence used as the embed title."""
+        return f"modules.logs.titles.{self.category}.{self.event}"
+
+
+@dataclass(frozen=True)
+class LogCategorySpec:
+    """One category of events — the unit a channel is bound to."""
+
+    id: str
+    emoji: str
+    order: int
+    events: Tuple[str, ...]
+
+    @property
+    def name_key(self) -> str:
+        return f"modules.logs.categories.{self.id}.name"
+
+    @property
+    def description_key(self) -> str:
+        return f"modules.logs.categories.{self.id}.description"
+
+    def event_key(self, event: str) -> str:
+        return f"{self.id}.{event}"
+
+
+# ---------------------------------------------------------------------------
+# The catalogue. Order inside a category is the order shown in /config.
+# Emojis come from utils/emojis.py (custom emojis only — CLAUDE.md rule 3).
+# ---------------------------------------------------------------------------
+
+_CATALOGUE: Tuple[Tuple[str, str, Tuple[str, ...]], ...] = (
+    (
+        "server", "<:groups:1519789805456724049>",
+        (
+            "ban_add", "ban_remove", "user_join", "user_leave", "user_kick",
+            "member_prune", "afk_channel_update", "afk_timeout_update",
+            "server_banner_update", "message_notifications_update",
+            "server_discovery_splash_update", "server_content_filter_update",
+            "server_features_update", "server_icon_update", "mfa_level_update",
+            "server_name_update", "server_description_update",
+            "server_owner_update", "partnered_update",
+            "server_boost_level_update", "boost_progress_bar_toggle",
+            "public_updates_channel_update", "server_rules_channel_update",
+            "server_splash_update", "system_channel_update",
+            "server_vanity_update", "verification_level_update",
+            "verified_update", "server_widget_update",
+            "server_preferred_locale_update", "onboarding_toggle",
+            "onboarding_channels_update", "onboarding_question_add",
+            "onboarding_question_remove", "onboarding_question_update",
+        ),
+    ),
+    (
+        "messages", "<:message:1519790643784843416>",
+        (
+            "message_delete", "message_bulk_delete", "message_edit",
+            "message_publish", "message_command_used",
+        ),
+    ),
+    (
+        "users", "<:user:1519798911517196511>",
+        (
+            "user_name_update", "user_roles_update", "user_roles_add",
+            "user_roles_remove", "user_avatar_update", "user_timed_out",
+            "user_timeout_removed",
+        ),
+    ),
+    (
+        "moderation", "<:shield:1521471376815292498>",
+        (
+            "auto_moderation", "ban_add", "ban_remove", "case_delete",
+            "mass_case_delete", "case_update", "kick_add", "kick_remove",
+            "mute_add", "mute_remove", "warn_add", "warn_remove",
+            "report_create", "reports_ignore", "reports_accept",
+            "user_note_add", "user_note_remove",
+        ),
+    ),
+    (
+        "channels", "<:text:1519791921462120601>",
+        (
+            "channel_create", "channel_delete", "channel_pins_update",
+            "channel_name_update", "channel_topic_update",
+            "channel_nsfw_update", "channel_parent_update",
+            "channel_permissions_update", "channel_type_update",
+            "channel_bitrate_update", "channel_user_limit_update",
+            "channel_slowmode_update", "channel_rtc_region_update",
+            "channel_video_quality_update",
+            "channel_default_archive_duration_update",
+            "channel_default_thread_slowmode_update",
+            "channel_default_reaction_emoji_update",
+            "channel_default_sort_order_update", "channel_forum_tags_update",
+            "channel_forum_layout_update", "channel_voice_status_update",
+        ),
+    ),
+    (
+        "roles", "<:manageuser:1519798563880698066>",
+        (
+            "role_create", "role_delete", "role_color_update",
+            "role_hoist_update", "role_mentionable_update", "role_name_update",
+            "role_permissions_update", "role_icon_update",
+        ),
+    ),
+    (
+        "threads", "<:folders:1520590403533934713>",
+        (
+            "thread_create", "thread_delete", "thread_name_update",
+            "thread_slowmode_update", "thread_archive_duration_update",
+            "thread_archive", "thread_unarchive", "thread_lock",
+            "thread_unlock",
+        ),
+    ),
+    (
+        "voice", "<:voice_chat:1535700758601666672>",
+        (
+            "voice_channel_full", "voice_user_join", "voice_user_switch",
+            "voice_user_leave", "voice_user_move", "voice_user_kick",
+        ),
+    ),
+    (
+        "invites", "<:link:1521517863607734385>",
+        ("invite_create", "invite_delete", "invite_post"),
+    ),
+    (
+        "automod", "<:filter:1520586655180783666>",
+        (
+            "automod_rule_create", "automod_rule_delete",
+            "automod_rule_toggle", "automod_rule_name_update",
+            "automod_rule_actions_update", "automod_rule_content_update",
+            "automod_rule_roles_update", "automod_rule_channels_update",
+            "automod_rule_whitelist_update",
+        ),
+    ),
+    (
+        "emojis", "<:emoji:1519800926636867675>",
+        (
+            "emoji_create", "emoji_delete", "emoji_name_update",
+            "emoji_roles_update",
+        ),
+    ),
+    (
+        "stickers", "<:image:1520593192892764260>",
+        (
+            "sticker_create", "sticker_delete", "sticker_name_update",
+            "sticker_description_update", "sticker_related_emoji_update",
+        ),
+    ),
+    (
+        "soundboard", "<:play:1519787501789773996>",
+        (
+            "sound_upload", "sound_name_update", "sound_volume_update",
+            "sound_emoji_update", "sound_delete",
+        ),
+    ),
+    (
+        "events", "<:time:1519798202990330087>",
+        (
+            "event_create", "event_delete", "event_name_update",
+            "event_description_update", "event_location_update",
+            "event_privacy_level_update", "event_start_time_update",
+            "event_end_time_update", "event_status_update",
+            "event_image_update", "event_user_subscribe",
+            "event_user_unsubscribe",
+        ),
+    ),
+    (
+        "stage", "<:mic_off:1520555496665255936>",
+        ("stage_start", "stage_end", "stage_topic_update", "stage_privacy_update"),
+    ),
+    (
+        "polls", "<:balance:1519801728961351730>",
+        (
+            "poll_create", "poll_delete", "poll_finalize", "poll_votes_add",
+            "poll_votes_remove",
+        ),
+    ),
+    (
+        "webhooks", "<:webhook:1519793325329219675>",
+        (
+            "webhook_create", "webhook_name_update", "webhook_avatar_update",
+            "webhook_channel_update", "webhook_delete",
+        ),
+    ),
+    (
+        "applications", "<:commands:1519794878933106830>",
+        ("app_add", "app_remove", "app_command_permission_update"),
+    ),
+)
+
+
+CATEGORIES: Dict[str, LogCategorySpec] = {
+    cat_id: LogCategorySpec(id=cat_id, emoji=emoji, order=index * 10, events=events)
+    for index, (cat_id, emoji, events) in enumerate(_CATALOGUE)
+}
+
+EVENTS: Dict[str, LogEventSpec] = {
+    f"{cat.id}.{event}": LogEventSpec(
+        key=f"{cat.id}.{event}",
+        category=cat.id,
+        event=event,
+        kind=_infer_kind(f"{cat.id}.{event}", event),
+    )
+    for cat in CATEGORIES.values()
+    for event in cat.events
+}
+
+
+# ---------------------------------------------------------------------------
+# Lookups
+# ---------------------------------------------------------------------------
+
+def ordered_categories() -> List[LogCategorySpec]:
+    """Categories in the order they are shown in ``/config``."""
+    return sorted(CATEGORIES.values(), key=lambda c: c.order)
+
+
+def get_category(category_id: str) -> Optional[LogCategorySpec]:
+    return CATEGORIES.get(category_id)
+
+
+def get_event(key: str) -> Optional[LogEventSpec]:
+    return EVENTS.get(key)
+
+
+def category_events(category_id: str) -> Tuple[str, ...]:
+    """Event keys (``"<cat>.<event>"``) of one category, in display order."""
+    category = CATEGORIES.get(category_id)
+    if not category:
+        return ()
+    return tuple(f"{category_id}.{event}" for event in category.events)
+
+
+def keys_for(event: str) -> Tuple[str, ...]:
+    """Every registry key matching a bare event name.
+
+    A single occurrence can feed several categories (``ban_add`` lives in
+    both ``server`` and ``moderation``); listeners emit the bare name and the
+    dispatcher fans it out to every category that declares it.
+    """
+    return tuple(key for key, spec in EVENTS.items() if spec.event == event)

--- a/serverlogs/renderer.py
+++ b/serverlogs/renderer.py
@@ -321,6 +321,32 @@ class LogEntry:
         if self._footer_text:
             embed.set_footer(text=truncate(self._footer_text, 2000),
                              icon_url=self._footer_icon)
+        return self._fit(embed)
+
+    def _fit(self, embed: discord.Embed) -> discord.Embed:
+        """Keep the whole embed inside Discord's total-size budget.
+
+        Every individual value is capped already, but a log made of many
+        fields (a permission diff spanning a dozen roles) can still add up
+        past the limit — and Discord rejects the *whole* message, so the log
+        would simply never arrive. Trailing fields are dropped first (they
+        carry the detail, the description carries the facts), the
+        description is shortened only if that is not enough, and the reader
+        is always told the log was shortened.
+        """
+        if len(embed) <= MAX_EMBED_TOTAL:
+            return embed
+
+        note = "\n-# " + t("modules.logs.values.size_limit", locale=self.locale)
+        budget = MAX_EMBED_TOTAL - len(note)
+
+        while embed.fields and len(embed) > budget:
+            embed.remove_field(len(embed.fields) - 1)
+        if len(embed) > budget:
+            description = embed.description or ""
+            keep = max(len(description) - (len(embed) - budget), 1)
+            embed.description = truncate(description, keep)
+        embed.description = (embed.description or "") + note
         return embed
 
 

--- a/serverlogs/renderer.py
+++ b/serverlogs/renderer.py
@@ -1,0 +1,369 @@
+"""Uniform rendering of every server-log message.
+
+**This is the only place that decides what a log looks like.** Listeners
+describe *what happened* by pushing labelled lines onto a :class:`LogEntry`;
+this module turns that into the embed everyone sees:
+
+.. code-block:: text
+
+    ┌──────────────────────────────────────────────┐
+    │ Role(s) added to a user                      │  title  = event title (i18n)
+    │ > **User:** @dyvion_ (<@120…>)               │  description = "> **Label:** value"
+    │ > **Added:** <@&966…>                        │
+    │ > **Reason:** Join Roles                     │
+    │                                     [avatar] │  thumbnail = the subject
+    │ Moddy#0001                       26/07 13:12 │  footer = executor, timestamp
+    └──────────────────────────────────────────────┘
+
+Changing the wording of a log therefore never means touching Python: the
+title comes from ``modules.logs.titles.<category>.<event>`` and every label
+from ``modules.logs.fields.<label>``, in all five locales.
+
+Embeds are a **documented exception** to the Components V2 rule (CLAUDE.md
+rule 1): logs are posted through channel webhooks, and Discord rejects the
+``IS_COMPONENTS_V2`` message flag on webhook messages that carry a classic
+embed — the same exception ``modules/starboard.py`` already relies on.
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime, timezone
+from typing import Any, Iterable, List, Optional, Sequence, Union
+
+import discord
+
+from serverlogs import registry
+from utils.i18n import t
+
+# Discord hard limits, with a safety margin so a rendered value can never
+# make the whole webhook call fail.
+MAX_DESCRIPTION = 4000
+MAX_FIELD_VALUE = 1000
+MAX_EMBED_TOTAL = 5800
+
+#: Accent colour per event kind (see registry.KIND_*).
+KIND_COLORS = {
+    registry.KIND_CREATE: 0x57F287,      # green  — something appeared
+    registry.KIND_DELETE: 0xED4245,      # red    — something disappeared
+    registry.KIND_UPDATE: 0x5865F2,      # blurple— something changed
+    registry.KIND_MODERATION: 0xF28500,  # orange — a moderator acted
+}
+FALLBACK_COLOR = 0x99AAB5
+
+
+# --------------------------------------------------------------------------- #
+# Value formatters — every listener formats through these, never by hand, so
+# a user/channel/role always reads the same way in every single log.
+# --------------------------------------------------------------------------- #
+
+def fmt_user(user: Optional[Union[discord.abc.User, discord.Member]]) -> str:
+    """``@name (<@id>)`` — the mention keeps it clickable even after a leave."""
+    if user is None:
+        return "—"
+    name = getattr(user, "name", None) or str(user)
+    return f"{escape(f'@{name}')} (<@{user.id}>)"
+
+def fmt_user_id(user_id: Optional[int]) -> str:
+    return f"`{user_id}`" if user_id else "—"
+
+
+def fmt_channel(channel: Any) -> str:
+    """``#name (<#id>)`` for anything that has a name and an id."""
+    if channel is None:
+        return "—"
+    name = getattr(channel, "name", None)
+    channel_id = getattr(channel, "id", None)
+    if channel_id is None:
+        return escape(str(channel))
+    if name:
+        return f"{escape(f'#{name}')} (<#{channel_id}>)"
+    return f"<#{channel_id}>"
+
+
+def fmt_role(role: Any) -> str:
+    if role is None:
+        return "—"
+    role_id = getattr(role, "id", None)
+    return f"<@&{role_id}>" if role_id else escape(str(role))
+
+
+def fmt_roles(roles: Iterable[Any]) -> str:
+    rendered = [fmt_role(role) for role in roles]
+    return ", ".join(rendered) if rendered else "—"
+
+
+def fmt_time(moment: Optional[datetime], style: str = "R") -> str:
+    """Discord timestamp — rendered in each reader's own timezone and language."""
+    if moment is None:
+        return "—"
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return f"<t:{int(moment.timestamp())}:{style}>"
+
+
+def fmt_bool(value: Optional[bool], locale: str) -> str:
+    if value is None:
+        return "—"
+    return t(f"modules.logs.values.{'yes' if value else 'no'}", locale=locale)
+
+
+def fmt_number(value: Optional[int]) -> str:
+    return f"`{value}`" if value is not None else "—"
+
+
+def fmt_code(value: Optional[str]) -> str:
+    if value in (None, ""):
+        return "—"
+    return f"`{escape_code(str(value))}`"
+
+
+def fmt_duration(seconds: Optional[int], locale: str) -> str:
+    """Human duration used by slowmodes, timeouts and archive durations."""
+    if seconds is None:
+        return "—"
+    if seconds <= 0:
+        return t("modules.logs.values.disabled", locale=locale)
+    units = (("day", 86400), ("hour", 3600), ("minute", 60), ("second", 1))
+    parts: List[str] = []
+    remaining = int(seconds)
+    for unit, size in units:
+        if remaining >= size:
+            amount, remaining = divmod(remaining, size)
+            parts.append(t(f"modules.logs.values.duration.{unit}",
+                           locale=locale, count=amount))
+        if len(parts) == 2:
+            break
+    return " ".join(parts)
+
+
+def fmt_permissions(permissions: Iterable[str], locale: str) -> str:
+    names = [t(f"modules.logs.permissions.{name}", locale=locale) for name in permissions]
+    return ", ".join(f"`{name}`" for name in names) if names else "—"
+
+
+def escape(text: Optional[str]) -> str:
+    """Neutralise markdown in user-controlled text (names, topics, reasons)."""
+    if not text:
+        return ""
+    return discord.utils.escape_markdown(str(text))
+
+
+def escape_code(text: str) -> str:
+    return str(text).replace("`", "ˋ")
+
+
+def truncate(text: str, limit: int) -> str:
+    text = str(text)
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+# --------------------------------------------------------------------------- #
+# The entry a listener builds
+# --------------------------------------------------------------------------- #
+
+class LogEntry:
+    """A single log message under construction.
+
+    Listeners only ever call :meth:`line`, :meth:`block`, :meth:`subject`,
+    :meth:`actor` and :meth:`attach` — the layout, colours, truncation and
+    overflow-to-file rules are enforced here for every event alike.
+    """
+
+    __slots__ = ("event", "locale", "kind", "_lines", "_blocks", "_files",
+                 "_thumbnail", "_image", "_footer_text", "_footer_icon",
+                 "_timestamp", "_title_override", "_url")
+
+    def __init__(self, event: str, locale: str, *, kind: Optional[str] = None):
+        self.event = event
+        self.locale = locale
+        self.kind = kind
+        self._lines: List[str] = []
+        self._blocks: List[tuple] = []          # (name, value, inline)
+        self._files: List[discord.File] = []
+        self._thumbnail: Optional[str] = None
+        self._image: Optional[str] = None
+        self._footer_text: Optional[str] = None
+        self._footer_icon: Optional[str] = None
+        self._timestamp: datetime = datetime.now(timezone.utc)
+        self._title_override: Optional[str] = None
+        self._url: Optional[str] = None
+
+    # -- content ---------------------------------------------------------- #
+
+    def line(self, label: str, value: Any) -> "LogEntry":
+        """Add a ``> **Label:** value`` line. ``label`` is an i18n field key."""
+        if value in (None, "", "—"):
+            return self
+        name = t(f"modules.logs.fields.{label}", locale=self.locale)
+        self._lines.append(f"> **{name}:** {value}")
+        return self
+
+    def raw_line(self, value: str) -> "LogEntry":
+        """Add a quoted line with no label (used for standalone notes)."""
+        if value:
+            self._lines.append(f"> {value}")
+        return self
+
+    def block(self, label: str, value: Any, *, inline: bool = False,
+              filename: Optional[str] = None) -> "LogEntry":
+        """Add a field for multi-line content (message bodies, before/after).
+
+        Content longer than a field allows is moved to a ``.txt`` attachment
+        automatically — a 3000-character message is never silently cut.
+        """
+        if value in (None, ""):
+            return self
+        name = t(f"modules.logs.fields.{label}", locale=self.locale)
+        text = str(value)
+        if len(text) > MAX_FIELD_VALUE:
+            self.attach(filename or f"{label}.txt", text)
+            note = t("modules.logs.values.moved_to_file", locale=self.locale)
+            self._blocks.append((name, f"{truncate(text, MAX_FIELD_VALUE - 120)}\n\n-# {note}",
+                                 inline))
+        else:
+            self._blocks.append((name, text, inline))
+        return self
+
+    def subject(self, user: Optional[Union[discord.abc.User, discord.Member]],
+                *, label: str = "user", with_id: bool = True) -> "LogEntry":
+        """The user/entity the event is about: line(s) + avatar thumbnail."""
+        if user is None:
+            return self
+        self.line(label, fmt_user(user))
+        if with_id:
+            self.line("id", fmt_user_id(user.id))
+        avatar = getattr(user, "display_avatar", None)
+        if avatar is not None:
+            self._thumbnail = avatar.url
+        return self
+
+    def actor(self, user: Optional[Union[discord.abc.User, discord.Member]],
+              reason: Optional[str] = None) -> "LogEntry":
+        """Who did it — rendered in the footer, plus the audit-log reason."""
+        if reason:
+            self.line("reason", escape(truncate(reason, 400)))
+        if user is not None:
+            self._footer_text = str(user)
+            avatar = getattr(user, "display_avatar", None)
+            self._footer_icon = avatar.url if avatar is not None else None
+        return self
+
+    def thumbnail(self, url: Optional[str]) -> "LogEntry":
+        if url:
+            self._thumbnail = url
+        return self
+
+    def image(self, url: Optional[str]) -> "LogEntry":
+        if url:
+            self._image = url
+        return self
+
+    def url(self, url: Optional[str]) -> "LogEntry":
+        if url:
+            self._url = url
+        return self
+
+    def title(self, text: str) -> "LogEntry":
+        """Override the registry title (rare — prefer an i18n title key)."""
+        self._title_override = text
+        return self
+
+    def at(self, moment: Optional[datetime]) -> "LogEntry":
+        if moment is not None:
+            self._timestamp = moment
+        return self
+
+    def attach(self, filename: str, content: Union[str, bytes]) -> "LogEntry":
+        """Attach a text file (transcripts, overflowing content, diffs)."""
+        data = content.encode("utf-8") if isinstance(content, str) else content
+        self._files.append(discord.File(io.BytesIO(data), filename=filename))
+        return self
+
+    def attach_file(self, file: discord.File) -> "LogEntry":
+        self._files.append(file)
+        return self
+
+    # -- output ----------------------------------------------------------- #
+
+    @property
+    def files(self) -> List[discord.File]:
+        return self._files
+
+    @property
+    def is_empty(self) -> bool:
+        return not self._lines and not self._blocks and not self._files
+
+    def to_embed(self) -> discord.Embed:
+        spec = registry.EVENTS.get(_full_key(self.event))
+        kind = self.kind or (spec.kind if spec else registry.KIND_UPDATE)
+        title = self._title_override or (
+            t(spec.title_key, locale=self.locale) if spec else self.event
+        )
+
+        embed = discord.Embed(
+            title=truncate(title, 250),
+            description=truncate("\n".join(self._lines), MAX_DESCRIPTION) or None,
+            colour=KIND_COLORS.get(kind, FALLBACK_COLOR),
+            timestamp=self._timestamp,
+            url=self._url,
+        )
+        for name, value, inline in self._blocks:
+            embed.add_field(name=truncate(name, 250),
+                            value=truncate(value, MAX_FIELD_VALUE),
+                            inline=inline)
+        if self._thumbnail:
+            embed.set_thumbnail(url=self._thumbnail)
+        if self._image:
+            embed.set_image(url=self._image)
+        if self._footer_text:
+            embed.set_footer(text=truncate(self._footer_text, 2000),
+                             icon_url=self._footer_icon)
+        return embed
+
+
+def _full_key(event: str) -> str:
+    """Accept either a bare event name or a full ``category.event`` key."""
+    if "." in event:
+        return event
+    keys = registry.keys_for(event)
+    return keys[0] if keys else event
+
+
+# --------------------------------------------------------------------------- #
+# Transcripts — a raid deleting 200 messages must not spam 200 embeds
+# --------------------------------------------------------------------------- #
+
+def build_transcript(messages: Sequence[discord.Message], *, guild_name: str,
+                     channel_name: str, header: str) -> discord.File:
+    """Render deleted/purged messages as a readable ``.txt`` attachment."""
+    lines = [
+        header,
+        f"Server : {guild_name}",
+        f"Channel: #{channel_name}",
+        f"Exported: {datetime.now(timezone.utc).isoformat(timespec='seconds')}",
+        f"Messages: {len(messages)}",
+        "=" * 72,
+        "",
+    ]
+    for message in messages:
+        author = getattr(message, "author", None)
+        author_name = f"{author} ({author.id})" if author else "Unknown author"
+        created = getattr(message, "created_at", None)
+        stamp = created.isoformat(timespec="seconds") if created else "unknown time"
+        lines.append(f"[{stamp}] {author_name}")
+        content = (getattr(message, "content", "") or "").rstrip()
+        lines.append(content if content else "(no text content)")
+        for attachment in getattr(message, "attachments", []) or []:
+            lines.append(f"  ↳ attachment: {attachment.filename} — {attachment.url}")
+        for embed in getattr(message, "embeds", []) or []:
+            if embed.title or embed.description:
+                lines.append(f"  ↳ embed: {embed.title or ''} {embed.description or ''}".rstrip())
+        for sticker in getattr(message, "stickers", []) or []:
+            lines.append(f"  ↳ sticker: {sticker.name}")
+        lines.append("")
+
+    data = "\n".join(lines).encode("utf-8")
+    return discord.File(io.BytesIO(data), filename=f"transcript-{channel_name}.txt")

--- a/serverlogs/service.py
+++ b/serverlogs/service.py
@@ -1,0 +1,160 @@
+"""The API every log listener uses.
+
+A listener never touches the configuration, the webhooks or the queues. It
+asks the service to *open* an entry for an event — which returns ``None``
+immediately when the server does not log that event, when the channel is
+muted or when the actor is on the ignore list — fills the entry in, and
+submits it:
+
+.. code-block:: python
+
+    entry = await service.open(member.guild, "user_join", subject=member)
+    if entry is None:
+        return
+    entry.line("account_created", fmt_time(member.created_at))
+    entry.line("member_count", fmt_number(member.guild.member_count))
+    await service.submit(member.guild, entry)
+
+That early ``None`` is what keeps the module cheap: on a server that logs
+nothing, every listener costs one dict lookup.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+import discord
+
+from serverlogs.audit import AuditCache, target_matcher
+from serverlogs.dispatcher import LogDispatcher
+from serverlogs.renderer import LogEntry
+from utils.i18n import i18n
+
+logger = logging.getLogger('moddy.serverlogs.service')
+
+MODULE_ID = "logs"
+
+
+class LogService:
+    """Configuration lookup + rendering context + delivery, in one object."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.dispatcher = LogDispatcher(bot)
+        self.audit = AuditCache()
+
+    # ------------------------------------------------------------------ #
+    # Configuration
+    # ------------------------------------------------------------------ #
+
+    async def module(self, guild: Optional[discord.Guild]):
+        """The guild's :class:`~modules.logs.LogsModule`, or ``None``."""
+        if guild is None or not getattr(self.bot, "module_manager", None):
+            return None
+        try:
+            module = await self.bot.module_manager.get_module_instance(guild.id, MODULE_ID)
+        except Exception as e:
+            logger.debug(f"[Logs] Could not load the logs module for {guild.id}: {e}")
+            return None
+        if module is None or not module.enabled:
+            return None
+        return module
+
+    def locale_for(self, guild: discord.Guild, module) -> str:
+        """Language of the log messages: the configured one, else the server's."""
+        configured = getattr(module, "locale", None)
+        if configured and configured != "auto":
+            return configured
+        preferred = str(guild.preferred_locale) if guild.preferred_locale else "en-US"
+        supported = i18n._supported_locales  # noqa: SLF001 — same package contract
+        if preferred in supported:
+            return preferred
+        base = preferred.split("-")[0]
+        for candidate in supported:
+            if candidate == base or candidate.startswith(f"{base}-"):
+                return candidate
+        return "en-US"
+
+    # ------------------------------------------------------------------ #
+    # Entry lifecycle
+    # ------------------------------------------------------------------ #
+
+    async def open(self, guild: Optional[discord.Guild], event: str, *,
+                   channel: Optional[discord.abc.GuildChannel] = None,
+                   subject: Optional[discord.abc.User] = None,
+                   actor: Optional[discord.abc.User] = None) -> Optional[LogEntry]:
+        """Start a log entry, or ``None`` when this event must not be logged.
+
+        ``channel`` and ``subject``/``actor`` are checked against the
+        server-wide ignore lists here, so no listener has to remember to.
+        """
+        module = await self.module(guild)
+        if module is None or not module.is_event_logged(event):
+            return None
+        if channel is not None and module.is_ignored_channel(channel):
+            return None
+        for user in (subject, actor):
+            if user is not None and module.is_ignored_actor(user):
+                return None
+
+        entry = LogEntry(event, self.locale_for(guild, module))
+        if subject is not None:
+            entry.subject(subject)
+        return entry
+
+    async def submit(self, guild: discord.Guild, entry: Optional[LogEntry]) -> None:
+        """Render and queue the entry for every channel bound to its event."""
+        if entry is None or entry.is_empty:
+            return
+        module = await self.module(guild)
+        if module is None:
+            return
+
+        channel_ids = module.channels_for(entry.event)
+        if not channel_ids:
+            return
+        if not module.attach_transcripts:
+            entry.files.clear()
+
+        embed = entry.to_embed()
+        for index, channel_id in enumerate(channel_ids):
+            # discord.File objects are single-use streams; re-read them for
+            # every destination so a fan-out doesn't send empty attachments.
+            files = entry.files if index == 0 else _clone_files(entry.files)
+            self.dispatcher.enqueue(channel_id, embed, files)
+
+    # ------------------------------------------------------------------ #
+    # Audit log
+    # ------------------------------------------------------------------ #
+
+    async def executor(self, guild: discord.Guild, action: discord.AuditLogAction,
+                       target_id: Optional[int] = None, *, wait: float = 2.0,
+                       extra=None) -> Tuple[Optional[discord.abc.User], Optional[str]]:
+        """``(who, reason)`` for an action, from the audit-log cache."""
+        if guild is None:
+            return None, None
+        entry = await self.audit.wait_for(
+            guild.id, target_matcher(action, target_id, extra), timeout=wait)
+        if entry is None:
+            return None, None
+        return entry.user, entry.reason
+
+    async def close(self) -> None:
+        await self.dispatcher.close()
+
+
+def _clone_files(files):
+    """Duplicate in-memory files so each destination gets its own stream."""
+    import io
+
+    clones = []
+    for file in files:
+        try:
+            file.fp.seek(0)
+            data = file.fp.read()
+            file.fp.seek(0)
+            clones.append(discord.File(io.BytesIO(data), filename=file.filename))
+        except Exception:
+            continue
+    return clones

--- a/services/case_service.py
+++ b/services/case_service.py
@@ -179,6 +179,10 @@ class CaseService:
                     expires_at=expires_at, note=note,
                 )
                 self._invalidate_global(spec, subject_id)
+                await self._log_to_server(
+                    spec, scope_id, subject_id, action_value, issuer_id, reason,
+                    expires_at, existing["reference"],
+                )
                 return {
                     "id": existing["id"], "reference": existing["reference"],
                     "created": False, "sanction_id": sanction_id,
@@ -200,6 +204,10 @@ class CaseService:
         )
         result["created"] = True
         self._invalidate_global(spec, subject_id)
+        await self._log_to_server(
+            spec, scope_id, subject_id, action_value, issuer_id, reason,
+            expires_at, result.get("reference"),
+        )
         return result
 
     async def revoke_sanction(
@@ -230,4 +238,32 @@ class CaseService:
             action_value, by_type_value, by_id,
         )
         self._invalidate_global(spec, subject_id)
+        if revoked:
+            await self._log_to_server(
+                spec, scope_id, subject_id, action_value, by_id, None, None, None,
+                revoked=True,
+            )
         return revoked
+
+    async def _log_to_server(self, spec: CaseSource, scope_id, subject_id,
+                             action: str, issuer_id, reason: Optional[str],
+                             expires_at, reference: Optional[str], *,
+                             revoked: bool = False) -> None:
+        """Mirror a guild-scoped sanction into the server's own mod-log.
+
+        Only guild cases are mirrored: a Moddy-team global sanction is not a
+        server's business, and it is not its moderators who applied it. A
+        failure here never propagates — the sanction is already recorded.
+        """
+        if spec.case_type is not CaseType.GUILD or not scope_id:
+            return
+        try:
+            from serverlogs.listeners.moderation import log_sanction
+
+            await log_sanction(
+                self.bot, guild_id=scope_id, action=action, subject_id=subject_id,
+                issuer_id=issuer_id, reason=reason, expires_at=expires_at,
+                reference=reference, revoked=revoked,
+            )
+        except Exception as exc:
+            logger.debug("Server-log mirror failed for a %s sanction: %s", action, exc)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -16,8 +16,8 @@ from modules.logs import LogsModule, config_from_raw
 from serverlogs import registry
 from serverlogs.dispatcher import LogDispatcher, MAX_EMBEDS_PER_MESSAGE
 from serverlogs.renderer import (
-    KIND_COLORS, LogEntry, build_transcript, fmt_duration, fmt_number,
-    fmt_time, fmt_user,
+    KIND_COLORS, MAX_EMBED_TOTAL, LogEntry, build_transcript, fmt_duration,
+    fmt_number, fmt_time, fmt_user,
 )
 
 
@@ -45,6 +45,16 @@ def test_shared_events_resolve_to_several_categories():
     """A ban is both a server event and a moderation event."""
     assert set(registry.keys_for("ban_add")) == {"server.ban_add", "moderation.ban_add"}
     assert registry.keys_for("user_join") == ("server.user_join",)
+
+
+def test_categories_use_custom_emojis():
+    """CLAUDE.md rule 3: custom emojis only, straight from utils/emojis.py."""
+    import utils.emojis as emojis
+
+    known = {value for name, value in vars(emojis).items()
+             if name.isupper() and isinstance(value, str)}
+    for category in registry.CATEGORIES.values():
+        assert category.emoji in known, category.id
 
 
 def test_category_order_is_stable():
@@ -194,6 +204,25 @@ def test_a_short_block_stays_inline():
     entry.block("message", "hello")
     assert entry.files == []
     assert entry.to_embed().fields[0].value == "hello"
+
+
+def test_an_oversized_embed_is_cut_down_to_a_deliverable_size():
+    """Discord rejects the whole message past its total budget, not just the field."""
+    entry = LogEntry("channel_permissions_update", "en-US")
+    for index in range(25):
+        entry.block(f"role_{index}", "y" * 900)
+    embed = entry.to_embed()
+    assert len(embed) <= MAX_EMBED_TOTAL
+    assert len(embed.fields) < 25
+    assert "-#" in (embed.description or "")
+
+
+def test_an_embed_within_budget_is_left_alone():
+    entry = LogEntry("message_delete", "en-US")
+    entry.block("message", "hello")
+    embed = entry.to_embed()
+    assert embed.description is None
+    assert len(embed.fields) == 1
 
 
 def test_markdown_in_names_is_escaped():

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,278 @@
+"""Advanced server logs — registry, routing, rendering and delivery.
+
+These cover the parts that decide whether a log is emitted at all and what
+it contains; the Discord listeners themselves are thin forwarders (see
+``cogs/logs.py``) and are exercised through the builders' inputs.
+"""
+
+import asyncio
+import types
+from datetime import datetime, timezone
+
+import discord
+import pytest
+
+from modules.logs import LogsModule, config_from_raw
+from serverlogs import registry
+from serverlogs.dispatcher import LogDispatcher, MAX_EMBEDS_PER_MESSAGE
+from serverlogs.renderer import (
+    KIND_COLORS, LogEntry, build_transcript, fmt_duration, fmt_number,
+    fmt_time, fmt_user,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+
+def test_every_event_belongs_to_its_category():
+    for key, spec in registry.EVENTS.items():
+        assert key == f"{spec.category}.{spec.event}"
+        assert spec.event in registry.CATEGORIES[spec.category].events
+
+
+def test_event_kinds_are_known():
+    valid = set(KIND_COLORS)
+    assert {spec.kind for spec in registry.EVENTS.values()} <= valid
+
+
+def test_categories_have_unique_events():
+    for category in registry.CATEGORIES.values():
+        assert len(category.events) == len(set(category.events)), category.id
+
+
+def test_shared_events_resolve_to_several_categories():
+    """A ban is both a server event and a moderation event."""
+    assert set(registry.keys_for("ban_add")) == {"server.ban_add", "moderation.ban_add"}
+    assert registry.keys_for("user_join") == ("server.user_join",)
+
+
+def test_category_order_is_stable():
+    ordered = [c.id for c in registry.ordered_categories()]
+    assert ordered[0] == "server"
+    assert len(ordered) == len(registry.CATEGORIES)
+
+
+# --------------------------------------------------------------------------- #
+# Configuration and routing
+# --------------------------------------------------------------------------- #
+
+def _module(**overrides) -> LogsModule:
+    raw = {
+        "categories": {
+            "server": {"channel_ids": [111], "disabled_events": []},
+            "moderation": {"channel_ids": [222], "disabled_events": []},
+        },
+    }
+    raw.update(overrides)
+    return config_from_raw(None, 1, raw)
+
+
+def test_routing_fans_out_to_every_configured_category():
+    module = _module()
+    assert module.channels_for("ban_add") == [111, 222]
+    assert module.channels_for("user_join") == [111]
+
+
+def test_an_excluded_event_is_not_routed():
+    module = _module(categories={
+        "server": {"channel_ids": [111], "disabled_events": ["user_join"]},
+    })
+    assert module.channels_for("user_join") == []
+    assert module.channels_for("user_leave") == [111]
+
+
+def test_a_category_with_no_channel_routes_nothing():
+    module = config_from_raw(None, 1, {"categories": {
+        "server": {"channel_ids": [], "disabled_events": []}}})
+    assert module.channels_for("user_join") == []
+    assert module.enabled is False
+
+
+def test_a_new_registry_event_is_enabled_by_default():
+    """Only exclusions are stored, so events added later start logged."""
+    module = _module(categories={
+        "channels": {"channel_ids": [333], "disabled_events": ["channel_create"]},
+    })
+    for event in registry.CATEGORIES["channels"].events:
+        expected = [] if event == "channel_create" else [333]
+        assert module.channels_for(event) == expected, event
+
+
+def test_unknown_categories_and_events_are_dropped():
+    module = config_from_raw(None, 1, {"categories": {
+        "server": {"channel_ids": [111], "disabled_events": ["not_an_event"]},
+        "not_a_category": {"channel_ids": [999]},
+    }})
+    assert "not_a_category" not in module.categories
+    assert module.categories["server"].disabled_events == set()
+
+
+def test_snowflakes_stored_as_strings_are_accepted():
+    """The dashboard writes 64-bit ids as JSON strings."""
+    module = config_from_raw(None, 1, {"categories": {
+        "server": {"channel_ids": ["111", "111", "222"]}}})
+    assert module.channels_for("user_join") == [111, 222]
+
+
+def test_round_trip_through_the_stored_schema():
+    module = _module(ignore_bots=True, ignored_channel_ids=[7], locale="fr")
+    restored = config_from_raw(None, 1, module.to_config())
+    assert restored.to_config() == module.to_config()
+    assert restored.ignore_bots is True
+    assert restored.locale == "fr"
+
+
+def test_an_empty_category_is_not_persisted():
+    module = _module()
+    module.category("emojis")  # touched but never configured
+    assert "emojis" not in module.to_config()["categories"]
+
+
+# --------------------------------------------------------------------------- #
+# Ignore lists
+# --------------------------------------------------------------------------- #
+
+def test_ignored_channel_covers_the_parent_category():
+    module = _module(ignored_channel_ids=[500])
+    parent = types.SimpleNamespace(id=500, category=None, parent=None)
+    channel = types.SimpleNamespace(id=42, category=parent, parent=None)
+    assert module.is_ignored_channel(channel) is True
+    assert module.is_ignored_channel(
+        types.SimpleNamespace(id=43, category=None, parent=None)) is False
+
+
+def test_ignored_roles_and_bots():
+    module = _module(ignore_bots=True, ignored_role_ids=[9])
+    bot_user = types.SimpleNamespace(bot=True, roles=[])
+    staff = types.SimpleNamespace(bot=False, roles=[types.SimpleNamespace(id=9)])
+    human = types.SimpleNamespace(bot=False, roles=[types.SimpleNamespace(id=1)])
+    assert module.is_ignored_actor(bot_user) is True
+    assert module.is_ignored_actor(staff) is True
+    assert module.is_ignored_actor(human) is False
+    assert module.is_ignored_actor(None) is False
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+def test_entry_renders_quoted_labelled_lines():
+    entry = LogEntry("user_join", "en-US")
+    entry.line("member_count", fmt_number(664))
+    embed = entry.to_embed()
+    assert embed.description.startswith("> **")
+    assert "`664`" in embed.description
+    assert embed.colour.value == KIND_COLORS[registry.KIND_CREATE]
+
+
+def test_moderation_events_use_the_moderation_accent():
+    assert LogEntry("ban_add", "en-US").to_embed().colour.value == \
+        KIND_COLORS[registry.KIND_MODERATION]
+    assert LogEntry("channel_delete", "en-US").to_embed().colour.value == \
+        KIND_COLORS[registry.KIND_DELETE]
+
+
+def test_empty_values_are_skipped():
+    entry = LogEntry("user_join", "en-US")
+    entry.line("reason", None)
+    entry.line("member_count", "")
+    assert entry.is_empty
+
+
+def test_a_long_block_moves_to_an_attachment():
+    entry = LogEntry("message_delete", "en-US")
+    entry.block("message", "x" * 3000, filename="message.txt")
+    assert len(entry.files) == 1
+    assert entry.files[0].filename == "message.txt"
+    field = entry.to_embed().fields[0]
+    assert len(field.value) <= 1024
+
+
+def test_a_short_block_stays_inline():
+    entry = LogEntry("message_delete", "en-US")
+    entry.block("message", "hello")
+    assert entry.files == []
+    assert entry.to_embed().fields[0].value == "hello"
+
+
+def test_markdown_in_names_is_escaped():
+    user = types.SimpleNamespace(id=5, name="**boss**", display_avatar=None)
+    assert "\\*\\*boss\\*\\*" in fmt_user(user)
+    assert "(<@5>)" in fmt_user(user)
+
+
+def test_relative_timestamps_are_discord_formatted():
+    moment = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert fmt_time(moment) == f"<t:{int(moment.timestamp())}:R>"
+    assert fmt_time(None) == "—"
+
+
+def test_durations_read_in_the_reader_language():
+    assert fmt_duration(0, "en-US")          # "Disabled", not empty
+    assert "1" in fmt_duration(3600, "en-US")
+    assert fmt_duration(None, "en-US") == "—"
+
+
+def test_transcript_lists_every_message():
+    messages = [
+        types.SimpleNamespace(
+            author=types.SimpleNamespace(id=1, __str__=lambda self: "alice"),
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            content="first", attachments=[], embeds=[], stickers=[]),
+        types.SimpleNamespace(
+            author=None, created_at=None, content="",
+            attachments=[], embeds=[], stickers=[]),
+    ]
+    file = build_transcript(messages, guild_name="Guild", channel_name="general",
+                            header="Transcript")
+    body = file.fp.read().decode("utf-8")
+    assert "Messages: 2" in body
+    assert "first" in body
+    assert "(no text content)" in body
+    assert file.filename == "transcript-general.txt"
+
+
+# --------------------------------------------------------------------------- #
+# Delivery
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_dispatcher_batches_embeds_into_one_call():
+    sent = []
+
+    class _Channel:
+        id = 1
+        guild = None
+
+        async def send(self, **kwargs):
+            sent.append(kwargs)
+
+    bot = types.SimpleNamespace(get_channel=lambda _id: _Channel(), user=None)
+    dispatcher = LogDispatcher(bot)
+    # No webhook is resolvable without a guild, so delivery falls back to send.
+    dispatcher._webhooks[1] = None
+
+    for index in range(MAX_EMBEDS_PER_MESSAGE + 2):
+        dispatcher.enqueue(1, discord.Embed(title=str(index)))
+    await asyncio.sleep(1.2)
+    await dispatcher.close()
+
+    assert sent, "nothing was delivered"
+    assert sum(len(call["embeds"]) for call in sent) == MAX_EMBEDS_PER_MESSAGE + 2
+    assert max(len(call["embeds"]) for call in sent) > 1, "no batching happened"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_drops_the_oldest_under_a_flood():
+    bot = types.SimpleNamespace(get_channel=lambda _id: None, user=None)
+    instance = LogDispatcher(bot)
+    queue = asyncio.Queue(maxsize=2)
+    instance._queues[1] = queue
+
+    for index in range(5):
+        instance.enqueue(1, discord.Embed(title=str(index)))
+
+    assert queue.qsize() <= 2
+    assert instance._dropped[1] == 3
+    await instance.close()

--- a/tests/test_logs_i18n.py
+++ b/tests/test_logs_i18n.py
@@ -1,0 +1,126 @@
+"""Every server-log string must exist in every locale.
+
+The logs system has 163 events across 18 categories and roughly a hundred
+field labels, all resolved at render time. A missing key does not crash: it
+renders as ``[modules.logs.…]`` in a production log channel. These tests are
+what stops that from shipping.
+
+The field/value keys are discovered by reading the listener sources, so a new
+``entry.line("something")`` fails here until it is translated — which is
+exactly the point.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from serverlogs import registry
+
+ROOT = Path(__file__).resolve().parent.parent
+LOCALES = ("fr", "en-US", "es-ES", "pt-BR", "de")
+
+#: Keys built at runtime from a variable rather than a literal, so the source
+#: scan cannot see them. Kept explicit rather than loosening the regex.
+DYNAMIC_FIELD_KEYS = {
+    "keyword_filter", "regex_patterns", "presets", "allow_list",
+}
+
+_LINE_RE = re.compile(r"\.(?:line|block)\(\s*[\"']([a-z_]+)[\"']")
+_LABEL_RE = re.compile(r"label\s*=\s*[\"']([a-z_]+)[\"']\s*[,)]")
+_VALUE_RE = re.compile(r"modules\.logs\.values\.([a-z_]+)[\"']")
+
+
+def _load(locale: str) -> dict:
+    with open(ROOT / "locales" / f"{locale}.json", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _logs_block(locale: str) -> dict:
+    block = _load(locale).get("modules", {}).get("logs")
+    assert block, f"locales/{locale}.json has no modules.logs block"
+    return block
+
+
+def _sources():
+    for path in (ROOT / "serverlogs").rglob("*.py"):
+        yield path.read_text(encoding="utf-8")
+
+
+def _used_field_keys() -> set:
+    keys = set(DYNAMIC_FIELD_KEYS)
+    for source in _sources():
+        keys |= set(_LINE_RE.findall(source))
+        keys |= set(_LABEL_RE.findall(source))
+    return keys
+
+
+def _used_value_keys() -> set:
+    keys = set()
+    for source in _sources():
+        keys |= set(_VALUE_RE.findall(source))
+    return keys
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_every_event_has_a_name_and_a_title(locale):
+    block = _logs_block(locale)
+    missing = []
+    for spec in registry.EVENTS.values():
+        if not block.get("events", {}).get(spec.category, {}).get(spec.event):
+            missing.append(f"events.{spec.key}")
+        if not block.get("titles", {}).get(spec.category, {}).get(spec.event):
+            missing.append(f"titles.{spec.key}")
+    assert not missing, f"{locale} is missing: {missing[:20]} ({len(missing)} total)"
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_every_category_is_described(locale):
+    block = _logs_block(locale)
+    missing = [
+        category.id for category in registry.CATEGORIES.values()
+        if not block.get("categories", {}).get(category.id, {}).get("name")
+        or not block.get("categories", {}).get(category.id, {}).get("description")
+    ]
+    assert not missing, f"{locale} has undescribed categories: {missing}"
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_every_field_label_used_by_a_listener_is_translated(locale):
+    fields = _logs_block(locale).get("fields", {})
+    missing = sorted(key for key in _used_field_keys() if key not in fields)
+    assert not missing, f"{locale} is missing field labels: {missing}"
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_every_standalone_value_is_translated(locale):
+    values = _logs_block(locale).get("values", {})
+    missing = sorted(key for key in _used_value_keys() if key not in values)
+    assert not missing, f"{locale} is missing values: {missing}"
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_every_discord_permission_is_translated(locale):
+    import discord
+
+    permissions = _logs_block(locale).get("permissions", {})
+    missing = sorted(name for name in discord.Permissions.VALID_FLAGS
+                     if name not in permissions)
+    assert not missing, f"{locale} is missing permission names: {missing}"
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_no_stale_event_translations(locale):
+    """A renamed event must not leave its old translation behind."""
+    block = _logs_block(locale)
+    stale = []
+    for section in ("events", "titles"):
+        for category_id, events in block.get(section, {}).items():
+            category = registry.CATEGORIES.get(category_id)
+            if category is None:
+                stale.append(f"{section}.{category_id}")
+                continue
+            stale.extend(f"{section}.{category_id}.{event}" for event in events
+                         if event not in category.events)
+    assert not stale, f"{locale} has stale entries: {stale}"

--- a/tests/test_persistent_views.py
+++ b/tests/test_persistent_views.py
@@ -119,6 +119,9 @@ def _dynamic_item_cases():
     from cogs.reminder import ReminderManageButton
     from cogs.saved_messages import SavedMessagesListButton, SavedMessagesDetailButton
     from modules.configs.adaptive_slowmode_config import SlowmodeListButton
+    from modules.configs.logs_config import (
+        LogsCategoryButton, LogsCategoryChannels, LogsCategoryEvents,
+    )
     from staff.commands.team.help import HelpDeptSelect
     from staff.commands.dev.serverlist import ServerListNavButton
     from staff.commands.manage.staff import (
@@ -141,6 +144,9 @@ def _dynamic_item_cases():
         (SavedMessagesListButton, ("view", _SNOWFLAKE, 0)),
         (SavedMessagesDetailButton, ("back", _SNOWFLAKE, 42, 0)),
         (SlowmodeListButton, ("edit", _SNOWFLAKE)),
+        (LogsCategoryChannels, ("server",)),
+        (LogsCategoryEvents, ("server", 1)),
+        (LogsCategoryButton, ("next", "server", 1)),
         (HelpDeptSelect, (_SNOWFLAKE,)),
         (ServerListNavButton, ("prev", _SNOWFLAKE, 2)),
         (StaffPanelRolesSelect, (_SNOWFLAKE, _SNOWFLAKE2)),

--- a/utils/persistent_views.py
+++ b/utils/persistent_views.py
@@ -62,6 +62,9 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
     from modules.configs.voice_transcription_config import VoiceTranscriptionConfigView
     from modules.configs.bot_customization_config import BotCustomizationConfigView
     from modules.configs.altguard_config import AltGuardConfigView
+    from modules.configs.logs_config import (
+        LogsConfigView, LogsOptionsView, LogsPersistence,
+    )
     from utils.altguard_views import AltGuardPanelView
 
     return [
@@ -124,6 +127,14 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
         # modal is excluded like every other modal)
         AltGuardConfigView,
         AltGuardPanelView,
+        # Group 12f — /config server logs: the root and options panels
+        # (guild permission auth) plus the category panel's dynamic items,
+        # which carry the category and page in their custom_id.
+        # LogsCategoryView itself is deliberately not registered — see its
+        # docstring and docs/PERSISTENT_VIEWS.md "Deliberate exclusions".
+        LogsConfigView,
+        LogsOptionsView,
+        LogsPersistence,
         # Group 13 — /config automod AI panel (guild permission auth;
         # AutomodAIPrecedentsView is deliberately excluded, see
         # docs/PERSISTENT_VIEWS.md Step 12)


### PR DESCRIPTION
Adds a full server-logs feature: **163 events across 18 categories**, each category bound to one or more channels through `/config` → Logs.

## What it does

One embed per event in the channel its category is bound to — title from i18n, facts as `> **Label:** value` lines, the subject's avatar as thumbnail, the executor in the footer, and an accent colour stating the nature of the event (green created, red deleted, blurple changed, orange a moderator acted).

Categories: server (35), channels (21), moderation (17), events (12), threads (9), automod (9), roles (8), users (7), voice (6), messages (5), stickers (5), soundboard (5), polls (5), webhooks (5), emojis (4), stage (4), invites (3), applications (3).

## Structure

```
serverlogs/
├── registry.py      single catalogue of categories + events (source of truth)
├── renderer.py      the only place deciding what a log looks like + formatters
├── dispatcher.py    per-channel webhooks, 10-embed batching, bounded queues
├── audit.py         gateway-fed audit-log cache ("who did this", no REST call)
├── service.py       listener API: open() / submit() / executor()
└── listeners/       one builder module per category + _diff.py (before/after)

modules/logs.py                  configuration + routing
modules/configs/logs_config.py   /config panel (3 screens, applied immediately)
cogs/logs.py                     Discord wiring only (forwards to the builders)
```

Each layer has one job: `cogs/logs.py` never decides what a log says, `renderer.py` is the only thing that decides what one looks like, and `registry.py` is the only place an event is declared. Adding an event is the registry + two i18n keys + one builder; changing the wording of a log is locale JSON only, no Python.

## Design decisions

- **Classic embeds, not Components V2.** Logs go out through channel webhooks, and Discord rejects the `IS_COMPONENTS_V2` flag on a webhook message carrying a classic embed — the same documented exception `modules/starboard.py` relies on. The `/config` panel itself is Components V2 as usual.
- **Only exclusions are persisted.** A category stores its channels and the events ticked *off*, so an event added to the registry later starts enabled on servers that already bound its category.
- **The category panel applies every change immediately.** It is built from `DynamicItem`s carrying the category and page in their `custom_id`; a dynamic item is rebuilt on every click, so there is no `self` on which to stage edits behind a Save button. Same reasoning as `StaffManagerPanel`.
- **One act, one log (`merge_duplicates`, on by default).** Discord and Moddy describe the same act several ways on purpose: a mute is a case (`moderation.mute_add`), a Discord timeout (`users.user_timed_out`) and that timeout mirrored back into the moderation category — three near-identical embeds when a server sends everything to one channel. Declared *merge families* let the service hold the siblings for 3 s (they come from different sources, in no guaranteed order) and deliver the richest one, enriched with the labels the others had and it did not, naming what it absorbed. Merging is **per channel**, so a server that already splits its categories across channels loses nothing; and only declared families are ever held back — a generic "same event, same subject" rule would collapse two messages deleted in a row from the same author, and losing a log is worse than showing two. Toggled off in the Options screen for one log per registry event.
- **Delivery is built for the raid case**, which is when logs fire hardest: webhooks (their own rate-limit bucket), up to 10 embeds per request batched over 0.75 s, one bounded queue and worker per destination channel that drops the oldest entries under a flood rather than growing without bound, and a `channel.send` fallback when `manage_webhooks` is missing.
- **Audit correlation costs no REST call**: every `on_audit_log_entry_create` feeds a short-lived cache, and a listener needing an executor waits up to 2 s for a match.
- **i18n is enforced by tests.** `tests/test_logs_i18n.py` reads the listener sources, so a new `entry.line("x")` fails the suite until it is translated in `fr`, `en-US`, `es-ES`, `pt-BR` and `de`. A missing key does not crash — it renders as `[modules.logs.…]` in a production log channel, which is exactly what must not ship.

## Documentation

`docs/LOGS.md` covers the architecture, the stored schema of `guilds.data.modules.logs` with the backend/dashboard contract, merging, delivery, how to add an event, and a *Known gaps* section naming every deliberate hole. `CLAUDE.md`, `docs/PERSISTENT_VIEWS.md` (the `LogsCategoryView` exclusion) and `docs/sessions/` updated.

## Known gaps (documented, not hidden)

- **Never run against a real Discord server.** Worth checking on a test guild before production: webhook creation and reuse, the `manage_webhooks` fallback, batching under a burst of deletions, the 1–2 s audit-correlation windows, the merged rendering, and one rendering per category.
- **`channel_voice_status_update`** is matched on the raw audit action id `192` — Discord ships no gateway event and discord.py has no enum member. If the id is wrong the event is simply inert.
- **Nine `moderation` events have no caller yet** (`case_delete`, `mass_case_delete`, `kick_remove`, `report_create`, `reports_ignore`, `reports_accept`, `user_note_add`, `user_note_remove`, and `case_update` beyond the `restrict`/`revoke_access` sanctions): Moddy cannot delete a case and has no report system. They are declared on purpose so they light up the day those features land, with their hook-ups documented.
- **Merge families are hand-declared**, so a future pair of events describing one act has to be added to `_MERGE_FAMILIES` or it will duplicate again. Family events are also delivered ~3 s late (up to ~5 s for a kick, which already waits on the audit log).
- **Logs are not premium-gated** and `MAX_CHANNELS_PER_CATEGORY = 3` / `MAX_IGNORED_* = 25` are working values — both are open product decisions, documented rather than decided.

## Tests

`python3 -m pytest -q` → **1026 passed** (66 of them new: `tests/test_logs.py`, `tests/test_logs_i18n.py`), `tests/test_persistent_views.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSib5xQLYRem1UchkooDhc