### PR TITLE
Add Tickets module: configurable support tickets with panels and categories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ moddy/
 │   ├── logs.py                #   Advanced server logs — Discord wiring only
 │   ├── social_notifications.py #  Social notifications dispatch + feeds service wiring
 │   ├── altguard.py            #   AltGuard verdicts, membership events, /altguard verify|unverify
+│   ├── tickets.py             #   /ticket group (module-gated) + ticket channel cleanup
 │   ├── interserver_commands.py #  Inter-server commands
 │   ├── ping.py, user.py, avatar.py, banner.py, roll.py, moddy.py
 │   ├── subscription.py        #   Premium features
@@ -74,6 +75,7 @@ moddy/
 │   ├── interserver.py         #   Inter-server message relay
 │   ├── social_notifications.py #  Social notifications (via moddy-feeds service)
 │   ├── altguard.py            #   AltGuard anti multi-account verification gate
+│   ├── tickets.py             #   Tickets (panels, categories, per-role permissions)
 │   ├── automod_ai.py          #   Automod AI (applies decisions, cases+evidence, scalable features)
 │   ├── bot_customization.py   #   Bot identity per guild (nick/avatar/banner/bio + name style)
 │   ├── voice_transcription.py #   Voice message transcription (button or automatic)
@@ -86,6 +88,9 @@ moddy/
 │       ├── automod_ai_precedents_view.py  # Learned-precedents browser (S7)
 │       ├── welcome_channel_config.py      # Welcome messages list + add/manage (Modal V2)
 │       ├── welcome_dm_config.py           # Welcome DMs list + add/manage (Modal V2)
+│       ├── tickets_config.py              # Tickets: panel list (root screen)
+│       ├── tickets_panel_config.py        # Tickets: one panel (channel, style, categories)
+│       ├── tickets_category_config.py     # Tickets: one category + its per-role permissions
 │       ├── voice_transcription_config.py  # Voice transcription (status, mode, channels)
 │       ├── bot_customization_config.py    # Bot customization (identity Modal V2 + name style)
 │       ├── logs_config.py                 # Server logs (categories, events, options)
@@ -141,6 +146,7 @@ moddy/
 │       ├── reminders.py, saved_messages.py, saved_roles.py
 │       ├── moderation.py, interserver.py, attributes.py
 │       ├── altguard.py          #   AltGuard verifications + gate state (altguard_*)
+│       ├── tickets.py           #   Live ticket state (tickets table)
 │       ├── appeals.py           #   Automod sanction appeals (case_appeals)
 │       ├── enforcements.py      #   Global sanction appeal countdowns (case_enforcements)
 │       ├── eval_candidates.py   #   Automod eval/annotation corpus (automod_eval_candidates)
@@ -166,6 +172,7 @@ moddy/
 │   ├── altguard_views.py      #   AltGuard panel (persistent), consent Modal V2, link + log cards
 │   ├── automod_shadow_views.py #  Automod shadow-mode (dry_run) SIMULATION card + annotation buttons (persistent)
 │   ├── automod_render.py      #   Shared automod card helpers (barème breakdown, sanction name/accent)
+│   ├── ticket_views.py        #   Ticket panel, control bar, closing card, participants
 │   ├── transcription_views.py #   Voice transcription cards + persistent Transcribe button
 │   ├── appeal_views.py        #   Automod appeal UI (DM buttons + reviewer panels, persistent)
 │   ├── expiration_views.py    #   Sanction-expiration DM (unban/unmute/unwarn + invite)
@@ -206,6 +213,7 @@ moddy/
 │   ├── global_sanction_service.py # Global sanctions: grouped cases, notice DM, 48h countdown, Redis
 │   ├── appeal_service.py      #   Automod sanction appeals (server / Moddy team, binding)
 │   ├── precedent_service.py   #   Automod server precedents (record + serve, RAG)
+│   ├── ticket_service.py      #   Ticket lifecycle (open/close/escalate/move/participants)
 │   ├── transcription_service.py #  Voice/audio speech-to-text (shared by cog + module)
 │   └── railway_diagnostic.py  #   Railway diagnostics
 │
@@ -235,6 +243,7 @@ moddy/
     ├── test_bot_customization.py  # Bot customization validation (bio budget, styles)
     ├── test_expiration_notifications.py # Expired sanctions: unban, invite, DM card
     ├── test_task_signature.py #   moddy:tasks HMAC contract (canonicalization, replay, dedup)
+    ├── test_tickets.py        #   Tickets: schema, permissions, overwrites, screens, i18n
     ├── test_transcription.py  #   Voice transcription helpers, guard rails, cards
     ├── test_logs.py           #   Server logs: registry, routing, rendering, delivery
     └── test_logs_i18n.py      #   Server logs: i18n completeness on the 5 locales
@@ -393,6 +402,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/MODULE_SYSTEM.md](docs/MODULE_SYSTEM.md) | Creating or modifying server modules |
 | [docs/WELCOME_MESSAGES.md](docs/WELCOME_MESSAGES.md) | Welcome messages module (`welcome_channel`) — config schema, placeholders, backend/dashboard contract |
 | [docs/WELCOME_DM.md](docs/WELCOME_DM.md) | Welcome DM module (`welcome_dm`) — config schema, placeholders, backend/dashboard contract |
+| [docs/TICKETS.md](docs/TICKETS.md) | **Tickets** — panels, categories, per-role permissions, escalation, module-gated `/ticket` commands |
 | [docs/ALTGUARD.md](docs/ALTGUARD.md) | **AltGuard** — anti multi-account verification gate, consent, service contract, staff commands |
 | [docs/ALTGUARD_INTEGRATION.md](docs/ALTGUARD_INTEGRATION.md) | AltGuard ↔ bot exact wire contract — payload types, error codes, debugging |
 | [docs/AUTOMOD_AI.md](docs/AUTOMOD_AI.md) | Automod AI — detection pipeline, nano decider, scalable features, rules safety check |

--- a/bot.py
+++ b/bot.py
@@ -8,7 +8,7 @@ from discord.ext import commands, tasks
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Optional, Set
+from typing import Dict, Optional, Set
 import os
 import sys
 from pathlib import Path
@@ -129,6 +129,8 @@ class ModdyBot(ModdyFrameworkBot):
         from services.altguard_client import AltGuardClient
         # AltGuard anti multi-account verification (HTTP + altguard:* Pub/Sub)
         self.altguard = AltGuardClient(self)
+        from services.ticket_service import TicketService
+        self.tickets = TicketService(self)  # ticket lifecycle (open/close/escalate…)
         from gateway import Gateway
         self.gateway = Gateway()
         self.redis = None  # Redis client (shared with backend)
@@ -149,6 +151,16 @@ class ModdyBot(ModdyFrameworkBot):
         # framework cog; synced ONLY to OFFICIAL guilds. Never added to the
         # global tree, so they can never leak to non-official servers.
         self.staff_slash_groups = []
+
+        # Commands owned by a server module (e.g. /ticket), published ONLY in
+        # the guilds where that module is enabled — see
+        # register_module_commands(). module_id -> [app command objects].
+        self.module_slash_commands: Dict[str, list] = {}
+
+        # What each guild's module command set was the last time it was synced.
+        # Discord rate-limits guild command syncs hard, so a config save that
+        # does not change which modules own commands must not spend one.
+        self._guild_module_commands: Dict[int, frozenset] = {}
 
         # Serveur HTTP interne pour /status
         self.internal_api_server = None
@@ -1075,19 +1087,95 @@ class ModdyBot(ModdyFrameworkBot):
             logger.error(f"[FAIL] Could not fetch OFFICIAL guilds: {e}")
             return set()
 
-    def _register_guild_command_set(self, guild: discord.Guild, official_ids: set):
+    def register_module_commands(self, module_id: str, commands_list: list) -> None:
+        """Publish these commands only in guilds where ``module_id`` is enabled.
+
+        A cog calls this at load time with commands it deliberately never added
+        to the global tree (declare them at module level, not as a Cog
+        attribute, or discord.py registers them globally for you). They are then
+        added to a guild's tree by :meth:`_register_guild_command_set` and
+        removed again the moment the module is switched off, so a server that
+        does not use a module never sees its commands at all.
+        """
+        self.module_slash_commands[module_id] = list(commands_list)
+        logger.info(f"Module commands registered for '{module_id}': "
+                    f"{[c.name for c in commands_list]}")
+
+    async def get_enabled_module_ids(self, guild_id: int) -> Set[str]:
+        """Modules currently enabled in a guild, restricted to those with commands.
+
+        Only modules that actually own commands are looked at: the answer feeds
+        the command tree and nothing else, so there is no reason to pay for the
+        rest.
+        """
+        if not self.module_manager or not self.module_slash_commands:
+            return set()
+
+        enabled = set()
+        for module_id in self.module_slash_commands:
+            try:
+                module = await self.module_manager.get_module_instance(guild_id, module_id)
+            except Exception as e:
+                logger.error(f"[FAIL] Could not read module {module_id} for guild "
+                             f"{guild_id}: {e}")
+                continue
+            if module and module.enabled:
+                enabled.add(module_id)
+        return enabled
+
+    def _register_guild_command_set(self, guild: discord.Guild, official_ids: set,
+                                    module_ids: Optional[Set[str]] = None):
         """(Re)build the per-guild command tree: guild-only commands for every
-        guild, plus the staff slash groups for OFFICIAL guilds only."""
+        guild, the commands of the modules this guild has enabled, plus the
+        staff slash groups for OFFICIAL guilds only."""
         self.tree.clear_commands(guild=guild)
 
         # Guild-only commands (e.g. /config) for every server with Moddy.
         for command in self._guild_only_commands:
             self.tree.add_command(command, guild=guild)
 
+        # Commands owned by an enabled module (e.g. /ticket).
+        for module_id in sorted(module_ids or ()):
+            for command in self.module_slash_commands.get(module_id, []):
+                self.tree.add_command(command, guild=guild)
+
         # Staff command groups only on OFFICIAL servers.
         if guild.id in official_ids:
             for group in (self.staff_slash_groups or []):
                 self.tree.add_command(group, guild=guild)
+
+    async def resync_module_commands(self, guild_id: int) -> bool:
+        """Re-sync a guild's commands if its enabled-module set just changed.
+
+        Called after any module configuration change (``/config``, the
+        dashboard, a deletion). Returns True when a sync was actually sent —
+        which only happens when the set of modules owning commands changed,
+        because guild command syncs are rate-limited and a save that toggles a
+        colour must not cost one.
+        """
+        guild = self.get_guild(guild_id)
+        if guild is None or not self.module_slash_commands:
+            return False
+
+        module_ids = await self.get_enabled_module_ids(guild_id)
+        if self._guild_module_commands.get(guild_id) == frozenset(module_ids):
+            return False
+
+        try:
+            official_ids = await self.get_official_guild_ids()
+            self._register_guild_command_set(guild, official_ids, module_ids)
+            await self.tree.sync(guild=guild)
+            self._guild_module_commands[guild_id] = frozenset(module_ids)
+            logger.info(f"Module commands re-synced for {guild.name} ({guild_id}): "
+                        f"{sorted(module_ids) or 'none'}")
+            return True
+        except discord.Forbidden:
+            logger.warning(f"[WARN] Cannot sync commands for guild {guild_id} "
+                           f"(missing applications.commands scope)")
+        except Exception as e:
+            logger.error(f"[FAIL] Error re-syncing module commands for guild "
+                         f"{guild_id}: {e}")
+        return False
 
     async def sync_all_guild_commands(self):
         """
@@ -1106,11 +1194,14 @@ class ModdyBot(ModdyFrameworkBot):
             for guild in self.guilds:
                 try:
                     # IMPORTANT: Clear d'abord toutes les commandes de ce serveur
-                    # puis ajoute guild-only (+ staff groups si serveur officiel).
-                    self._register_guild_command_set(guild, official_ids)
+                    # puis ajoute guild-only (+ commandes des modules activés,
+                    # + staff groups si serveur officiel).
+                    module_ids = await self.get_enabled_module_ids(guild.id)
+                    self._register_guild_command_set(guild, official_ids, module_ids)
 
                     # Sync les commandes de ce serveur (ou sync vide si rien)
                     await self.tree.sync(guild=guild)
+                    self._guild_module_commands[guild.id] = frozenset(module_ids)
 
                     guild_count += 1
                     logger.info(f"Guild commands synced for {guild.name} ({guild.id})")
@@ -1138,12 +1229,15 @@ class ModdyBot(ModdyFrameworkBot):
             guild: Le serveur pour lequel synchroniser les commandes
         """
         try:
-            # Clear puis ajoute guild-only (+ staff groups si serveur officiel).
+            # Clear puis ajoute guild-only (+ commandes des modules activés,
+            # + staff groups si serveur officiel).
             official_ids = await self.get_official_guild_ids()
-            self._register_guild_command_set(guild, official_ids)
+            module_ids = await self.get_enabled_module_ids(guild.id)
+            self._register_guild_command_set(guild, official_ids, module_ids)
 
             # Synchroniser les commandes pour ce serveur (ou sync vide si rien)
             await self.tree.sync(guild=guild)
+            self._guild_module_commands[guild.id] = frozenset(module_ids)
 
             logger.info(f"Commands synced for {guild.name} ({guild.id})")
         except Exception as e:

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -273,6 +273,14 @@ class ConfigMainView(BaseView):
                 user_id,
                 locale
             )
+        elif module_id == 'tickets':
+            from modules.configs.tickets_config import TicketsConfigView
+            config_view = await TicketsConfigView.create(
+                bot,
+                guild_id,
+                user_id,
+                locale
+            )
         elif module_id == 'automod_ai':
             from modules.configs.automod_ai_config import AutomodAIConfigView
             config_view = AutomodAIConfigView(
@@ -285,9 +293,6 @@ class ConfigMainView(BaseView):
             # Session 7: load the learned-precedents count before first render.
             await config_view.load_precedent_stats()
         # Ajouter d'autres modules ici au fur et à mesure
-        # elif module_id == 'ticket':
-        #     from modules.configs.ticket_config import TicketConfigView
-        #     config_view = TicketConfigView(...)
 
         if config_view:
             # Affiche la vue de configuration du module

--- a/cogs/tickets.py
+++ b/cogs/tickets.py
@@ -1,0 +1,434 @@
+"""
+Tickets cog — the ``/ticket`` command group and the module's Discord events.
+
+**Every** ticket action is available here as a slash command, including the
+five that also have a button on the pinned control bar. The buttons are the
+shortcut; the commands are the contract. Both call the same
+:class:`~services.ticket_service.TicketService` method, so they can never drift
+apart.
+
+The group is declared at **module level**, not as a Cog attribute: a Cog
+attribute would be added to the global command tree by discord.py, and the
+whole point is that ``/ticket`` exists **only in guilds where the Tickets
+module is enabled**. ``setup()`` hands it to
+``ModdyBot.register_module_commands``, which publishes it per guild and
+withdraws it the moment the module is switched off.
+
+See docs/TICKETS.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Union
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from modules.tickets import (
+    MODULE_ID,
+    PERM_PARTICIPANTS,
+    PERM_RENAME,
+    member_permissions,
+)
+from services.ticket_service import TicketError
+from utils.components_v2 import create_success_message
+from utils.i18n import i18n, t
+from utils.ticket_views import (
+    TicketParticipantsView,
+    TicketRenameModal,
+    handle_ticket_error,
+    run_staff_thread,
+    send_error,
+    send_success,
+    start_escalation,
+)
+
+logger = logging.getLogger('moddy.cogs.tickets')
+
+
+# --------------------------------------------------------------------------- #
+# The command group (module-level on purpose — see the module docstring)
+# --------------------------------------------------------------------------- #
+ticket_group = app_commands.Group(
+    name="ticket",
+    description="Manage the ticket you are in",
+    guild_only=True,
+)
+
+
+async def _service_and_ticket(interaction: discord.Interaction):
+    """``(service, ticket, panel, category)`` for the channel the command ran in.
+
+    Answers the user and returns ``None`` when the channel is not a ticket —
+    the check every single subcommand starts with.
+    """
+    service = getattr(interaction.client, 'tickets', None)
+    locale = i18n.get_user_locale(interaction)
+    if service is None or not isinstance(interaction.channel, discord.TextChannel):
+        await send_error(interaction,
+                         t('modules.tickets.errors.not_a_ticket', locale=locale), locale)
+        return None
+    try:
+        ticket, panel, category = await service.resolve(interaction.channel)
+    except TicketError as e:
+        await handle_ticket_error(interaction, e)
+        return None
+    return service, ticket, panel, category
+
+
+# --------------------------------------------------------------------------- #
+# Close / reopen
+# --------------------------------------------------------------------------- #
+@ticket_group.command(name="close", description="Close this ticket")
+@app_commands.describe(reason="Why the ticket is being closed")
+async def ticket_close(interaction: discord.Interaction, reason: Optional[str] = None):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    service = resolved[0]
+    locale = i18n.get_user_locale(interaction)
+
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    try:
+        await service.close_ticket(interaction.channel, interaction.user, reason)
+    except TicketError as e:
+        await handle_ticket_error(interaction, e)
+        return
+    await send_success(interaction,
+                       t('modules.tickets.close.done_title', locale=locale),
+                       t('modules.tickets.close.done_description', locale=locale))
+
+
+@ticket_group.command(name="reopen", description="Reopen this closed ticket")
+async def ticket_reopen(interaction: discord.Interaction):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    service = resolved[0]
+    locale = i18n.get_user_locale(interaction)
+
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    try:
+        await service.reopen_ticket(interaction.channel, interaction.user)
+    except TicketError as e:
+        await handle_ticket_error(interaction, e)
+        return
+    await send_success(interaction,
+                       t('modules.tickets.reopen.done_title', locale=locale),
+                       t('modules.tickets.reopen.done_description', locale=locale))
+
+
+@ticket_group.command(name="close-request",
+                      description="Ask the staff to close this ticket")
+@app_commands.describe(reason="Why you would like the ticket closed")
+async def ticket_close_request(interaction: discord.Interaction,
+                               reason: Optional[str] = None):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    service = resolved[0]
+    locale = i18n.get_user_locale(interaction)
+
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    try:
+        await service.request_close(interaction.channel, interaction.user, reason)
+    except TicketError as e:
+        await handle_ticket_error(interaction, e)
+        return
+    await send_success(
+        interaction,
+        t('modules.tickets.close_request.sent_title', locale=locale),
+        t('modules.tickets.close_request.sent_description', locale=locale))
+
+
+# --------------------------------------------------------------------------- #
+# Escalation
+# --------------------------------------------------------------------------- #
+@ticket_group.command(name="escalate",
+                      description="Restrict this ticket to the responsibles")
+@app_commands.describe(reason="Why the ticket is being escalated")
+async def ticket_escalate(interaction: discord.Interaction,
+                          reason: Optional[str] = None):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    service, ticket, panel, category = resolved
+    await start_escalation(interaction, service, ticket, category, reason)
+
+
+@ticket_group.command(name="deescalate", description="Undo the escalation")
+async def ticket_deescalate(interaction: discord.Interaction):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    service = resolved[0]
+    locale = i18n.get_user_locale(interaction)
+
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    try:
+        await service.deescalate(interaction.channel, interaction.user)
+    except TicketError as e:
+        await handle_ticket_error(interaction, e)
+        return
+    await send_success(
+        interaction,
+        t('modules.tickets.escalate.cancelled_title', locale=locale),
+        t('modules.tickets.escalate.cancelled_description', locale=locale))
+
+
+# --------------------------------------------------------------------------- #
+# Move
+# --------------------------------------------------------------------------- #
+async def _category_autocomplete(interaction: discord.Interaction, current: str
+                                 ) -> List[app_commands.Choice[str]]:
+    """Every ticket category of the guild, as ``Panel › Category``.
+
+    The value is ``panel_id:category_id`` because a category is only unique
+    inside its panel.
+    """
+    service = getattr(interaction.client, 'tickets', None)
+    if service is None or interaction.guild_id is None:
+        return []
+    module = await service.get_module(interaction.guild_id)
+    if not module:
+        return []
+
+    needle = (current or "").lower()
+    choices = []
+    for panel in module.panels:
+        for category in panel.get('categories', []):
+            if not category.get('enabled') or not category.get('discord_category_id'):
+                continue
+            label = f"{panel['name']} › {category['name']}"[:100]
+            if needle and needle not in label.lower():
+                continue
+            choices.append(app_commands.Choice(
+                name=label, value=f"{panel['id']}:{category['id']}"))
+            if len(choices) >= 25:
+                return choices
+    return choices
+
+
+@ticket_group.command(name="move", description="Move this ticket to another category")
+@app_commands.describe(category="The category the ticket should move to")
+@app_commands.autocomplete(category=_category_autocomplete)
+async def ticket_move(interaction: discord.Interaction, category: str):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    service = resolved[0]
+    locale = i18n.get_user_locale(interaction)
+
+    panel_id, _, category_id = category.partition(":")
+    if not panel_id or not category_id:
+        await send_error(interaction,
+                         t('modules.tickets.errors.unknown_category', locale=locale),
+                         locale)
+        return
+
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    try:
+        await service.move_ticket(interaction.channel, interaction.user,
+                                  panel_id, category_id)
+    except TicketError as e:
+        await handle_ticket_error(interaction, e)
+        return
+    await send_success(interaction,
+                       t('modules.tickets.move.done_title', locale=locale),
+                       t('modules.tickets.move.done_description', locale=locale))
+
+
+# --------------------------------------------------------------------------- #
+# Rename
+# --------------------------------------------------------------------------- #
+@ticket_group.command(name="rename", description="Rename this ticket")
+@app_commands.describe(name="The new channel name (leave empty to open a form)")
+async def ticket_rename(interaction: discord.Interaction, name: Optional[str] = None):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    service, ticket, panel, category = resolved
+    locale = i18n.get_user_locale(interaction)
+
+    if PERM_RENAME not in member_permissions(interaction.user, category, ticket):
+        await send_error(interaction,
+                         t('modules.tickets.errors.missing_permission', locale=locale),
+                         locale)
+        return
+
+    async def apply(inner: discord.Interaction, new_name: str):
+        await inner.response.defer(ephemeral=True, thinking=True)
+        try:
+            final = await service.rename_ticket(inner.channel, inner.user, new_name)
+        except TicketError as e:
+            await handle_ticket_error(inner, e)
+            return
+        await send_success(
+            inner, t('modules.tickets.rename.done_title', locale=locale),
+            t('modules.tickets.rename.done_description', locale=locale, name=final))
+
+    if name is None:
+        modal = TicketRenameModal(locale, interaction.channel.name, apply)
+        modal.bot = interaction.client
+        await interaction.response.send_modal(modal)
+        return
+    await apply(interaction, name)
+
+
+# --------------------------------------------------------------------------- #
+# Participants
+# --------------------------------------------------------------------------- #
+@ticket_group.command(name="add", description="Add a member or a role to this ticket")
+@app_commands.describe(target="The member or role to add")
+async def ticket_add(interaction: discord.Interaction,
+                     target: Union[discord.Member, discord.Role]):
+    await _participant_action(interaction, target, add=True)
+
+
+@ticket_group.command(name="remove",
+                      description="Remove a member or a role from this ticket")
+@app_commands.describe(target="The member or role to remove")
+async def ticket_remove(interaction: discord.Interaction,
+                        target: Union[discord.Member, discord.Role]):
+    await _participant_action(interaction, target, add=False)
+
+
+async def _participant_action(interaction: discord.Interaction,
+                              target: Union[discord.Member, discord.Role],
+                              *, add: bool):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    service = resolved[0]
+    locale = i18n.get_user_locale(interaction)
+
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    try:
+        if add:
+            await service.add_participant(interaction.channel, interaction.user, target)
+        else:
+            await service.remove_participant(interaction.channel, interaction.user, target)
+    except TicketError as e:
+        await handle_ticket_error(interaction, e)
+        return
+
+    key = 'added' if add else 'removed'
+    await send_success(
+        interaction,
+        t(f'modules.tickets.participants.{key}_title', locale=locale),
+        t(f'modules.tickets.participants.{key}_description', locale=locale,
+          target=target.mention))
+
+
+@ticket_group.command(name="participants",
+                      description="See and edit who has access to this ticket")
+async def ticket_participants(interaction: discord.Interaction):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    service, ticket, panel, category = resolved
+    locale = i18n.get_user_locale(interaction)
+
+    if PERM_PARTICIPANTS not in member_permissions(interaction.user, category, ticket):
+        await send_error(interaction,
+                         t('modules.tickets.errors.missing_permission', locale=locale),
+                         locale)
+        return
+    await interaction.response.send_message(
+        view=TicketParticipantsView(interaction.guild, ticket, locale), ephemeral=True)
+
+
+# --------------------------------------------------------------------------- #
+# Staff thread
+# --------------------------------------------------------------------------- #
+@ticket_group.command(name="staff-thread",
+                      description="Open or join the private staff thread")
+async def ticket_staff_thread(interaction: discord.Interaction):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    await run_staff_thread(interaction, resolved[0])
+
+
+# --------------------------------------------------------------------------- #
+# Info
+# --------------------------------------------------------------------------- #
+@ticket_group.command(name="info", description="Show this ticket's details")
+async def ticket_info(interaction: discord.Interaction):
+    resolved = await _service_and_ticket(interaction)
+    if not resolved:
+        return
+    service, ticket, panel, category = resolved
+    locale = i18n.get_user_locale(interaction)
+
+    granted = sorted(member_permissions(interaction.user, category, ticket))
+    fields = [
+        {"name": t('modules.tickets.fields.opener', locale=locale),
+         "value": f"<@{ticket['owner_id']}>"},
+        {"name": t('modules.tickets.fields.category', locale=locale),
+         "value": f"`{category['name']}`"},
+        {"name": t('modules.tickets.fields.status', locale=locale),
+         "value": t(f"modules.tickets.status.{ticket['status']}", locale=locale)},
+    ]
+    if ticket.get('escalated'):
+        fields.append({
+            "name": t('modules.tickets.fields.escalated', locale=locale),
+            "value": t('modules.tickets.status.escalated', locale=locale),
+        })
+    participants = [f"<@{uid}>" for uid in ticket.get('participants', [])]
+    participants += [f"<@&{rid}>" for rid in ticket.get('participant_roles', [])]
+    if participants:
+        fields.append({
+            "name": t('modules.tickets.fields.participants', locale=locale),
+            "value": ", ".join(participants)[:1000],
+        })
+    fields.append({
+        "name": t('modules.tickets.fields.your_permissions', locale=locale),
+        "value": ", ".join(
+            t(f'modules.tickets.permissions.{p}.name', locale=locale) for p in granted
+        ) or t('modules.tickets.fields.none', locale=locale),
+    })
+
+    await interaction.response.send_message(
+        view=create_success_message(
+            t('modules.tickets.info.title', locale=locale, number=ticket['number']),
+            t('modules.tickets.info.description', locale=locale),
+            fields=fields),
+        ephemeral=True)
+
+
+# --------------------------------------------------------------------------- #
+# The cog (events + registration)
+# --------------------------------------------------------------------------- #
+class Tickets(commands.Cog):
+    """Keeps the ticket table in step with what actually exists in Discord."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_guild_channel_delete(self, channel: discord.abc.GuildChannel):
+        """A ticket channel deleted by hand must not leave a row behind.
+
+        Without this, the member's open-ticket quota would count a channel that
+        no longer exists and they could never open another one.
+        """
+        service = getattr(self.bot, 'tickets', None)
+        if service is None or not self.bot.db:
+            return
+        try:
+            ticket = await service.get_ticket(channel.id)
+            if ticket:
+                await service.forget_channel(channel.id)
+                logger.info(f"[Tickets] #{ticket['number']} forgotten "
+                            f"(channel {channel.id} deleted)")
+        except Exception as e:
+            logger.error(f"[Tickets] Cleanup failed for channel {channel.id}: {e}")
+
+
+async def setup(bot):
+    await bot.add_cog(Tickets(bot))
+    # Published per guild, only where the module is enabled — never globally.
+    bot.register_module_commands(MODULE_ID, [ticket_group])

--- a/db/base.py
+++ b/db/base.py
@@ -34,6 +34,7 @@ from db.repositories.banners import BannerRepository
 from db.repositories.forms import FormsRepository
 from db.repositories.social import SocialSubscriptionsRepository
 from db.repositories.altguard import AltGuardRepository
+from db.repositories.tickets import TicketsRepository
 
 logger = logging.getLogger('moddy.database')
 
@@ -69,6 +70,7 @@ class ModdyDatabase(
     FormsRepository,
     SocialSubscriptionsRepository,
     AltGuardRepository,
+    TicketsRepository,
 ):
     """Gestionnaire principal de la base de données"""
 
@@ -812,6 +814,44 @@ class ModdyDatabase(
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_altguard_members_status "
                 "ON altguard_members (guild_id, status)")
+
+            # tickets — one row per ticket channel that exists in Discord.
+            # The module's *configuration* (panels, categories, permissions)
+            # lives in guilds.data.modules.tickets like every other module;
+            # this table is the runtime state every ticket action resolves
+            # from. channel_id is UNIQUE because a ticket action always
+            # happens inside its own channel. `number` is a per-guild counter
+            # used in channel names and references ("ticket 42").
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS tickets (
+                    id                   BIGSERIAL PRIMARY KEY,
+                    guild_id             BIGINT NOT NULL,
+                    channel_id           BIGINT NOT NULL UNIQUE,
+                    panel_id             TEXT NOT NULL,
+                    category_id          TEXT NOT NULL,
+                    number               INTEGER NOT NULL,
+                    owner_id             BIGINT NOT NULL,
+                    status               TEXT NOT NULL DEFAULT 'open'
+                        CHECK (status IN ('open','closed')),
+                    escalated            BOOLEAN NOT NULL DEFAULT FALSE,
+                    staff_thread_id      BIGINT,
+                    participants         BIGINT[] NOT NULL DEFAULT '{}',
+                    participant_roles    BIGINT[] NOT NULL DEFAULT '{}',
+                    close_requested_by   BIGINT,
+                    close_request_reason TEXT,
+                    opened_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    closed_at            TIMESTAMPTZ,
+                    closed_by            BIGINT,
+                    close_reason         TEXT,
+                    CONSTRAINT tickets_guild_number UNIQUE (guild_id, number)
+                )
+            """)
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_tickets_guild_status "
+                "ON tickets (guild_id, status, number DESC)")
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_tickets_owner "
+                "ON tickets (guild_id, owner_id, status)")
 
             # Table des rôles sauvegardés (Auto Restore Roles module)
             await conn.execute("""

--- a/db/repositories/tickets.py
+++ b/db/repositories/tickets.py
@@ -1,0 +1,271 @@
+"""
+Tickets repository — the live state of every ticket channel.
+
+The *configuration* of the Tickets module (panels, categories, permissions)
+lives in ``guilds.data.modules.tickets`` like every other module. This table
+holds the opposite half: one row per ticket **channel** that exists in Discord,
+which is what every runtime action needs to resolve.
+
+``channel_id`` is UNIQUE, and it is the only lookup key the runtime uses: a
+ticket action always happens *inside* the ticket channel, so the channel id is
+the ticket's identity. That is also why the ticket control buttons can use
+static custom_ids (see ``utils/ticket_views.py``).
+
+``number`` is a per-guild counter (``UNIQUE (guild_id, number)``) used in
+channel names and references — humans say "ticket 42", not a snowflake.
+
+See docs/TICKETS.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger('moddy.database')
+
+STATUS_OPEN = "open"
+STATUS_CLOSED = "closed"
+STATUSES = (STATUS_OPEN, STATUS_CLOSED)
+
+# How many times ``create_ticket`` retries when two members open a ticket at the
+# exact same moment and land on the same ``number``.
+_NUMBER_RETRIES = 5
+
+
+def _row_to_dict(row) -> Dict[str, Any]:
+    """Convert an asyncpg Record into a plain ticket dict."""
+    return {
+        "id": row["id"],
+        "guild_id": row["guild_id"],
+        "channel_id": row["channel_id"],
+        "panel_id": row["panel_id"],
+        "category_id": row["category_id"],
+        "number": row["number"],
+        "owner_id": row["owner_id"],
+        "status": row["status"],
+        "escalated": row["escalated"],
+        "staff_thread_id": row["staff_thread_id"],
+        "participants": list(row["participants"] or []),
+        "participant_roles": list(row["participant_roles"] or []),
+        "close_requested_by": row["close_requested_by"],
+        "close_request_reason": row["close_request_reason"],
+        "opened_at": row["opened_at"],
+        "closed_at": row["closed_at"],
+        "closed_by": row["closed_by"],
+        "close_reason": row["close_reason"],
+    }
+
+
+class TicketsRepository:
+    """CRUD for the ``tickets`` table."""
+
+    # ------------------------------------------------------------------ #
+    # Creation
+    # ------------------------------------------------------------------ #
+
+    async def next_ticket_number(self, guild_id: int) -> int:
+        """The number the next ticket of this guild would get.
+
+        Read *before* the channel is created so it can go straight into the
+        channel name: renaming a channel afterwards would spend one of the two
+        renames Discord allows per channel per 10 minutes, and a staffer's
+        ``/ticket rename`` right after opening would then hang.
+
+        It is a prediction, not a reservation — see ``create_ticket``.
+        """
+        async with self.pool.acquire() as conn:
+            return (await conn.fetchval(
+                "SELECT COALESCE(MAX(number), 0) + 1 FROM tickets WHERE guild_id = $1",
+                guild_id) or 1)
+
+    async def create_ticket(
+        self,
+        *,
+        guild_id: int,
+        channel_id: int,
+        panel_id: str,
+        category_id: str,
+        owner_id: int,
+        number: Optional[int] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Insert a ticket row, allocating the next per-guild number.
+
+        ``number`` is the value ``next_ticket_number`` predicted, so the channel
+        could already be named with it. Two simultaneous opens can still collide
+        on ``UNIQUE (guild_id, number)``; the insert then falls back to a fresh
+        ``MAX(number) + 1`` and retries, which is cheaper and simpler than
+        holding an advisory lock for what is a rare race. The channel name is
+        left as it is in that case — a ticket named one off from its number
+        beats a rename that may not go through for ten minutes.
+        """
+        async with self.pool.acquire() as conn:
+            for attempt in range(_NUMBER_RETRIES):
+                try:
+                    if number is not None and attempt == 0:
+                        row = await conn.fetchrow("""
+                            INSERT INTO tickets (
+                                guild_id, channel_id, panel_id, category_id,
+                                number, owner_id
+                            )
+                            VALUES ($1, $2, $3, $4, $5, $6)
+                            RETURNING *
+                        """, guild_id, channel_id, panel_id, category_id,
+                             number, owner_id)
+                    else:
+                        row = await conn.fetchrow("""
+                            INSERT INTO tickets (
+                                guild_id, channel_id, panel_id, category_id,
+                                number, owner_id
+                            )
+                            VALUES (
+                                $1, $2, $3, $4,
+                                (SELECT COALESCE(MAX(number), 0) + 1
+                                   FROM tickets WHERE guild_id = $1),
+                                $5
+                            )
+                            RETURNING *
+                        """, guild_id, channel_id, panel_id, category_id, owner_id)
+                    return _row_to_dict(row) if row else None
+                except Exception as e:  # asyncpg.UniqueViolationError and friends
+                    if 'tickets_guild_number' in str(e) or 'unique' in str(e).lower():
+                        continue
+                    logger.error(f"[Tickets] Could not create ticket: {e}")
+                    return None
+        logger.error(f"[Tickets] Gave up allocating a number for guild {guild_id}")
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Reads
+    # ------------------------------------------------------------------ #
+
+    async def get_ticket_by_channel(self, channel_id: int) -> Optional[Dict[str, Any]]:
+        """The ticket owning this channel, whatever its status."""
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT * FROM tickets WHERE channel_id = $1", channel_id)
+            return _row_to_dict(row) if row else None
+
+    async def get_ticket_by_number(self, guild_id: int, number: int) -> Optional[Dict[str, Any]]:
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT * FROM tickets WHERE guild_id = $1 AND number = $2",
+                guild_id, number)
+            return _row_to_dict(row) if row else None
+
+    async def count_open_tickets(self, guild_id: int, owner_id: int,
+                                 category_id: Optional[str] = None) -> int:
+        """Open tickets a member owns — the per-category anti-spam limit."""
+        async with self.pool.acquire() as conn:
+            if category_id is None:
+                return await conn.fetchval("""
+                    SELECT COUNT(*) FROM tickets
+                    WHERE guild_id = $1 AND owner_id = $2 AND status = 'open'
+                """, guild_id, owner_id) or 0
+            return await conn.fetchval("""
+                SELECT COUNT(*) FROM tickets
+                WHERE guild_id = $1 AND owner_id = $2 AND category_id = $3
+                  AND status = 'open'
+            """, guild_id, owner_id, category_id) or 0
+
+    async def list_guild_tickets(self, guild_id: int, *, status: Optional[str] = None,
+                                 limit: int = 50) -> List[Dict[str, Any]]:
+        async with self.pool.acquire() as conn:
+            if status:
+                rows = await conn.fetch("""
+                    SELECT * FROM tickets
+                    WHERE guild_id = $1 AND status = $2
+                    ORDER BY number DESC LIMIT $3
+                """, guild_id, status, limit)
+            else:
+                rows = await conn.fetch("""
+                    SELECT * FROM tickets WHERE guild_id = $1
+                    ORDER BY number DESC LIMIT $2
+                """, guild_id, limit)
+            return [_row_to_dict(r) for r in rows]
+
+    # ------------------------------------------------------------------ #
+    # Updates
+    # ------------------------------------------------------------------ #
+
+    async def set_ticket_status(self, channel_id: int, status: str, *,
+                                actor_id: Optional[int] = None,
+                                reason: Optional[str] = None) -> None:
+        """Close or reopen a ticket. Reopening clears the closure metadata."""
+        if status not in STATUSES:
+            raise ValueError(f"unknown ticket status: {status}")
+        async with self.pool.acquire() as conn:
+            if status == STATUS_CLOSED:
+                await conn.execute("""
+                    UPDATE tickets
+                    SET status = 'closed', closed_at = now(), closed_by = $2,
+                        close_reason = $3, close_requested_by = NULL,
+                        close_request_reason = NULL
+                    WHERE channel_id = $1
+                """, channel_id, actor_id, reason)
+            else:
+                await conn.execute("""
+                    UPDATE tickets
+                    SET status = 'open', closed_at = NULL, closed_by = NULL,
+                        close_reason = NULL
+                    WHERE channel_id = $1
+                """, channel_id)
+
+    async def set_close_request(self, channel_id: int, requester_id: Optional[int],
+                                reason: Optional[str]) -> None:
+        """Record (or clear, with ``requester_id=None``) a pending close request."""
+        async with self.pool.acquire() as conn:
+            await conn.execute("""
+                UPDATE tickets
+                SET close_requested_by = $2, close_request_reason = $3
+                WHERE channel_id = $1
+            """, channel_id, requester_id, reason)
+
+    async def set_ticket_category(self, channel_id: int, panel_id: str,
+                                  category_id: str) -> None:
+        async with self.pool.acquire() as conn:
+            await conn.execute("""
+                UPDATE tickets SET panel_id = $2, category_id = $3
+                WHERE channel_id = $1
+            """, channel_id, panel_id, category_id)
+
+    async def set_escalated(self, channel_id: int, escalated: bool) -> None:
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE tickets SET escalated = $2 WHERE channel_id = $1",
+                channel_id, escalated)
+
+    async def set_staff_thread(self, channel_id: int,
+                               thread_id: Optional[int]) -> None:
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE tickets SET staff_thread_id = $2 WHERE channel_id = $1",
+                channel_id, thread_id)
+
+    async def set_participants(self, channel_id: int, *,
+                               users: Optional[Sequence[int]] = None,
+                               roles: Optional[Sequence[int]] = None) -> None:
+        """Replace the manually added users and/or roles of a ticket."""
+        async with self.pool.acquire() as conn:
+            if users is not None and roles is not None:
+                await conn.execute("""
+                    UPDATE tickets SET participants = $2, participant_roles = $3
+                    WHERE channel_id = $1
+                """, channel_id, list(users), list(roles))
+            elif users is not None:
+                await conn.execute(
+                    "UPDATE tickets SET participants = $2 WHERE channel_id = $1",
+                    channel_id, list(users))
+            elif roles is not None:
+                await conn.execute(
+                    "UPDATE tickets SET participant_roles = $2 WHERE channel_id = $1",
+                    channel_id, list(roles))
+
+    # ------------------------------------------------------------------ #
+    # Deletion
+    # ------------------------------------------------------------------ #
+
+    async def delete_ticket(self, channel_id: int) -> None:
+        """Forget a ticket — called when its channel is deleted in Discord."""
+        async with self.pool.acquire() as conn:
+            await conn.execute("DELETE FROM tickets WHERE channel_id = $1", channel_id)

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -520,6 +520,42 @@ Voir → [GLOBAL_SANCTIONS.md](GLOBAL_SANCTIONS.md).
 
 ---
 
+### 12. Table `tickets`
+
+L'**état vivant** de chaque salon de ticket existant dans Discord. La
+*configuration* du module Tickets (panneaux, catégories, permissions) vit dans
+`guilds.data.modules.tickets` comme tout autre module ; cette table est l'autre
+moitié : ce que chaque action de ticket doit résoudre.
+
+`channel_id` est **UNIQUE** et c'est la seule clé de lecture utilisée à
+l'exécution : une action de ticket se passe toujours *dans* son propre salon,
+donc l'id du salon **est** l'identité du ticket. C'est aussi pour ça que les
+boutons de la barre de contrôle peuvent utiliser des `custom_id` statiques.
+
+**Colonnes:**
+- `id` (BIGSERIAL, PRIMARY KEY)
+- `guild_id` / `channel_id` (BIGINT) — `channel_id` UNIQUE
+- `panel_id` / `category_id` (TEXT) — les ids stockés dans la config du module
+- `number` (INTEGER) — compteur par serveur, `UNIQUE (guild_id, number)`
+- `owner_id` (BIGINT) — qui a ouvert le ticket
+- `status` (TEXT) — `open` | `closed`
+- `escalated` (BOOLEAN) — le ticket est réservé aux responsables
+- `staff_thread_id` (BIGINT) — le thread privé du staff, s'il existe
+- `participants` / `participant_roles` (BIGINT[]) — ajoutés à la main
+- `close_requested_by` / `close_request_reason` — demande de fermeture en attente
+- `opened_at` / `closed_at` / `closed_by` / `close_reason`
+
+**Index:**
+- `idx_tickets_guild_status` sur `(guild_id, status, number DESC)`
+- `idx_tickets_owner` sur `(guild_id, owner_id, status)` — la limite de tickets
+  ouverts par membre
+
+**Repository:** `db/repositories/tickets.py` — `TicketsRepository`
+
+Voir → [TICKETS.md](TICKETS.md).
+
+---
+
 ## Système d'attributs et de données
 
 Moddy utilise deux types de champs JSONB pour stocker les informations:

--- a/docs/MODULE_SYSTEM.md
+++ b/docs/MODULE_SYSTEM.md
@@ -158,6 +158,47 @@ stockée et chargée, l'erreur est renvoyée dans `hook_error`.
 Voir l'implémentation de référence : `modules/altguard.py` et
 [ALTGUARD_INTEGRATION.md §5](ALTGUARD_INTEGRATION.md).
 
+### 3 ter. Commandes slash réservées aux serveurs qui utilisent le module
+
+Un module peut posséder ses propres commandes slash, publiées **uniquement dans
+les serveurs où il est activé** (`/ticket` pour le module Tickets). Un serveur
+qui n'utilise pas le module ne voit jamais ces commandes.
+
+Trois choses à faire :
+
+1. **Déclarer le groupe au niveau du module**, jamais comme attribut de Cog —
+   un attribut de Cog est ajouté à l'arbre global par discord.py, ce qui est
+   exactement ce qu'on veut éviter. Les callbacks récupèrent le bot via
+   `interaction.client`.
+
+   ```python
+   # cogs/mon_module.py
+   mon_groupe = app_commands.Group(name="…", description="…", guild_only=True)
+   ```
+
+2. **L'enregistrer dans `setup()`** :
+
+   ```python
+   async def setup(bot):
+       await bot.add_cog(MonCog(bot))
+       bot.register_module_commands(MODULE_ID, [mon_groupe])
+   ```
+
+3. **S'assurer que `module.enabled`** reflète bien « ce serveur utilise la
+   fonctionnalité » : c'est la seule condition qui décide de la publication.
+
+Le reste est automatique :
+`ModdyBot._register_guild_command_set()` ajoute le groupe à l'arbre d'un serveur
+quand `get_enabled_module_ids(guild_id)` contient le module, et `ModuleManager`
+appelle `bot.resync_module_commands(guild_id)` après **chaque** sauvegarde,
+suppression ou rechargement poussé par le dashboard. Le bot saute le sync quand
+l'ensemble des modules activés n'a pas changé : les syncs de commandes par
+serveur sont rate-limités, et une sauvegarde qui ne change qu'une couleur ne
+doit pas en consommer un.
+
+Voir l'implémentation de référence : `cogs/tickets.py` et
+[TICKETS.md](TICKETS.md#slash-commands-published-per-guild).
+
 ### 4. Stockage en base de données
 
 Les configurations sont stockées dans PostgreSQL :

--- a/docs/PERSISTENT_VIEWS.md
+++ b/docs/PERSISTENT_VIEWS.md
@@ -461,6 +461,40 @@ was easier not to" is not one.
   custom_ids are static and `interaction.guild_id` plus a Manage Server
   check is the whole auth context they need.
 
+- **`modules/configs/tickets_panel_config.py::TicketPanelConfigView`,
+  `modules/configs/tickets_category_config.py::TicketCategoryConfigView` /
+  `TicketPermissionsConfigView`** — the `/config` → Tickets screens below the
+  module root. Every one of their children is a persistent `DynamicItem`
+  carrying the panel id, and where relevant the category and role ids, in its
+  `custom_id` (`moddy:tickets:pnlbtn:<action>:<panel>`,
+  `moddy:tickets:catdest:<panel>:<category>`,
+  `moddy:tickets:permset:<panel>:<category>:<role>`, …), registered through
+  `TicketsConfigPersistence.register_persistent` (`bot.add_dynamic_items(...)`,
+  same marker-view pattern as `LogsPersistence`). Registering the wrappers as
+  shells would be meaningless: none of them can be built without the entity
+  they configure, and there is nothing left for them to carry once their
+  children reconstruct themselves from their custom_id on every click. That is
+  also why these screens apply every change immediately instead of staging
+  edits behind a Save button — same reasoning as `LogsCategoryView` and
+  `StaffManagerPanel`. The root screen (`TicketsConfigView`) *is* registered
+  normally: its custom_ids are static and `interaction.guild_id` plus a Manage
+  Server check is the whole auth context it needs.
+- **`utils/ticket_views.py::TicketPanelView`** — the public ticket panel
+  message. A `BaseView` with `timeout=None` whose only interactive children are
+  `TicketOpenButton` / `TicketOpenSelect`, persistent `DynamicItem`s
+  (`moddy:tickets:open:<panel>:<category>`,
+  `moddy:tickets:opensel:<panel>`) registered separately through
+  `TicketsPersistence` — same pattern as `TranscribePromptView`. Registering
+  the wrapper would be meaningless: it cannot be built without a panel.
+  The *ticket-channel* views (`TicketControlView`, `TicketClosedView`,
+  `TicketCloseRequestView`, `TicketEscalationView`, `TicketEscalateConfirmView`,
+  `TicketParticipantsView`) are registered normally with **static** custom_ids:
+  a ticket action always happens inside its own channel, so
+  `interaction.channel_id` is the ticket's identity and an id in the custom_id
+  would only add a second source of truth that could disagree with the channel.
+  `build_close_dm` has zero interactive children ("nothing to register" case
+  above).
+
 ---
 
 ## Current coverage

--- a/docs/PREMIUM.md
+++ b/docs/PREMIUM.md
@@ -104,7 +104,9 @@ User-scoped changes go on `moddy:subscription:updates` instead — see
 implement all three (premium identity, free name style), and
 [`modules/social_notifications.py`](../modules/social_notifications.py) shows
 the quota-style variant (premium raises a limit instead of unlocking a
-feature).
+feature). [`modules/tickets.py::get_limits`](../modules/tickets.py) is the same
+variant with one addition worth copying: a **failed premium lookup falls back
+to the free quota**, so an outage can never hand out the premium one.
 
 ---
 
@@ -116,3 +118,5 @@ feature).
 | Bot Customization — name style (font, effect, colours) | ✅ | ✅ |
 | Social Notifications — accounts per platform | `FREE_PER_PLATFORM_LIMIT` | `PREMIUM_PER_PLATFORM_LIMIT` |
 | Social Notifications — poll interval | slow tier | fast tier |
+| Tickets — panels per server | `FREE_MAX_PANELS` (3) | `PREMIUM_MAX_PANELS` (10) |
+| Tickets — categories per panel | `FREE_MAX_CATEGORIES` (5) | `PREMIUM_MAX_CATEGORIES` (15) |

--- a/docs/TICKETS.md
+++ b/docs/TICKETS.md
@@ -1,0 +1,407 @@
+# Tickets — support tickets with panels, categories and per-role permissions
+
+> Server module `tickets`. Configured in `/config` → **Tickets**, used through
+> a **panel** message and the `/ticket` command group.
+
+---
+
+## Table of contents
+
+1. [The three levels](#the-three-levels)
+2. [Files](#files)
+3. [Limits (free / premium)](#limits-free--premium)
+4. [Configuration schema](#configuration-schema)
+5. [The permission model](#the-permission-model)
+6. [Channel permissions, escalation and closure](#channel-permissions-escalation-and-closure)
+7. [The `tickets` table](#the-tickets-table)
+8. [Actions](#actions)
+9. [Slash commands, published per guild](#slash-commands-published-per-guild)
+10. [Persistence](#persistence)
+11. [i18n](#i18n)
+12. [Backend / dashboard contract](#backend--dashboard-contract)
+13. [Extending the module](#extending-the-module)
+
+---
+
+## The three levels
+
+Keeping these apart is what keeps the rest simple.
+
+| Level | What it is | Where it lives |
+|---|---|---|
+| **Panel** | One message in a public channel, with its own title, description, colour, and either **buttons** or a **dropdown**. | `guilds.data.modules.tickets.panels[]` |
+| **Category** | One entry inside a panel — the button or dropdown option a member clicks. Decides *where* the ticket opens, *who* may open it, *what* each staff role may do in it, its *language* and its *messages*. | `panels[].categories[]` |
+| **Ticket** | The channel a member ends up in. | the `tickets` table |
+
+A guild can have several panels; each panel has its own categories. A category
+that has no destination category, or that is paused, simply does not appear on
+the panel — and a panel with nothing left to click is taken down rather than
+left up with dead buttons.
+
+---
+
+## Files
+
+```
+modules/tickets.py                      Config schema, limits, permission model,
+                                        panel posting/refresh. No ticket action.
+services/ticket_service.py              Every ticket verb (bot.tickets).
+utils/ticket_views.py                   Panel, control bar, closing card, close
+                                        request, escalation notice, participants.
+cogs/tickets.py                         /ticket group + channel cleanup listener.
+db/repositories/tickets.py              The tickets table.
+modules/configs/tickets_config.py       /config root: the panel list.
+modules/configs/tickets_panel_config.py /config: one panel.
+modules/configs/tickets_category_config.py
+                                        /config: one category + its permissions.
+tests/test_tickets.py                   Schema, permissions, overwrites, screens, i18n.
+```
+
+The split between `modules/tickets.py` (configuration) and
+`services/ticket_service.py` (actions) is deliberate: the config surface and the
+runtime surface can then be read, changed and tested separately, and neither
+grows a dependency on the other's state.
+
+---
+
+## Limits (free / premium)
+
+| | Free | Premium |
+|---|---|---|
+| Panels per server | **3** | **10** |
+| Categories per panel | **5** | **15** |
+
+Constants: `FREE_MAX_PANELS`, `PREMIUM_MAX_PANELS`, `FREE_MAX_CATEGORIES`,
+`PREMIUM_MAX_CATEGORIES` in `modules/tickets.py`.
+
+`get_limits(bot, guild_id)` reads premium **at the moment of the action**, never
+from a rendered panel — a config screen can sit open for hours and a stale
+render must never be an entitlement (see [PREMIUM.md](PREMIUM.md)). A failed
+premium lookup falls back to the **free** quota: an outage must not silently
+hand out the premium one.
+
+Discord's own ceilings cap the plan on top of that:
+`max_categories_for_style(style, limit)` returns at most 15 for a button panel
+(three rows of five) and 25 for a dropdown.
+
+The limit is enforced in three places, on purpose: the **Add** button is
+disabled at the cap, the click re-checks it against a fresh read, and
+`validate_config` rejects an over-quota config however it arrived — including
+straight from the dashboard.
+
+---
+
+## Configuration schema
+
+Stored in `guilds.data.modules.tickets`. Everything that reads it goes through
+`normalize_config()`, so a config written by the dashboard, an old one missing a
+key added later, and one just built by `/config` all come out identical.
+
+```jsonc
+{
+  "panels": [
+    {
+      "id": "p_a1b2c3",            // generated, stable, used in custom_ids
+      "name": "Support",           // internal name (config screens only)
+      "channel_id": 123,           // where the panel message is posted
+      "message_id": 456,           // the posted message — written by the bot
+      "title": "Need help?",       // shown to members (falls back to name)
+      "description": "Pick a category below",
+      "accent_color": 5793266,     // 0xRRGGBB
+      "style": "buttons",          // "buttons" | "select"
+      "placeholder": "Choose…",    // dropdown placeholder ("select" only)
+      "enabled": true,
+      "categories": [
+        {
+          "id": "c_d4e5f6",
+          "name": "General support",   // button label / option label
+          "emoji": "<:support:123>",   // optional
+          "description": "Anything else",  // dropdown option description
+          "button_style": "primary",   // primary | secondary | success | danger
+          "discord_category_id": 789,  // where the ticket channel is created
+          "allowed_role_ids": [],      // empty = everyone
+          "denied_role_ids": [],
+          "ping_role_ids": [],         // mentioned when a ticket opens
+          "permissions": {             // role id (string) -> permissions
+            "111": ["view", "close", "staff_thread"],
+            "222": ["admin"]
+          },
+          "locale": "fr",              // en-US | fr | es-ES | pt-BR | de
+          "open_message": "…",         // pinned in the ticket
+          "close_message": "…",        // added to the closing card
+          "name_format": "ticket-{number}",
+          "max_open_per_user": 1,
+          "enabled": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Snowflakes may arrive as strings** — JSON has no 64-bit integer, so the
+dashboard writes them as text. `normalize_config` parses them back; never
+compare a raw stored id to a `discord.Object.id` without going through it.
+
+`permissions` keys are **strings** for the same reason.
+
+### Placeholders
+
+Usable in `open_message` / `close_message`: `{user}` `{username}`
+`{display_name}` `{server}` `{category}` `{number}` `{ticket}`.
+
+Usable in `name_format`: `{number}` (zero-padded to 4) `{username}`
+`{display_name}` `{category}`.
+
+`render_text()` substitutes them with plain `str.replace`, **not**
+`str.format` — an admin who types a stray `{` would otherwise blow up the
+message for everyone.
+
+---
+
+## The permission model
+
+Seven permissions, granted **per role, per category**:
+
+| Key | What it allows |
+|---|---|
+| `view` | See and talk in the tickets of this category |
+| `close` | Close and reopen a ticket |
+| `staff_thread` | Open and join the private staff thread |
+| `rename` | Rename the ticket channel |
+| `move` | Move the ticket to another category |
+| `participants` | Add and remove members and roles |
+| `admin` | Everything above — **and keeps access after an escalation** |
+
+Resolution (`member_permissions(member, category, ticket)`), in this order:
+
+1. A **guild administrator** always has everything.
+2. Each of the member's roles contributes what it was granted;
+   `admin` expands to the full set.
+3. The ticket **owner**, and anyone added to the ticket by hand (member or
+   role), always gets `view` — and nothing else. That mirrors the channel
+   overwrites exactly: someone who can read the ticket but whom the permission
+   model claims cannot see it would be refused the actions open to everyone in
+   it. Closing your own ticket is the server's decision (grant `close` to a
+   members role for that); *asking* for it needs no permission at all.
+
+### Who may open a ticket
+
+`can_open(member, category)`:
+
+- A **denied** role always wins — over an allowed role, and over being a guild
+  administrator. A deny list that could be walked past would be a trap.
+- An **empty allow list means everyone**, which is what an admin expects from a
+  field they never filled in.
+- Otherwise the member needs one of the allowed roles (guild administrators pass).
+
+---
+
+## Channel permissions, escalation and closure
+
+`TicketService.build_overwrites()` rebuilds the **whole** overwrite map from
+scratch on every change rather than patching it. That is what keeps escalation,
+closure and participant edits from drifting into states nobody can explain.
+
+| State | Who can see the channel |
+|---|---|
+| Open | `@everyone` denied · the bot · every role with `view` · the opener · everyone added by hand |
+| **Escalated** | the bot · only roles with `admin` · the opener · everyone added by hand (unless dropped) |
+| **Closed** | the bot · every role with `view` — the opener and the manual participants are hidden |
+
+- **Escalation** keeps the opener (a ticket without them is meaningless) and the
+  manually added people, and the flow *offers to drop them* — that question is
+  only asked when there is somebody to ask about, so the confirmation never
+  becomes noise. It refuses outright when no role holds `admin`: escalating with
+  nobody to escalate *to* would lock the ticket down to its opener and the
+  server admins.
+- **Closing keeps the channel.** Nothing is destroyed by a click: the ticket is
+  locked, a closing card is posted with **Reopen** and **Delete the channel**,
+  and the opener gets a DM (best effort — closed DMs are the norm, not an
+  error). Deleting requires `admin`.
+- **Reopening restores the map exactly**, because it is rebuilt, not undone.
+
+---
+
+## The `tickets` table
+
+One row per ticket **channel** that exists in Discord. `channel_id` is UNIQUE
+and is the only lookup key the runtime uses: a ticket action always happens
+inside its own channel, so the channel id *is* the ticket's identity. That is
+also why the ticket control buttons need no id in their `custom_id`.
+
+```sql
+CREATE TABLE tickets (
+    id                   BIGSERIAL PRIMARY KEY,
+    guild_id             BIGINT NOT NULL,
+    channel_id           BIGINT NOT NULL UNIQUE,
+    panel_id             TEXT NOT NULL,
+    category_id          TEXT NOT NULL,
+    number               INTEGER NOT NULL,      -- per-guild counter
+    owner_id             BIGINT NOT NULL,
+    status               TEXT NOT NULL DEFAULT 'open',   -- open | closed
+    escalated            BOOLEAN NOT NULL DEFAULT FALSE,
+    staff_thread_id      BIGINT,
+    participants         BIGINT[] NOT NULL DEFAULT '{}',
+    participant_roles    BIGINT[] NOT NULL DEFAULT '{}',
+    close_requested_by   BIGINT,
+    close_request_reason TEXT,
+    opened_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    closed_at            TIMESTAMPTZ,
+    closed_by            BIGINT,
+    close_reason         TEXT,
+    CONSTRAINT tickets_guild_number UNIQUE (guild_id, number)
+);
+```
+
+`number` is **predicted** by `next_ticket_number()` before the channel is
+created, so the channel gets its final name in the same call that creates it —
+renaming afterwards would spend one of the two renames Discord allows per
+channel per 10 minutes, and a staffer's `/ticket rename` right after opening
+would then hang. Two simultaneous opens can still collide on
+`tickets_guild_number`; the insert falls back to a fresh `MAX(number) + 1` and
+retries, leaving the channel name one off rather than attempting a rename that
+may not go through for ten minutes. Cheaper and simpler than an advisory lock
+for a rare race.
+
+A ticket channel deleted by hand is forgotten by
+`Tickets.on_guild_channel_delete`. Without it, the member's open-ticket quota
+would count a channel that no longer exists and they could never open another.
+
+---
+
+## Actions
+
+Every one of them is a method on `bot.tickets`
+(`services/ticket_service.py`), a `/ticket` subcommand, **and** — for the five
+most used — a button on the pinned control bar. The buttons are the shortcut;
+the commands are the contract. Both call the same method, so they cannot drift.
+
+| Action | Permission | Notes |
+|---|---|---|
+| `open_ticket` | `can_open` | Enforces `max_open_per_user`. Name, overwrites and topic go in with the channel, in one call. |
+| `close_ticket` | `close` | Locks, posts the closing card, DMs the opener. |
+| `reopen_ticket` | `close` | |
+| `delete_ticket` | `admin` | Destroys the channel. |
+| `request_close` | none beyond `view` | Refused to someone who *can* close — they are told to just close it. |
+| `cancel_close_request` | `close`, or being the requester | |
+| `escalate` | `admin` | Asks about manual participants when there are any. |
+| `deescalate` | `admin` | |
+| `move_ticket` | `move` **in the current category** | The destination's permissions replace the current ones — that is the point of moving. |
+| `rename_ticket` | `rename` | |
+| `add_participant` / `remove_participant` | `participants` | Members *or* whole roles. The opener cannot be removed. |
+| `open_staff_thread` | `staff_thread` | Private thread; each staffer joins by running the action once (Discord has no role-based thread membership). |
+
+Failures are raised as `TicketError` carrying an **i18n key**, never a formatted
+string: the caller decides whether to answer in the actor's language (a slash
+command) or the ticket's (a message posted in the channel).
+
+---
+
+## Slash commands, published per guild
+
+`/ticket` exists **only in the guilds where the module is enabled**. The
+mechanism is generic, not ticket-specific:
+
+1. The group is declared at **module level** in `cogs/tickets.py`, never as a
+   Cog attribute — a Cog attribute would be added to the global tree by
+   discord.py, which is exactly what must not happen.
+2. `setup()` calls `bot.register_module_commands("tickets", [ticket_group])`.
+3. `ModdyBot._register_guild_command_set()` adds it to a guild's tree only when
+   `get_enabled_module_ids(guild_id)` contains the module.
+4. `ModuleManager` calls `bot.resync_module_commands(guild_id)` after **every**
+   config save, delete or dashboard-pushed reload. The bot skips the sync when
+   the enabled set did not change — guild command syncs are rate-limited, and a
+   save that only changes a colour must not spend one.
+
+To give another module its own commands, do the same three things: declare the
+group at module level, register it in `setup()`, and make sure the module's
+`enabled` reflects what "this server uses the feature" means.
+
+---
+
+## Persistence
+
+See [PERSISTENT_VIEWS.md](PERSISTENT_VIEWS.md). Three different models here, for
+three different reasons:
+
+| Surface | Model | Why |
+|---|---|---|
+| Ticket control bar, closing card, close request, escalation notice, participants, escalation confirmation | **Registered views, static custom_ids** | The channel the click comes from *is* the ticket. An id in the custom_id would only add a second source of truth that could disagree with the channel. |
+| The public panel's buttons / dropdown | **`DynamicItem`** (`TicketOpenButton`, `TicketOpenSelect`), registered by `TicketsPersistence` | They carry the panel and category ids. |
+| `/config` panel, category and permission screens | **`DynamicItem`**, registered by `TicketsConfigPersistence`; the wrapper views are deliberately *not* registered | They are scoped to an entity (a panel, a category, a role) that a static custom_id cannot carry — same as `LogsCategoryView`. |
+
+The `/config` **root** (`TicketsConfigView`) is a normal registered view:
+`interaction.guild_id` plus a Manage Server check is the whole auth context it
+needs.
+
+Because a `DynamicItem` reconstructs from scratch on every click, there is no
+`self` to stage edits on — which is why the panel, category and permission
+screens **apply every change immediately** instead of batching behind a Save
+button. Deleting a panel or a category is the one exception: it asks first, on
+the same screen.
+
+Authorization is never carried by a view. Every callback resolves the ticket
+from the channel, the category from the guild's config and the actor's
+permissions from their roles. A stale button clicked a month after a restart is
+therefore exactly as safe as a fresh one.
+
+---
+
+## i18n
+
+Two independent languages, and mixing them up is the easy mistake:
+
+- **The actor's language** (`i18n.get_user_locale(interaction)`) for anything
+  ephemeral — errors, confirmations, the `/config` screens.
+- **The category's language** (`category['locale']`) for anything posted *in*
+  the ticket — the control bar, the closing card, the escalation notice, the
+  staff thread, the DM. A ticket speaks one language, whoever is typing.
+
+Keys live under `modules.tickets.*` in the five locale files.
+`tests/test_tickets.py` asserts the five stay in step, key for key.
+
+Command names and descriptions are localized separately, in all 32 Discord
+locales — see [COMMAND_LOCALIZATION.md](COMMAND_LOCALIZATION.md).
+
+---
+
+## Backend / dashboard contract
+
+The dashboard writes `guilds.data.modules.tickets` directly and notifies the bot
+on Redis with `module_id: "tickets"` (see
+[MODULE_SYSTEM.md §3bis](MODULE_SYSTEM.md)). `TicketsModule.on_external_config_change`
+then does what `/config` does on save:
+
+- **updated** → re-post every enabled panel, take down the paused ones. Reloading
+  the config alone is not enough: a panel is a *message*, and its title, its
+  buttons and its very existence are stored state that only a re-post brings in
+  line.
+- **deleted** → take every panel message down and write nothing back (the config
+  is already gone; writing would half-resurrect the module).
+
+The recap relayed to `moddy:dashboard` reports `panels`, `panels_posted` and
+`panels_failed`, so an admin can tell a save that stored fine but could not post.
+
+`message_id` is **owned by the bot**. The dashboard should round-trip whatever
+it reads there and never invent one.
+
+Enabling or disabling the module also adds or removes `/ticket` in that guild —
+handled automatically, no extra event needed.
+
+---
+
+## Extending the module
+
+- **A new ticket action**: add the method to `TicketService` (raising
+  `TicketError` with an i18n key), then a `/ticket` subcommand. Only add a
+  button if it belongs in the five most-used — the control bar is one row.
+- **A new permission**: add the constant, put it in `TICKET_PERMISSIONS`, add
+  `modules.tickets.permissions.<key>.{name,description}` to the five locale
+  files. `admin` expands to the whole tuple, so it needs nothing else. The
+  permission dropdown and the audit line pick it up on their own.
+- **A new per-category setting**: add it to `normalize_category()` with a safe
+  default (every stored config predates it), then to the right modal —
+  identity, messages or options.
+- **A new panel style**: add it to `PANEL_STYLES`, teach `build_panel_view()`
+  to render it and `max_categories_for_style()` its ceiling.

--- a/docs/sessions/2026-08-23_tickets-module.md
+++ b/docs/sessions/2026-08-23_tickets-module.md
@@ -1,0 +1,160 @@
+# 2026-08-23 — Tickets module
+
+Full implementation of the **Tickets** server module: panels, categories,
+per-role permissions, the whole ticket lifecycle, and a generic mechanism for
+publishing a module's slash commands only where that module is enabled.
+
+---
+
+## What was done
+
+### The module (three levels)
+
+- **Panel** — one message in a public channel, with its own title, description,
+  accent colour and either **buttons** or a **dropdown**.
+- **Category** — one entry inside a panel: where the ticket opens, who may open
+  it, what each staff role may do in it, its language, its messages.
+- **Ticket** — the channel itself, tracked in a new `tickets` table.
+
+Free servers get 3 panels × 5 categories; premium 10 × 15. Discord's own
+ceilings (15 buttons / 25 dropdown options) cap the plan on top of that.
+
+### Permissions
+
+Seven, granted per role per category: `view`, `close`, `staff_thread`,
+`rename`, `move`, `participants`, `admin`. `admin` expands to everything **and**
+survives an escalation. Guild administrators always have everything; the ticket
+owner and anyone added by hand get `view` and nothing else — mirroring the
+channel overwrites, so the permission model never disagrees with what someone
+can actually read.
+
+### Actions
+
+`close`, `reopen`, `delete`, `close-request`, `escalate`, `deescalate`, `move`,
+`rename`, `add`, `remove`, `participants`, `staff-thread`, `info` — every one a
+`/ticket` subcommand, the five most used also on the pinned control bar.
+
+### Files added
+
+```
+modules/tickets.py                          config schema, limits, permission model, panels
+services/ticket_service.py                  every ticket verb (bot.tickets)
+utils/ticket_views.py                       panel, control bar, closing card, request, participants
+cogs/tickets.py                             /ticket group + channel cleanup
+db/repositories/tickets.py                  the tickets table
+modules/configs/tickets_config.py           /config root (panel list)
+modules/configs/tickets_panel_config.py     /config one panel
+modules/configs/tickets_category_config.py  /config one category + permissions
+tests/test_tickets.py                       77 tests
+docs/TICKETS.md
+```
+
+### Files modified
+
+- `bot.py` — `bot.tickets`; `register_module_commands()`,
+  `get_enabled_module_ids()`, `resync_module_commands()`, and
+  `_register_guild_command_set()` now takes the enabled-module set.
+- `modules/module_manager.py` — `_sync_module_commands()` called after every
+  save / delete / dashboard-pushed reload.
+- `db/base.py` — the `tickets` table + `TicketsRepository` mixin.
+- `cogs/config.py` — route to the Tickets panel.
+- `utils/emojis.py` — a `TICKETS` section (aliases onto existing icons, see
+  "Follow-ups").
+- `utils/persistent_views.py`, `tests/test_persistent_views.py` — registration
+  and contract coverage for the eight new view classes and the twelve new
+  dynamic items.
+- `locales/{fr,en-US,es-ES,pt-BR,de}.json` — ~180 keys under `modules.tickets`.
+- `locales/commands/*.json` — `/ticket` and its 12 subcommands in all 32
+  Discord locales.
+- `CLAUDE.md`, `docs/{DATABASE,MODULE_SYSTEM,PERSISTENT_VIEWS,PREMIUM}.md`.
+
+---
+
+## Decisions, and why
+
+**Config and runtime are separate files.** `modules/tickets.py` owns the schema
+and never performs an action; `services/ticket_service.py` owns the actions and
+never writes config. Either half can be read, changed and tested without the
+other. It is also what makes "every action is available as a slash command"
+true by construction: the buttons and the commands are two thin shells over the
+same method, so they cannot drift.
+
+**A ticket action always happens inside its own channel**, so `channel_id` is
+the ticket's identity — `tickets.channel_id` is UNIQUE, and the ticket-channel
+views use **static** custom_ids. Putting an id in those custom_ids would only
+create a second source of truth that could disagree with the channel.
+
+**The `/config` screens below the root are dynamic items**, because they are
+scoped to a panel, a category or a role, which a static custom_id cannot carry.
+That forces immediate application of every change (a `DynamicItem` has no
+`self` to stage edits on) — the same trade `LogsCategoryView` already makes.
+Deleting a panel or a category is the one thing that asks first.
+
+**Closing keeps the channel.** Nothing is destroyed by a click: the ticket is
+locked, a card with **Reopen** / **Delete the channel** is posted, and deleting
+needs `admin`. Overwrites are rebuilt from scratch on every change rather than
+patched, so escalation, closure and participant edits can never drift into a
+state nobody can explain.
+
+**A denied role beats everything**, including being a guild administrator. A
+deny list that could be walked past would be a trap rather than a setting.
+
+**The participants panel replaces the list instead of adding to it.** A picker
+that already shows who is in reads as "this is who is in", and unselecting is
+then the obvious way to remove someone; an add-only picker would need a second,
+mirror-image remove control for no gain.
+
+**The escalation confirmation only appears when there is something to confirm** —
+when manual participants exist. A confirmation that always appears stops being
+read.
+
+**Two languages, never mixed**: the actor's for anything ephemeral, the
+category's for anything posted in the ticket. A ticket speaks one language,
+whoever is typing. `TicketError` therefore carries an i18n *key*, never a
+formatted string, and the caller picks the locale.
+
+**A failed premium lookup falls back to the free quota.** Failing open on the
+limit would let an outage hand out the premium one.
+
+**Module-gated commands are a generic mechanism, not a ticket special case.**
+Declare the group at module level (a Cog attribute would be added to the global
+tree by discord.py), register it in `setup()`, and the bot publishes it per
+guild — skipping the sync entirely when the enabled set did not change, because
+guild command syncs are rate-limited.
+
+---
+
+## Follow-ups
+
+1. **Icons.** `utils/emojis.py` gained a `TICKETS` section whose 14 constants
+   are **aliases onto existing icons**, not dedicated artwork (`TICKET` →
+   `SUPPORT`, `TICKET_CLOSE` → `LOGOUT`, `TICKET_ESCALATE` → `SHIELD`, …).
+   Everything references the constants, so replacing the ids in that one block
+   is the whole job. Marked `(placeholder)` inline.
+2. **Transcripts.** Closing keeps the channel, so history is not lost — but
+   there is no export. An HTML/JSON transcript posted to a log channel on close
+   would be the natural next feature, and the `tickets` row already carries
+   everything it would need.
+3. **A ticket log channel.** Opens/closes/escalations are only visible in the
+   ticket itself today. A per-panel log channel would fit next to
+   `ping_role_ids`.
+4. **Staff thread membership.** Discord has no role-based thread membership, so
+   each staffer joins the private thread by running the action once. If that
+   proves annoying on busy servers, pre-adding the members of the smallest role
+   holding `staff_thread` is the obvious escalation — at a real API cost.
+5. **`/ticket` outside a ticket.** Every subcommand answers "this channel is not
+   a ticket". A `/ticket list` for staff (open tickets of the server) would give
+   the group a reason to exist outside a ticket channel.
+
+---
+
+## Verification
+
+```
+python3 -m pytest -q          # 1164 passed
+```
+
+Including `tests/test_persistent_views.py` (every new view builds as a bare
+shell, no custom_id collision, no dynamic-item template overlap) and
+`tests/test_command_localizations.py` (the 32 `/ticket` translations are valid
+Discord names).

--- a/locales/commands/bg.json
+++ b/locales/commands/bg.json
@@ -276,6 +276,100 @@
           "description": "Членът, чиято проверка да се отмени"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Управлявай тикета, в който си"
+    },
+    "ticket close": {
+      "name": "затвори",
+      "description": "Затваря този тикет",
+      "parameters": {
+        "reason": {
+          "name": "причина",
+          "description": "Защо тикетът се затваря или ескалира"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "отвори-отново",
+      "description": "Отваря отново този затворен тикет"
+    },
+    "ticket close-request": {
+      "name": "поискай-затваряне",
+      "description": "Моли екипа да затвори този тикет",
+      "parameters": {
+        "reason": {
+          "name": "причина",
+          "description": "Защо тикетът се затваря или ескалира"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "ескалирай",
+      "description": "Ограничава тикета до отговорниците",
+      "parameters": {
+        "reason": {
+          "name": "причина",
+          "description": "Защо тикетът се затваря или ескалира"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "отмени-ескалацията",
+      "description": "Отменя ескалацията"
+    },
+    "ticket move": {
+      "name": "премести",
+      "description": "Премества този тикет в друга категория",
+      "parameters": {
+        "category": {
+          "name": "категория",
+          "description": "Категорията, в която да се премести тикетът"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "преименувай",
+      "description": "Преименува този тикет",
+      "parameters": {
+        "name": {
+          "name": "име",
+          "description": "Новото име на канала (празно отваря формуляр)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "добави",
+      "description": "Добавя член или роля към този тикет",
+      "parameters": {
+        "target": {
+          "name": "цел",
+          "description": "Засегнатият член или роля"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "премахни",
+      "description": "Премахва член или роля от този тикет",
+      "parameters": {
+        "target": {
+          "name": "цел",
+          "description": "Засегнатият член или роля"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "участници",
+      "description": "Показва и променя кой има достъп до тикета"
+    },
+    "ticket staff-thread": {
+      "name": "нишка-на-екипа",
+      "description": "Отваря частната нишка на екипа или се присъединява"
+    },
+    "ticket info": {
+      "name": "инфо",
+      "description": "Показва подробностите за този тикет"
     }
   }
 }

--- a/locales/commands/cs.json
+++ b/locales/commands/cs.json
@@ -276,6 +276,100 @@
           "description": "Člen, kterému se ověření zruší"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Spravuj ticket, ve kterém jsi"
+    },
+    "ticket close": {
+      "name": "zavřít",
+      "description": "Zavře tento ticket",
+      "parameters": {
+        "reason": {
+          "name": "důvod",
+          "description": "Proč se ticket zavírá nebo eskaluje"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "znovu-otevřít",
+      "description": "Znovu otevře tento zavřený ticket"
+    },
+    "ticket close-request": {
+      "name": "požádat-o-zavření",
+      "description": "Požádá tým o zavření tohoto ticketu",
+      "parameters": {
+        "reason": {
+          "name": "důvod",
+          "description": "Proč se ticket zavírá nebo eskaluje"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eskalovat",
+      "description": "Vyhradí tento ticket odpovědným osobám",
+      "parameters": {
+        "reason": {
+          "name": "důvod",
+          "description": "Proč se ticket zavírá nebo eskaluje"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "zrušit-eskalaci",
+      "description": "Zruší eskalaci"
+    },
+    "ticket move": {
+      "name": "přesunout",
+      "description": "Přesune tento ticket do jiné kategorie",
+      "parameters": {
+        "category": {
+          "name": "kategorie",
+          "description": "Kategorie, do které ticket přesunout"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "přejmenovat",
+      "description": "Přejmenuje tento ticket",
+      "parameters": {
+        "name": {
+          "name": "název",
+          "description": "Nový název kanálu (prázdné otevře formulář)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "přidat",
+      "description": "Přidá člena nebo roli do tohoto ticketu",
+      "parameters": {
+        "target": {
+          "name": "cíl",
+          "description": "Dotčený člen nebo role"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "odebrat",
+      "description": "Odebere člena nebo roli z tohoto ticketu",
+      "parameters": {
+        "target": {
+          "name": "cíl",
+          "description": "Dotčený člen nebo role"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "účastníci",
+      "description": "Zobrazí a upraví, kdo má k ticketu přístup"
+    },
+    "ticket staff-thread": {
+      "name": "vlákno-týmu",
+      "description": "Otevře soukromé vlákno týmu nebo se do něj připojí"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Zobrazí podrobnosti tohoto ticketu"
     }
   }
 }

--- a/locales/commands/da.json
+++ b/locales/commands/da.json
@@ -276,6 +276,100 @@
           "description": "Medlemmet der skal afverificeres"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Administrer den sag, du er i"
+    },
+    "ticket close": {
+      "name": "luk",
+      "description": "Lukker denne sag",
+      "parameters": {
+        "reason": {
+          "name": "årsag",
+          "description": "Hvorfor sagen lukkes eller eskaleres"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "genåbn",
+      "description": "Genåbner denne lukkede sag"
+    },
+    "ticket close-request": {
+      "name": "bed-om-lukning",
+      "description": "Beder staben om at lukke denne sag",
+      "parameters": {
+        "reason": {
+          "name": "årsag",
+          "description": "Hvorfor sagen lukkes eller eskaleres"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eskaler",
+      "description": "Begrænser sagen til de ansvarlige",
+      "parameters": {
+        "reason": {
+          "name": "årsag",
+          "description": "Hvorfor sagen lukkes eller eskaleres"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "annuller-eskalering",
+      "description": "Annullerer eskaleringen"
+    },
+    "ticket move": {
+      "name": "flyt",
+      "description": "Flytter denne sag til en anden kategori",
+      "parameters": {
+        "category": {
+          "name": "kategori",
+          "description": "Kategorien sagen skal flyttes til"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "omdøb",
+      "description": "Omdøber denne sag",
+      "parameters": {
+        "name": {
+          "name": "navn",
+          "description": "Det nye kanalnavn (lad stå tomt for en formular)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "tilføj",
+      "description": "Tilføjer et medlem eller en rolle til sagen",
+      "parameters": {
+        "target": {
+          "name": "mål",
+          "description": "Det berørte medlem eller den berørte rolle"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "fjern",
+      "description": "Fjerner et medlem eller en rolle fra sagen",
+      "parameters": {
+        "target": {
+          "name": "mål",
+          "description": "Det berørte medlem eller den berørte rolle"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "deltagere",
+      "description": "Se og rediger, hvem der har adgang til sagen"
+    },
+    "ticket staff-thread": {
+      "name": "stab-tråd",
+      "description": "Åbner eller deltager i den private stab-tråd"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Viser detaljerne for denne sag"
     }
   }
 }

--- a/locales/commands/de.json
+++ b/locales/commands/de.json
@@ -276,6 +276,100 @@
           "description": "Das Mitglied, dem die Verifizierung entzogen wird"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Verwalte das Ticket, in dem du bist"
+    },
+    "ticket close": {
+      "name": "schliessen",
+      "description": "Schließt dieses Ticket",
+      "parameters": {
+        "reason": {
+          "name": "grund",
+          "description": "Warum das Ticket geschlossen oder eskaliert wird"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "wieder-oeffnen",
+      "description": "Öffnet dieses geschlossene Ticket wieder"
+    },
+    "ticket close-request": {
+      "name": "schliessung-anfragen",
+      "description": "Bittet das Team, dieses Ticket zu schließen",
+      "parameters": {
+        "reason": {
+          "name": "grund",
+          "description": "Warum das Ticket geschlossen oder eskaliert wird"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eskalieren",
+      "description": "Beschränkt dieses Ticket auf die Verantwortlichen",
+      "parameters": {
+        "reason": {
+          "name": "grund",
+          "description": "Warum das Ticket geschlossen oder eskaliert wird"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "eskalation-aufheben",
+      "description": "Hebt die Eskalation auf"
+    },
+    "ticket move": {
+      "name": "verschieben",
+      "description": "Verschiebt dieses Ticket in eine andere Kategorie",
+      "parameters": {
+        "category": {
+          "name": "kategorie",
+          "description": "Die Kategorie, in die das Ticket verschoben wird"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "umbenennen",
+      "description": "Benennt dieses Ticket um",
+      "parameters": {
+        "name": {
+          "name": "name",
+          "description": "Der neue Kanalname (leer lassen für ein Formular)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "hinzufuegen",
+      "description": "Fügt ein Mitglied oder eine Rolle zu diesem Ticket hinzu",
+      "parameters": {
+        "target": {
+          "name": "ziel",
+          "description": "Das betroffene Mitglied oder die betroffene Rolle"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "entfernen",
+      "description": "Entfernt ein Mitglied oder eine Rolle aus diesem Ticket",
+      "parameters": {
+        "target": {
+          "name": "ziel",
+          "description": "Das betroffene Mitglied oder die betroffene Rolle"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "teilnehmer",
+      "description": "Zeigt und ändert, wer Zugriff auf dieses Ticket hat"
+    },
+    "ticket staff-thread": {
+      "name": "team-thread",
+      "description": "Öffnet den privaten Team-Thread oder tritt ihm bei"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Zeigt die Details dieses Tickets"
     }
   }
 }

--- a/locales/commands/el.json
+++ b/locales/commands/el.json
@@ -276,6 +276,100 @@
           "description": "Το μέλος του οποίου ακυρώνεται η επαλήθευση"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Διαχειρίσου το αίτημα στο οποίο βρίσκεσαι"
+    },
+    "ticket close": {
+      "name": "κλείσιμο",
+      "description": "Κλείνει αυτό το αίτημα",
+      "parameters": {
+        "reason": {
+          "name": "αιτία",
+          "description": "Γιατί κλείνει ή κλιμακώνεται το αίτημα"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "επανάνοιγμα",
+      "description": "Ανοίγει ξανά αυτό το κλειστό αίτημα"
+    },
+    "ticket close-request": {
+      "name": "αίτημα-κλεισίματος",
+      "description": "Ζητά από την ομάδα να κλείσει αυτό το αίτημα",
+      "parameters": {
+        "reason": {
+          "name": "αιτία",
+          "description": "Γιατί κλείνει ή κλιμακώνεται το αίτημα"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "κλιμάκωση",
+      "description": "Περιορίζει το αίτημα στους υπεύθυνους",
+      "parameters": {
+        "reason": {
+          "name": "αιτία",
+          "description": "Γιατί κλείνει ή κλιμακώνεται το αίτημα"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "ακύρωση-κλιμάκωσης",
+      "description": "Ακυρώνει την κλιμάκωση"
+    },
+    "ticket move": {
+      "name": "μετακίνηση",
+      "description": "Μετακινεί αυτό το αίτημα σε άλλη κατηγορία",
+      "parameters": {
+        "category": {
+          "name": "κατηγορία",
+          "description": "Η κατηγορία στην οποία θα μετακινηθεί το αίτημα"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "μετονομασία",
+      "description": "Μετονομάζει αυτό το αίτημα",
+      "parameters": {
+        "name": {
+          "name": "όνομα",
+          "description": "Το νέο όνομα καναλιού (κενό για φόρμα)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "προσθήκη",
+      "description": "Προσθέτει μέλος ή ρόλο σε αυτό το αίτημα",
+      "parameters": {
+        "target": {
+          "name": "στόχος",
+          "description": "Το σχετικό μέλος ή ρόλος"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "αφαίρεση",
+      "description": "Αφαιρεί μέλος ή ρόλο από αυτό το αίτημα",
+      "parameters": {
+        "target": {
+          "name": "στόχος",
+          "description": "Το σχετικό μέλος ή ρόλος"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "συμμετέχοντες",
+      "description": "Δείχνει και αλλάζει ποιος έχει πρόσβαση στο αίτημα"
+    },
+    "ticket staff-thread": {
+      "name": "νήμα-ομάδας",
+      "description": "Ανοίγει ή μπαίνει στο ιδιωτικό νήμα της ομάδας"
+    },
+    "ticket info": {
+      "name": "πληροφορίες",
+      "description": "Δείχνει τις λεπτομέρειες αυτού του αιτήματος"
     }
   }
 }

--- a/locales/commands/en-GB.json
+++ b/locales/commands/en-GB.json
@@ -276,6 +276,100 @@
           "description": "The member to un-verify"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Manage the ticket you are in"
+    },
+    "ticket close": {
+      "name": "close",
+      "description": "Close this ticket",
+      "parameters": {
+        "reason": {
+          "name": "reason",
+          "description": "Why the ticket is being closed or escalated"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "reopen",
+      "description": "Reopen this closed ticket"
+    },
+    "ticket close-request": {
+      "name": "close-request",
+      "description": "Ask the staff to close this ticket",
+      "parameters": {
+        "reason": {
+          "name": "reason",
+          "description": "Why the ticket is being closed or escalated"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "escalate",
+      "description": "Restrict this ticket to the responsibles",
+      "parameters": {
+        "reason": {
+          "name": "reason",
+          "description": "Why the ticket is being closed or escalated"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "deescalate",
+      "description": "Undo the escalation"
+    },
+    "ticket move": {
+      "name": "move",
+      "description": "Move this ticket to another category",
+      "parameters": {
+        "category": {
+          "name": "category",
+          "description": "The category the ticket should move to"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "rename",
+      "description": "Rename this ticket",
+      "parameters": {
+        "name": {
+          "name": "name",
+          "description": "The new channel name (leave empty to open a form)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "add",
+      "description": "Add a member or a role to this ticket",
+      "parameters": {
+        "target": {
+          "name": "target",
+          "description": "The member or role concerned"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "remove",
+      "description": "Remove a member or a role from this ticket",
+      "parameters": {
+        "target": {
+          "name": "target",
+          "description": "The member or role concerned"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "participants",
+      "description": "See and edit who has access to this ticket"
+    },
+    "ticket staff-thread": {
+      "name": "staff-thread",
+      "description": "Open or join the private staff thread"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Show this ticket's details"
     }
   }
 }

--- a/locales/commands/en-US.json
+++ b/locales/commands/en-US.json
@@ -276,6 +276,100 @@
           "description": "The member to un-verify"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Manage the ticket you are in"
+    },
+    "ticket close": {
+      "name": "close",
+      "description": "Close this ticket",
+      "parameters": {
+        "reason": {
+          "name": "reason",
+          "description": "Why the ticket is being closed or escalated"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "reopen",
+      "description": "Reopen this closed ticket"
+    },
+    "ticket close-request": {
+      "name": "close-request",
+      "description": "Ask the staff to close this ticket",
+      "parameters": {
+        "reason": {
+          "name": "reason",
+          "description": "Why the ticket is being closed or escalated"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "escalate",
+      "description": "Restrict this ticket to the responsibles",
+      "parameters": {
+        "reason": {
+          "name": "reason",
+          "description": "Why the ticket is being closed or escalated"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "deescalate",
+      "description": "Undo the escalation"
+    },
+    "ticket move": {
+      "name": "move",
+      "description": "Move this ticket to another category",
+      "parameters": {
+        "category": {
+          "name": "category",
+          "description": "The category the ticket should move to"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "rename",
+      "description": "Rename this ticket",
+      "parameters": {
+        "name": {
+          "name": "name",
+          "description": "The new channel name (leave empty to open a form)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "add",
+      "description": "Add a member or a role to this ticket",
+      "parameters": {
+        "target": {
+          "name": "target",
+          "description": "The member or role concerned"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "remove",
+      "description": "Remove a member or a role from this ticket",
+      "parameters": {
+        "target": {
+          "name": "target",
+          "description": "The member or role concerned"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "participants",
+      "description": "See and edit who has access to this ticket"
+    },
+    "ticket staff-thread": {
+      "name": "staff-thread",
+      "description": "Open or join the private staff thread"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Show this ticket's details"
     }
   }
 }

--- a/locales/commands/es-419.json
+++ b/locales/commands/es-419.json
@@ -276,6 +276,100 @@
           "description": "El miembro a desverificar"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Gestiona el ticket en el que estás"
+    },
+    "ticket close": {
+      "name": "cerrar",
+      "description": "Cierra este ticket",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Por qué se cierra o se escala el ticket"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "reabrir",
+      "description": "Reabre este ticket cerrado"
+    },
+    "ticket close-request": {
+      "name": "pedir-cierre",
+      "description": "Pide al staff que cierre este ticket",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Por qué se cierra o se escala el ticket"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "escalar",
+      "description": "Reserva este ticket a los responsables",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Por qué se cierra o se escala el ticket"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "cancelar-escalado",
+      "description": "Cancela el escalado"
+    },
+    "ticket move": {
+      "name": "mover",
+      "description": "Mueve este ticket a otra categoría",
+      "parameters": {
+        "category": {
+          "name": "categoría",
+          "description": "La categoría a la que mover el ticket"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "renombrar",
+      "description": "Renombra este ticket",
+      "parameters": {
+        "name": {
+          "name": "nombre",
+          "description": "El nuevo nombre del canal (vacío para abrir un formulario)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "añadir",
+      "description": "Añade un miembro o un rol a este ticket",
+      "parameters": {
+        "target": {
+          "name": "objetivo",
+          "description": "El miembro o el rol en cuestión"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "quitar",
+      "description": "Quita un miembro o un rol de este ticket",
+      "parameters": {
+        "target": {
+          "name": "objetivo",
+          "description": "El miembro o el rol en cuestión"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "participantes",
+      "description": "Consulta y edita quién tiene acceso a este ticket"
+    },
+    "ticket staff-thread": {
+      "name": "hilo-staff",
+      "description": "Abre o entra en el hilo privado del staff"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Muestra los detalles de este ticket"
     }
   }
 }

--- a/locales/commands/es-ES.json
+++ b/locales/commands/es-ES.json
@@ -276,6 +276,100 @@
           "description": "El miembro a desverificar"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Gestiona el ticket en el que estás"
+    },
+    "ticket close": {
+      "name": "cerrar",
+      "description": "Cierra este ticket",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Por qué se cierra o se escala el ticket"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "reabrir",
+      "description": "Reabre este ticket cerrado"
+    },
+    "ticket close-request": {
+      "name": "pedir-cierre",
+      "description": "Pide al staff que cierre este ticket",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Por qué se cierra o se escala el ticket"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "escalar",
+      "description": "Reserva este ticket a los responsables",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Por qué se cierra o se escala el ticket"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "cancelar-escalado",
+      "description": "Cancela el escalado"
+    },
+    "ticket move": {
+      "name": "mover",
+      "description": "Mueve este ticket a otra categoría",
+      "parameters": {
+        "category": {
+          "name": "categoría",
+          "description": "La categoría a la que mover el ticket"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "renombrar",
+      "description": "Renombra este ticket",
+      "parameters": {
+        "name": {
+          "name": "nombre",
+          "description": "El nuevo nombre del canal (vacío para abrir un formulario)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "añadir",
+      "description": "Añade un miembro o un rol a este ticket",
+      "parameters": {
+        "target": {
+          "name": "objetivo",
+          "description": "El miembro o el rol en cuestión"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "quitar",
+      "description": "Quita un miembro o un rol de este ticket",
+      "parameters": {
+        "target": {
+          "name": "objetivo",
+          "description": "El miembro o el rol en cuestión"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "participantes",
+      "description": "Consulta y edita quién tiene acceso a este ticket"
+    },
+    "ticket staff-thread": {
+      "name": "hilo-staff",
+      "description": "Abre o entra en el hilo privado del staff"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Muestra los detalles de este ticket"
     }
   }
 }

--- a/locales/commands/fi.json
+++ b/locales/commands/fi.json
@@ -276,6 +276,100 @@
           "description": "Jäsen, jonka vahvistus poistetaan"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Hallitse tikettiä, jossa olet"
+    },
+    "ticket close": {
+      "name": "sulje",
+      "description": "Sulkee tämän tiketin",
+      "parameters": {
+        "reason": {
+          "name": "syy",
+          "description": "Miksi tiketti suljetaan tai eskaloidaan"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "avaa-uudelleen",
+      "description": "Avaa tämän suljetun tiketin uudelleen"
+    },
+    "ticket close-request": {
+      "name": "pyydä-sulkemista",
+      "description": "Pyytää henkilökuntaa sulkemaan tämän tiketin",
+      "parameters": {
+        "reason": {
+          "name": "syy",
+          "description": "Miksi tiketti suljetaan tai eskaloidaan"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eskaloi",
+      "description": "Rajaa tiketin vain vastuuhenkilöille",
+      "parameters": {
+        "reason": {
+          "name": "syy",
+          "description": "Miksi tiketti suljetaan tai eskaloidaan"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "peru-eskalointi",
+      "description": "Peruu eskaloinnin"
+    },
+    "ticket move": {
+      "name": "siirrä",
+      "description": "Siirtää tämän tiketin toiseen kategoriaan",
+      "parameters": {
+        "category": {
+          "name": "kategoria",
+          "description": "Kategoria, johon tiketti siirretään"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "nimeä-uudelleen",
+      "description": "Nimeää tämän tiketin uudelleen",
+      "parameters": {
+        "name": {
+          "name": "nimi",
+          "description": "Uusi kanavan nimi (tyhjä avaa lomakkeen)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "lisää",
+      "description": "Lisää jäsenen tai roolin tähän tikettiin",
+      "parameters": {
+        "target": {
+          "name": "kohde",
+          "description": "Kyseessä oleva jäsen tai rooli"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "poista",
+      "description": "Poistaa jäsenen tai roolin tästä tiketistä",
+      "parameters": {
+        "target": {
+          "name": "kohde",
+          "description": "Kyseessä oleva jäsen tai rooli"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "osallistujat",
+      "description": "Näytä ja muokkaa, kenellä on pääsy tähän tikettiin"
+    },
+    "ticket staff-thread": {
+      "name": "henkilökunnan-ketju",
+      "description": "Avaa yksityisen henkilökunnan ketjun tai liittyy siihen"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Näyttää tämän tiketin tiedot"
     }
   }
 }

--- a/locales/commands/fr.json
+++ b/locales/commands/fr.json
@@ -276,6 +276,100 @@
           "description": "Le membre à dévérifier"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Gérer le ticket dans lequel vous êtes"
+    },
+    "ticket close": {
+      "name": "fermer",
+      "description": "Ferme ce ticket",
+      "parameters": {
+        "reason": {
+          "name": "raison",
+          "description": "Pourquoi le ticket est fermé ou escaladé"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "rouvrir",
+      "description": "Rouvre ce ticket fermé"
+    },
+    "ticket close-request": {
+      "name": "demander-fermeture",
+      "description": "Demande au staff de fermer ce ticket",
+      "parameters": {
+        "reason": {
+          "name": "raison",
+          "description": "Pourquoi le ticket est fermé ou escaladé"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "escalader",
+      "description": "Réserve ce ticket aux responsables",
+      "parameters": {
+        "reason": {
+          "name": "raison",
+          "description": "Pourquoi le ticket est fermé ou escaladé"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "annuler-escalade",
+      "description": "Annule l'escalade"
+    },
+    "ticket move": {
+      "name": "deplacer",
+      "description": "Déplace ce ticket vers une autre catégorie",
+      "parameters": {
+        "category": {
+          "name": "categorie",
+          "description": "La catégorie vers laquelle déplacer le ticket"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "renommer",
+      "description": "Renomme ce ticket",
+      "parameters": {
+        "name": {
+          "name": "nom",
+          "description": "Le nouveau nom du salon (laissez vide pour un formulaire)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "ajouter",
+      "description": "Ajoute un membre ou un rôle à ce ticket",
+      "parameters": {
+        "target": {
+          "name": "cible",
+          "description": "Le membre ou le rôle concerné"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "retirer",
+      "description": "Retire un membre ou un rôle de ce ticket",
+      "parameters": {
+        "target": {
+          "name": "cible",
+          "description": "Le membre ou le rôle concerné"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "participants",
+      "description": "Affiche et modifie qui a accès à ce ticket"
+    },
+    "ticket staff-thread": {
+      "name": "thread-staff",
+      "description": "Ouvre ou rejoint le thread privé du staff"
+    },
+    "ticket info": {
+      "name": "infos",
+      "description": "Affiche les détails de ce ticket"
     }
   }
 }

--- a/locales/commands/hi.json
+++ b/locales/commands/hi.json
@@ -276,6 +276,100 @@
           "description": "वह सदस्य जिसका सत्यापन हटाना है"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "आप जिस टिकट में हैं उसे प्रबंधित करें"
+    },
+    "ticket close": {
+      "name": "बंद-करें",
+      "description": "यह टिकट बंद करता है",
+      "parameters": {
+        "reason": {
+          "name": "कारण",
+          "description": "टिकट क्यों बंद या आगे बढ़ाया जा रहा है"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "फिर-खोलें",
+      "description": "इस बंद टिकट को फिर से खोलता है"
+    },
+    "ticket close-request": {
+      "name": "बंद-करने-का-अनुरोध",
+      "description": "स्टाफ़ से यह टिकट बंद करने का अनुरोध करता है",
+      "parameters": {
+        "reason": {
+          "name": "कारण",
+          "description": "टिकट क्यों बंद या आगे बढ़ाया जा रहा है"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "आगे-बढ़ाएँ",
+      "description": "इस टिकट को केवल ज़िम्मेदारों तक सीमित करता है",
+      "parameters": {
+        "reason": {
+          "name": "कारण",
+          "description": "टिकट क्यों बंद या आगे बढ़ाया जा रहा है"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "वापस-लें",
+      "description": "आगे बढ़ाना रद्द करता है"
+    },
+    "ticket move": {
+      "name": "स्थानांतरित",
+      "description": "इस टिकट को दूसरी श्रेणी में ले जाता है",
+      "parameters": {
+        "category": {
+          "name": "श्रेणी",
+          "description": "वह श्रेणी जहाँ टिकट ले जाना है"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "नाम-बदलें",
+      "description": "इस टिकट का नाम बदलता है",
+      "parameters": {
+        "name": {
+          "name": "नाम",
+          "description": "नया चैनल नाम (खाली छोड़ें तो फ़ॉर्म खुलेगा)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "जोड़ें",
+      "description": "इस टिकट में सदस्य या भूमिका जोड़ता है",
+      "parameters": {
+        "target": {
+          "name": "लक्ष्य",
+          "description": "संबंधित सदस्य या भूमिका"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "हटाएँ",
+      "description": "इस टिकट से सदस्य या भूमिका हटाता है",
+      "parameters": {
+        "target": {
+          "name": "लक्ष्य",
+          "description": "संबंधित सदस्य या भूमिका"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "प्रतिभागी",
+      "description": "देखें और बदलें कि इस टिकट तक किसकी पहुँच है"
+    },
+    "ticket staff-thread": {
+      "name": "स्टाफ़-थ्रेड",
+      "description": "निजी स्टाफ़ थ्रेड खोलता है या उसमें शामिल होता है"
+    },
+    "ticket info": {
+      "name": "जानकारी",
+      "description": "इस टिकट का विवरण दिखाता है"
     }
   }
 }

--- a/locales/commands/hr.json
+++ b/locales/commands/hr.json
@@ -276,6 +276,100 @@
           "description": "Član kojem se poništava provjera"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Upravljaj tiketom u kojem se nalaziš"
+    },
+    "ticket close": {
+      "name": "zatvori",
+      "description": "Zatvara ovaj tiket",
+      "parameters": {
+        "reason": {
+          "name": "razlog",
+          "description": "Zašto se tiket zatvara ili eskalira"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "ponovno-otvori",
+      "description": "Ponovno otvara ovaj zatvoreni tiket"
+    },
+    "ticket close-request": {
+      "name": "zatraži-zatvaranje",
+      "description": "Traži od tima da zatvori ovaj tiket",
+      "parameters": {
+        "reason": {
+          "name": "razlog",
+          "description": "Zašto se tiket zatvara ili eskalira"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eskaliraj",
+      "description": "Ograničava ovaj tiket na odgovorne",
+      "parameters": {
+        "reason": {
+          "name": "razlog",
+          "description": "Zašto se tiket zatvara ili eskalira"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "poništi-eskalaciju",
+      "description": "Poništava eskalaciju"
+    },
+    "ticket move": {
+      "name": "premjesti",
+      "description": "Premješta ovaj tiket u drugu kategoriju",
+      "parameters": {
+        "category": {
+          "name": "kategorija",
+          "description": "Kategorija u koju premjestiti tiket"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "preimenuj",
+      "description": "Preimenuje ovaj tiket",
+      "parameters": {
+        "name": {
+          "name": "naziv",
+          "description": "Novi naziv kanala (prazno otvara obrazac)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "dodaj",
+      "description": "Dodaje člana ili ulogu u ovaj tiket",
+      "parameters": {
+        "target": {
+          "name": "meta",
+          "description": "Član ili uloga o kojoj je riječ"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "ukloni",
+      "description": "Uklanja člana ili ulogu iz ovog tiketa",
+      "parameters": {
+        "target": {
+          "name": "meta",
+          "description": "Član ili uloga o kojoj je riječ"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "sudionici",
+      "description": "Prikazuje i mijenja tko ima pristup ovom tiketu"
+    },
+    "ticket staff-thread": {
+      "name": "nit-tima",
+      "description": "Otvara privatnu nit tima ili joj se pridružuje"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Prikazuje pojedinosti ovog tiketa"
     }
   }
 }

--- a/locales/commands/hu.json
+++ b/locales/commands/hu.json
@@ -276,6 +276,100 @@
           "description": "A tag, akinek visszavonják az ellenőrzését"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Kezeld a hibajegyet, amelyben vagy"
+    },
+    "ticket close": {
+      "name": "lezárás",
+      "description": "Lezárja ezt a hibajegyet",
+      "parameters": {
+        "reason": {
+          "name": "indok",
+          "description": "Miért zárul le vagy eszkalálódik a hibajegy"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "újranyitás",
+      "description": "Újranyitja ezt a lezárt hibajegyet"
+    },
+    "ticket close-request": {
+      "name": "lezárás-kérése",
+      "description": "Megkéri a csapatot a hibajegy lezárására",
+      "parameters": {
+        "reason": {
+          "name": "indok",
+          "description": "Miért zárul le vagy eszkalálódik a hibajegy"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eszkalálás",
+      "description": "A hibajegyet a felelősökre korlátozza",
+      "parameters": {
+        "reason": {
+          "name": "indok",
+          "description": "Miért zárul le vagy eszkalálódik a hibajegy"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "eszkalálás-visszavonása",
+      "description": "Visszavonja az eszkalálást"
+    },
+    "ticket move": {
+      "name": "áthelyezés",
+      "description": "Áthelyezi ezt a hibajegyet másik kategóriába",
+      "parameters": {
+        "category": {
+          "name": "kategória",
+          "description": "A kategória, ahová a hibajegy kerüljön"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "átnevezés",
+      "description": "Átnevezi ezt a hibajegyet",
+      "parameters": {
+        "name": {
+          "name": "név",
+          "description": "Az új csatornanév (üresen űrlap nyílik)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "hozzáadás",
+      "description": "Tagot vagy rangot ad a hibajegyhez",
+      "parameters": {
+        "target": {
+          "name": "cél",
+          "description": "Az érintett tag vagy rang"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "eltávolítás",
+      "description": "Tagot vagy rangot távolít el a hibajegyből",
+      "parameters": {
+        "target": {
+          "name": "cél",
+          "description": "Az érintett tag vagy rang"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "résztvevők",
+      "description": "Megmutatja és módosítja, ki fér hozzá a hibajegyhez"
+    },
+    "ticket staff-thread": {
+      "name": "csapat-szál",
+      "description": "Megnyitja a privát csapatszálat vagy csatlakozik hozzá"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Megmutatja a hibajegy részleteit"
     }
   }
 }

--- a/locales/commands/id.json
+++ b/locales/commands/id.json
@@ -276,6 +276,100 @@
           "description": "Anggota yang verifikasinya dibatalkan"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Kelola tiket tempat kamu berada"
+    },
+    "ticket close": {
+      "name": "tutup",
+      "description": "Menutup tiket ini",
+      "parameters": {
+        "reason": {
+          "name": "alasan",
+          "description": "Alasan tiket ditutup atau dieskalasi"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "buka-lagi",
+      "description": "Membuka kembali tiket yang sudah ditutup ini"
+    },
+    "ticket close-request": {
+      "name": "minta-penutupan",
+      "description": "Meminta staf menutup tiket ini",
+      "parameters": {
+        "reason": {
+          "name": "alasan",
+          "description": "Alasan tiket ditutup atau dieskalasi"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eskalasi",
+      "description": "Membatasi tiket ini untuk para penanggung jawab",
+      "parameters": {
+        "reason": {
+          "name": "alasan",
+          "description": "Alasan tiket ditutup atau dieskalasi"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "batalkan-eskalasi",
+      "description": "Membatalkan eskalasi"
+    },
+    "ticket move": {
+      "name": "pindahkan",
+      "description": "Memindahkan tiket ini ke kategori lain",
+      "parameters": {
+        "category": {
+          "name": "kategori",
+          "description": "Kategori tujuan pemindahan tiket"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "ganti-nama",
+      "description": "Mengganti nama tiket ini",
+      "parameters": {
+        "name": {
+          "name": "nama",
+          "description": "Nama kanal baru (kosongkan untuk membuka formulir)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "tambah",
+      "description": "Menambahkan anggota atau peran ke tiket ini",
+      "parameters": {
+        "target": {
+          "name": "target",
+          "description": "Anggota atau peran yang dimaksud"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "hapus",
+      "description": "Menghapus anggota atau peran dari tiket ini",
+      "parameters": {
+        "target": {
+          "name": "target",
+          "description": "Anggota atau peran yang dimaksud"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "peserta",
+      "description": "Lihat dan ubah siapa saja yang bisa mengakses tiket ini"
+    },
+    "ticket staff-thread": {
+      "name": "utas-staf",
+      "description": "Membuka atau bergabung ke utas privat staf"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Menampilkan detail tiket ini"
     }
   }
 }

--- a/locales/commands/it.json
+++ b/locales/commands/it.json
@@ -276,6 +276,100 @@
           "description": "Il membro di cui annullare la verifica"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Gestisci il ticket in cui ti trovi"
+    },
+    "ticket close": {
+      "name": "chiudi",
+      "description": "Chiude questo ticket",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Perché il ticket viene chiuso o escalato"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "riapri",
+      "description": "Riapre questo ticket chiuso"
+    },
+    "ticket close-request": {
+      "name": "chiedi-chiusura",
+      "description": "Chiede allo staff di chiudere questo ticket",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Perché il ticket viene chiuso o escalato"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "escala",
+      "description": "Riserva questo ticket ai responsabili",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Perché il ticket viene chiuso o escalato"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "annulla-escalation",
+      "description": "Annulla l'escalation"
+    },
+    "ticket move": {
+      "name": "sposta",
+      "description": "Sposta questo ticket in un'altra categoria",
+      "parameters": {
+        "category": {
+          "name": "categoria",
+          "description": "La categoria in cui spostare il ticket"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "rinomina",
+      "description": "Rinomina questo ticket",
+      "parameters": {
+        "name": {
+          "name": "nome",
+          "description": "Il nuovo nome del canale (vuoto per aprire un modulo)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "aggiungi",
+      "description": "Aggiunge un membro o un ruolo a questo ticket",
+      "parameters": {
+        "target": {
+          "name": "bersaglio",
+          "description": "Il membro o il ruolo interessato"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "rimuovi",
+      "description": "Rimuove un membro o un ruolo da questo ticket",
+      "parameters": {
+        "target": {
+          "name": "bersaglio",
+          "description": "Il membro o il ruolo interessato"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "partecipanti",
+      "description": "Mostra e modifica chi ha accesso a questo ticket"
+    },
+    "ticket staff-thread": {
+      "name": "thread-staff",
+      "description": "Apre o entra nel thread privato dello staff"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Mostra i dettagli di questo ticket"
     }
   }
 }

--- a/locales/commands/ja.json
+++ b/locales/commands/ja.json
@@ -276,6 +276,100 @@
           "description": "認証を解除するメンバー"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "今いるチケットを管理します"
+    },
+    "ticket close": {
+      "name": "クローズ",
+      "description": "このチケットをクローズします",
+      "parameters": {
+        "reason": {
+          "name": "理由",
+          "description": "チケットをクローズまたはエスカレーションする理由"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "再オープン",
+      "description": "クローズしたこのチケットを再オープンします"
+    },
+    "ticket close-request": {
+      "name": "クローズ依頼",
+      "description": "スタッフにこのチケットのクローズを依頼します",
+      "parameters": {
+        "reason": {
+          "name": "理由",
+          "description": "チケットをクローズまたはエスカレーションする理由"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "エスカレーション",
+      "description": "このチケットを責任者だけに限定します",
+      "parameters": {
+        "reason": {
+          "name": "理由",
+          "description": "チケットをクローズまたはエスカレーションする理由"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "エスカレーション解除",
+      "description": "エスカレーションを解除します"
+    },
+    "ticket move": {
+      "name": "移動",
+      "description": "このチケットを別のカテゴリーへ移動します",
+      "parameters": {
+        "category": {
+          "name": "カテゴリー",
+          "description": "チケットの移動先カテゴリー"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "名前変更",
+      "description": "このチケットの名前を変更します",
+      "parameters": {
+        "name": {
+          "name": "名前",
+          "description": "新しいチャンネル名（空欄でフォームを表示）"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "追加",
+      "description": "このチケットにメンバーまたはロールを追加します",
+      "parameters": {
+        "target": {
+          "name": "対象",
+          "description": "対象のメンバーまたはロール"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "削除",
+      "description": "このチケットからメンバーまたはロールを外します",
+      "parameters": {
+        "target": {
+          "name": "対象",
+          "description": "対象のメンバーまたはロール"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "参加者",
+      "description": "このチケットにアクセスできる相手を確認・変更します"
+    },
+    "ticket staff-thread": {
+      "name": "スタッフスレッド",
+      "description": "スタッフ専用スレッドを開くか参加します"
+    },
+    "ticket info": {
+      "name": "情報",
+      "description": "このチケットの詳細を表示します"
     }
   }
 }

--- a/locales/commands/ko.json
+++ b/locales/commands/ko.json
@@ -276,6 +276,100 @@
           "description": "인증을 해제할 멤버"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "현재 있는 티켓을 관리합니다"
+    },
+    "ticket close": {
+      "name": "닫기",
+      "description": "이 티켓을 닫습니다",
+      "parameters": {
+        "reason": {
+          "name": "사유",
+          "description": "티켓을 닫거나 에스컬레이션하는 이유"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "다시열기",
+      "description": "닫힌 이 티켓을 다시 엽니다"
+    },
+    "ticket close-request": {
+      "name": "닫기요청",
+      "description": "스태프에게 이 티켓을 닫아 달라고 요청합니다",
+      "parameters": {
+        "reason": {
+          "name": "사유",
+          "description": "티켓을 닫거나 에스컬레이션하는 이유"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "에스컬레이션",
+      "description": "이 티켓을 책임자에게만 남깁니다",
+      "parameters": {
+        "reason": {
+          "name": "사유",
+          "description": "티켓을 닫거나 에스컬레이션하는 이유"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "에스컬레이션취소",
+      "description": "에스컬레이션을 취소합니다"
+    },
+    "ticket move": {
+      "name": "이동",
+      "description": "이 티켓을 다른 카테고리로 옮깁니다",
+      "parameters": {
+        "category": {
+          "name": "카테고리",
+          "description": "티켓을 옮길 카테고리"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "이름변경",
+      "description": "이 티켓의 이름을 바꿉니다",
+      "parameters": {
+        "name": {
+          "name": "이름",
+          "description": "새 채널 이름 (비우면 양식이 열립니다)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "추가",
+      "description": "이 티켓에 멤버나 역할을 추가합니다",
+      "parameters": {
+        "target": {
+          "name": "대상",
+          "description": "해당 멤버 또는 역할"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "제거",
+      "description": "이 티켓에서 멤버나 역할을 제거합니다",
+      "parameters": {
+        "target": {
+          "name": "대상",
+          "description": "해당 멤버 또는 역할"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "참여자",
+      "description": "이 티켓에 접근할 수 있는 대상을 보고 수정합니다"
+    },
+    "ticket staff-thread": {
+      "name": "스태프스레드",
+      "description": "비공개 스태프 스레드를 열거나 참여합니다"
+    },
+    "ticket info": {
+      "name": "정보",
+      "description": "이 티켓의 세부 정보를 표시합니다"
     }
   }
 }

--- a/locales/commands/lt.json
+++ b/locales/commands/lt.json
@@ -276,6 +276,100 @@
           "description": "Narys, kurio patvirtinimą atšaukti"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Tvarkyk bilietą, kuriame esi"
+    },
+    "ticket close": {
+      "name": "uždaryti",
+      "description": "Uždaro šį bilietą",
+      "parameters": {
+        "reason": {
+          "name": "priežastis",
+          "description": "Kodėl bilietas uždaromas arba eskaluojamas"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "atidaryti-vėl",
+      "description": "Vėl atidaro šį uždarytą bilietą"
+    },
+    "ticket close-request": {
+      "name": "prašyti-uždaryti",
+      "description": "Paprašo komandos uždaryti šį bilietą",
+      "parameters": {
+        "reason": {
+          "name": "priežastis",
+          "description": "Kodėl bilietas uždaromas arba eskaluojamas"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eskaluoti",
+      "description": "Palieka šį bilietą tik atsakingiems",
+      "parameters": {
+        "reason": {
+          "name": "priežastis",
+          "description": "Kodėl bilietas uždaromas arba eskaluojamas"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "atšaukti-eskalavimą",
+      "description": "Atšaukia eskalavimą"
+    },
+    "ticket move": {
+      "name": "perkelti",
+      "description": "Perkelia šį bilietą į kitą kategoriją",
+      "parameters": {
+        "category": {
+          "name": "kategorija",
+          "description": "Kategorija, į kurią perkelti bilietą"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "pervadinti",
+      "description": "Pervadina šį bilietą",
+      "parameters": {
+        "name": {
+          "name": "pavadinimas",
+          "description": "Naujas kanalo pavadinimas (tuščia atveria formą)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "pridėti",
+      "description": "Prideda narį arba rolę į šį bilietą",
+      "parameters": {
+        "target": {
+          "name": "taikinys",
+          "description": "Susijęs narys arba rolė"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "pašalinti",
+      "description": "Pašalina narį arba rolę iš šio bilieto",
+      "parameters": {
+        "target": {
+          "name": "taikinys",
+          "description": "Susijęs narys arba rolė"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "dalyviai",
+      "description": "Rodo ir keičia, kas turi prieigą prie šio bilieto"
+    },
+    "ticket staff-thread": {
+      "name": "komandos-gija",
+      "description": "Atidaro privačią komandos giją arba prie jos prisijungia"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Rodo šio bilieto informaciją"
     }
   }
 }

--- a/locales/commands/nl.json
+++ b/locales/commands/nl.json
@@ -276,6 +276,100 @@
           "description": "Het lid dat gedeverifieerd wordt"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Beheer het ticket waarin je zit"
+    },
+    "ticket close": {
+      "name": "sluiten",
+      "description": "Sluit dit ticket",
+      "parameters": {
+        "reason": {
+          "name": "reden",
+          "description": "Waarom het ticket wordt gesloten of geëscaleerd"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "heropenen",
+      "description": "Heropent dit gesloten ticket"
+    },
+    "ticket close-request": {
+      "name": "sluiting-vragen",
+      "description": "Vraagt de staff om dit ticket te sluiten",
+      "parameters": {
+        "reason": {
+          "name": "reden",
+          "description": "Waarom het ticket wordt gesloten of geëscaleerd"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "escaleren",
+      "description": "Beperkt dit ticket tot de verantwoordelijken",
+      "parameters": {
+        "reason": {
+          "name": "reden",
+          "description": "Waarom het ticket wordt gesloten of geëscaleerd"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "escalatie-annuleren",
+      "description": "Annuleert de escalatie"
+    },
+    "ticket move": {
+      "name": "verplaatsen",
+      "description": "Verplaatst dit ticket naar een andere categorie",
+      "parameters": {
+        "category": {
+          "name": "categorie",
+          "description": "De categorie waarnaar het ticket moet verhuizen"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "hernoemen",
+      "description": "Hernoemt dit ticket",
+      "parameters": {
+        "name": {
+          "name": "naam",
+          "description": "De nieuwe kanaalnaam (leeg laten voor een formulier)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "toevoegen",
+      "description": "Voegt een lid of een rol toe aan dit ticket",
+      "parameters": {
+        "target": {
+          "name": "doel",
+          "description": "Het betrokken lid of de betrokken rol"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "verwijderen",
+      "description": "Verwijdert een lid of een rol uit dit ticket",
+      "parameters": {
+        "target": {
+          "name": "doel",
+          "description": "Het betrokken lid of de betrokken rol"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "deelnemers",
+      "description": "Bekijk en bewerk wie toegang heeft tot dit ticket"
+    },
+    "ticket staff-thread": {
+      "name": "staff-thread",
+      "description": "Opent of neemt deel aan de privé staff-thread"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Toont de details van dit ticket"
     }
   }
 }

--- a/locales/commands/no.json
+++ b/locales/commands/no.json
@@ -276,6 +276,100 @@
           "description": "Medlemmet som skal avverifiseres"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Administrer saken du er i"
+    },
+    "ticket close": {
+      "name": "lukk",
+      "description": "Lukker denne saken",
+      "parameters": {
+        "reason": {
+          "name": "årsak",
+          "description": "Hvorfor saken lukkes eller eskaleres"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "gjenåpne",
+      "description": "Gjenåpner denne lukkede saken"
+    },
+    "ticket close-request": {
+      "name": "be-om-lukking",
+      "description": "Ber staben om å lukke denne saken",
+      "parameters": {
+        "reason": {
+          "name": "årsak",
+          "description": "Hvorfor saken lukkes eller eskaleres"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eskaler",
+      "description": "Begrenser saken til de ansvarlige",
+      "parameters": {
+        "reason": {
+          "name": "årsak",
+          "description": "Hvorfor saken lukkes eller eskaleres"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "avbryt-eskalering",
+      "description": "Avbryter eskaleringen"
+    },
+    "ticket move": {
+      "name": "flytt",
+      "description": "Flytter denne saken til en annen kategori",
+      "parameters": {
+        "category": {
+          "name": "kategori",
+          "description": "Kategorien saken skal flyttes til"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "gi-nytt-navn",
+      "description": "Gir denne saken et nytt navn",
+      "parameters": {
+        "name": {
+          "name": "navn",
+          "description": "Det nye kanalnavnet (la stå tomt for et skjema)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "legg-til",
+      "description": "Legger til et medlem eller en rolle i saken",
+      "parameters": {
+        "target": {
+          "name": "mål",
+          "description": "Berørt medlem eller rolle"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "fjern",
+      "description": "Fjerner et medlem eller en rolle fra saken",
+      "parameters": {
+        "target": {
+          "name": "mål",
+          "description": "Berørt medlem eller rolle"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "deltakere",
+      "description": "Se og endre hvem som har tilgang til saken"
+    },
+    "ticket staff-thread": {
+      "name": "stab-tråd",
+      "description": "Åpner eller blir med i den private stab-tråden"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Viser detaljene for denne saken"
     }
   }
 }

--- a/locales/commands/pl.json
+++ b/locales/commands/pl.json
@@ -276,6 +276,100 @@
           "description": "Członek, któremu cofnąć weryfikację"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Zarządzaj zgłoszeniem, w którym jesteś"
+    },
+    "ticket close": {
+      "name": "zamknij",
+      "description": "Zamyka to zgłoszenie",
+      "parameters": {
+        "reason": {
+          "name": "powód",
+          "description": "Dlaczego zgłoszenie jest zamykane lub eskalowane"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "otwórz-ponownie",
+      "description": "Otwiera ponownie to zamknięte zgłoszenie"
+    },
+    "ticket close-request": {
+      "name": "poproś-o-zamknięcie",
+      "description": "Prosi zespół o zamknięcie tego zgłoszenia",
+      "parameters": {
+        "reason": {
+          "name": "powód",
+          "description": "Dlaczego zgłoszenie jest zamykane lub eskalowane"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eskaluj",
+      "description": "Ogranicza to zgłoszenie do osób odpowiedzialnych",
+      "parameters": {
+        "reason": {
+          "name": "powód",
+          "description": "Dlaczego zgłoszenie jest zamykane lub eskalowane"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "anuluj-eskalację",
+      "description": "Anuluje eskalację"
+    },
+    "ticket move": {
+      "name": "przenieś",
+      "description": "Przenosi to zgłoszenie do innej kategorii",
+      "parameters": {
+        "category": {
+          "name": "kategoria",
+          "description": "Kategoria, do której przenieść zgłoszenie"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "zmień-nazwę",
+      "description": "Zmienia nazwę tego zgłoszenia",
+      "parameters": {
+        "name": {
+          "name": "nazwa",
+          "description": "Nowa nazwa kanału (puste otwiera formularz)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "dodaj",
+      "description": "Dodaje członka lub rolę do tego zgłoszenia",
+      "parameters": {
+        "target": {
+          "name": "cel",
+          "description": "Członek lub rola, której to dotyczy"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "usuń",
+      "description": "Usuwa członka lub rolę z tego zgłoszenia",
+      "parameters": {
+        "target": {
+          "name": "cel",
+          "description": "Członek lub rola, której to dotyczy"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "uczestnicy",
+      "description": "Pokazuje i zmienia, kto ma dostęp do tego zgłoszenia"
+    },
+    "ticket staff-thread": {
+      "name": "wątek-zespołu",
+      "description": "Otwiera prywatny wątek zespołu lub do niego dołącza"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Pokazuje szczegóły tego zgłoszenia"
     }
   }
 }

--- a/locales/commands/pt-BR.json
+++ b/locales/commands/pt-BR.json
@@ -276,6 +276,100 @@
           "description": "O membro a desverificar"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Gerencie o ticket em que você está"
+    },
+    "ticket close": {
+      "name": "fechar",
+      "description": "Fecha este ticket",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Por que o ticket está sendo fechado ou escalonado"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "reabrir",
+      "description": "Reabre este ticket fechado"
+    },
+    "ticket close-request": {
+      "name": "pedir-fechamento",
+      "description": "Pede à equipe para fechar este ticket",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Por que o ticket está sendo fechado ou escalonado"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "escalonar",
+      "description": "Reserva este ticket aos responsáveis",
+      "parameters": {
+        "reason": {
+          "name": "motivo",
+          "description": "Por que o ticket está sendo fechado ou escalonado"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "cancelar-escalonamento",
+      "description": "Cancela o escalonamento"
+    },
+    "ticket move": {
+      "name": "mover",
+      "description": "Move este ticket para outra categoria",
+      "parameters": {
+        "category": {
+          "name": "categoria",
+          "description": "A categoria para onde mover o ticket"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "renomear",
+      "description": "Renomeia este ticket",
+      "parameters": {
+        "name": {
+          "name": "nome",
+          "description": "O novo nome do canal (vazio para abrir um formulário)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "adicionar",
+      "description": "Adiciona um membro ou cargo a este ticket",
+      "parameters": {
+        "target": {
+          "name": "alvo",
+          "description": "O membro ou cargo em questão"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "remover",
+      "description": "Remove um membro ou cargo deste ticket",
+      "parameters": {
+        "target": {
+          "name": "alvo",
+          "description": "O membro ou cargo em questão"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "participantes",
+      "description": "Veja e edite quem tem acesso a este ticket"
+    },
+    "ticket staff-thread": {
+      "name": "topico-equipe",
+      "description": "Abre ou entra no tópico privado da equipe"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Mostra os detalhes deste ticket"
     }
   }
 }

--- a/locales/commands/ro.json
+++ b/locales/commands/ro.json
@@ -276,6 +276,100 @@
           "description": "Membrul căruia i se anulează verificarea"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Gestionează tichetul în care te afli"
+    },
+    "ticket close": {
+      "name": "închide",
+      "description": "Închide acest tichet",
+      "parameters": {
+        "reason": {
+          "name": "motiv",
+          "description": "De ce este închis sau escaladat tichetul"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "redeschide",
+      "description": "Redeschide acest tichet închis"
+    },
+    "ticket close-request": {
+      "name": "cere-închiderea",
+      "description": "Cere echipei să închidă acest tichet",
+      "parameters": {
+        "reason": {
+          "name": "motiv",
+          "description": "De ce este închis sau escaladat tichetul"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "escaladează",
+      "description": "Restrânge acest tichet la responsabili",
+      "parameters": {
+        "reason": {
+          "name": "motiv",
+          "description": "De ce este închis sau escaladat tichetul"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "anulează-escaladarea",
+      "description": "Anulează escaladarea"
+    },
+    "ticket move": {
+      "name": "mută",
+      "description": "Mută acest tichet în altă categorie",
+      "parameters": {
+        "category": {
+          "name": "categorie",
+          "description": "Categoria în care să fie mutat tichetul"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "redenumește",
+      "description": "Redenumește acest tichet",
+      "parameters": {
+        "name": {
+          "name": "nume",
+          "description": "Noul nume al canalului (gol deschide un formular)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "adaugă",
+      "description": "Adaugă un membru sau un rol la acest tichet",
+      "parameters": {
+        "target": {
+          "name": "țintă",
+          "description": "Membrul sau rolul vizat"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "elimină",
+      "description": "Elimină un membru sau un rol din acest tichet",
+      "parameters": {
+        "target": {
+          "name": "țintă",
+          "description": "Membrul sau rolul vizat"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "participanți",
+      "description": "Vezi și modifică cine are acces la acest tichet"
+    },
+    "ticket staff-thread": {
+      "name": "discuție-echipă",
+      "description": "Deschide sau intră în discuția privată a echipei"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Afișează detaliile acestui tichet"
     }
   }
 }

--- a/locales/commands/ru.json
+++ b/locales/commands/ru.json
@@ -276,6 +276,100 @@
           "description": "Участник, с которого снять проверку"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Управление тикетом, в котором вы находитесь"
+    },
+    "ticket close": {
+      "name": "закрыть",
+      "description": "Закрывает этот тикет",
+      "parameters": {
+        "reason": {
+          "name": "причина",
+          "description": "Почему тикет закрывается или эскалируется"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "открыть-снова",
+      "description": "Снова открывает этот закрытый тикет"
+    },
+    "ticket close-request": {
+      "name": "запросить-закрытие",
+      "description": "Просит команду закрыть этот тикет",
+      "parameters": {
+        "reason": {
+          "name": "причина",
+          "description": "Почему тикет закрывается или эскалируется"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "эскалация",
+      "description": "Оставляет тикет только ответственным",
+      "parameters": {
+        "reason": {
+          "name": "причина",
+          "description": "Почему тикет закрывается или эскалируется"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "отменить-эскалацию",
+      "description": "Отменяет эскалацию"
+    },
+    "ticket move": {
+      "name": "переместить",
+      "description": "Перемещает этот тикет в другую категорию",
+      "parameters": {
+        "category": {
+          "name": "категория",
+          "description": "Категория, в которую переместить тикет"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "переименовать",
+      "description": "Переименовывает этот тикет",
+      "parameters": {
+        "name": {
+          "name": "имя",
+          "description": "Новое название канала (пусто — откроется форма)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "добавить",
+      "description": "Добавляет участника или роль в этот тикет",
+      "parameters": {
+        "target": {
+          "name": "цель",
+          "description": "Затронутый участник или роль"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "убрать",
+      "description": "Убирает участника или роль из этого тикета",
+      "parameters": {
+        "target": {
+          "name": "цель",
+          "description": "Затронутый участник или роль"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "участники",
+      "description": "Показывает и меняет, у кого есть доступ к тикету"
+    },
+    "ticket staff-thread": {
+      "name": "ветка-команды",
+      "description": "Открывает приватную ветку команды или входит в неё"
+    },
+    "ticket info": {
+      "name": "инфо",
+      "description": "Показывает подробности этого тикета"
     }
   }
 }

--- a/locales/commands/sv-SE.json
+++ b/locales/commands/sv-SE.json
@@ -276,6 +276,100 @@
           "description": "Medlemmen som ska avverifieras"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Hantera ärendet du befinner dig i"
+    },
+    "ticket close": {
+      "name": "stäng",
+      "description": "Stänger det här ärendet",
+      "parameters": {
+        "reason": {
+          "name": "anledning",
+          "description": "Varför ärendet stängs eller eskaleras"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "återöppna",
+      "description": "Återöppnar det här stängda ärendet"
+    },
+    "ticket close-request": {
+      "name": "begär-stängning",
+      "description": "Ber personalen att stänga det här ärendet",
+      "parameters": {
+        "reason": {
+          "name": "anledning",
+          "description": "Varför ärendet stängs eller eskaleras"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "eskalera",
+      "description": "Begränsar ärendet till de ansvariga",
+      "parameters": {
+        "reason": {
+          "name": "anledning",
+          "description": "Varför ärendet stängs eller eskaleras"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "avbryt-eskalering",
+      "description": "Avbryter eskaleringen"
+    },
+    "ticket move": {
+      "name": "flytta",
+      "description": "Flyttar ärendet till en annan kategori",
+      "parameters": {
+        "category": {
+          "name": "kategori",
+          "description": "Kategorin ärendet ska flyttas till"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "byt-namn",
+      "description": "Byter namn på ärendet",
+      "parameters": {
+        "name": {
+          "name": "namn",
+          "description": "Det nya kanalnamnet (lämna tomt för ett formulär)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "lägg-till",
+      "description": "Lägger till en medlem eller roll i ärendet",
+      "parameters": {
+        "target": {
+          "name": "mål",
+          "description": "Berörd medlem eller roll"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "ta-bort",
+      "description": "Tar bort en medlem eller roll från ärendet",
+      "parameters": {
+        "target": {
+          "name": "mål",
+          "description": "Berörd medlem eller roll"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "deltagare",
+      "description": "Visa och ändra vem som har åtkomst till ärendet"
+    },
+    "ticket staff-thread": {
+      "name": "personaltråd",
+      "description": "Öppnar eller går med i den privata personaltråden"
+    },
+    "ticket info": {
+      "name": "info",
+      "description": "Visar detaljerna för det här ärendet"
     }
   }
 }

--- a/locales/commands/th.json
+++ b/locales/commands/th.json
@@ -276,6 +276,100 @@
           "description": "สมาชิกที่จะยกเลิกการยืนยัน"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "จัดการทิกเก็ตที่คุณอยู่"
+    },
+    "ticket close": {
+      "name": "ปิด",
+      "description": "ปิดทิกเก็ตนี้",
+      "parameters": {
+        "reason": {
+          "name": "เหตุผล",
+          "description": "เหตุผลที่ปิดหรือยกระดับทิกเก็ต"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "เปิดใหม่",
+      "description": "เปิดทิกเก็ตที่ปิดไปแล้วนี้อีกครั้ง"
+    },
+    "ticket close-request": {
+      "name": "ขอปิด",
+      "description": "ขอให้ทีมงานปิดทิกเก็ตนี้",
+      "parameters": {
+        "reason": {
+          "name": "เหตุผล",
+          "description": "เหตุผลที่ปิดหรือยกระดับทิกเก็ต"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "ยกระดับ",
+      "description": "จำกัดทิกเก็ตนี้ไว้ให้ผู้รับผิดชอบ",
+      "parameters": {
+        "reason": {
+          "name": "เหตุผล",
+          "description": "เหตุผลที่ปิดหรือยกระดับทิกเก็ต"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "ยกเลิกการยกระดับ",
+      "description": "ยกเลิกการยกระดับ"
+    },
+    "ticket move": {
+      "name": "ย้าย",
+      "description": "ย้ายทิกเก็ตนี้ไปยังหมวดหมู่อื่น",
+      "parameters": {
+        "category": {
+          "name": "หมวดหมู่",
+          "description": "หมวดหมู่ที่จะย้ายทิกเก็ตไป"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "เปลี่ยนชื่อ",
+      "description": "เปลี่ยนชื่อทิกเก็ตนี้",
+      "parameters": {
+        "name": {
+          "name": "ชื่อ",
+          "description": "ชื่อช่องใหม่ (เว้นว่างเพื่อเปิดแบบฟอร์ม)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "เพิ่ม",
+      "description": "เพิ่มสมาชิกหรือบทบาทเข้าทิกเก็ตนี้",
+      "parameters": {
+        "target": {
+          "name": "เป้าหมาย",
+          "description": "สมาชิกหรือบทบาทที่เกี่ยวข้อง"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "นำออก",
+      "description": "นำสมาชิกหรือบทบาทออกจากทิกเก็ตนี้",
+      "parameters": {
+        "target": {
+          "name": "เป้าหมาย",
+          "description": "สมาชิกหรือบทบาทที่เกี่ยวข้อง"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "ผู้เข้าร่วม",
+      "description": "ดูและแก้ไขว่าใครเข้าถึงทิกเก็ตนี้ได้"
+    },
+    "ticket staff-thread": {
+      "name": "เธรดทีมงาน",
+      "description": "เปิดหรือเข้าร่วมเธรดส่วนตัวของทีมงาน"
+    },
+    "ticket info": {
+      "name": "ข้อมูล",
+      "description": "แสดงรายละเอียดของทิกเก็ตนี้"
     }
   }
 }

--- a/locales/commands/tr.json
+++ b/locales/commands/tr.json
@@ -276,6 +276,100 @@
           "description": "Doğrulaması kaldırılacak üye"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "İçinde bulunduğun talebi yönet"
+    },
+    "ticket close": {
+      "name": "kapat",
+      "description": "Bu talebi kapatır",
+      "parameters": {
+        "reason": {
+          "name": "sebep",
+          "description": "Talebin neden kapatıldığı veya yükseltildiği"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "yeniden-aç",
+      "description": "Kapalı olan bu talebi yeniden açar"
+    },
+    "ticket close-request": {
+      "name": "kapatma-iste",
+      "description": "Ekipten bu talebi kapatmasını ister",
+      "parameters": {
+        "reason": {
+          "name": "sebep",
+          "description": "Talebin neden kapatıldığı veya yükseltildiği"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "yükselt",
+      "description": "Bu talebi yalnızca sorumlulara bırakır",
+      "parameters": {
+        "reason": {
+          "name": "sebep",
+          "description": "Talebin neden kapatıldığı veya yükseltildiği"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "yükseltmeyi-geri-al",
+      "description": "Yükseltmeyi geri alır"
+    },
+    "ticket move": {
+      "name": "taşı",
+      "description": "Bu talebi başka bir kategoriye taşır",
+      "parameters": {
+        "category": {
+          "name": "kategori",
+          "description": "Talebin taşınacağı kategori"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "yeniden-adlandır",
+      "description": "Bu talebi yeniden adlandırır",
+      "parameters": {
+        "name": {
+          "name": "ad",
+          "description": "Yeni kanal adı (boş bırakılırsa form açılır)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "ekle",
+      "description": "Bu talebe bir üye veya rol ekler",
+      "parameters": {
+        "target": {
+          "name": "hedef",
+          "description": "İlgili üye veya rol"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "çıkar",
+      "description": "Bu talepten bir üye veya rol çıkarır",
+      "parameters": {
+        "target": {
+          "name": "hedef",
+          "description": "İlgili üye veya rol"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "katılımcılar",
+      "description": "Bu talebe kimin eriştiğini gösterir ve değiştirir"
+    },
+    "ticket staff-thread": {
+      "name": "ekip-konusu",
+      "description": "Özel ekip konusunu açar veya ona katılır"
+    },
+    "ticket info": {
+      "name": "bilgi",
+      "description": "Bu talebin ayrıntılarını gösterir"
     }
   }
 }

--- a/locales/commands/uk.json
+++ b/locales/commands/uk.json
@@ -276,6 +276,100 @@
           "description": "Учасник, з якого зняти перевірку"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Керування тікетом, у якому ви перебуваєте"
+    },
+    "ticket close": {
+      "name": "закрити",
+      "description": "Закриває цей тікет",
+      "parameters": {
+        "reason": {
+          "name": "причина",
+          "description": "Чому тікет закривається або ескалюється"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "відкрити-знову",
+      "description": "Знову відкриває цей закритий тікет"
+    },
+    "ticket close-request": {
+      "name": "запросити-закриття",
+      "description": "Просить команду закрити цей тікет",
+      "parameters": {
+        "reason": {
+          "name": "причина",
+          "description": "Чому тікет закривається або ескалюється"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "ескалація",
+      "description": "Залишає тікет лише відповідальним",
+      "parameters": {
+        "reason": {
+          "name": "причина",
+          "description": "Чому тікет закривається або ескалюється"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "скасувати-ескалацію",
+      "description": "Скасовує ескалацію"
+    },
+    "ticket move": {
+      "name": "перемістити",
+      "description": "Переміщує цей тікет до іншої категорії",
+      "parameters": {
+        "category": {
+          "name": "категорія",
+          "description": "Категорія, до якої перемістити тікет"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "перейменувати",
+      "description": "Перейменовує цей тікет",
+      "parameters": {
+        "name": {
+          "name": "назва",
+          "description": "Нова назва каналу (порожньо — відкриється форма)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "додати",
+      "description": "Додає учасника або роль до цього тікета",
+      "parameters": {
+        "target": {
+          "name": "ціль",
+          "description": "Причетний учасник або роль"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "прибрати",
+      "description": "Прибирає учасника або роль із цього тікета",
+      "parameters": {
+        "target": {
+          "name": "ціль",
+          "description": "Причетний учасник або роль"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "учасники",
+      "description": "Показує та змінює, хто має доступ до тікета"
+    },
+    "ticket staff-thread": {
+      "name": "гілка-команди",
+      "description": "Відкриває приватну гілку команди або приєднується"
+    },
+    "ticket info": {
+      "name": "інфо",
+      "description": "Показує подробиці цього тікета"
     }
   }
 }

--- a/locales/commands/vi.json
+++ b/locales/commands/vi.json
@@ -276,6 +276,100 @@
           "description": "Thành viên bị hủy xác minh"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "Quản lý ticket bạn đang ở trong"
+    },
+    "ticket close": {
+      "name": "đóng",
+      "description": "Đóng ticket này",
+      "parameters": {
+        "reason": {
+          "name": "lý-do",
+          "description": "Lý do ticket bị đóng hoặc được nâng cấp"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "mở-lại",
+      "description": "Mở lại ticket đã đóng này"
+    },
+    "ticket close-request": {
+      "name": "yêu-cầu-đóng",
+      "description": "Đề nghị đội ngũ đóng ticket này",
+      "parameters": {
+        "reason": {
+          "name": "lý-do",
+          "description": "Lý do ticket bị đóng hoặc được nâng cấp"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "nâng-cấp",
+      "description": "Giới hạn ticket này cho những người phụ trách",
+      "parameters": {
+        "reason": {
+          "name": "lý-do",
+          "description": "Lý do ticket bị đóng hoặc được nâng cấp"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "hủy-nâng-cấp",
+      "description": "Hủy việc nâng cấp"
+    },
+    "ticket move": {
+      "name": "chuyển",
+      "description": "Chuyển ticket này sang danh mục khác",
+      "parameters": {
+        "category": {
+          "name": "danh-mục",
+          "description": "Danh mục sẽ chuyển ticket đến"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "đổi-tên",
+      "description": "Đổi tên ticket này",
+      "parameters": {
+        "name": {
+          "name": "tên",
+          "description": "Tên kênh mới (để trống để mở biểu mẫu)"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "thêm",
+      "description": "Thêm một thành viên hoặc vai trò vào ticket này",
+      "parameters": {
+        "target": {
+          "name": "mục-tiêu",
+          "description": "Thành viên hoặc vai trò liên quan"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "xóa",
+      "description": "Xóa một thành viên hoặc vai trò khỏi ticket này",
+      "parameters": {
+        "target": {
+          "name": "mục-tiêu",
+          "description": "Thành viên hoặc vai trò liên quan"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "người-tham-gia",
+      "description": "Xem và sửa ai có quyền truy cập ticket này"
+    },
+    "ticket staff-thread": {
+      "name": "luồng-đội-ngũ",
+      "description": "Mở hoặc tham gia luồng riêng của đội ngũ"
+    },
+    "ticket info": {
+      "name": "thông-tin",
+      "description": "Hiển thị chi tiết của ticket này"
     }
   }
 }

--- a/locales/commands/zh-CN.json
+++ b/locales/commands/zh-CN.json
@@ -276,6 +276,100 @@
           "description": "要取消验证的成员"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "管理你所在的工单"
+    },
+    "ticket close": {
+      "name": "关闭",
+      "description": "关闭这个工单",
+      "parameters": {
+        "reason": {
+          "name": "原因",
+          "description": "关闭或升级这个工单的原因"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "重新打开",
+      "description": "重新打开这个已关闭的工单"
+    },
+    "ticket close-request": {
+      "name": "申请关闭",
+      "description": "请求团队关闭这个工单",
+      "parameters": {
+        "reason": {
+          "name": "原因",
+          "description": "关闭或升级这个工单的原因"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "升级",
+      "description": "将这个工单限定给负责人",
+      "parameters": {
+        "reason": {
+          "name": "原因",
+          "description": "关闭或升级这个工单的原因"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "取消升级",
+      "description": "取消升级"
+    },
+    "ticket move": {
+      "name": "移动",
+      "description": "将这个工单移到另一个分类",
+      "parameters": {
+        "category": {
+          "name": "分类",
+          "description": "要把工单移到的分类"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "重命名",
+      "description": "重命名这个工单",
+      "parameters": {
+        "name": {
+          "name": "名称",
+          "description": "新的频道名称（留空则打开表单）"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "添加",
+      "description": "向这个工单添加成员或身份组",
+      "parameters": {
+        "target": {
+          "name": "目标",
+          "description": "相关的成员或身份组"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "移除",
+      "description": "从这个工单移除成员或身份组",
+      "parameters": {
+        "target": {
+          "name": "目标",
+          "description": "相关的成员或身份组"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "参与者",
+      "description": "查看并修改谁可以访问这个工单"
+    },
+    "ticket staff-thread": {
+      "name": "团队帖子",
+      "description": "打开或加入团队私密帖子"
+    },
+    "ticket info": {
+      "name": "信息",
+      "description": "显示这个工单的详情"
     }
   }
 }

--- a/locales/commands/zh-TW.json
+++ b/locales/commands/zh-TW.json
@@ -276,6 +276,100 @@
           "description": "要取消驗證的成員"
         }
       }
+    },
+    "ticket": {
+      "name": "ticket",
+      "description": "管理你所在的服務單"
+    },
+    "ticket close": {
+      "name": "關閉",
+      "description": "關閉這個服務單",
+      "parameters": {
+        "reason": {
+          "name": "原因",
+          "description": "關閉或升級這個服務單的原因"
+        }
+      }
+    },
+    "ticket reopen": {
+      "name": "重新開啟",
+      "description": "重新開啟這個已關閉的服務單"
+    },
+    "ticket close-request": {
+      "name": "申請關閉",
+      "description": "請團隊關閉這個服務單",
+      "parameters": {
+        "reason": {
+          "name": "原因",
+          "description": "關閉或升級這個服務單的原因"
+        }
+      }
+    },
+    "ticket escalate": {
+      "name": "升級",
+      "description": "將這個服務單限定給負責人",
+      "parameters": {
+        "reason": {
+          "name": "原因",
+          "description": "關閉或升級這個服務單的原因"
+        }
+      }
+    },
+    "ticket deescalate": {
+      "name": "取消升級",
+      "description": "取消升級"
+    },
+    "ticket move": {
+      "name": "移動",
+      "description": "將這個服務單移到另一個分類",
+      "parameters": {
+        "category": {
+          "name": "分類",
+          "description": "要把服務單移到的分類"
+        }
+      }
+    },
+    "ticket rename": {
+      "name": "重新命名",
+      "description": "重新命名這個服務單",
+      "parameters": {
+        "name": {
+          "name": "名稱",
+          "description": "新的頻道名稱（留空則開啟表單）"
+        }
+      }
+    },
+    "ticket add": {
+      "name": "新增",
+      "description": "為這個服務單新增成員或身分組",
+      "parameters": {
+        "target": {
+          "name": "目標",
+          "description": "相關的成員或身分組"
+        }
+      }
+    },
+    "ticket remove": {
+      "name": "移除",
+      "description": "從這個服務單移除成員或身分組",
+      "parameters": {
+        "target": {
+          "name": "目標",
+          "description": "相關的成員或身分組"
+        }
+      }
+    },
+    "ticket participants": {
+      "name": "參與者",
+      "description": "查看並修改誰可以存取這個服務單"
+    },
+    "ticket staff-thread": {
+      "name": "團隊討論串",
+      "description": "開啟或加入團隊私人討論串"
+    },
+    "ticket info": {
+      "name": "資訊",
+      "description": "顯示這個服務單的詳細資料"
     }
   }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -2795,6 +2795,314 @@
           "app_command_permission_update": "Die Berechtigungen eines Befehls wurden geändert"
         }
       }
+    },
+    "tickets": {
+      "description": "Support-Tickets mit Panels, Kategorien und Rechten pro Rolle",
+      "config": {
+        "title": "Tickets",
+        "description": "Lass deine Mitglieder über ein Panel ein Support-Ticket öffnen. Jedes Panel bietet eine oder mehrere Kategorien, und jede Kategorie legt fest, wo das Ticket geöffnet wird, wer es öffnen darf und was dein Team darin tun kann.",
+        "quota": "Panels: `{count}/{max}` · Kategorien pro Panel: `{categories}`",
+        "premium_hint": "Premium hebt diese Grenzen auf 10 Panels und 15 Kategorien pro Panel an.",
+        "manage_placeholder": "Wähle ein Panel zum Konfigurieren",
+        "empty": "Noch kein Panel. Erstelle eins, damit deine Mitglieder Tickets öffnen können.",
+        "add_panel": "Panel hinzufügen",
+        "entry_summary": "{categories} Kategorie(n) · {style}",
+        "no_channel": "kein Kanal",
+        "paused": "pausiert",
+        "not_posted": "Dieses Panel wurde noch nicht gepostet — nutze **Erneut posten**."
+      },
+      "panel": {
+        "modal_title_new": "Neues Ticket-Panel",
+        "modal_title_edit": "Panel bearbeiten",
+        "name_label": "Interner Name",
+        "name_hint": "Nur du siehst ihn, in dieser Konfiguration",
+        "title_label": "Titel für die Mitglieder",
+        "title_hint": "Leer lassen, um den internen Namen zu verwenden",
+        "description_label": "Beschreibung",
+        "description_hint": "Der Text über den Buttons",
+        "color_label": "Akzentfarbe",
+        "color_hint": "Hexadezimal, zum Beispiel #5865F2",
+        "placeholder_label": "Text des Auswahlmenüs",
+        "placeholder_hint": "Wird nur verwendet, wenn das Panel als Auswahlmenü erscheint",
+        "subtitle": "Ticket-Panel",
+        "paused_notice": "Dieses Panel ist pausiert: Seine Nachricht wird entfernt und niemand kann darüber ein Ticket öffnen.",
+        "channel_title": "Kanal des Panels",
+        "channel_hint": "Wo die Nachricht gepostet wird, auf die die Mitglieder klicken",
+        "channel_placeholder": "Wähle einen Kanal",
+        "style_title": "Wie Mitglieder wählen",
+        "style_hint": "Buttons sind schneller; ein Auswahlmenü fasst mehr Kategorien",
+        "style_buttons": "Buttons",
+        "style_buttons_hint": "Ein Button pro Kategorie, bis zu 15",
+        "style_select": "Auswahlmenü",
+        "style_select_hint": "Eine Liste, bis zu 25 Kategorien",
+        "categories_title": "Kategorien",
+        "categories_hint": "{count}/{max} · eine pro Button oder Menüeintrag",
+        "no_category": "Keine Kategorie. Ein Panel ohne Kategorie wird nie gepostet.",
+        "category_placeholder": "Wähle eine Kategorie zum Konfigurieren",
+        "category_summary": "{roles} Rolle(n) mit Rechten · Sprache `{language}`",
+        "no_destination": "kein Ziel",
+        "edit": "Bearbeiten",
+        "add_category": "Kategorie hinzufügen",
+        "repost": "Erneut posten",
+        "pause": "Pausieren",
+        "resume": "Fortsetzen",
+        "delete": "Löschen",
+        "delete_title": "Dieses Panel löschen?",
+        "delete_description": "Seine Nachricht wird entfernt und seine {categories} Kategorie(n) gehen verloren. Bereits offene Tickets sind nicht betroffen.",
+        "delete_confirm": "Panel löschen",
+        "repost_failed": "Das Panel konnte nicht gepostet werden. Prüfe, ob Moddy in den Kanal schreiben darf und ob das Panel mindestens eine nutzbare Kategorie hat."
+      },
+      "category": {
+        "modal_title_new": "Neue Kategorie",
+        "modal_title_edit": "Kategorie bearbeiten",
+        "name_label": "Name",
+        "name_hint": "Steht auf dem Button oder dem Menüeintrag",
+        "emoji_label": "Emoji",
+        "emoji_hint": "Optional, zum Beispiel ein Server-Emoji",
+        "description_label": "Kurzbeschreibung",
+        "description_hint": "Steht in einem Auswahlmenü unter dem Namen",
+        "color_label": "Farbe des Buttons",
+        "color_hint": "Wird ignoriert, wenn das Panel als Auswahlmenü erscheint",
+        "color_primary": "Blau",
+        "color_secondary": "Grau",
+        "color_success": "Grün",
+        "color_danger": "Rot",
+        "subtitle": "Kategorie des Panels „{panel}“",
+        "paused_notice": "Diese Kategorie ist pausiert: Sie erscheint nicht mehr auf dem Panel.",
+        "destination_title": "Wo Tickets erstellt werden",
+        "destination_hint": "Die Discord-Kategorie, in der der Ticket-Kanal erstellt wird",
+        "destination_placeholder": "Wähle eine Discord-Kategorie",
+        "access_title": "Wer ein Ticket öffnen darf",
+        "access_hint": "Leer lassen, um es allen zu erlauben",
+        "allowed_placeholder": "Rollen, die öffnen dürfen",
+        "denied_hint": "Eine gesperrte Rolle gewinnt immer, auch wenn das Mitglied zusätzlich eine erlaubte hat.",
+        "denied_placeholder": "Gesperrte Rollen",
+        "language_title": "Sprache der Tickets",
+        "language_hint": "Alle Nachrichten dieser Tickets verwenden diese Sprache",
+        "summary_title": "Hinter den Buttons unten konfiguriert",
+        "summary_permissions": "Rechte — {roles} Rolle(n)",
+        "summary_messages": "Nachrichten — {count}/2 angepasst",
+        "summary_options": "Optionen — Name `{format}`, `{max}` offene(s) Ticket(s) pro Mitglied",
+        "identity": "Identität",
+        "permissions": "Rechte",
+        "messages": "Nachrichten",
+        "options": "Optionen",
+        "pause": "Pausieren",
+        "resume": "Fortsetzen",
+        "delete": "Löschen",
+        "delete_title": "Diese Kategorie löschen?",
+        "delete_description": "Sie verschwindet vom Panel und ihre Rechte gehen verloren. Bereits darin offene Tickets funktionieren bis zu ihrer Schließung weiter.",
+        "delete_confirm": "Kategorie löschen"
+      },
+      "messages": {
+        "modal_title": "Nachrichten des Tickets",
+        "open_label": "Eröffnungsnachricht",
+        "open_hint": "Wird im Ticket gepostet und angepinnt. Leer lassen für die Standardnachricht.",
+        "close_label": "Schlussnachricht",
+        "close_hint": "Wird der Karte hinzugefügt, die beim Schließen gepostet wird",
+        "placeholders_header": "Verfügbare Platzhalter:",
+        "ph_user": "Erwähnung des Mitglieds",
+        "ph_username": "sein Benutzername",
+        "ph_display_name": "sein Anzeigename",
+        "ph_server": "der Servername",
+        "ph_category": "der Name der Kategorie",
+        "ph_number": "die Ticketnummer",
+        "ph_ticket": "Erwähnung des Ticket-Kanals"
+      },
+      "options": {
+        "modal_title": "Optionen der Kategorie",
+        "name_format_label": "Name des Kanals",
+        "name_format_hint": "zum Beispiel ticket-{number}",
+        "max_open_label": "Offene Tickets pro Mitglied",
+        "max_open_hint": "Zwischen 1 und {max}, in dieser Kategorie",
+        "ping_label": "Zu erwähnende Rollen",
+        "ping_hint": "Werden beim Öffnen eines Tickets erwähnt"
+      },
+      "permissions": {
+        "title": "Rechte der Tickets",
+        "subtitle": "Kategorie „{category}“",
+        "description": "Wähle eine Rolle und hake ab, was sie in den Tickets dieser Kategorie darf. Server-Administratoren haben immer alles.",
+        "configured_title": "Rollen mit Rechten",
+        "nobody": "Noch keine Rolle kann diese Tickets bearbeiten — nur die Server-Administratoren.",
+        "pick_role": "Zu konfigurierende Rolle",
+        "pick_role_hint": "Wähle sie erneut, um ihre Rechte zu ändern oder zu entziehen",
+        "role_placeholder": "Wähle eine Rolle",
+        "perms_placeholder": "Wähle die Rechte",
+        "defaults_hint": "Neue Rolle: eine Startauswahl ist vorangehakt, gespeichert wird erst, wenn du sie bestätigst.",
+        "clear": "Alles entziehen",
+        "view": {
+          "name": "Ticket sehen",
+          "description": "In den Tickets dieser Kategorie lesen und schreiben"
+        },
+        "close": {
+          "name": "Schließen",
+          "description": "Ein Ticket schließen und wieder öffnen"
+        },
+        "staff_thread": {
+          "name": "Team-Thread",
+          "description": "Den privaten Team-Thread öffnen und betreten"
+        },
+        "rename": {
+          "name": "Umbenennen",
+          "description": "Den Namen des Ticket-Kanals ändern"
+        },
+        "move": {
+          "name": "Kategorie wechseln",
+          "description": "Das Ticket in eine andere Kategorie verschieben"
+        },
+        "participants": {
+          "name": "Teilnehmer verwalten",
+          "description": "Mitglieder und Rollen hinzufügen und entfernen"
+        },
+        "admin": {
+          "name": "Verantwortlich",
+          "description": "Alles oben, und behält den Zugriff nach einer Eskalation"
+        }
+      },
+      "channel": {
+        "topic": "Ticket von {user} · {category}",
+        "default_open_message": "Danke, dass du ein Ticket geöffnet hast. Beschreibe dein Anliegen so genau wie möglich — das Team antwortet dir hier.",
+        "title": "Ticket #{number}",
+        "meta": "Geöffnet von",
+        "commands_hint": "Alle Aktionen gibt es auch als `/ticket`-Befehle."
+      },
+      "actions": {
+        "close": "Schließen",
+        "close_request": "Schließung anfragen",
+        "escalate": "Eskalieren",
+        "staff_thread": "Team-Thread",
+        "participants": "Teilnehmer",
+        "reopen": "Wieder öffnen",
+        "delete": "Kanal löschen",
+        "deescalate": "Eskalation aufheben",
+        "rename": "Umbenennen"
+      },
+      "fields": {
+        "reason": "Grund",
+        "reason_hint": "Optional",
+        "channel_name": "Neuer Name",
+        "channel_name_hint": "Buchstaben, Ziffern und Bindestriche",
+        "participants": "Teilnehmer",
+        "opener": "Geöffnet von",
+        "category": "Kategorie",
+        "status": "Status",
+        "escalated": "Eskalation",
+        "your_permissions": "Deine Rechte hier",
+        "none": "keine"
+      },
+      "status": {
+        "open": "Offen",
+        "closed": "Geschlossen",
+        "escalated": "Eskaliert"
+      },
+      "open": {
+        "success_title": "Ticket geöffnet",
+        "success_description": "Dein Ticket ist bereit: {channel}"
+      },
+      "close": {
+        "done_title": "Ticket geschlossen",
+        "done_description": "Das Ticket ist gesperrt. Über die Karte im Kanal lässt es sich wieder öffnen oder endgültig löschen.",
+        "card_title": "Ticket geschlossen",
+        "by": "Geschlossen von",
+        "dm_title": "Dein Ticket wurde geschlossen",
+        "dm_description": "Dein Ticket #`{number}` ({category}) auf **{server}** wurde geschlossen."
+      },
+      "close_request": {
+        "sent_title": "Anfrage gesendet",
+        "sent_description": "Das Team wurde benachrichtigt und schließt das Ticket, wenn alles erledigt ist.",
+        "card_title": "Schließung angefragt",
+        "card_description": "{user} möchte, dass dieses Ticket geschlossen wird.",
+        "accept": "Ticket schließen",
+        "refuse": "Offen lassen",
+        "refused": "{user} hat das Ticket offen gelassen."
+      },
+      "reopen": {
+        "done_title": "Ticket wieder geöffnet",
+        "done_description": "Alle, die Zugriff hatten, haben ihn zurück."
+      },
+      "delete": {
+        "pending_title": "Wird gelöscht",
+        "pending_description": "Der Kanal und sein Gespräch werden gelöscht."
+      },
+      "escalate": {
+        "card_title": "Ticket eskaliert",
+        "card_description": "{user} hat dieses Ticket eskaliert: Nur die Verantwortlichen, der Ersteller und die von Hand hinzugefügten Personen haben noch Zugriff.",
+        "done_title": "Ticket eskaliert",
+        "done_description": "Der Zugriff ist jetzt auf die Verantwortlichen beschränkt.",
+        "cancelled_title": "Eskalation aufgehoben",
+        "cancelled_description": "Die Team-Rollen haben ihren Zugriff zurück.",
+        "confirm_title": "Dieses Ticket eskalieren?",
+        "confirm_description": "Die Team-Rollen verlieren den Zugriff. Der Ersteller bleibt. Was soll mit den von Hand hinzugefügten Personen geschehen?",
+        "keep": "Behalten",
+        "drop": "Entfernen"
+      },
+      "move": {
+        "done_title": "Ticket verschoben",
+        "done_description": "Das Ticket folgt jetzt den Rechten seiner neuen Kategorie."
+      },
+      "rename": {
+        "done_title": "Ticket umbenannt",
+        "done_description": "Der Kanal heißt jetzt `{name}`."
+      },
+      "participants": {
+        "title": "Teilnehmer des Tickets",
+        "description": "Alle hier ausgewählten Personen haben Zugriff auf das Ticket, zusätzlich zum Ersteller und den Team-Rollen. Wähle jemanden ab, um ihn zu entfernen.",
+        "owner_note": "Geöffnet von",
+        "members_title": "Mitglieder",
+        "members_description": "Einzeln hinzugefügt",
+        "members_placeholder": "Wähle die Mitglieder",
+        "roles_title": "Rollen",
+        "roles_description": "Alle mit der Rolle erhalten Zugriff",
+        "roles_placeholder": "Wähle die Rollen",
+        "added_title": "Hinzugefügt",
+        "added_description": "{target} hat jetzt Zugriff auf dieses Ticket.",
+        "removed_title": "Entfernt",
+        "removed_description": "{target} hat keinen Zugriff mehr auf dieses Ticket."
+      },
+      "staff_thread": {
+        "name": "staff-{number}",
+        "intro": "Privater Team-Thread für Ticket #{number}. Das Mitglied, das das Ticket geöffnet hat, sieht ihn nicht.",
+        "done_title": "Team-Thread",
+        "done_description": "Du wurdest zu {thread} hinzugefügt."
+      },
+      "info": {
+        "title": "Ticket #{number}",
+        "description": "Alles, was Moddy über dieses Ticket weiß."
+      },
+      "errors": {
+        "title": "Ticket",
+        "not_a_ticket": "Dieser Kanal ist kein Ticket.",
+        "module_disabled": "Das Ticket-Modul ist auf diesem Server nicht aktiviert.",
+        "category_gone": "Die Kategorie dieses Tickets gibt es nicht mehr. Bitte einen Administrator, es in eine andere zu verschieben.",
+        "missing_permission": "Du hast nicht das Recht, das in diesem Ticket zu tun.",
+        "unavailable": "Tickets sind vorübergehend nicht verfügbar. Versuch es gleich noch einmal.",
+        "cannot_open": "Du kannst in dieser Kategorie kein Ticket öffnen.",
+        "category_disabled": "Diese Kategorie nimmt gerade keine Tickets an.",
+        "destination_missing": "Diese Kategorie hat kein gültiges Ziel. Sag einem Administrator Bescheid.",
+        "too_many_open": "Du hast bereits `{max}` offene(s) Ticket(s) in dieser Kategorie. Schließe eins, bevor du ein weiteres öffnest.",
+        "cannot_create_channel": "Moddy konnte den Ticket-Kanal nicht erstellen. Prüfe die Rechte in der Zielkategorie.",
+        "already_closed": "Dieses Ticket ist bereits geschlossen.",
+        "not_closed": "Dieses Ticket ist nicht geschlossen.",
+        "can_close_directly": "Du kannst dieses Ticket selbst schließen — du musst nicht fragen.",
+        "close_already_requested": "Für dieses Ticket liegt bereits eine Schließungsanfrage vor.",
+        "no_close_request": "Für dieses Ticket liegt keine Schließungsanfrage vor.",
+        "already_escalated": "Dieses Ticket ist bereits eskaliert.",
+        "not_escalated": "Dieses Ticket ist nicht eskaliert.",
+        "no_responsible_role": "Keine Rolle hat in dieser Kategorie das Recht **Verantwortlich**, es gibt also niemanden, an den eskaliert werden könnte.",
+        "unknown_category": "Diese Kategorie gibt es nicht.",
+        "same_category": "Das Ticket ist bereits in dieser Kategorie.",
+        "cannot_edit_channel": "Moddy konnte den Ticket-Kanal nicht bearbeiten. Prüfe die Rechte.",
+        "invalid_name": "Dieser Name kann nicht für einen Kanal verwendet werden.",
+        "already_participant": "Diese Person hat bereits Zugriff auf dieses Ticket.",
+        "not_a_participant": "Diese Person wurde diesem Ticket nicht hinzugefügt.",
+        "cannot_remove_owner": "Das Mitglied, das das Ticket geöffnet hat, kann nicht daraus entfernt werden. Schließe stattdessen das Ticket.",
+        "cannot_create_thread": "Moddy konnte den Team-Thread nicht erstellen. Private Threads brauchen das Recht, sie in diesem Kanal zu erstellen.",
+        "use_close_request": "Du kannst dieses Ticket nicht schließen. Nutze **Schließung anfragen**, um das Team darum zu bitten.",
+        "panel_limit": "Dieser Server hat sein Limit von `{max}` Ticket-Panels erreicht.",
+        "category_limit": "Dieses Panel hat sein Limit von `{max}` Kategorien erreicht.",
+        "premium_upsell": "Premium hebt die Grenzen auf 10 Panels und 15 Kategorien pro Panel an. [Mehr erfahren]({url})",
+        "invalid_emoji": "Dieses Emoji kann nicht verwendet werden. Nutze ein Server-Emoji oder ein Standard-Emoji."
+      }
     }
   },
   "languages": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -2795,6 +2795,314 @@
           "app_command_permission_update": "A command's permissions were updated"
         }
       }
+    },
+    "tickets": {
+      "description": "Support tickets with panels, categories and per-role permissions",
+      "config": {
+        "title": "Tickets",
+        "description": "Let your members open a support ticket from a panel. Each panel offers one or more categories, and each category decides where the ticket opens, who can open it and what your staff can do inside.",
+        "quota": "Panels: `{count}/{max}` · Categories per panel: `{categories}`",
+        "premium_hint": "Premium raises these limits to 10 panels and 15 categories per panel.",
+        "manage_placeholder": "Select a panel to configure",
+        "empty": "No panel yet. Create one to let your members open tickets.",
+        "add_panel": "Add a panel",
+        "entry_summary": "{categories} category(ies) · {style}",
+        "no_channel": "no channel yet",
+        "paused": "paused",
+        "not_posted": "This panel has not been posted yet — use **Post again**."
+      },
+      "panel": {
+        "modal_title_new": "New ticket panel",
+        "modal_title_edit": "Edit the panel",
+        "name_label": "Internal name",
+        "name_hint": "Only you see it, in this configuration screen",
+        "title_label": "Title shown to members",
+        "title_hint": "Leave empty to use the internal name",
+        "description_label": "Description",
+        "description_hint": "The text displayed above the buttons",
+        "color_label": "Accent colour",
+        "color_hint": "Hexadecimal, e.g. #5865F2",
+        "placeholder_label": "Dropdown placeholder",
+        "placeholder_hint": "Only used when the panel renders as a dropdown",
+        "subtitle": "Ticket panel",
+        "paused_notice": "This panel is paused: its message is taken down and nobody can open a ticket from it.",
+        "channel_title": "Channel of the panel",
+        "channel_hint": "Where the message members click is posted",
+        "channel_placeholder": "Select a channel",
+        "style_title": "How members choose",
+        "style_hint": "Buttons are quicker; a dropdown scales to many categories",
+        "style_buttons": "Buttons",
+        "style_buttons_hint": "One button per category, up to 15",
+        "style_select": "Dropdown",
+        "style_select_hint": "One list, up to 25 categories",
+        "categories_title": "Categories",
+        "categories_hint": "{count}/{max} · one per button or dropdown entry",
+        "no_category": "No category yet. A panel with no category is never posted.",
+        "category_placeholder": "Select a category to configure",
+        "category_summary": "{roles} role(s) with permissions · language `{language}`",
+        "no_destination": "no destination",
+        "edit": "Edit",
+        "add_category": "Add a category",
+        "repost": "Post again",
+        "pause": "Pause",
+        "resume": "Resume",
+        "delete": "Delete",
+        "delete_title": "Delete this panel?",
+        "delete_description": "Its message will be taken down and its {categories} category(ies) will be lost. Tickets already open are not affected.",
+        "delete_confirm": "Delete the panel",
+        "repost_failed": "The panel could not be posted. Check that Moddy can write in the channel and that the panel has at least one usable category."
+      },
+      "category": {
+        "modal_title_new": "New category",
+        "modal_title_edit": "Edit the category",
+        "name_label": "Name",
+        "name_hint": "Shown on the button or the dropdown entry",
+        "emoji_label": "Emoji",
+        "emoji_hint": "Optional, e.g. a server emoji",
+        "description_label": "Short description",
+        "description_hint": "Shown under the name in a dropdown",
+        "color_label": "Button colour",
+        "color_hint": "Ignored when the panel renders as a dropdown",
+        "color_primary": "Blue",
+        "color_secondary": "Grey",
+        "color_success": "Green",
+        "color_danger": "Red",
+        "subtitle": "Category of the panel “{panel}”",
+        "paused_notice": "This category is paused: it no longer appears on the panel.",
+        "destination_title": "Where tickets are created",
+        "destination_hint": "The Discord category the ticket channel is created in",
+        "destination_placeholder": "Select a Discord category",
+        "access_title": "Who can open a ticket",
+        "access_hint": "Leave empty to allow everyone",
+        "allowed_placeholder": "Roles allowed to open",
+        "denied_hint": "A denied role always wins, even if the member also has an allowed one.",
+        "denied_placeholder": "Roles denied",
+        "language_title": "Language of the tickets",
+        "language_hint": "Every message inside these tickets uses this language",
+        "summary_title": "Configured behind the buttons below",
+        "summary_permissions": "Permissions — {roles} role(s)",
+        "summary_messages": "Messages — {count}/2 customised",
+        "summary_options": "Options — name `{format}`, `{max}` open ticket(s) per member",
+        "identity": "Identity",
+        "permissions": "Permissions",
+        "messages": "Messages",
+        "options": "Options",
+        "pause": "Pause",
+        "resume": "Resume",
+        "delete": "Delete",
+        "delete_title": "Delete this category?",
+        "delete_description": "It disappears from the panel and its permissions are lost. Tickets already open in it keep working until they are closed.",
+        "delete_confirm": "Delete the category"
+      },
+      "messages": {
+        "modal_title": "Ticket messages",
+        "open_label": "Opening message",
+        "open_hint": "Posted in the ticket, pinned. Leave empty for the default one.",
+        "close_label": "Closing message",
+        "close_hint": "Added to the card posted when the ticket is closed",
+        "placeholders_header": "Available placeholders:",
+        "ph_user": "mention of the member",
+        "ph_username": "their username",
+        "ph_display_name": "their display name",
+        "ph_server": "the server name",
+        "ph_category": "the category name",
+        "ph_number": "the ticket number",
+        "ph_ticket": "mention of the ticket channel"
+      },
+      "options": {
+        "modal_title": "Category options",
+        "name_format_label": "Channel name",
+        "name_format_hint": "e.g. ticket-{number}",
+        "max_open_label": "Open tickets per member",
+        "max_open_hint": "Between 1 and {max}, in this category",
+        "ping_label": "Roles to ping",
+        "ping_hint": "Mentioned when a ticket opens"
+      },
+      "permissions": {
+        "title": "Ticket permissions",
+        "subtitle": "Category “{category}”",
+        "description": "Pick a role, then tick what it may do in the tickets of this category. Server administrators always have everything.",
+        "configured_title": "Roles with permissions",
+        "nobody": "No role can work these tickets yet — only the server administrators can.",
+        "pick_role": "Role to configure",
+        "pick_role_hint": "Pick it again to change or revoke its permissions",
+        "role_placeholder": "Select a role",
+        "perms_placeholder": "Select the permissions",
+        "defaults_hint": "New role: a starting set is pre-selected, nothing is saved until you confirm it.",
+        "clear": "Revoke everything",
+        "view": {
+          "name": "See the ticket",
+          "description": "Read and write in the tickets of this category"
+        },
+        "close": {
+          "name": "Close",
+          "description": "Close and reopen a ticket"
+        },
+        "staff_thread": {
+          "name": "Staff thread",
+          "description": "Open and join the private staff thread"
+        },
+        "rename": {
+          "name": "Rename",
+          "description": "Change the ticket channel name"
+        },
+        "move": {
+          "name": "Change category",
+          "description": "Move the ticket to another category"
+        },
+        "participants": {
+          "name": "Manage participants",
+          "description": "Add and remove members and roles"
+        },
+        "admin": {
+          "name": "Responsible",
+          "description": "Everything above, and keeps access after an escalation"
+        }
+      },
+      "channel": {
+        "topic": "Ticket of {user} · {category}",
+        "default_open_message": "Thanks for opening a ticket. Describe your request as precisely as you can — the team will answer you here.",
+        "title": "Ticket #{number}",
+        "meta": "Opened by",
+        "commands_hint": "Every action is also available with the `/ticket` commands."
+      },
+      "actions": {
+        "close": "Close",
+        "close_request": "Request closure",
+        "escalate": "Escalate",
+        "staff_thread": "Staff thread",
+        "participants": "Participants",
+        "reopen": "Reopen",
+        "delete": "Delete the channel",
+        "deescalate": "Cancel the escalation",
+        "rename": "Rename"
+      },
+      "fields": {
+        "reason": "Reason",
+        "reason_hint": "Optional",
+        "channel_name": "New name",
+        "channel_name_hint": "Letters, digits and dashes",
+        "participants": "Participants",
+        "opener": "Opened by",
+        "category": "Category",
+        "status": "Status",
+        "escalated": "Escalation",
+        "your_permissions": "Your permissions here",
+        "none": "none"
+      },
+      "status": {
+        "open": "Open",
+        "closed": "Closed",
+        "escalated": "Escalated"
+      },
+      "open": {
+        "success_title": "Ticket opened",
+        "success_description": "Your ticket is ready: {channel}"
+      },
+      "close": {
+        "done_title": "Ticket closed",
+        "done_description": "The ticket is locked. It can be reopened, or deleted for good, from the card in the channel.",
+        "card_title": "Ticket closed",
+        "by": "Closed by",
+        "dm_title": "Your ticket has been closed",
+        "dm_description": "Your ticket #`{number}` ({category}) on **{server}** has been closed."
+      },
+      "close_request": {
+        "sent_title": "Request sent",
+        "sent_description": "The team has been notified and will close the ticket if it is done.",
+        "card_title": "Closure requested",
+        "card_description": "{user} would like this ticket to be closed.",
+        "accept": "Close the ticket",
+        "refuse": "Keep it open",
+        "refused": "{user} kept the ticket open."
+      },
+      "reopen": {
+        "done_title": "Ticket reopened",
+        "done_description": "Everyone who had access to it is back."
+      },
+      "delete": {
+        "pending_title": "Deleting",
+        "pending_description": "The channel and its conversation are being deleted."
+      },
+      "escalate": {
+        "card_title": "Ticket escalated",
+        "card_description": "{user} escalated this ticket: only the responsibles, its opener and the people added by hand still have access.",
+        "done_title": "Ticket escalated",
+        "done_description": "Access is now limited to the responsibles.",
+        "cancelled_title": "Escalation cancelled",
+        "cancelled_description": "The staff roles have their access back.",
+        "confirm_title": "Escalate this ticket?",
+        "confirm_description": "The staff roles lose access. Its opener stays. What should happen to the people added by hand?",
+        "keep": "Keep them",
+        "drop": "Remove them"
+      },
+      "move": {
+        "done_title": "Ticket moved",
+        "done_description": "The ticket now follows the permissions of its new category."
+      },
+      "rename": {
+        "done_title": "Ticket renamed",
+        "done_description": "The channel is now `{name}`."
+      },
+      "participants": {
+        "title": "Ticket participants",
+        "description": "Everyone selected here has access to the ticket, on top of its opener and the staff roles. Unselect someone to remove them.",
+        "owner_note": "Opened by",
+        "members_title": "Members",
+        "members_description": "Added one by one",
+        "members_placeholder": "Select the members",
+        "roles_title": "Roles",
+        "roles_description": "Everyone holding the role gets access",
+        "roles_placeholder": "Select the roles",
+        "added_title": "Added",
+        "added_description": "{target} now has access to this ticket.",
+        "removed_title": "Removed",
+        "removed_description": "{target} no longer has access to this ticket."
+      },
+      "staff_thread": {
+        "name": "staff-{number}",
+        "intro": "Private staff thread for ticket #{number}. The member who opened the ticket cannot see it.",
+        "done_title": "Staff thread",
+        "done_description": "You have been added to {thread}."
+      },
+      "info": {
+        "title": "Ticket #{number}",
+        "description": "Everything Moddy knows about this ticket."
+      },
+      "errors": {
+        "title": "Ticket",
+        "not_a_ticket": "This channel is not a ticket.",
+        "module_disabled": "The ticket module is not enabled on this server.",
+        "category_gone": "The category this ticket belongs to no longer exists. Ask an administrator to move it to another one.",
+        "missing_permission": "You do not have the permission to do this in this ticket.",
+        "unavailable": "Tickets are temporarily unavailable. Try again in a moment.",
+        "cannot_open": "You cannot open a ticket in this category.",
+        "category_disabled": "This category is not accepting tickets right now.",
+        "destination_missing": "This category has no valid destination. Warn an administrator.",
+        "too_many_open": "You already have `{max}` open ticket(s) in this category. Close one before opening another.",
+        "cannot_create_channel": "Moddy could not create the ticket channel. Check its permissions on the destination category.",
+        "already_closed": "This ticket is already closed.",
+        "not_closed": "This ticket is not closed.",
+        "can_close_directly": "You can close this ticket yourself — no need to ask.",
+        "close_already_requested": "A closure request is already pending on this ticket.",
+        "no_close_request": "No closure request is pending on this ticket.",
+        "already_escalated": "This ticket is already escalated.",
+        "not_escalated": "This ticket is not escalated.",
+        "no_responsible_role": "No role holds the **Responsible** permission in this category, so there is nobody to escalate to.",
+        "unknown_category": "That category does not exist.",
+        "same_category": "The ticket is already in that category.",
+        "cannot_edit_channel": "Moddy could not edit the ticket channel. Check its permissions.",
+        "invalid_name": "That name cannot be used for a channel.",
+        "already_participant": "They already have access to this ticket.",
+        "not_a_participant": "They were not added to this ticket.",
+        "cannot_remove_owner": "The member who opened the ticket cannot be removed from it. Close the ticket instead.",
+        "cannot_create_thread": "Moddy could not create the staff thread. Private threads require permission to create them in this channel.",
+        "use_close_request": "You cannot close this ticket. Use **Request closure** to ask the team to.",
+        "panel_limit": "This server has reached its limit of `{max}` ticket panels.",
+        "category_limit": "This panel has reached its limit of `{max}` categories.",
+        "premium_upsell": "Premium raises the limits to 10 panels and 15 categories per panel. [Learn more]({url})",
+        "invalid_emoji": "That emoji cannot be used. Use a server emoji or a standard one."
+      }
     }
   },
   "languages": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -2795,6 +2795,314 @@
           "app_command_permission_update": "Se han modificado los permisos de un comando"
         }
       }
+    },
+    "tickets": {
+      "description": "Tickets de soporte con paneles, categorías y permisos por rol",
+      "config": {
+        "title": "Tickets",
+        "description": "Permite que tus miembros abran un ticket de soporte desde un panel. Cada panel ofrece una o varias categorías, y cada categoría decide dónde se abre el ticket, quién puede abrirlo y qué puede hacer tu staff dentro.",
+        "quota": "Paneles: `{count}/{max}` · Categorías por panel: `{categories}`",
+        "premium_hint": "Premium eleva estos límites a 10 paneles y 15 categorías por panel.",
+        "manage_placeholder": "Selecciona un panel para configurarlo",
+        "empty": "Todavía no hay ningún panel. Crea uno para que tus miembros puedan abrir tickets.",
+        "add_panel": "Añadir un panel",
+        "entry_summary": "{categories} categoría(s) · {style}",
+        "no_channel": "sin canal",
+        "paused": "en pausa",
+        "not_posted": "Este panel aún no se ha publicado — usa **Volver a publicar**."
+      },
+      "panel": {
+        "modal_title_new": "Nuevo panel de tickets",
+        "modal_title_edit": "Editar el panel",
+        "name_label": "Nombre interno",
+        "name_hint": "Solo lo ves tú, en esta pantalla de configuración",
+        "title_label": "Título mostrado a los miembros",
+        "title_hint": "Déjalo vacío para usar el nombre interno",
+        "description_label": "Descripción",
+        "description_hint": "El texto que aparece encima de los botones",
+        "color_label": "Color de acento",
+        "color_hint": "Hexadecimal, por ejemplo #5865F2",
+        "placeholder_label": "Texto del desplegable",
+        "placeholder_hint": "Solo se usa cuando el panel se muestra como desplegable",
+        "subtitle": "Panel de tickets",
+        "paused_notice": "Este panel está en pausa: su mensaje se retira y nadie puede abrir un ticket desde él.",
+        "channel_title": "Canal del panel",
+        "channel_hint": "Donde se publica el mensaje en el que hacen clic los miembros",
+        "channel_placeholder": "Selecciona un canal",
+        "style_title": "Cómo eligen los miembros",
+        "style_hint": "Los botones son más rápidos; el desplegable admite más categorías",
+        "style_buttons": "Botones",
+        "style_buttons_hint": "Un botón por categoría, hasta 15",
+        "style_select": "Desplegable",
+        "style_select_hint": "Una sola lista, hasta 25 categorías",
+        "categories_title": "Categorías",
+        "categories_hint": "{count}/{max} · una por botón o entrada del desplegable",
+        "no_category": "Ninguna categoría. Un panel sin categorías nunca se publica.",
+        "category_placeholder": "Selecciona una categoría para configurarla",
+        "category_summary": "{roles} rol(es) con permisos · idioma `{language}`",
+        "no_destination": "sin destino",
+        "edit": "Editar",
+        "add_category": "Añadir una categoría",
+        "repost": "Volver a publicar",
+        "pause": "Pausar",
+        "resume": "Reanudar",
+        "delete": "Eliminar",
+        "delete_title": "¿Eliminar este panel?",
+        "delete_description": "Su mensaje se retirará y se perderán sus {categories} categoría(s). Los tickets ya abiertos no se ven afectados.",
+        "delete_confirm": "Eliminar el panel",
+        "repost_failed": "No se ha podido publicar el panel. Comprueba que Moddy puede escribir en el canal y que el panel tiene al menos una categoría utilizable."
+      },
+      "category": {
+        "modal_title_new": "Nueva categoría",
+        "modal_title_edit": "Editar la categoría",
+        "name_label": "Nombre",
+        "name_hint": "Se muestra en el botón o en la entrada del desplegable",
+        "emoji_label": "Emoji",
+        "emoji_hint": "Opcional, por ejemplo un emoji del servidor",
+        "description_label": "Descripción breve",
+        "description_hint": "Se muestra bajo el nombre en un desplegable",
+        "color_label": "Color del botón",
+        "color_hint": "Se ignora si el panel se muestra como desplegable",
+        "color_primary": "Azul",
+        "color_secondary": "Gris",
+        "color_success": "Verde",
+        "color_danger": "Rojo",
+        "subtitle": "Categoría del panel «{panel}»",
+        "paused_notice": "Esta categoría está en pausa: ya no aparece en el panel.",
+        "destination_title": "Dónde se crean los tickets",
+        "destination_hint": "La categoría de Discord en la que se crea el canal del ticket",
+        "destination_placeholder": "Selecciona una categoría de Discord",
+        "access_title": "Quién puede abrir un ticket",
+        "access_hint": "Déjalo vacío para permitir a todo el mundo",
+        "allowed_placeholder": "Roles autorizados a abrir",
+        "denied_hint": "Un rol prohibido siempre gana, aunque el miembro tenga también uno autorizado.",
+        "denied_placeholder": "Roles prohibidos",
+        "language_title": "Idioma de los tickets",
+        "language_hint": "Todos los mensajes de estos tickets usan este idioma",
+        "summary_title": "Configurado tras los botones de abajo",
+        "summary_permissions": "Permisos — {roles} rol(es)",
+        "summary_messages": "Mensajes — {count}/2 personalizado(s)",
+        "summary_options": "Opciones — nombre `{format}`, `{max}` ticket(s) abierto(s) por miembro",
+        "identity": "Identidad",
+        "permissions": "Permisos",
+        "messages": "Mensajes",
+        "options": "Opciones",
+        "pause": "Pausar",
+        "resume": "Reanudar",
+        "delete": "Eliminar",
+        "delete_title": "¿Eliminar esta categoría?",
+        "delete_description": "Desaparece del panel y se pierden sus permisos. Los tickets ya abiertos en ella siguen funcionando hasta que se cierren.",
+        "delete_confirm": "Eliminar la categoría"
+      },
+      "messages": {
+        "modal_title": "Mensajes del ticket",
+        "open_label": "Mensaje de apertura",
+        "open_hint": "Publicado en el ticket y fijado. Déjalo vacío para el predeterminado.",
+        "close_label": "Mensaje de cierre",
+        "close_hint": "Se añade a la tarjeta publicada al cerrar el ticket",
+        "placeholders_header": "Variables disponibles:",
+        "ph_user": "mención del miembro",
+        "ph_username": "su nombre de usuario",
+        "ph_display_name": "su nombre visible",
+        "ph_server": "el nombre del servidor",
+        "ph_category": "el nombre de la categoría",
+        "ph_number": "el número del ticket",
+        "ph_ticket": "mención del canal del ticket"
+      },
+      "options": {
+        "modal_title": "Opciones de la categoría",
+        "name_format_label": "Nombre del canal",
+        "name_format_hint": "por ejemplo ticket-{number}",
+        "max_open_label": "Tickets abiertos por miembro",
+        "max_open_hint": "Entre 1 y {max}, en esta categoría",
+        "ping_label": "Roles a mencionar",
+        "ping_hint": "Mencionados al abrirse un ticket"
+      },
+      "permissions": {
+        "title": "Permisos de los tickets",
+        "subtitle": "Categoría «{category}»",
+        "description": "Elige un rol y marca lo que puede hacer en los tickets de esta categoría. Los administradores del servidor siempre lo tienen todo.",
+        "configured_title": "Roles con permisos",
+        "nobody": "Ningún rol puede atender aún estos tickets — solo los administradores del servidor.",
+        "pick_role": "Rol a configurar",
+        "pick_role_hint": "Vuelve a seleccionarlo para cambiar o retirar sus permisos",
+        "role_placeholder": "Selecciona un rol",
+        "perms_placeholder": "Selecciona los permisos",
+        "defaults_hint": "Rol nuevo: hay una selección inicial marcada; no se guarda nada hasta que la confirmes.",
+        "clear": "Retirar todo",
+        "view": {
+          "name": "Ver el ticket",
+          "description": "Leer y escribir en los tickets de esta categoría"
+        },
+        "close": {
+          "name": "Cerrar",
+          "description": "Cerrar y reabrir un ticket"
+        },
+        "staff_thread": {
+          "name": "Hilo del staff",
+          "description": "Abrir y unirse al hilo privado del staff"
+        },
+        "rename": {
+          "name": "Renombrar",
+          "description": "Cambiar el nombre del canal del ticket"
+        },
+        "move": {
+          "name": "Cambiar de categoría",
+          "description": "Mover el ticket a otra categoría"
+        },
+        "participants": {
+          "name": "Gestionar participantes",
+          "description": "Añadir y quitar miembros y roles"
+        },
+        "admin": {
+          "name": "Responsable",
+          "description": "Todo lo anterior, y conserva el acceso tras un escalado"
+        }
+      },
+      "channel": {
+        "topic": "Ticket de {user} · {category}",
+        "default_open_message": "Gracias por abrir un ticket. Describe tu solicitud con el mayor detalle posible — el equipo te responderá aquí.",
+        "title": "Ticket #{number}",
+        "meta": "Abierto por",
+        "commands_hint": "Todas las acciones están también disponibles con los comandos `/ticket`."
+      },
+      "actions": {
+        "close": "Cerrar",
+        "close_request": "Solicitar el cierre",
+        "escalate": "Escalar",
+        "staff_thread": "Hilo del staff",
+        "participants": "Participantes",
+        "reopen": "Reabrir",
+        "delete": "Eliminar el canal",
+        "deescalate": "Cancelar el escalado",
+        "rename": "Renombrar"
+      },
+      "fields": {
+        "reason": "Motivo",
+        "reason_hint": "Opcional",
+        "channel_name": "Nuevo nombre",
+        "channel_name_hint": "Letras, números y guiones",
+        "participants": "Participantes",
+        "opener": "Abierto por",
+        "category": "Categoría",
+        "status": "Estado",
+        "escalated": "Escalado",
+        "your_permissions": "Tus permisos aquí",
+        "none": "ninguno"
+      },
+      "status": {
+        "open": "Abierto",
+        "closed": "Cerrado",
+        "escalated": "Escalado"
+      },
+      "open": {
+        "success_title": "Ticket abierto",
+        "success_description": "Tu ticket está listo: {channel}"
+      },
+      "close": {
+        "done_title": "Ticket cerrado",
+        "done_description": "El ticket está bloqueado. Se puede reabrir, o eliminar definitivamente, desde la tarjeta publicada en el canal.",
+        "card_title": "Ticket cerrado",
+        "by": "Cerrado por",
+        "dm_title": "Tu ticket ha sido cerrado",
+        "dm_description": "Tu ticket #`{number}` ({category}) en **{server}** ha sido cerrado."
+      },
+      "close_request": {
+        "sent_title": "Solicitud enviada",
+        "sent_description": "El equipo ha sido avisado y cerrará el ticket si todo está resuelto.",
+        "card_title": "Cierre solicitado",
+        "card_description": "{user} querría que se cerrara este ticket.",
+        "accept": "Cerrar el ticket",
+        "refuse": "Mantenerlo abierto",
+        "refused": "{user} ha mantenido el ticket abierto."
+      },
+      "reopen": {
+        "done_title": "Ticket reabierto",
+        "done_description": "Todos los que tenían acceso lo recuperan."
+      },
+      "delete": {
+        "pending_title": "Eliminando",
+        "pending_description": "Se están eliminando el canal y su conversación."
+      },
+      "escalate": {
+        "card_title": "Ticket escalado",
+        "card_description": "{user} ha escalado este ticket: solo los responsables, quien lo abrió y las personas añadidas a mano conservan el acceso.",
+        "done_title": "Ticket escalado",
+        "done_description": "El acceso queda limitado a los responsables.",
+        "cancelled_title": "Escalado cancelado",
+        "cancelled_description": "Los roles del staff recuperan su acceso.",
+        "confirm_title": "¿Escalar este ticket?",
+        "confirm_description": "Los roles del staff pierden el acceso. Quien lo abrió lo conserva. ¿Qué hacer con las personas añadidas a mano?",
+        "keep": "Mantenerlas",
+        "drop": "Quitarlas"
+      },
+      "move": {
+        "done_title": "Ticket movido",
+        "done_description": "El ticket sigue ahora los permisos de su nueva categoría."
+      },
+      "rename": {
+        "done_title": "Ticket renombrado",
+        "done_description": "El canal se llama ahora `{name}`."
+      },
+      "participants": {
+        "title": "Participantes del ticket",
+        "description": "Todas las personas seleccionadas aquí tienen acceso al ticket, además de quien lo abrió y de los roles del staff. Deselecciona a alguien para quitarlo.",
+        "owner_note": "Abierto por",
+        "members_title": "Miembros",
+        "members_description": "Añadidos uno a uno",
+        "members_placeholder": "Selecciona los miembros",
+        "roles_title": "Roles",
+        "roles_description": "Todos los que tengan el rol obtienen acceso",
+        "roles_placeholder": "Selecciona los roles",
+        "added_title": "Añadido",
+        "added_description": "{target} ya tiene acceso a este ticket.",
+        "removed_title": "Quitado",
+        "removed_description": "{target} ya no tiene acceso a este ticket."
+      },
+      "staff_thread": {
+        "name": "staff-{number}",
+        "intro": "Hilo privado del staff para el ticket #{number}. El miembro que abrió el ticket no lo ve.",
+        "done_title": "Hilo del staff",
+        "done_description": "Se te ha añadido a {thread}."
+      },
+      "info": {
+        "title": "Ticket #{number}",
+        "description": "Todo lo que Moddy sabe de este ticket."
+      },
+      "errors": {
+        "title": "Ticket",
+        "not_a_ticket": "Este canal no es un ticket.",
+        "module_disabled": "El módulo de tickets no está activado en este servidor.",
+        "category_gone": "La categoría de este ticket ya no existe. Pide a un administrador que lo mueva a otra.",
+        "missing_permission": "No tienes permiso para hacer eso en este ticket.",
+        "unavailable": "Los tickets no están disponibles temporalmente. Inténtalo de nuevo en un momento.",
+        "cannot_open": "No puedes abrir un ticket en esta categoría.",
+        "category_disabled": "Esta categoría no acepta tickets por ahora.",
+        "destination_missing": "Esta categoría no tiene un destino válido. Avisa a un administrador.",
+        "too_many_open": "Ya tienes `{max}` ticket(s) abierto(s) en esta categoría. Cierra uno antes de abrir otro.",
+        "cannot_create_channel": "Moddy no ha podido crear el canal del ticket. Comprueba sus permisos en la categoría de destino.",
+        "already_closed": "Este ticket ya está cerrado.",
+        "not_closed": "Este ticket no está cerrado.",
+        "can_close_directly": "Puedes cerrar este ticket tú mismo — no hace falta pedirlo.",
+        "close_already_requested": "Ya hay una solicitud de cierre pendiente en este ticket.",
+        "no_close_request": "No hay ninguna solicitud de cierre pendiente en este ticket.",
+        "already_escalated": "Este ticket ya está escalado.",
+        "not_escalated": "Este ticket no está escalado.",
+        "no_responsible_role": "Ningún rol tiene el permiso **Responsable** en esta categoría, así que no hay a quién escalar.",
+        "unknown_category": "Esa categoría no existe.",
+        "same_category": "El ticket ya está en esa categoría.",
+        "cannot_edit_channel": "Moddy no ha podido editar el canal del ticket. Comprueba sus permisos.",
+        "invalid_name": "Ese nombre no se puede usar para un canal.",
+        "already_participant": "Esa persona ya tiene acceso a este ticket.",
+        "not_a_participant": "Esa persona no fue añadida a este ticket.",
+        "cannot_remove_owner": "El miembro que abrió el ticket no puede ser retirado de él. Cierra el ticket en su lugar.",
+        "cannot_create_thread": "Moddy no ha podido crear el hilo del staff. Los hilos privados requieren permiso para crearlos en este canal.",
+        "use_close_request": "No puedes cerrar este ticket. Usa **Solicitar el cierre** para pedírselo al equipo.",
+        "panel_limit": "Este servidor ha alcanzado su límite de `{max}` paneles de tickets.",
+        "category_limit": "Este panel ha alcanzado su límite de `{max}` categorías.",
+        "premium_upsell": "Premium eleva los límites a 10 paneles y 15 categorías por panel. [Más información]({url})",
+        "invalid_emoji": "Ese emoji no se puede usar. Usa un emoji del servidor o uno estándar."
+      }
     }
   },
   "languages": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2794,6 +2794,314 @@
           "app_command_permission_update": "Modification des permissions d'une commande"
         }
       }
+    },
+    "tickets": {
+      "description": "Tickets de support avec panneaux, catégories et permissions par rôle",
+      "config": {
+        "title": "Tickets",
+        "description": "Permettez à vos membres d'ouvrir un ticket de support depuis un panneau. Chaque panneau propose une ou plusieurs catégories, et chaque catégorie décide où le ticket s'ouvre, qui peut l'ouvrir et ce que votre staff peut y faire.",
+        "quota": "Panneaux : `{count}/{max}` · Catégories par panneau : `{categories}`",
+        "premium_hint": "Premium fait passer ces limites à 10 panneaux et 15 catégories par panneau.",
+        "manage_placeholder": "Sélectionnez un panneau à configurer",
+        "empty": "Aucun panneau pour le moment. Créez-en un pour que vos membres puissent ouvrir des tickets.",
+        "add_panel": "Ajouter un panneau",
+        "entry_summary": "{categories} catégorie(s) · {style}",
+        "no_channel": "aucun salon",
+        "paused": "en pause",
+        "not_posted": "Ce panneau n'a pas encore été publié — utilisez **Republier**."
+      },
+      "panel": {
+        "modal_title_new": "Nouveau panneau de tickets",
+        "modal_title_edit": "Modifier le panneau",
+        "name_label": "Nom interne",
+        "name_hint": "Vous seul le voyez, dans cet écran de configuration",
+        "title_label": "Titre affiché aux membres",
+        "title_hint": "Laissez vide pour utiliser le nom interne",
+        "description_label": "Description",
+        "description_hint": "Le texte affiché au-dessus des boutons",
+        "color_label": "Couleur d'accent",
+        "color_hint": "Hexadécimal, par exemple #5865F2",
+        "placeholder_label": "Texte du menu déroulant",
+        "placeholder_hint": "Utilisé uniquement si le panneau s'affiche en menu déroulant",
+        "subtitle": "Panneau de tickets",
+        "paused_notice": "Ce panneau est en pause : son message est retiré et personne ne peut y ouvrir de ticket.",
+        "channel_title": "Salon du panneau",
+        "channel_hint": "Là où est publié le message sur lequel les membres cliquent",
+        "channel_placeholder": "Sélectionnez un salon",
+        "style_title": "Comment les membres choisissent",
+        "style_hint": "Les boutons sont plus rapides ; le menu déroulant tient plus de catégories",
+        "style_buttons": "Boutons",
+        "style_buttons_hint": "Un bouton par catégorie, jusqu'à 15",
+        "style_select": "Menu déroulant",
+        "style_select_hint": "Une seule liste, jusqu'à 25 catégories",
+        "categories_title": "Catégories",
+        "categories_hint": "{count}/{max} · une par bouton ou par entrée du menu",
+        "no_category": "Aucune catégorie. Un panneau sans catégorie n'est jamais publié.",
+        "category_placeholder": "Sélectionnez une catégorie à configurer",
+        "category_summary": "{roles} rôle(s) avec des permissions · langue `{language}`",
+        "no_destination": "aucune destination",
+        "edit": "Modifier",
+        "add_category": "Ajouter une catégorie",
+        "repost": "Republier",
+        "pause": "Mettre en pause",
+        "resume": "Réactiver",
+        "delete": "Supprimer",
+        "delete_title": "Supprimer ce panneau ?",
+        "delete_description": "Son message sera retiré et ses {categories} catégorie(s) seront perdues. Les tickets déjà ouverts ne sont pas affectés.",
+        "delete_confirm": "Supprimer le panneau",
+        "repost_failed": "Le panneau n'a pas pu être publié. Vérifiez que Moddy peut écrire dans le salon et que le panneau a au moins une catégorie utilisable."
+      },
+      "category": {
+        "modal_title_new": "Nouvelle catégorie",
+        "modal_title_edit": "Modifier la catégorie",
+        "name_label": "Nom",
+        "name_hint": "Affiché sur le bouton ou l'entrée du menu",
+        "emoji_label": "Émoji",
+        "emoji_hint": "Facultatif, par exemple un émoji du serveur",
+        "description_label": "Description courte",
+        "description_hint": "Affichée sous le nom dans un menu déroulant",
+        "color_label": "Couleur du bouton",
+        "color_hint": "Ignorée si le panneau s'affiche en menu déroulant",
+        "color_primary": "Bleu",
+        "color_secondary": "Gris",
+        "color_success": "Vert",
+        "color_danger": "Rouge",
+        "subtitle": "Catégorie du panneau « {panel} »",
+        "paused_notice": "Cette catégorie est en pause : elle n'apparaît plus sur le panneau.",
+        "destination_title": "Où les tickets sont créés",
+        "destination_hint": "La catégorie Discord dans laquelle le salon du ticket est créé",
+        "destination_placeholder": "Sélectionnez une catégorie Discord",
+        "access_title": "Qui peut ouvrir un ticket",
+        "access_hint": "Laissez vide pour autoriser tout le monde",
+        "allowed_placeholder": "Rôles autorisés à ouvrir",
+        "denied_hint": "Un rôle interdit l'emporte toujours, même si le membre a aussi un rôle autorisé.",
+        "denied_placeholder": "Rôles interdits",
+        "language_title": "Langue des tickets",
+        "language_hint": "Tous les messages de ces tickets utilisent cette langue",
+        "summary_title": "Configuré derrière les boutons ci-dessous",
+        "summary_permissions": "Permissions — {roles} rôle(s)",
+        "summary_messages": "Messages — {count}/2 personnalisé(s)",
+        "summary_options": "Options — nom `{format}`, `{max}` ticket(s) ouvert(s) par membre",
+        "identity": "Identité",
+        "permissions": "Permissions",
+        "messages": "Messages",
+        "options": "Options",
+        "pause": "Mettre en pause",
+        "resume": "Réactiver",
+        "delete": "Supprimer",
+        "delete_title": "Supprimer cette catégorie ?",
+        "delete_description": "Elle disparaît du panneau et ses permissions sont perdues. Les tickets déjà ouverts dedans continuent de fonctionner jusqu'à leur fermeture.",
+        "delete_confirm": "Supprimer la catégorie"
+      },
+      "messages": {
+        "modal_title": "Messages du ticket",
+        "open_label": "Message d'ouverture",
+        "open_hint": "Publié dans le ticket, épinglé. Laissez vide pour celui par défaut.",
+        "close_label": "Message de fermeture",
+        "close_hint": "Ajouté à la carte publiée à la fermeture du ticket",
+        "placeholders_header": "Variables disponibles :",
+        "ph_user": "mention du membre",
+        "ph_username": "son nom d'utilisateur",
+        "ph_display_name": "son nom affiché",
+        "ph_server": "le nom du serveur",
+        "ph_category": "le nom de la catégorie",
+        "ph_number": "le numéro du ticket",
+        "ph_ticket": "mention du salon du ticket"
+      },
+      "options": {
+        "modal_title": "Options de la catégorie",
+        "name_format_label": "Nom du salon",
+        "name_format_hint": "par exemple ticket-{number}",
+        "max_open_label": "Tickets ouverts par membre",
+        "max_open_hint": "Entre 1 et {max}, dans cette catégorie",
+        "ping_label": "Rôles à mentionner",
+        "ping_hint": "Mentionnés à l'ouverture d'un ticket"
+      },
+      "permissions": {
+        "title": "Permissions des tickets",
+        "subtitle": "Catégorie « {category} »",
+        "description": "Choisissez un rôle, puis cochez ce qu'il a le droit de faire dans les tickets de cette catégorie. Les administrateurs du serveur ont toujours tout.",
+        "configured_title": "Rôles avec des permissions",
+        "nobody": "Aucun rôle ne peut encore traiter ces tickets — seuls les administrateurs du serveur le peuvent.",
+        "pick_role": "Rôle à configurer",
+        "pick_role_hint": "Re-sélectionnez-le pour modifier ou retirer ses permissions",
+        "role_placeholder": "Sélectionnez un rôle",
+        "perms_placeholder": "Sélectionnez les permissions",
+        "defaults_hint": "Nouveau rôle : une sélection de départ est pré-cochée, rien n'est enregistré tant que vous ne la validez pas.",
+        "clear": "Tout retirer",
+        "view": {
+          "name": "Voir le ticket",
+          "description": "Lire et écrire dans les tickets de cette catégorie"
+        },
+        "close": {
+          "name": "Fermer",
+          "description": "Fermer et rouvrir un ticket"
+        },
+        "staff_thread": {
+          "name": "Thread staff",
+          "description": "Ouvrir et rejoindre le thread privé du staff"
+        },
+        "rename": {
+          "name": "Renommer",
+          "description": "Changer le nom du salon du ticket"
+        },
+        "move": {
+          "name": "Changer de catégorie",
+          "description": "Déplacer le ticket vers une autre catégorie"
+        },
+        "participants": {
+          "name": "Gérer les participants",
+          "description": "Ajouter et retirer des membres et des rôles"
+        },
+        "admin": {
+          "name": "Responsable",
+          "description": "Tout ce qui précède, et garde l'accès après une escalade"
+        }
+      },
+      "channel": {
+        "topic": "Ticket de {user} · {category}",
+        "default_open_message": "Merci d'avoir ouvert un ticket. Décrivez votre demande le plus précisément possible — l'équipe vous répondra ici.",
+        "title": "Ticket #{number}",
+        "meta": "Ouvert par",
+        "commands_hint": "Toutes les actions sont aussi disponibles avec les commandes `/ticket`."
+      },
+      "actions": {
+        "close": "Fermer",
+        "close_request": "Demander la fermeture",
+        "escalate": "Escalader",
+        "staff_thread": "Thread staff",
+        "participants": "Participants",
+        "reopen": "Rouvrir",
+        "delete": "Supprimer le salon",
+        "deescalate": "Annuler l'escalade",
+        "rename": "Renommer"
+      },
+      "fields": {
+        "reason": "Raison",
+        "reason_hint": "Facultatif",
+        "channel_name": "Nouveau nom",
+        "channel_name_hint": "Lettres, chiffres et tirets",
+        "participants": "Participants",
+        "opener": "Ouvert par",
+        "category": "Catégorie",
+        "status": "Statut",
+        "escalated": "Escalade",
+        "your_permissions": "Vos permissions ici",
+        "none": "aucune"
+      },
+      "status": {
+        "open": "Ouvert",
+        "closed": "Fermé",
+        "escalated": "Escaladé"
+      },
+      "open": {
+        "success_title": "Ticket ouvert",
+        "success_description": "Votre ticket est prêt : {channel}"
+      },
+      "close": {
+        "done_title": "Ticket fermé",
+        "done_description": "Le ticket est verrouillé. Il peut être rouvert, ou supprimé définitivement, depuis la carte publiée dans le salon.",
+        "card_title": "Ticket fermé",
+        "by": "Fermé par",
+        "dm_title": "Votre ticket a été fermé",
+        "dm_description": "Votre ticket #`{number}` ({category}) sur **{server}** a été fermé."
+      },
+      "close_request": {
+        "sent_title": "Demande envoyée",
+        "sent_description": "L'équipe a été prévenue et fermera le ticket si tout est réglé.",
+        "card_title": "Fermeture demandée",
+        "card_description": "{user} souhaite que ce ticket soit fermé.",
+        "accept": "Fermer le ticket",
+        "refuse": "Le garder ouvert",
+        "refused": "{user} a gardé le ticket ouvert."
+      },
+      "reopen": {
+        "done_title": "Ticket rouvert",
+        "done_description": "Tous ceux qui y avaient accès le retrouvent."
+      },
+      "delete": {
+        "pending_title": "Suppression",
+        "pending_description": "Le salon et sa conversation sont en cours de suppression."
+      },
+      "escalate": {
+        "card_title": "Ticket escaladé",
+        "card_description": "{user} a escaladé ce ticket : seuls les responsables, son auteur et les personnes ajoutées à la main y ont encore accès.",
+        "done_title": "Ticket escaladé",
+        "done_description": "L'accès est désormais limité aux responsables.",
+        "cancelled_title": "Escalade annulée",
+        "cancelled_description": "Les rôles du staff retrouvent leur accès.",
+        "confirm_title": "Escalader ce ticket ?",
+        "confirm_description": "Les rôles du staff perdent l'accès. Son auteur le garde. Que faire des personnes ajoutées à la main ?",
+        "keep": "Les garder",
+        "drop": "Les retirer"
+      },
+      "move": {
+        "done_title": "Ticket déplacé",
+        "done_description": "Le ticket suit maintenant les permissions de sa nouvelle catégorie."
+      },
+      "rename": {
+        "done_title": "Ticket renommé",
+        "done_description": "Le salon s'appelle maintenant `{name}`."
+      },
+      "participants": {
+        "title": "Participants du ticket",
+        "description": "Toutes les personnes sélectionnées ici ont accès au ticket, en plus de son auteur et des rôles du staff. Désélectionnez quelqu'un pour le retirer.",
+        "owner_note": "Ouvert par",
+        "members_title": "Membres",
+        "members_description": "Ajoutés un par un",
+        "members_placeholder": "Sélectionnez les membres",
+        "roles_title": "Rôles",
+        "roles_description": "Tous les porteurs du rôle obtiennent l'accès",
+        "roles_placeholder": "Sélectionnez les rôles",
+        "added_title": "Ajouté",
+        "added_description": "{target} a maintenant accès à ce ticket.",
+        "removed_title": "Retiré",
+        "removed_description": "{target} n'a plus accès à ce ticket."
+      },
+      "staff_thread": {
+        "name": "staff-{number}",
+        "intro": "Thread privé du staff pour le ticket #{number}. Le membre qui a ouvert le ticket ne le voit pas.",
+        "done_title": "Thread staff",
+        "done_description": "Vous avez été ajouté à {thread}."
+      },
+      "info": {
+        "title": "Ticket #{number}",
+        "description": "Tout ce que Moddy sait de ce ticket."
+      },
+      "errors": {
+        "title": "Ticket",
+        "not_a_ticket": "Ce salon n'est pas un ticket.",
+        "module_disabled": "Le module de tickets n'est pas activé sur ce serveur.",
+        "category_gone": "La catégorie de ce ticket n'existe plus. Demandez à un administrateur de le déplacer vers une autre.",
+        "missing_permission": "Vous n'avez pas la permission de faire cela dans ce ticket.",
+        "unavailable": "Les tickets sont temporairement indisponibles. Réessayez dans un instant.",
+        "cannot_open": "Vous ne pouvez pas ouvrir de ticket dans cette catégorie.",
+        "category_disabled": "Cette catégorie n'accepte pas de ticket pour le moment.",
+        "destination_missing": "Cette catégorie n'a pas de destination valide. Prévenez un administrateur.",
+        "too_many_open": "Vous avez déjà `{max}` ticket(s) ouvert(s) dans cette catégorie. Fermez-en un avant d'en ouvrir un autre.",
+        "cannot_create_channel": "Moddy n'a pas pu créer le salon du ticket. Vérifiez ses permissions sur la catégorie de destination.",
+        "already_closed": "Ce ticket est déjà fermé.",
+        "not_closed": "Ce ticket n'est pas fermé.",
+        "can_close_directly": "Vous pouvez fermer ce ticket vous-même — inutile de le demander.",
+        "close_already_requested": "Une demande de fermeture est déjà en attente sur ce ticket.",
+        "no_close_request": "Aucune demande de fermeture n'est en attente sur ce ticket.",
+        "already_escalated": "Ce ticket est déjà escaladé.",
+        "not_escalated": "Ce ticket n'est pas escaladé.",
+        "no_responsible_role": "Aucun rôle n'a la permission **Responsable** dans cette catégorie : il n'y a personne vers qui escalader.",
+        "unknown_category": "Cette catégorie n'existe pas.",
+        "same_category": "Le ticket est déjà dans cette catégorie.",
+        "cannot_edit_channel": "Moddy n'a pas pu modifier le salon du ticket. Vérifiez ses permissions.",
+        "invalid_name": "Ce nom ne peut pas être utilisé pour un salon.",
+        "already_participant": "Cette personne a déjà accès à ce ticket.",
+        "not_a_participant": "Cette personne n'a pas été ajoutée à ce ticket.",
+        "cannot_remove_owner": "Le membre qui a ouvert le ticket ne peut pas en être retiré. Fermez plutôt le ticket.",
+        "cannot_create_thread": "Moddy n'a pas pu créer le thread staff. Les threads privés nécessitent la permission de les créer dans ce salon.",
+        "use_close_request": "Vous ne pouvez pas fermer ce ticket. Utilisez **Demander la fermeture** pour le demander à l'équipe.",
+        "panel_limit": "Ce serveur a atteint sa limite de `{max}` panneaux de tickets.",
+        "category_limit": "Ce panneau a atteint sa limite de `{max}` catégories.",
+        "premium_upsell": "Premium fait passer les limites à 10 panneaux et 15 catégories par panneau. [En savoir plus]({url})",
+        "invalid_emoji": "Cet émoji ne peut pas être utilisé. Utilisez un émoji du serveur ou un émoji standard."
+      }
     }
   },
   "languages": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -2795,6 +2795,314 @@
           "app_command_permission_update": "Alteração das permissões de um comando"
         }
       }
+    },
+    "tickets": {
+      "description": "Tickets de suporte com painéis, categorias e permissões por cargo",
+      "config": {
+        "title": "Tickets",
+        "description": "Permita que os seus membros abram um ticket de suporte a partir de um painel. Cada painel oferece uma ou mais categorias, e cada categoria decide onde o ticket é aberto, quem pode abri-lo e o que a sua equipe pode fazer dentro dele.",
+        "quota": "Painéis: `{count}/{max}` · Categorias por painel: `{categories}`",
+        "premium_hint": "O Premium eleva esses limites para 10 painéis e 15 categorias por painel.",
+        "manage_placeholder": "Selecione um painel para configurar",
+        "empty": "Nenhum painel ainda. Crie um para que os seus membros possam abrir tickets.",
+        "add_panel": "Adicionar um painel",
+        "entry_summary": "{categories} categoria(s) · {style}",
+        "no_channel": "sem canal",
+        "paused": "pausado",
+        "not_posted": "Este painel ainda não foi publicado — use **Publicar novamente**."
+      },
+      "panel": {
+        "modal_title_new": "Novo painel de tickets",
+        "modal_title_edit": "Editar o painel",
+        "name_label": "Nome interno",
+        "name_hint": "Só você o vê, nesta tela de configuração",
+        "title_label": "Título exibido aos membros",
+        "title_hint": "Deixe vazio para usar o nome interno",
+        "description_label": "Descrição",
+        "description_hint": "O texto exibido acima dos botões",
+        "color_label": "Cor de destaque",
+        "color_hint": "Hexadecimal, por exemplo #5865F2",
+        "placeholder_label": "Texto do menu suspenso",
+        "placeholder_hint": "Usado apenas quando o painel aparece como menu suspenso",
+        "subtitle": "Painel de tickets",
+        "paused_notice": "Este painel está pausado: a mensagem dele é removida e ninguém pode abrir um ticket por ele.",
+        "channel_title": "Canal do painel",
+        "channel_hint": "Onde é publicada a mensagem em que os membros clicam",
+        "channel_placeholder": "Selecione um canal",
+        "style_title": "Como os membros escolhem",
+        "style_hint": "Botões são mais rápidos; o menu suspenso comporta mais categorias",
+        "style_buttons": "Botões",
+        "style_buttons_hint": "Um botão por categoria, até 15",
+        "style_select": "Menu suspenso",
+        "style_select_hint": "Uma única lista, até 25 categorias",
+        "categories_title": "Categorias",
+        "categories_hint": "{count}/{max} · uma por botão ou entrada do menu",
+        "no_category": "Nenhuma categoria. Um painel sem categorias nunca é publicado.",
+        "category_placeholder": "Selecione uma categoria para configurar",
+        "category_summary": "{roles} cargo(s) com permissões · idioma `{language}`",
+        "no_destination": "sem destino",
+        "edit": "Editar",
+        "add_category": "Adicionar uma categoria",
+        "repost": "Publicar novamente",
+        "pause": "Pausar",
+        "resume": "Retomar",
+        "delete": "Excluir",
+        "delete_title": "Excluir este painel?",
+        "delete_description": "A mensagem dele será removida e as suas {categories} categoria(s) serão perdidas. Os tickets já abertos não são afetados.",
+        "delete_confirm": "Excluir o painel",
+        "repost_failed": "O painel não pôde ser publicado. Verifique se o Moddy pode escrever no canal e se o painel tem pelo menos uma categoria utilizável."
+      },
+      "category": {
+        "modal_title_new": "Nova categoria",
+        "modal_title_edit": "Editar a categoria",
+        "name_label": "Nome",
+        "name_hint": "Exibido no botão ou na entrada do menu",
+        "emoji_label": "Emoji",
+        "emoji_hint": "Opcional, por exemplo um emoji do servidor",
+        "description_label": "Descrição curta",
+        "description_hint": "Exibida abaixo do nome num menu suspenso",
+        "color_label": "Cor do botão",
+        "color_hint": "Ignorada quando o painel aparece como menu suspenso",
+        "color_primary": "Azul",
+        "color_secondary": "Cinza",
+        "color_success": "Verde",
+        "color_danger": "Vermelho",
+        "subtitle": "Categoria do painel “{panel}”",
+        "paused_notice": "Esta categoria está pausada: ela não aparece mais no painel.",
+        "destination_title": "Onde os tickets são criados",
+        "destination_hint": "A categoria do Discord em que o canal do ticket é criado",
+        "destination_placeholder": "Selecione uma categoria do Discord",
+        "access_title": "Quem pode abrir um ticket",
+        "access_hint": "Deixe vazio para permitir todo mundo",
+        "allowed_placeholder": "Cargos autorizados a abrir",
+        "denied_hint": "Um cargo proibido sempre prevalece, mesmo que o membro também tenha um autorizado.",
+        "denied_placeholder": "Cargos proibidos",
+        "language_title": "Idioma dos tickets",
+        "language_hint": "Todas as mensagens desses tickets usam este idioma",
+        "summary_title": "Configurado atrás dos botões abaixo",
+        "summary_permissions": "Permissões — {roles} cargo(s)",
+        "summary_messages": "Mensagens — {count}/2 personalizada(s)",
+        "summary_options": "Opções — nome `{format}`, `{max}` ticket(s) aberto(s) por membro",
+        "identity": "Identidade",
+        "permissions": "Permissões",
+        "messages": "Mensagens",
+        "options": "Opções",
+        "pause": "Pausar",
+        "resume": "Retomar",
+        "delete": "Excluir",
+        "delete_title": "Excluir esta categoria?",
+        "delete_description": "Ela desaparece do painel e as suas permissões são perdidas. Os tickets já abertos nela continuam funcionando até serem fechados.",
+        "delete_confirm": "Excluir a categoria"
+      },
+      "messages": {
+        "modal_title": "Mensagens do ticket",
+        "open_label": "Mensagem de abertura",
+        "open_hint": "Publicada no ticket e fixada. Deixe vazio para a padrão.",
+        "close_label": "Mensagem de fechamento",
+        "close_hint": "Adicionada ao cartão publicado quando o ticket é fechado",
+        "placeholders_header": "Variáveis disponíveis:",
+        "ph_user": "menção do membro",
+        "ph_username": "o nome de usuário dele",
+        "ph_display_name": "o nome exibido dele",
+        "ph_server": "o nome do servidor",
+        "ph_category": "o nome da categoria",
+        "ph_number": "o número do ticket",
+        "ph_ticket": "menção do canal do ticket"
+      },
+      "options": {
+        "modal_title": "Opções da categoria",
+        "name_format_label": "Nome do canal",
+        "name_format_hint": "por exemplo ticket-{number}",
+        "max_open_label": "Tickets abertos por membro",
+        "max_open_hint": "Entre 1 e {max}, nesta categoria",
+        "ping_label": "Cargos a mencionar",
+        "ping_hint": "Mencionados quando um ticket é aberto"
+      },
+      "permissions": {
+        "title": "Permissões dos tickets",
+        "subtitle": "Categoria “{category}”",
+        "description": "Escolha um cargo e marque o que ele pode fazer nos tickets desta categoria. Os administradores do servidor sempre têm tudo.",
+        "configured_title": "Cargos com permissões",
+        "nobody": "Nenhum cargo pode atender esses tickets ainda — apenas os administradores do servidor.",
+        "pick_role": "Cargo a configurar",
+        "pick_role_hint": "Selecione-o novamente para alterar ou retirar as permissões dele",
+        "role_placeholder": "Selecione um cargo",
+        "perms_placeholder": "Selecione as permissões",
+        "defaults_hint": "Cargo novo: há uma seleção inicial marcada; nada é salvo até você confirmá-la.",
+        "clear": "Retirar tudo",
+        "view": {
+          "name": "Ver o ticket",
+          "description": "Ler e escrever nos tickets desta categoria"
+        },
+        "close": {
+          "name": "Fechar",
+          "description": "Fechar e reabrir um ticket"
+        },
+        "staff_thread": {
+          "name": "Tópico da equipe",
+          "description": "Abrir e entrar no tópico privado da equipe"
+        },
+        "rename": {
+          "name": "Renomear",
+          "description": "Alterar o nome do canal do ticket"
+        },
+        "move": {
+          "name": "Mudar de categoria",
+          "description": "Mover o ticket para outra categoria"
+        },
+        "participants": {
+          "name": "Gerenciar participantes",
+          "description": "Adicionar e remover membros e cargos"
+        },
+        "admin": {
+          "name": "Responsável",
+          "description": "Tudo acima, e mantém o acesso após um escalonamento"
+        }
+      },
+      "channel": {
+        "topic": "Ticket de {user} · {category}",
+        "default_open_message": "Obrigado por abrir um ticket. Descreva o seu pedido da forma mais precisa possível — a equipe responderá aqui.",
+        "title": "Ticket #{number}",
+        "meta": "Aberto por",
+        "commands_hint": "Todas as ações também estão disponíveis com os comandos `/ticket`."
+      },
+      "actions": {
+        "close": "Fechar",
+        "close_request": "Pedir o fechamento",
+        "escalate": "Escalonar",
+        "staff_thread": "Tópico da equipe",
+        "participants": "Participantes",
+        "reopen": "Reabrir",
+        "delete": "Excluir o canal",
+        "deescalate": "Cancelar o escalonamento",
+        "rename": "Renomear"
+      },
+      "fields": {
+        "reason": "Motivo",
+        "reason_hint": "Opcional",
+        "channel_name": "Novo nome",
+        "channel_name_hint": "Letras, números e hifens",
+        "participants": "Participantes",
+        "opener": "Aberto por",
+        "category": "Categoria",
+        "status": "Status",
+        "escalated": "Escalonamento",
+        "your_permissions": "Suas permissões aqui",
+        "none": "nenhuma"
+      },
+      "status": {
+        "open": "Aberto",
+        "closed": "Fechado",
+        "escalated": "Escalonado"
+      },
+      "open": {
+        "success_title": "Ticket aberto",
+        "success_description": "O seu ticket está pronto: {channel}"
+      },
+      "close": {
+        "done_title": "Ticket fechado",
+        "done_description": "O ticket está trancado. Ele pode ser reaberto, ou excluído definitivamente, pelo cartão publicado no canal.",
+        "card_title": "Ticket fechado",
+        "by": "Fechado por",
+        "dm_title": "O seu ticket foi fechado",
+        "dm_description": "O seu ticket #`{number}` ({category}) em **{server}** foi fechado."
+      },
+      "close_request": {
+        "sent_title": "Pedido enviado",
+        "sent_description": "A equipe foi avisada e fechará o ticket se estiver tudo resolvido.",
+        "card_title": "Fechamento pedido",
+        "card_description": "{user} gostaria que este ticket fosse fechado.",
+        "accept": "Fechar o ticket",
+        "refuse": "Mantê-lo aberto",
+        "refused": "{user} manteve o ticket aberto."
+      },
+      "reopen": {
+        "done_title": "Ticket reaberto",
+        "done_description": "Todos que tinham acesso o recuperam."
+      },
+      "delete": {
+        "pending_title": "Excluindo",
+        "pending_description": "O canal e a conversa dele estão sendo excluídos."
+      },
+      "escalate": {
+        "card_title": "Ticket escalonado",
+        "card_description": "{user} escalonou este ticket: apenas os responsáveis, quem o abriu e as pessoas adicionadas manualmente ainda têm acesso.",
+        "done_title": "Ticket escalonado",
+        "done_description": "O acesso agora está limitado aos responsáveis.",
+        "cancelled_title": "Escalonamento cancelado",
+        "cancelled_description": "Os cargos da equipe recuperam o acesso.",
+        "confirm_title": "Escalonar este ticket?",
+        "confirm_description": "Os cargos da equipe perdem o acesso. Quem o abriu permanece. O que fazer com as pessoas adicionadas manualmente?",
+        "keep": "Mantê-las",
+        "drop": "Removê-las"
+      },
+      "move": {
+        "done_title": "Ticket movido",
+        "done_description": "O ticket agora segue as permissões da nova categoria."
+      },
+      "rename": {
+        "done_title": "Ticket renomeado",
+        "done_description": "O canal agora se chama `{name}`."
+      },
+      "participants": {
+        "title": "Participantes do ticket",
+        "description": "Todas as pessoas selecionadas aqui têm acesso ao ticket, além de quem o abriu e dos cargos da equipe. Desmarque alguém para removê-lo.",
+        "owner_note": "Aberto por",
+        "members_title": "Membros",
+        "members_description": "Adicionados um a um",
+        "members_placeholder": "Selecione os membros",
+        "roles_title": "Cargos",
+        "roles_description": "Todos que tiverem o cargo ganham acesso",
+        "roles_placeholder": "Selecione os cargos",
+        "added_title": "Adicionado",
+        "added_description": "{target} agora tem acesso a este ticket.",
+        "removed_title": "Removido",
+        "removed_description": "{target} não tem mais acesso a este ticket."
+      },
+      "staff_thread": {
+        "name": "staff-{number}",
+        "intro": "Tópico privado da equipe para o ticket #{number}. O membro que abriu o ticket não o vê.",
+        "done_title": "Tópico da equipe",
+        "done_description": "Você foi adicionado a {thread}."
+      },
+      "info": {
+        "title": "Ticket #{number}",
+        "description": "Tudo o que o Moddy sabe sobre este ticket."
+      },
+      "errors": {
+        "title": "Ticket",
+        "not_a_ticket": "Este canal não é um ticket.",
+        "module_disabled": "O módulo de tickets não está ativado neste servidor.",
+        "category_gone": "A categoria deste ticket não existe mais. Peça a um administrador para movê-lo para outra.",
+        "missing_permission": "Você não tem permissão para fazer isso neste ticket.",
+        "unavailable": "Os tickets estão temporariamente indisponíveis. Tente novamente daqui a pouco.",
+        "cannot_open": "Você não pode abrir um ticket nesta categoria.",
+        "category_disabled": "Esta categoria não aceita tickets no momento.",
+        "destination_missing": "Esta categoria não tem um destino válido. Avise um administrador.",
+        "too_many_open": "Você já tem `{max}` ticket(s) aberto(s) nesta categoria. Feche um antes de abrir outro.",
+        "cannot_create_channel": "O Moddy não conseguiu criar o canal do ticket. Verifique as permissões dele na categoria de destino.",
+        "already_closed": "Este ticket já está fechado.",
+        "not_closed": "Este ticket não está fechado.",
+        "can_close_directly": "Você pode fechar este ticket sozinho — não precisa pedir.",
+        "close_already_requested": "Já há um pedido de fechamento pendente neste ticket.",
+        "no_close_request": "Não há nenhum pedido de fechamento pendente neste ticket.",
+        "already_escalated": "Este ticket já está escalonado.",
+        "not_escalated": "Este ticket não está escalonado.",
+        "no_responsible_role": "Nenhum cargo tem a permissão **Responsável** nesta categoria, então não há para quem escalonar.",
+        "unknown_category": "Essa categoria não existe.",
+        "same_category": "O ticket já está nessa categoria.",
+        "cannot_edit_channel": "O Moddy não conseguiu editar o canal do ticket. Verifique as permissões dele.",
+        "invalid_name": "Esse nome não pode ser usado para um canal.",
+        "already_participant": "Essa pessoa já tem acesso a este ticket.",
+        "not_a_participant": "Essa pessoa não foi adicionada a este ticket.",
+        "cannot_remove_owner": "O membro que abriu o ticket não pode ser removido dele. Feche o ticket em vez disso.",
+        "cannot_create_thread": "O Moddy não conseguiu criar o tópico da equipe. Tópicos privados exigem permissão para criá-los neste canal.",
+        "use_close_request": "Você não pode fechar este ticket. Use **Pedir o fechamento** para pedir à equipe.",
+        "panel_limit": "Este servidor atingiu o limite de `{max}` painéis de tickets.",
+        "category_limit": "Este painel atingiu o limite de `{max}` categorias.",
+        "premium_upsell": "O Premium eleva os limites para 10 painéis e 15 categorias por painel. [Saiba mais]({url})",
+        "invalid_emoji": "Esse emoji não pode ser usado. Use um emoji do servidor ou um padrão."
+      }
     }
   },
   "languages": {

--- a/modules/configs/tickets_category_config.py
+++ b/modules/configs/tickets_category_config.py
@@ -1,0 +1,1120 @@
+"""
+``/config`` → Tickets → panel → **one category**, and its per-role permissions.
+
+A category is the button (or dropdown option) a member clicks, and everything
+that follows from it: where the ticket channel is created, who may open one,
+what each staff role may do inside it, the language it speaks and the messages
+it shows.
+
+The screen is split the way the questions are:
+
+- the **category screen** holds what an admin changes often — destination,
+  access, language — as controls that show their own state;
+- **identity**, **messages** and **options** are wording and numbers, so they
+  live in modals;
+- **permissions** get their own screen, because "pick a role, then tick what it
+  may do" is inherently two steps.
+
+Persistence: every control is a :class:`discord.ui.DynamicItem` carrying the
+panel and category ids (and, on the permissions screen, the role id) in its
+``custom_id``, registered through :class:`TicketsConfigPersistence`. The
+wrapper views are therefore not registered — same reasoning as
+``LogsCategoryView``, see docs/PERSISTENT_VIEWS.md — which is also why every
+change here applies immediately.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseModal, BaseView
+from modules.configs._common import check_guild_perms
+from modules.configs.tickets_config import (
+    load_config,
+    render_panel,
+    render_root,
+    report_save_error,
+    save_config,
+)
+from modules.tickets import (
+    BUTTON_STYLES,
+    DEFAULT_ACCENT_COLOR,
+    DEFAULT_BUTTON_STYLE,
+    DEFAULT_MAX_OPEN_PER_USER,
+    DEFAULT_NAME_FORMAT,
+    DEFAULT_ROLE_PERMISSIONS,
+    MAX_CATEGORY_DESCRIPTION,
+    MAX_CATEGORY_NAME,
+    MAX_CHANNEL_NAME,
+    MAX_OPEN_PER_USER_CEILING,
+    MAX_TICKET_MESSAGE,
+    NAME_PLACEHOLDERS,
+    PERM_ADMIN,
+    PLACEHOLDERS,
+    TICKET_LOCALES,
+    TICKET_PERMISSIONS,
+    find_panel,
+    get_limits,
+    locate_category,
+    max_categories_for_style,
+    new_category_id,
+    parse_emoji,
+)
+from utils.components_v2 import create_error_message
+from utils.emojis import (
+    BACK, DELETE, EDIT, INFO, MESSAGE, PAUSE, PLAY, REQUIRED_FIELDS,
+    TICKET_ACCESS, TICKET_CATEGORY, TICKET_LANGUAGE, TICKET_PERMISSIONS as PERM_EMOJI,
+    SETTINGS, WARNING,
+)
+from utils.i18n import i18n, t
+
+logger = logging.getLogger('moddy.modules.tickets_category_config')
+
+_ENTRY_ID = r"[a-z0-9_]+"
+
+_CAT_BUTTON_ACTIONS = "back|identity|messages|options|perms|toggle|delete|delconfirm"
+_PERM_BUTTON_ACTIONS = "back|clear"
+_ROLE_SCOPES = "allowed|denied"
+
+# Flags are the one Unicode emoji Moddy uses (see CLAUDE.md rule 3).
+_LOCALE_FLAGS = {
+    "en-US": "🇬🇧",
+    "fr": "🇫🇷",
+    "es-ES": "🇪🇸",
+    "pt-BR": "🇧🇷",
+    "de": "🇩🇪",
+}
+
+
+def _guarded(callback):
+    """Route a dynamic-item callback error to the central handler."""
+    async def wrapper(self, interaction: discord.Interaction):
+        try:
+            await callback(self, interaction)
+        except Exception as e:  # noqa: BLE001
+            from cogs.error_handler import report_component_error
+            await report_component_error(interaction, e, self.__class__.__name__)
+    return wrapper
+
+
+# =========================================================================== #
+# Navigation helpers
+# =========================================================================== #
+async def render_category(interaction: discord.Interaction, panel_id: str,
+                          category_id: str, *, confirm_delete: bool = False) -> None:
+    """(Re)build and show one category's editor, falling back up the tree."""
+    bot = interaction.client
+    locale = i18n.get_user_locale(interaction)
+    config = await load_config(bot, interaction.guild_id)
+    panel, category = locate_category(config, panel_id, category_id)
+    if not category:
+        await (render_panel(interaction, panel_id) if panel
+               else render_root(interaction))
+        return
+
+    view = TicketCategoryConfigView(bot, interaction.guild_id, locale, panel,
+                                    category, confirm_delete=confirm_delete)
+    await _edit(interaction, view)
+
+
+async def render_permissions(interaction: discord.Interaction, panel_id: str,
+                             category_id: str,
+                             role_id: Optional[int] = None) -> None:
+    """(Re)build and show the permissions screen of one category."""
+    bot = interaction.client
+    locale = i18n.get_user_locale(interaction)
+    config = await load_config(bot, interaction.guild_id)
+    panel, category = locate_category(config, panel_id, category_id)
+    if not category:
+        await (render_panel(interaction, panel_id) if panel
+               else render_root(interaction))
+        return
+
+    view = TicketPermissionsConfigView(bot, interaction.guild_id, locale, panel,
+                                       category, role_id)
+    await _edit(interaction, view)
+
+
+async def _edit(interaction: discord.Interaction, view: ui.LayoutView) -> None:
+    if interaction.response.is_done():
+        await interaction.edit_original_response(view=view)
+    else:
+        await interaction.response.edit_message(view=view)
+
+
+async def _update_category(interaction: discord.Interaction, panel_id: str,
+                           category_id: str, fields: Dict[str, Any], *,
+                           repost: bool = False) -> None:
+    """Apply ``fields`` to one category, persist, and re-render its editor.
+
+    ``repost`` is only True for the handful of fields the *panel message*
+    shows (name, emoji, colour, description, availability) — everything else
+    changes what happens inside a ticket, not what the panel looks like.
+    """
+    bot = interaction.client
+    config = await load_config(bot, interaction.guild_id)
+    panel, category = locate_category(config, panel_id, category_id)
+    if not category:
+        await render_root(interaction)
+        return
+
+    category.update(fields)
+    if not interaction.response.is_done():
+        await interaction.response.defer()
+
+    success, error = await save_config(
+        bot, interaction.guild_id, config, interaction.user.id,
+        repost_panel_id=panel_id if repost else None)
+    if not success:
+        await report_save_error(interaction, error)
+        return
+    await render_category(interaction, panel_id, category_id)
+
+
+async def start_category_creation(interaction: discord.Interaction,
+                                  panel_id: str) -> None:
+    """Ask for the new category's identity, then open its editor."""
+    bot = interaction.client
+    locale = i18n.get_user_locale(interaction)
+    config = await load_config(bot, interaction.guild_id)
+    panel = find_panel(config, panel_id)
+    if not panel:
+        await render_root(interaction)
+        return
+
+    limits = await get_limits(bot, interaction.guild_id)
+    cap = max_categories_for_style(panel['style'], limits['max_categories'])
+    if len(panel.get('categories', [])) >= cap:
+        description = t('modules.tickets.errors.category_limit', locale=locale, max=cap)
+        if not limits.get('premium'):
+            from modules.configs.tickets_config import PREMIUM_URL
+            description += ("\n\n" + t('modules.tickets.errors.premium_upsell',
+                                       locale=locale, url=PREMIUM_URL))
+        await interaction.response.send_message(
+            view=create_error_message(
+                t('modules.tickets.errors.title', locale=locale), description),
+            ephemeral=True)
+        return
+
+    async def create(inner: discord.Interaction, fields: Dict[str, Any]):
+        inner_config = await load_config(bot, inner.guild_id)
+        inner_panel = find_panel(inner_config, panel_id)
+        if not inner_panel:
+            await render_root(inner)
+            return
+        category_id = new_category_id()
+        inner_panel.setdefault('categories', []).append({
+            'id': category_id, 'enabled': True, **fields,
+        })
+        if not inner.response.is_done():
+            await inner.response.defer()
+        success, error = await save_config(bot, inner.guild_id, inner_config,
+                                           inner.user.id, repost_panel_id=panel_id)
+        if not success:
+            await report_save_error(inner, error)
+            return
+        await render_category(inner, panel_id, category_id)
+
+    modal = CategoryIdentityModal(locale, None, create)
+    modal.bot = bot
+    await interaction.response.send_modal(modal)
+
+
+def _placeholder_help(locale: str, placeholders) -> str:
+    """The ``{placeholder}`` cheat-sheet, fetched without kwargs.
+
+    Passing them as translation kwargs would substitute the braces away, which
+    is exactly what this block must not do.
+    """
+    lines = [t('modules.tickets.messages.placeholders_header', locale=locale)]
+    for placeholder in placeholders:
+        key = placeholder.strip('{}')
+        lines.append(f"`{placeholder}` — "
+                     f"{t(f'modules.tickets.messages.ph_{key}', locale=locale)}")
+    return "\n".join(lines)
+
+
+# =========================================================================== #
+# Modals
+# =========================================================================== #
+class CategoryIdentityModal(BaseModal):
+    """What the member sees on the panel: name, icon, blurb, button colour."""
+
+    def __init__(self, locale: str, category: Optional[Dict[str, Any]], callback_func):
+        category = category or {}
+        super().__init__(
+            title=t('modules.tickets.category.modal_title_new' if not category
+                    else 'modules.tickets.category.modal_title_edit',
+                    locale=locale)[:45],
+            timeout=None,
+        )
+        self.locale = locale
+        self.callback_func = callback_func
+
+        self.name_input = ui.TextInput(
+            style=discord.TextStyle.short, required=True,
+            max_length=MAX_CATEGORY_NAME, default=category.get('name'),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.category.name_label', locale=locale)[:45],
+            description=t('modules.tickets.category.name_hint', locale=locale)[:100],
+            component=self.name_input,
+        ))
+
+        self.emoji_input = ui.TextInput(
+            style=discord.TextStyle.short, required=False,
+            max_length=64, default=category.get('emoji'),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.category.emoji_label', locale=locale)[:45],
+            description=t('modules.tickets.category.emoji_hint', locale=locale)[:100],
+            component=self.emoji_input,
+        ))
+
+        self.description_input = ui.TextInput(
+            style=discord.TextStyle.short, required=False,
+            max_length=MAX_CATEGORY_DESCRIPTION, default=category.get('description'),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.category.description_label', locale=locale)[:45],
+            description=t('modules.tickets.category.description_hint',
+                          locale=locale)[:100],
+            component=self.description_input,
+        ))
+
+        current_style = category.get('button_style', DEFAULT_BUTTON_STYLE)
+        self.style_select = ui.Select(
+            options=[
+                discord.SelectOption(
+                    label=t(f'modules.tickets.category.color_{name}', locale=locale)[:100],
+                    value=name, default=current_style == name,
+                ) for name in BUTTON_STYLES
+            ],
+            min_values=1, max_values=1,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.category.color_label', locale=locale)[:45],
+            description=t('modules.tickets.category.color_hint', locale=locale)[:100],
+            component=self.style_select,
+        ))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        emoji_raw = (self.emoji_input.value or '').strip() or None
+        # Reject an emoji Discord would refuse rather than letting it break the
+        # whole panel message the next time it is posted.
+        emoji = emoji_raw if (emoji_raw is None or parse_emoji(emoji_raw)) else None
+        if emoji_raw and emoji is None:
+            locale = i18n.get_user_locale(interaction)
+            await interaction.response.send_message(
+                view=create_error_message(
+                    t('modules.tickets.errors.title', locale=locale),
+                    t('modules.tickets.errors.invalid_emoji', locale=locale)),
+                ephemeral=True)
+            return
+
+        values = self.style_select.values
+        await self.callback_func(interaction, {
+            'name': (self.name_input.value or '').strip(),
+            'emoji': emoji,
+            'description': (self.description_input.value or '').strip() or None,
+            'button_style': values[0] if values else DEFAULT_BUTTON_STYLE,
+        })
+
+
+class CategoryMessagesModal(BaseModal):
+    """The two messages a ticket shows: when it opens, and when it closes."""
+
+    def __init__(self, locale: str, category: Dict[str, Any], callback_func):
+        super().__init__(
+            title=t('modules.tickets.messages.modal_title', locale=locale)[:45],
+            timeout=None,
+        )
+        self.callback_func = callback_func
+
+        self.open_input = ui.TextInput(
+            style=discord.TextStyle.paragraph, required=False,
+            max_length=MAX_TICKET_MESSAGE, default=category.get('open_message'),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.messages.open_label', locale=locale)[:45],
+            description=t('modules.tickets.messages.open_hint', locale=locale)[:100],
+            component=self.open_input,
+        ))
+
+        self.add_item(ui.TextDisplay(_placeholder_help(locale, PLACEHOLDERS)))
+
+        self.close_input = ui.TextInput(
+            style=discord.TextStyle.paragraph, required=False,
+            max_length=MAX_TICKET_MESSAGE, default=category.get('close_message'),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.messages.close_label', locale=locale)[:45],
+            description=t('modules.tickets.messages.close_hint', locale=locale)[:100],
+            component=self.close_input,
+        ))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await self.callback_func(interaction, {
+            'open_message': (self.open_input.value or '').strip() or None,
+            'close_message': (self.close_input.value or '').strip() or None,
+        })
+
+
+class CategoryOptionsModal(BaseModal):
+    """Channel naming, the anti-spam limit, and who gets pinged on a new ticket."""
+
+    def __init__(self, locale: str, category: Dict[str, Any], callback_func):
+        super().__init__(
+            title=t('modules.tickets.options.modal_title', locale=locale)[:45],
+            timeout=None,
+        )
+        self.locale = locale
+        self.callback_func = callback_func
+
+        self.name_format_input = ui.TextInput(
+            style=discord.TextStyle.short, required=False,
+            max_length=MAX_CHANNEL_NAME,
+            default=category.get('name_format') or DEFAULT_NAME_FORMAT,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.options.name_format_label', locale=locale)[:45],
+            description=t('modules.tickets.options.name_format_hint',
+                          locale=locale)[:100],
+            component=self.name_format_input,
+        ))
+
+        self.add_item(ui.TextDisplay(_placeholder_help(locale, NAME_PLACEHOLDERS)))
+
+        self.max_open_input = ui.TextInput(
+            style=discord.TextStyle.short, required=False, max_length=2,
+            default=str(category.get('max_open_per_user', DEFAULT_MAX_OPEN_PER_USER)),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.options.max_open_label', locale=locale)[:45],
+            description=t('modules.tickets.options.max_open_hint',
+                          locale=locale, max=MAX_OPEN_PER_USER_CEILING)[:100],
+            component=self.max_open_input,
+        ))
+
+        self.ping_select = ui.RoleSelect(min_values=0, max_values=10, required=False)
+        self.ping_select.default_values = [
+            discord.Object(id=rid) for rid in category.get('ping_role_ids', [])
+        ]
+        self.add_item(ui.Label(
+            text=t('modules.tickets.options.ping_label', locale=locale)[:45],
+            description=t('modules.tickets.options.ping_hint', locale=locale)[:100],
+            component=self.ping_select,
+        ))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        raw = (self.max_open_input.value or '').strip()
+        try:
+            max_open = int(raw) if raw else DEFAULT_MAX_OPEN_PER_USER
+        except ValueError:
+            max_open = DEFAULT_MAX_OPEN_PER_USER
+        max_open = max(1, min(max_open, MAX_OPEN_PER_USER_CEILING))
+
+        await self.callback_func(interaction, {
+            'name_format': (self.name_format_input.value or '').strip()
+                           or DEFAULT_NAME_FORMAT,
+            'max_open_per_user': max_open,
+            'ping_role_ids': [role.id for role in self.ping_select.values],
+        })
+
+
+# =========================================================================== #
+# Category screen — dynamic items
+# =========================================================================== #
+class TicketCategoryButton(
+    ui.DynamicItem[ui.Button],
+    template=(rf"moddy:tickets:catbtn:(?P<action>{_CAT_BUTTON_ACTIONS}):"
+              rf"(?P<panel_id>{_ENTRY_ID}):(?P<category_id>{_ENTRY_ID})"),
+):
+    """An action button on the category editor. Auth: Manage Server."""
+
+    def __init__(self, action: str, panel_id: str, category_id: str, *,
+                 label: str = "—", style: discord.ButtonStyle = discord.ButtonStyle.secondary,
+                 emoji: Optional[str] = None):
+        super().__init__(ui.Button(
+            label=label[:80], style=style,
+            emoji=discord.PartialEmoji.from_str(emoji) if emoji else None,
+            custom_id=f"moddy:tickets:catbtn:{action}:{panel_id}:{category_id}",
+        ))
+        self.action = action
+        self.panel_id = panel_id
+        self.category_id = category_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['action'], match['panel_id'], match['category_id'])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        await getattr(self, f"_on_{self.action}")(interaction)
+
+    async def _category(self, interaction) -> Optional[Dict[str, Any]]:
+        config = await load_config(interaction.client, interaction.guild_id)
+        _, category = locate_category(config, self.panel_id, self.category_id)
+        return category
+
+    # -- actions ----------------------------------------------------------- #
+    async def _on_back(self, interaction: discord.Interaction):
+        await render_panel(interaction, self.panel_id)
+
+    async def _on_identity(self, interaction: discord.Interaction):
+        category = await self._category(interaction)
+        if not category:
+            await render_panel(interaction, self.panel_id)
+            return
+        modal = CategoryIdentityModal(
+            i18n.get_user_locale(interaction), category, self._apply_identity)
+        modal.bot = interaction.client
+        await interaction.response.send_modal(modal)
+
+    async def _apply_identity(self, interaction, fields):
+        await _update_category(interaction, self.panel_id, self.category_id,
+                               fields, repost=True)
+
+    async def _on_messages(self, interaction: discord.Interaction):
+        category = await self._category(interaction)
+        if not category:
+            await render_panel(interaction, self.panel_id)
+            return
+        modal = CategoryMessagesModal(
+            i18n.get_user_locale(interaction), category, self._apply_plain)
+        modal.bot = interaction.client
+        await interaction.response.send_modal(modal)
+
+    async def _on_options(self, interaction: discord.Interaction):
+        category = await self._category(interaction)
+        if not category:
+            await render_panel(interaction, self.panel_id)
+            return
+        modal = CategoryOptionsModal(
+            i18n.get_user_locale(interaction), category, self._apply_plain)
+        modal.bot = interaction.client
+        await interaction.response.send_modal(modal)
+
+    async def _apply_plain(self, interaction, fields):
+        await _update_category(interaction, self.panel_id, self.category_id, fields)
+
+    async def _on_perms(self, interaction: discord.Interaction):
+        await render_permissions(interaction, self.panel_id, self.category_id)
+
+    async def _on_toggle(self, interaction: discord.Interaction):
+        category = await self._category(interaction)
+        if not category:
+            await render_panel(interaction, self.panel_id)
+            return
+        await _update_category(interaction, self.panel_id, self.category_id,
+                               {'enabled': not category.get('enabled', True)},
+                               repost=True)
+
+    async def _on_delete(self, interaction: discord.Interaction):
+        await render_category(interaction, self.panel_id, self.category_id,
+                              confirm_delete=True)
+
+    async def _on_delconfirm(self, interaction: discord.Interaction):
+        bot = interaction.client
+        config = await load_config(bot, interaction.guild_id)
+        panel = find_panel(config, self.panel_id)
+        if not panel:
+            await render_root(interaction)
+            return
+
+        panel['categories'] = [c for c in panel.get('categories', [])
+                               if c['id'] != self.category_id]
+        await interaction.response.defer()
+        success, error = await save_config(bot, interaction.guild_id, config,
+                                           interaction.user.id,
+                                           repost_panel_id=self.panel_id)
+        if not success:
+            await report_save_error(interaction, error)
+            return
+        await render_panel(interaction, self.panel_id)
+
+
+class TicketCategoryDestination(
+    ui.DynamicItem[ui.ChannelSelect],
+    template=(rf"moddy:tickets:catdest:(?P<panel_id>{_ENTRY_ID}):"
+              rf"(?P<category_id>{_ENTRY_ID})"),
+):
+    """Which Discord category the ticket channels are created in."""
+
+    def __init__(self, panel_id: str, category_id: str, *,
+                 placeholder: Optional[str] = None,
+                 current: Optional[discord.CategoryChannel] = None):
+        select = ui.ChannelSelect(
+            placeholder=placeholder,
+            channel_types=[discord.ChannelType.category],
+            min_values=0, max_values=1,
+            custom_id=f"moddy:tickets:catdest:{panel_id}:{category_id}",
+        )
+        if current is not None:
+            select.default_values = [current]
+        super().__init__(select)
+        self.panel_id = panel_id
+        self.category_id = category_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['panel_id'], match['category_id'])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        values = interaction.data.get('values') or []
+        # A category with no destination cannot be opened, so it disappears
+        # from the panel — hence the re-post.
+        await _update_category(
+            interaction, self.panel_id, self.category_id,
+            {'discord_category_id': int(values[0]) if values else None}, repost=True)
+
+
+class TicketCategoryRoles(
+    ui.DynamicItem[ui.RoleSelect],
+    template=(rf"moddy:tickets:catroles:(?P<scope>{_ROLE_SCOPES}):"
+              rf"(?P<panel_id>{_ENTRY_ID}):(?P<category_id>{_ENTRY_ID})"),
+):
+    """The allow list / deny list deciding who may open this category."""
+
+    def __init__(self, scope: str, panel_id: str, category_id: str, *,
+                 placeholder: Optional[str] = None,
+                 current: Optional[List[int]] = None):
+        select = ui.RoleSelect(
+            placeholder=placeholder, min_values=0, max_values=10,
+            custom_id=f"moddy:tickets:catroles:{scope}:{panel_id}:{category_id}",
+        )
+        select.default_values = [discord.Object(id=rid) for rid in (current or [])]
+        super().__init__(select)
+        self.scope = scope
+        self.panel_id = panel_id
+        self.category_id = category_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['scope'], match['panel_id'], match['category_id'])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        role_ids = [int(v) for v in (interaction.data.get('values') or [])]
+        field = 'allowed_role_ids' if self.scope == 'allowed' else 'denied_role_ids'
+        await _update_category(interaction, self.panel_id, self.category_id,
+                               {field: role_ids})
+
+
+class TicketCategoryLocale(
+    ui.DynamicItem[ui.Select],
+    template=(rf"moddy:tickets:catlang:(?P<panel_id>{_ENTRY_ID}):"
+              rf"(?P<category_id>{_ENTRY_ID})"),
+):
+    """The language every message of this category's tickets is written in."""
+
+    def __init__(self, panel_id: str, category_id: str, *,
+                 locale: str = "en-US", current: Optional[str] = None):
+        super().__init__(ui.Select(
+            options=[
+                discord.SelectOption(
+                    label=t(f'languages.{code}', locale=locale),
+                    value=code, emoji=_LOCALE_FLAGS.get(code),
+                    default=code == current,
+                ) for code in TICKET_LOCALES
+            ],
+            min_values=1, max_values=1,
+            custom_id=f"moddy:tickets:catlang:{panel_id}:{category_id}",
+        ))
+        self.panel_id = panel_id
+        self.category_id = category_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['panel_id'], match['category_id'])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        values = interaction.data.get('values') or []
+        if not values:
+            await interaction.response.defer()
+            return
+        await _update_category(interaction, self.panel_id, self.category_id,
+                               {'locale': values[0]})
+
+
+# =========================================================================== #
+# Category screen
+# =========================================================================== #
+class TicketCategoryConfigView(BaseView):
+    """One category: destination, access, language, and the way in to the rest.
+
+    Not registered — see the module docstring. Auth: Manage Server, re-checked
+    inside every dynamic item's callback.
+    """
+
+    def __init__(self, bot, guild_id: int, locale: str, panel: Dict[str, Any],
+                 category: Dict[str, Any], *, confirm_delete: bool = False):
+        super().__init__()  # timeout=None
+        self.bot = bot
+        self.guild_id = guild_id
+        self.locale = locale
+        self.panel = panel
+        self.category = category
+        self.confirm_delete = confirm_delete
+
+        self._build_view()
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container(accent_colour=discord.Colour(
+            self.panel.get('accent_color') or DEFAULT_ACCENT_COLOR))
+
+        icon = self.category.get('emoji') or TICKET_CATEGORY
+        container.add_item(ui.TextDisplay(f"### {icon} {self.category['name']}"))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.tickets.category.subtitle', locale=self.locale, panel=self.panel['name'])}"))
+
+        if not self.category.get('enabled', True):
+            container.add_item(ui.TextDisplay(
+                f"{WARNING} {t('modules.tickets.category.paused_notice', locale=self.locale)}"))
+
+        if self.confirm_delete:
+            self._build_delete_confirmation(container)
+            self.add_item(container)
+            return
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # 1. Destination.
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.tickets.category.destination_title', locale=self.locale)}**{REQUIRED_FIELDS}\n"
+            f"-# {t('modules.tickets.category.destination_hint', locale=self.locale)}"))
+        current = self.bot.get_channel(self.category['discord_category_id']) \
+            if self.bot and self.category.get('discord_category_id') else None
+        dest_row = ui.ActionRow()
+        dest_row.add_item(TicketCategoryDestination(
+            self.panel['id'], self.category['id'],
+            placeholder=t('modules.tickets.category.destination_placeholder',
+                          locale=self.locale),
+            current=current if isinstance(current, discord.CategoryChannel) else None,
+        ))
+        container.add_item(dest_row)
+
+        # 2. Access.
+        container.add_item(ui.TextDisplay(
+            f"**{TICKET_ACCESS} {t('modules.tickets.category.access_title', locale=self.locale)}**\n"
+            f"-# {t('modules.tickets.category.access_hint', locale=self.locale)}"))
+        allowed_row = ui.ActionRow()
+        allowed_row.add_item(TicketCategoryRoles(
+            'allowed', self.panel['id'], self.category['id'],
+            placeholder=t('modules.tickets.category.allowed_placeholder',
+                          locale=self.locale),
+            current=self.category.get('allowed_role_ids', []),
+        ))
+        container.add_item(allowed_row)
+
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.tickets.category.denied_hint', locale=self.locale)}"))
+        denied_row = ui.ActionRow()
+        denied_row.add_item(TicketCategoryRoles(
+            'denied', self.panel['id'], self.category['id'],
+            placeholder=t('modules.tickets.category.denied_placeholder',
+                          locale=self.locale),
+            current=self.category.get('denied_role_ids', []),
+        ))
+        container.add_item(denied_row)
+
+        # 3. Language.
+        container.add_item(ui.TextDisplay(
+            f"**{TICKET_LANGUAGE} {t('modules.tickets.category.language_title', locale=self.locale)}**\n"
+            f"-# {t('modules.tickets.category.language_hint', locale=self.locale)}"))
+        lang_row = ui.ActionRow()
+        lang_row.add_item(TicketCategoryLocale(
+            self.panel['id'], self.category['id'],
+            locale=self.locale, current=self.category.get('locale')))
+        container.add_item(lang_row)
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # 4. What is configured behind the buttons below.
+        container.add_item(ui.TextDisplay(self._summary()))
+
+        self.add_item(container)
+        self._build_buttons()
+
+    def _summary(self) -> str:
+        """One line per modal-backed setting — the only way to read them here."""
+        roles = len(self.category.get('permissions', {}))
+        messages = sum(1 for key in ('open_message', 'close_message')
+                       if self.category.get(key))
+        return (
+            f"**{t('modules.tickets.category.summary_title', locale=self.locale)}**\n"
+            f"-# {PERM_EMOJI} "
+            f"{t('modules.tickets.category.summary_permissions', locale=self.locale, roles=roles)}\n"
+            f"-# {MESSAGE} "
+            f"{t('modules.tickets.category.summary_messages', locale=self.locale, count=messages)}\n"
+            f"-# {SETTINGS} "
+            f"{t('modules.tickets.category.summary_options', locale=self.locale, format=self.category.get('name_format', ''), max=self.category.get('max_open_per_user', 1))}"
+        )
+
+    def _build_delete_confirmation(self, container: ui.Container):
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+        container.add_item(ui.TextDisplay(
+            f"{WARNING} **{t('modules.tickets.category.delete_title', locale=self.locale)}**\n"
+            f"{t('modules.tickets.category.delete_description', locale=self.locale)}"))
+
+        row = ui.ActionRow()
+        row.add_item(TicketCategoryButton(
+            'back', self.panel['id'], self.category['id'],
+            label=t('modules.config.buttons.cancel', locale=self.locale),
+            style=discord.ButtonStyle.secondary, emoji=BACK))
+        row.add_item(TicketCategoryButton(
+            'delconfirm', self.panel['id'], self.category['id'],
+            label=t('modules.tickets.category.delete_confirm', locale=self.locale),
+            style=discord.ButtonStyle.danger, emoji=DELETE))
+        container.add_item(row)
+
+    def _build_buttons(self):
+        panel_id, category_id = self.panel['id'], self.category['id']
+        enabled = self.category.get('enabled', True)
+
+        row = ui.ActionRow()
+        row.add_item(TicketCategoryButton(
+            'back', panel_id, category_id,
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary, emoji=BACK))
+        row.add_item(TicketCategoryButton(
+            'identity', panel_id, category_id,
+            label=t('modules.tickets.category.identity', locale=self.locale),
+            style=discord.ButtonStyle.primary, emoji=EDIT))
+        row.add_item(TicketCategoryButton(
+            'perms', panel_id, category_id,
+            label=t('modules.tickets.category.permissions', locale=self.locale),
+            style=discord.ButtonStyle.primary, emoji=PERM_EMOJI))
+        row.add_item(TicketCategoryButton(
+            'messages', panel_id, category_id,
+            label=t('modules.tickets.category.messages', locale=self.locale),
+            style=discord.ButtonStyle.secondary, emoji=MESSAGE))
+        row.add_item(TicketCategoryButton(
+            'options', panel_id, category_id,
+            label=t('modules.tickets.category.options', locale=self.locale),
+            style=discord.ButtonStyle.secondary, emoji=SETTINGS))
+        self.add_item(row)
+
+        row2 = ui.ActionRow()
+        row2.add_item(TicketCategoryButton(
+            'toggle', panel_id, category_id,
+            label=t('modules.tickets.category.pause' if enabled
+                    else 'modules.tickets.category.resume', locale=self.locale),
+            style=discord.ButtonStyle.secondary, emoji=PAUSE if enabled else PLAY))
+        row2.add_item(TicketCategoryButton(
+            'delete', panel_id, category_id,
+            label=t('modules.tickets.category.delete', locale=self.locale),
+            style=discord.ButtonStyle.danger, emoji=DELETE))
+        self.add_item(row2)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_guild_perms(interaction)
+
+
+# =========================================================================== #
+# Permissions screen — dynamic items
+# =========================================================================== #
+class TicketPermRoleSelect(
+    ui.DynamicItem[ui.RoleSelect],
+    template=(rf"moddy:tickets:permrole:(?P<panel_id>{_ENTRY_ID}):"
+              rf"(?P<category_id>{_ENTRY_ID})"),
+):
+    """Pick the role whose permissions are being edited."""
+
+    def __init__(self, panel_id: str, category_id: str, *,
+                 placeholder: Optional[str] = None,
+                 current: Optional[int] = None):
+        select = ui.RoleSelect(
+            placeholder=placeholder, min_values=0, max_values=1,
+            custom_id=f"moddy:tickets:permrole:{panel_id}:{category_id}",
+        )
+        if current:
+            select.default_values = [discord.Object(id=current)]
+        super().__init__(select)
+        self.panel_id = panel_id
+        self.category_id = category_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['panel_id'], match['category_id'])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        values = interaction.data.get('values') or []
+        await render_permissions(interaction, self.panel_id, self.category_id,
+                                 int(values[0]) if values else None)
+
+
+class TicketPermSelect(
+    ui.DynamicItem[ui.Select],
+    template=(rf"moddy:tickets:permset:(?P<panel_id>{_ENTRY_ID}):"
+              rf"(?P<category_id>{_ENTRY_ID}):(?P<role_id>[0-9]+)"),
+):
+    """What the selected role may do inside this category's tickets."""
+
+    def __init__(self, panel_id: str, category_id: str, role_id: int, *,
+                 locale: str = "en-US", granted: Optional[List[str]] = None,
+                 placeholder: Optional[str] = None):
+        granted = granted or []
+        super().__init__(ui.Select(
+            placeholder=placeholder,
+            options=[
+                discord.SelectOption(
+                    label=t(f'modules.tickets.permissions.{perm}.name', locale=locale)[:100],
+                    value=perm,
+                    description=t(f'modules.tickets.permissions.{perm}.description',
+                                  locale=locale)[:100],
+                    default=perm in granted,
+                ) for perm in TICKET_PERMISSIONS
+            ],
+            min_values=0, max_values=len(TICKET_PERMISSIONS),
+            custom_id=f"moddy:tickets:permset:{panel_id}:{category_id}:{role_id}",
+        ))
+        self.panel_id = panel_id
+        self.category_id = category_id
+        self.role_id = role_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['panel_id'], match['category_id'], int(match['role_id']))
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        chosen = [p for p in TICKET_PERMISSIONS
+                  if p in (interaction.data.get('values') or [])]
+
+        bot = interaction.client
+        config = await load_config(bot, interaction.guild_id)
+        _, category = locate_category(config, self.panel_id, self.category_id)
+        if not category:
+            await render_root(interaction)
+            return
+
+        permissions = dict(category.get('permissions', {}))
+        if chosen:
+            permissions[str(self.role_id)] = chosen
+        else:
+            # No permission left is the same thing as no entry — keeping an
+            # empty one would show a role in the list that can do nothing.
+            permissions.pop(str(self.role_id), None)
+        category['permissions'] = permissions
+
+        await interaction.response.defer()
+        success, error = await save_config(bot, interaction.guild_id, config,
+                                           interaction.user.id)
+        if not success:
+            await report_save_error(interaction, error)
+            return
+        await render_permissions(interaction, self.panel_id, self.category_id,
+                                 self.role_id if chosen else None)
+
+
+class TicketPermButton(
+    ui.DynamicItem[ui.Button],
+    template=(rf"moddy:tickets:permbtn:(?P<action>{_PERM_BUTTON_ACTIONS}):"
+              rf"(?P<panel_id>{_ENTRY_ID}):(?P<category_id>{_ENTRY_ID}):"
+              rf"(?P<role_id>[0-9]+)"),
+):
+    """Back to the category, or revoke everything from the selected role.
+
+    ``role_id`` is ``0`` when no role is selected — always encoding it keeps
+    one template for both buttons instead of two that could cross-match.
+    """
+
+    def __init__(self, action: str, panel_id: str, category_id: str,
+                 role_id: int = 0, *, label: str = "—",
+                 style: discord.ButtonStyle = discord.ButtonStyle.secondary,
+                 emoji: Optional[str] = None):
+        super().__init__(ui.Button(
+            label=label[:80], style=style,
+            emoji=discord.PartialEmoji.from_str(emoji) if emoji else None,
+            custom_id=f"moddy:tickets:permbtn:{action}:{panel_id}:{category_id}:{role_id}",
+        ))
+        self.action = action
+        self.panel_id = panel_id
+        self.category_id = category_id
+        self.role_id = role_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['action'], match['panel_id'], match['category_id'],
+                   int(match['role_id']))
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+
+        if self.action == 'back':
+            await render_category(interaction, self.panel_id, self.category_id)
+            return
+
+        # 'clear'
+        bot = interaction.client
+        config = await load_config(bot, interaction.guild_id)
+        _, category = locate_category(config, self.panel_id, self.category_id)
+        if not category or not self.role_id:
+            await render_permissions(interaction, self.panel_id, self.category_id)
+            return
+
+        permissions = dict(category.get('permissions', {}))
+        permissions.pop(str(self.role_id), None)
+        category['permissions'] = permissions
+
+        await interaction.response.defer()
+        success, error = await save_config(bot, interaction.guild_id, config,
+                                           interaction.user.id)
+        if not success:
+            await report_save_error(interaction, error)
+            return
+        await render_permissions(interaction, self.panel_id, self.category_id)
+
+
+# =========================================================================== #
+# Permissions screen
+# =========================================================================== #
+class TicketPermissionsConfigView(BaseView):
+    """Pick a role, tick what it may do. Not registered — see module docstring."""
+
+    def __init__(self, bot, guild_id: int, locale: str, panel: Dict[str, Any],
+                 category: Dict[str, Any], role_id: Optional[int] = None):
+        super().__init__()  # timeout=None
+        self.bot = bot
+        self.guild_id = guild_id
+        self.locale = locale
+        self.panel = panel
+        self.category = category
+        self.role_id = role_id
+
+        self._build_view()
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container(accent_colour=discord.Colour(
+            self.panel.get('accent_color') or DEFAULT_ACCENT_COLOR))
+
+        container.add_item(ui.TextDisplay(
+            f"### {PERM_EMOJI} "
+            f"{t('modules.tickets.permissions.title', locale=self.locale)}"))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.tickets.permissions.subtitle', locale=self.locale, category=self.category['name'])}"))
+        container.add_item(ui.TextDisplay(
+            t('modules.tickets.permissions.description', locale=self.locale)))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # Who is already configured.
+        configured = self.category.get('permissions', {})
+        if configured:
+            container.add_item(ui.TextDisplay(
+                f"**{t('modules.tickets.permissions.configured_title', locale=self.locale)}**"))
+            for role_id, perms in configured.items():
+                container.add_item(ui.TextDisplay(self._render_role(role_id, perms)))
+        else:
+            container.add_item(ui.TextDisplay(
+                f"{WARNING} "
+                f"{t('modules.tickets.permissions.nobody', locale=self.locale)}"))
+
+        # Role picker.
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.tickets.permissions.pick_role', locale=self.locale)}**\n"
+            f"-# {t('modules.tickets.permissions.pick_role_hint', locale=self.locale)}"))
+        role_row = ui.ActionRow()
+        role_row.add_item(TicketPermRoleSelect(
+            self.panel['id'], self.category['id'],
+            placeholder=t('modules.tickets.permissions.role_placeholder',
+                          locale=self.locale),
+            current=self.role_id,
+        ))
+        container.add_item(role_row)
+
+        # Permission picker for the selected role.
+        if self.role_id:
+            granted = configured.get(str(self.role_id))
+            if granted is None:
+                # First time this role is touched: start from a sane set
+                # instead of an empty one nobody would understand.
+                granted = list(DEFAULT_ROLE_PERMISSIONS)
+                container.add_item(ui.TextDisplay(
+                    f"-# {INFO} "
+                    f"{t('modules.tickets.permissions.defaults_hint', locale=self.locale)}"))
+            perm_row = ui.ActionRow()
+            perm_row.add_item(TicketPermSelect(
+                self.panel['id'], self.category['id'], self.role_id,
+                locale=self.locale, granted=granted,
+                placeholder=t('modules.tickets.permissions.perms_placeholder',
+                              locale=self.locale),
+            ))
+            container.add_item(perm_row)
+
+        self.add_item(container)
+
+        row = ui.ActionRow()
+        row.add_item(TicketPermButton(
+            'back', self.panel['id'], self.category['id'], 0,
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary, emoji=BACK))
+        if self.role_id and str(self.role_id) in configured:
+            row.add_item(TicketPermButton(
+                'clear', self.panel['id'], self.category['id'], self.role_id,
+                label=t('modules.tickets.permissions.clear', locale=self.locale),
+                style=discord.ButtonStyle.danger, emoji=DELETE))
+        self.add_item(row)
+
+    def _render_role(self, role_id: str, perms: List[str]) -> str:
+        if PERM_ADMIN in perms:
+            summary = t('modules.tickets.permissions.admin.name', locale=self.locale)
+        else:
+            summary = ", ".join(
+                t(f'modules.tickets.permissions.{p}.name', locale=self.locale)
+                for p in TICKET_PERMISSIONS if p in perms)
+        return f"<@&{role_id}>\n-# {summary or '—'}"
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_guild_perms(interaction)
+
+
+# =========================================================================== #
+# Persistence marker
+# =========================================================================== #
+class TicketsConfigPersistence(BaseView):
+    """Marker view: registers every dynamic item of the ticket config screens.
+
+    The panel, category and permission screens are all built from dynamic
+    items rather than registered views, because each of them is scoped to an
+    entity (a panel, a category, a role) that a static custom_id cannot carry.
+    """
+
+    __persistent__ = True
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        from modules.configs.tickets_panel_config import (
+            TicketPanelButton, TicketPanelChannelSelect, TicketPanelSelect,
+        )
+        bot.add_dynamic_items(
+            TicketPanelButton, TicketPanelSelect, TicketPanelChannelSelect,
+            TicketCategoryButton, TicketCategoryDestination, TicketCategoryRoles,
+            TicketCategoryLocale,
+            TicketPermRoleSelect, TicketPermSelect, TicketPermButton,
+        )

--- a/modules/configs/tickets_config.py
+++ b/modules/configs/tickets_config.py
@@ -1,0 +1,465 @@
+"""
+``/config`` → Tickets: the panel list and the panel editor.
+
+The category editor lives next door in ``tickets_category_config.py``; both
+share the helpers at the top of this file.
+
+Navigation
+----------
+::
+
+    Panels  ──► Panel  ──► Category  ──► Permissions
+      │           │           └──► Identity / Messages / Options (modals)
+      │           └──► Appearance (modal)
+      └──► Add a panel (modal)
+
+Every change is applied **immediately** — there is no Save/Cancel batching.
+That is not a shortcut: the screens below are built from
+:class:`discord.ui.DynamicItem`\\ s that carry the panel (and category) id in
+their ``custom_id`` and reconstruct themselves from scratch on every click, so
+there is no ``self`` to stage edits on. Same reasoning, and the same trade, as
+the Logs category screen — see docs/PERSISTENT_VIEWS.md.
+
+Free servers get ``FREE_MAX_PANELS`` panels and ``FREE_MAX_CATEGORIES``
+categories per panel; premium raises both. The limit is re-read from the
+database at the moment of the action, never from the rendered panel (a screen
+can sit open for hours — see docs/PREMIUM.md).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseModal, BaseView
+from modules.configs._common import check_guild_perms
+from modules.tickets import (
+    DEFAULT_ACCENT_COLOR,
+    MAX_PANEL_DESCRIPTION,
+    MAX_PANEL_NAME,
+    MAX_PANEL_TITLE,
+    MODULE_ID,
+    find_panel,
+    get_limits,
+    new_panel_id,
+    normalize_config,
+)
+from utils.components_v2 import create_error_message
+from utils.emojis import (
+    ADD, BACK, INFO, PREMIUM, TICKET, TICKET_PANEL, WARNING,
+)
+from utils.i18n import i18n, t
+
+logger = logging.getLogger('moddy.modules.tickets_config')
+
+_ENTRY_ID = r"[a-z0-9_]+"
+
+# Root screen: guild-scoped, so static custom_ids are enough.
+_CID_ROOT_BACK = "moddy:tickets:cfg:back"
+_CID_ROOT_ADD = "moddy:tickets:cfg:add"
+_CID_ROOT_MANAGE = "moddy:tickets:cfg:manage"
+
+PREMIUM_URL = "https://dashboard.moddy.app/select-premium-servers"
+
+
+# =========================================================================== #
+# Shared helpers
+# =========================================================================== #
+async def load_config(bot, guild_id: int) -> Dict[str, Any]:
+    """The guild's ticket configuration, always in its normalised shape."""
+    saved = await bot.module_manager.get_module_config(guild_id, MODULE_ID)
+    return normalize_config(saved)
+
+
+async def save_config(bot, guild_id: int, config: Dict[str, Any],
+                      actor_id: Optional[int] = None,
+                      *, repost_panel_id: Optional[str] = None,
+                      repost_all: bool = False) -> Tuple[bool, Optional[str]]:
+    """Persist the configuration and bring the panel messages back in line.
+
+    ``repost_panel_id`` / ``repost_all`` are explicit because re-posting is a
+    delete + send round-trip: it is done for the changes that are *visible on
+    the panel message* (its wording, its colour, its buttons, its channel) and
+    skipped for the ones that are not (permissions, ticket messages, who may
+    open a category).
+    """
+    success, error = await bot.module_manager.save_module_config(
+        guild_id, MODULE_ID, normalize_config(config), actor_id=actor_id)
+    if not success:
+        return False, error
+
+    if not (repost_panel_id or repost_all):
+        return True, None
+
+    module = await bot.module_manager.get_module_instance(guild_id, MODULE_ID)
+    if not module:
+        return True, None
+    try:
+        if repost_all:
+            await module.refresh_all_panels()
+        else:
+            panel = module.get_panel(repost_panel_id)
+            if panel:
+                await module.refresh_panel(panel)
+    except Exception as e:  # a failed re-post must not undo a stored config
+        logger.error(f"[Tickets] Could not refresh panel(s) for guild {guild_id}: {e}")
+    return True, None
+
+
+async def report_save_error(interaction: discord.Interaction, error: Optional[str]) -> None:
+    locale = i18n.get_user_locale(interaction)
+    view = create_error_message(
+        t('modules.tickets.errors.title', locale=locale),
+        t('modules.config.save.error', locale=locale, error=error or ''))
+    if interaction.response.is_done():
+        await interaction.followup.send(view=view, ephemeral=True)
+    else:
+        await interaction.response.send_message(view=view, ephemeral=True)
+
+
+async def render_root(interaction: discord.Interaction) -> None:
+    """(Re)build and show the panel list."""
+    view = await TicketsConfigView.create(
+        interaction.client, interaction.guild_id, interaction.user.id,
+        i18n.get_user_locale(interaction))
+    await _edit(interaction, view)
+
+
+async def render_panel(interaction: discord.Interaction, panel_id: str) -> None:
+    """(Re)build and show one panel's editor, or fall back to the list."""
+    from modules.configs.tickets_panel_config import TicketPanelConfigView
+
+    bot = interaction.client
+    locale = i18n.get_user_locale(interaction)
+    config = await load_config(bot, interaction.guild_id)
+    panel = find_panel(config, panel_id)
+    if not panel:
+        await render_root(interaction)
+        return
+    limits = await get_limits(bot, interaction.guild_id)
+    await _edit(interaction, TicketPanelConfigView(
+        bot, interaction.guild_id, locale, panel, limits))
+
+
+async def _edit(interaction: discord.Interaction, view: ui.LayoutView) -> None:
+    """Replace the panel in place, whether or not the interaction was deferred."""
+    if interaction.response.is_done():
+        await interaction.edit_original_response(view=view)
+    else:
+        await interaction.response.edit_message(view=view)
+
+
+def parse_hex_color(value: Optional[str]) -> Optional[int]:
+    """``#RRGGBB`` / ``RRGGBB`` → int, ``None`` when empty or invalid."""
+    if not value:
+        return None
+    s = value.strip().lstrip("#")
+    if len(s) == 6 and all(c in "0123456789abcdefABCDEF" for c in s):
+        return int(s, 16)
+    return None
+
+
+def color_to_hex(value: Optional[int]) -> str:
+    return f"#{(value if value is not None else DEFAULT_ACCENT_COLOR):06X}"
+
+
+def premium_hint(locale: str, limits: Dict[str, Any]) -> Optional[str]:
+    """The one line that tells a free server what premium would give it."""
+    if limits.get('premium'):
+        return None
+    return (f"-# {PREMIUM} "
+            f"{t('modules.tickets.config.premium_hint', locale=locale)}")
+
+
+# =========================================================================== #
+# Add-a-panel modal
+# =========================================================================== #
+class PanelAppearanceModal(BaseModal):
+    """Name, wording, colour and rendering of a panel — the whole message."""
+
+    def __init__(self, locale: str, panel: Optional[Dict[str, Any]], callback_func):
+        panel = panel or {}
+        creating = not panel
+        super().__init__(
+            title=t('modules.tickets.panel.modal_title_new' if creating
+                    else 'modules.tickets.panel.modal_title_edit', locale=locale)[:45],
+            timeout=None,
+        )
+        self.locale = locale
+        self.callback_func = callback_func
+
+        self.name_input = ui.TextInput(
+            style=discord.TextStyle.short, required=True,
+            max_length=MAX_PANEL_NAME, default=panel.get('name'),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.panel.name_label', locale=locale)[:45],
+            description=t('modules.tickets.panel.name_hint', locale=locale)[:100],
+            component=self.name_input,
+        ))
+
+        self.title_input = ui.TextInput(
+            style=discord.TextStyle.short, required=False,
+            max_length=MAX_PANEL_TITLE, default=panel.get('title'),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.panel.title_label', locale=locale)[:45],
+            description=t('modules.tickets.panel.title_hint', locale=locale)[:100],
+            component=self.title_input,
+        ))
+
+        self.description_input = ui.TextInput(
+            style=discord.TextStyle.paragraph, required=False,
+            max_length=MAX_PANEL_DESCRIPTION, default=panel.get('description'),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.panel.description_label', locale=locale)[:45],
+            description=t('modules.tickets.panel.description_hint', locale=locale)[:100],
+            component=self.description_input,
+        ))
+
+        self.color_input = ui.TextInput(
+            style=discord.TextStyle.short, required=False,
+            min_length=0, max_length=7,
+            default=color_to_hex(panel.get('accent_color')),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.panel.color_label', locale=locale)[:45],
+            description=t('modules.tickets.panel.color_hint', locale=locale)[:100],
+            component=self.color_input,
+        ))
+
+        # The dropdown placeholder lives here rather than on the panel screen:
+        # it is wording, like everything else in this modal. It is simply
+        # ignored while the panel renders as buttons.
+        self.placeholder_input = ui.TextInput(
+            style=discord.TextStyle.short, required=False,
+            max_length=150, default=panel.get('placeholder'),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.panel.placeholder_label', locale=locale)[:45],
+            description=t('modules.tickets.panel.placeholder_hint', locale=locale)[:100],
+            component=self.placeholder_input,
+        ))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await self.callback_func(interaction, {
+            'name': (self.name_input.value or '').strip(),
+            'title': (self.title_input.value or '').strip() or None,
+            'description': (self.description_input.value or '').strip() or None,
+            'accent_color': parse_hex_color(self.color_input.value),
+            'placeholder': (self.placeholder_input.value or '').strip() or None,
+        })
+
+
+# =========================================================================== #
+# Root screen — the panel list
+# =========================================================================== #
+class TicketsConfigView(BaseView):
+    """The Tickets entry in ``/config``: every panel of the guild.
+
+    Persistent: yes. Auth: Manage Server in the guild, re-checked on every
+    click via ``check_guild_perms`` — never a stored ``user_id``, which cannot
+    survive a restarted shell.
+    """
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, guild_id: Optional[int] = None,
+                 user_id: Optional[int] = None, locale: str = "en-US",
+                 panels: Optional[List[Dict[str, Any]]] = None,
+                 limits: Optional[Dict[str, Any]] = None):
+        super().__init__()  # timeout=None
+        self.bot = bot
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.locale = locale
+        self.panels = panels or []
+        self.limits = limits or {'premium': False, 'max_panels': 0, 'max_categories': 0}
+
+        self._build_view()
+
+    @classmethod
+    async def create(cls, bot, guild_id: int, user_id: int, locale: str):
+        config = await load_config(bot, guild_id)
+        limits = await get_limits(bot, guild_id)
+        return cls(bot, guild_id, user_id, locale, config['panels'], limits)
+
+    # -- construction ------------------------------------------------------ #
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container()
+
+        container.add_item(ui.TextDisplay(
+            f"### {TICKET} {t('modules.tickets.config.title', locale=self.locale)}"))
+        container.add_item(ui.TextDisplay(
+            t('modules.tickets.config.description', locale=self.locale)))
+
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.tickets.config.quota', locale=self.locale, count=len(self.panels), max=self.limits['max_panels'], categories=self.limits['max_categories'])}"))
+        hint = premium_hint(self.locale, self.limits)
+        if hint:
+            container.add_item(ui.TextDisplay(hint))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        if self.panels:
+            for panel in self.panels:
+                container.add_item(ui.TextDisplay(self._render_entry(panel)))
+
+            row = ui.ActionRow()
+            select = ui.Select(
+                placeholder=t('modules.tickets.config.manage_placeholder',
+                              locale=self.locale),
+                options=[
+                    discord.SelectOption(
+                        label=panel['name'][:100], value=panel['id'],
+                        description=self._entry_summary(panel)[:100] or None,
+                    ) for panel in self.panels[:25]
+                ],
+                min_values=1, max_values=1, custom_id=_CID_ROOT_MANAGE,
+            )
+            select.callback = self.on_manage
+            row.add_item(select)
+            container.add_item(row)
+        else:
+            container.add_item(ui.TextDisplay(
+                f"{INFO} {t('modules.tickets.config.empty', locale=self.locale)}"))
+            if self.bot is None:
+                # Registration shell: render the select anyway so a real
+                # message's dropdown still dispatches after a restart.
+                row = ui.ActionRow()
+                select = ui.Select(
+                    placeholder=t('modules.tickets.config.manage_placeholder',
+                                  locale=self.locale),
+                    options=[discord.SelectOption(label="—", value="none")],
+                    min_values=1, max_values=1, custom_id=_CID_ROOT_MANAGE,
+                    disabled=True,
+                )
+                select.callback = self.on_manage
+                row.add_item(select)
+                container.add_item(row)
+
+        self.add_item(container)
+
+        button_row = ui.ActionRow()
+        back = ui.Button(
+            emoji=discord.PartialEmoji.from_str(BACK),
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary, custom_id=_CID_ROOT_BACK,
+        )
+        back.callback = self.on_back
+        button_row.add_item(back)
+
+        add = ui.Button(
+            emoji=discord.PartialEmoji.from_str(ADD),
+            label=t('modules.tickets.config.add_panel', locale=self.locale),
+            style=discord.ButtonStyle.success, custom_id=_CID_ROOT_ADD,
+            disabled=len(self.panels) >= self.limits['max_panels'],
+        )
+        add.callback = self.on_add
+        button_row.add_item(add)
+        self.add_item(button_row)
+
+    def _entry_summary(self, panel: Dict[str, Any]) -> str:
+        categories = len(panel.get('categories', []))
+        style = t(f"modules.tickets.panel.style_{panel['style']}", locale=self.locale)
+        return t('modules.tickets.config.entry_summary', locale=self.locale,
+                 categories=categories, style=style)
+
+    def _render_entry(self, panel: Dict[str, Any]) -> str:
+        channel = self.bot.get_channel(panel['channel_id']) \
+            if self.bot and panel.get('channel_id') else None
+        target = channel.mention if channel else \
+            t('modules.tickets.config.no_channel', locale=self.locale)
+
+        state = "" if panel.get('enabled') else \
+            f" · {t('modules.tickets.config.paused', locale=self.locale)}"
+        line = f"{TICKET_PANEL} **{panel['name']}** — {target}{state}"
+        line += f"\n-# {self._entry_summary(panel)}"
+        if panel.get('enabled') and panel.get('channel_id') and not panel.get('message_id'):
+            line += (f"\n-# {WARNING} "
+                     f"{t('modules.tickets.config.not_posted', locale=self.locale)}")
+        return line
+
+    # -- callbacks --------------------------------------------------------- #
+    async def on_add(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+
+        config = await load_config(bot, interaction.guild_id)
+        limits = await get_limits(bot, interaction.guild_id)
+        if len(config['panels']) >= limits['max_panels']:
+            await self._limit_reached(interaction, locale, limits)
+            return
+
+        modal = PanelAppearanceModal(locale, None, self._create_panel)
+        modal.bot = bot
+        await interaction.response.send_modal(modal)
+
+    async def _create_panel(self, interaction: discord.Interaction,
+                            fields: Dict[str, Any]):
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        config = await load_config(bot, interaction.guild_id)
+        limits = await get_limits(bot, interaction.guild_id)
+
+        if len(config['panels']) >= limits['max_panels']:
+            await self._limit_reached(interaction, locale, limits)
+            return
+
+        panel_id = new_panel_id()
+        config['panels'].append({
+            'id': panel_id, 'enabled': True, 'categories': [], **fields,
+        })
+        success, error = await save_config(bot, interaction.guild_id, config,
+                                           interaction.user.id)
+        if not success:
+            await report_save_error(interaction, error)
+            return
+        await render_panel(interaction, panel_id)
+
+    async def _limit_reached(self, interaction: discord.Interaction, locale: str,
+                             limits: Dict[str, Any]):
+        description = t('modules.tickets.errors.panel_limit', locale=locale,
+                        max=limits['max_panels'])
+        if not limits.get('premium'):
+            description += ("\n\n" +
+                            t('modules.tickets.errors.premium_upsell', locale=locale,
+                              url=PREMIUM_URL))
+        view = create_error_message(
+            t('modules.tickets.errors.title', locale=locale), description)
+        if interaction.response.is_done():
+            await interaction.followup.send(view=view, ephemeral=True)
+        else:
+            await interaction.response.send_message(view=view, ephemeral=True)
+
+    async def on_manage(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        values = interaction.data.get('values') or []
+        if not values or values[0] == "none":
+            await interaction.response.defer()
+            return
+        await render_panel(interaction, values[0])
+
+    async def on_back(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        from cogs.config import ConfigMainView
+        locale = i18n.get_user_locale(interaction)
+        await interaction.response.edit_message(view=ConfigMainView(
+            interaction.client, interaction.guild_id, interaction.user.id, locale))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_guild_perms(interaction)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: Manage Server in the guild (checked on every click)."""
+        bot.add_view(cls())

--- a/modules/configs/tickets_panel_config.py
+++ b/modules/configs/tickets_panel_config.py
@@ -1,0 +1,502 @@
+"""
+``/config`` → Tickets → **one panel**.
+
+Where the panel message goes, how it renders, and the categories it offers.
+
+Persistence
+-----------
+Every control here is a :class:`discord.ui.DynamicItem` carrying the panel id
+in its ``custom_id`` (``moddy:tickets:pnl…:<panel_id>``), registered through
+:class:`~modules.configs.tickets_category_config.TicketsConfigPersistence`.
+The wrapper view is therefore **not** registered: it cannot be built without a
+panel, and there is nothing left for it to carry once its children reconstruct
+themselves on every click. Same pattern as ``LogsCategoryView`` — see
+docs/PERSISTENT_VIEWS.md "Deliberate exclusions".
+
+That is also why changes apply immediately: a ``DynamicItem`` has no ``self``
+to stage them on.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseView
+from modules.configs._common import check_guild_perms
+from modules.configs.tickets_config import (
+    PanelAppearanceModal,
+    load_config,
+    premium_hint,
+    render_panel,
+    render_root,
+    report_save_error,
+    save_config,
+)
+from modules.tickets import (
+    DEFAULT_ACCENT_COLOR,
+    PANEL_CHANNEL_TYPES,
+    STYLE_BUTTONS,
+    STYLE_SELECT,
+    find_panel,
+    get_limits,
+    max_categories_for_style,
+)
+from utils.components_v2 import create_error_message
+from utils.emojis import (
+    ADD, BACK, DELETE, EDIT, INFO, PAUSE, PLAY, REQUIRED_FIELDS, SYNC,
+    TICKET_CATEGORY, TICKET_PANEL, WARNING,
+)
+from utils.i18n import i18n, t
+
+logger = logging.getLogger('moddy.modules.tickets_panel_config')
+
+_ENTRY_ID = r"[a-z0-9_]+"
+
+# One template per component *type*, with disjoint action alternations, so no
+# two DynamicItem classes can ever cross-match (see docs/PERSISTENT_VIEWS.md).
+_BUTTON_ACTIONS = "back|edit|addcat|repost|toggle|delete|delconfirm"
+_SELECT_ACTIONS = "style|category"
+
+
+def _guarded(callback):
+    """Route a dynamic-item callback error to the central handler."""
+    async def wrapper(self, interaction: discord.Interaction):
+        try:
+            await callback(self, interaction)
+        except Exception as e:  # noqa: BLE001
+            from cogs.error_handler import report_component_error
+            await report_component_error(interaction, e, self.__class__.__name__)
+    return wrapper
+
+
+# =========================================================================== #
+# Dynamic items
+# =========================================================================== #
+class TicketPanelButton(
+    ui.DynamicItem[ui.Button],
+    template=rf"moddy:tickets:pnlbtn:(?P<action>{_BUTTON_ACTIONS}):(?P<panel_id>{_ENTRY_ID})",
+):
+    """An action button on the panel editor. Auth: Manage Server."""
+
+    def __init__(self, action: str, panel_id: str, *, label: str = "—",
+                 style: discord.ButtonStyle = discord.ButtonStyle.secondary,
+                 emoji: Optional[str] = None, disabled: bool = False):
+        super().__init__(
+            ui.Button(
+                label=label[:80], style=style, disabled=disabled,
+                emoji=discord.PartialEmoji.from_str(emoji) if emoji else None,
+                custom_id=f"moddy:tickets:pnlbtn:{action}:{panel_id}",
+            )
+        )
+        self.action = action
+        self.panel_id = panel_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['action'], match['panel_id'])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        handler = getattr(self, f"_on_{self.action}")
+        await handler(interaction)
+
+    # -- actions ----------------------------------------------------------- #
+    async def _on_back(self, interaction: discord.Interaction):
+        await render_root(interaction)
+
+    async def _on_edit(self, interaction: discord.Interaction):
+        panel = await _fetch_panel(interaction, self.panel_id)
+        if panel is None:
+            await render_root(interaction)
+            return
+        modal = PanelAppearanceModal(
+            i18n.get_user_locale(interaction), panel, self._apply_edit)
+        modal.bot = interaction.client
+        await interaction.response.send_modal(modal)
+
+    async def _apply_edit(self, interaction: discord.Interaction,
+                          fields: Dict[str, Any]):
+        await _update_panel(interaction, self.panel_id, fields, repost=True)
+
+    async def _on_addcat(self, interaction: discord.Interaction):
+        from modules.configs.tickets_category_config import start_category_creation
+        await start_category_creation(interaction, self.panel_id)
+
+    async def _on_repost(self, interaction: discord.Interaction):
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        await interaction.response.defer()
+
+        module = await bot.module_manager.get_module_instance(
+            interaction.guild_id, 'tickets')
+        panel = module.get_panel(self.panel_id) if module else None
+        message = await module.refresh_panel(panel) if panel else None
+
+        await render_panel(interaction, self.panel_id)
+        if message is None:
+            await interaction.followup.send(
+                view=create_error_message(
+                    t('modules.tickets.errors.title', locale=locale),
+                    t('modules.tickets.panel.repost_failed', locale=locale)),
+                ephemeral=True)
+
+    async def _on_toggle(self, interaction: discord.Interaction):
+        panel = await _fetch_panel(interaction, self.panel_id)
+        if panel is None:
+            await render_root(interaction)
+            return
+        await _update_panel(interaction, self.panel_id,
+                            {'enabled': not panel.get('enabled', True)}, repost=True)
+
+    async def _on_delete(self, interaction: discord.Interaction):
+        """First click: ask. The panel screen re-renders in confirmation mode."""
+        panel = await _fetch_panel(interaction, self.panel_id)
+        if panel is None:
+            await render_root(interaction)
+            return
+        bot = interaction.client
+        limits = await get_limits(bot, interaction.guild_id)
+        await interaction.response.edit_message(view=TicketPanelConfigView(
+            bot, interaction.guild_id, i18n.get_user_locale(interaction),
+            panel, limits, confirm_delete=True))
+
+    async def _on_delconfirm(self, interaction: discord.Interaction):
+        bot = interaction.client
+        await interaction.response.defer()
+
+        # Take the message down before forgetting where it is.
+        module = await bot.module_manager.get_module_instance(
+            interaction.guild_id, 'tickets')
+        panel = module.get_panel(self.panel_id) if module else None
+        if panel:
+            await module.delete_panel(panel, persist=False)
+
+        config = await load_config(bot, interaction.guild_id)
+        config['panels'] = [p for p in config['panels'] if p['id'] != self.panel_id]
+        success, error = await save_config(bot, interaction.guild_id, config,
+                                           interaction.user.id)
+        if not success:
+            await report_save_error(interaction, error)
+            return
+        await render_root(interaction)
+
+
+class TicketPanelSelect(
+    ui.DynamicItem[ui.Select],
+    template=rf"moddy:tickets:pnlsel:(?P<action>{_SELECT_ACTIONS}):(?P<panel_id>{_ENTRY_ID})",
+):
+    """A dropdown on the panel editor (channel, style, category picker)."""
+
+    def __init__(self, action: str, panel_id: str, *,
+                 item: Optional[ui.Item] = None):
+        super().__init__(item or ui.Select(
+            options=[discord.SelectOption(label="—", value="none")],
+            custom_id=f"moddy:tickets:pnlsel:{action}:{panel_id}",
+        ))
+        self.action = action
+        self.panel_id = panel_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['action'], match['panel_id'])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        values = interaction.data.get('values') or []
+
+        if self.action == 'style':
+            if not values:
+                await interaction.response.defer()
+                return
+            await _update_panel(interaction, self.panel_id,
+                                {'style': values[0]}, repost=True)
+            return
+
+        # 'category'
+        if not values or values[0] == "none":
+            await interaction.response.defer()
+            return
+        from modules.configs.tickets_category_config import render_category
+        await render_category(interaction, self.panel_id, values[0])
+
+
+class TicketPanelChannelSelect(
+    ui.DynamicItem[ui.ChannelSelect],
+    template=rf"moddy:tickets:pnlchan:(?P<panel_id>{_ENTRY_ID})",
+):
+    """Where the panel message is posted. Auth: Manage Server."""
+
+    def __init__(self, panel_id: str, *, placeholder: Optional[str] = None,
+                 channel: Optional[discord.abc.GuildChannel] = None):
+        select = ui.ChannelSelect(
+            placeholder=placeholder, channel_types=PANEL_CHANNEL_TYPES,
+            min_values=0, max_values=1,
+            custom_id=f"moddy:tickets:pnlchan:{panel_id}",
+        )
+        if channel is not None:
+            select.default_values = [channel]
+        super().__init__(select)
+        self.panel_id = panel_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['panel_id'])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        values = interaction.data.get('values') or []
+        await _update_panel(interaction, self.panel_id,
+                            {'channel_id': int(values[0]) if values else None},
+                            repost=True)
+
+
+# =========================================================================== #
+# Shared write path
+# =========================================================================== #
+async def _fetch_panel(interaction: discord.Interaction,
+                       panel_id: str) -> Optional[Dict[str, Any]]:
+    config = await load_config(interaction.client, interaction.guild_id)
+    return find_panel(config, panel_id)
+
+
+async def _update_panel(interaction: discord.Interaction, panel_id: str,
+                        fields: Dict[str, Any], *, repost: bool) -> None:
+    """Apply ``fields`` to one panel, persist, and re-render the editor."""
+    bot = interaction.client
+    config = await load_config(bot, interaction.guild_id)
+    panel = find_panel(config, panel_id)
+    if not panel:
+        await render_root(interaction)
+        return
+
+    panel.update(fields)
+    if not interaction.response.is_done():
+        await interaction.response.defer()
+
+    success, error = await save_config(
+        bot, interaction.guild_id, config, interaction.user.id,
+        repost_panel_id=panel_id if repost else None)
+    if not success:
+        await report_save_error(interaction, error)
+        return
+    await render_panel(interaction, panel_id)
+
+
+# =========================================================================== #
+# The panel editor
+# =========================================================================== #
+class TicketPanelConfigView(BaseView):
+    """One panel: its message, its rendering, its categories.
+
+    Not registered — see the module docstring. Auth: Manage Server, re-checked
+    inside every dynamic item's callback.
+    """
+
+    def __init__(self, bot, guild_id: int, locale: str, panel: Dict[str, Any],
+                 limits: Dict[str, Any], *, confirm_delete: bool = False):
+        super().__init__()  # timeout=None
+        self.bot = bot
+        self.guild_id = guild_id
+        self.locale = locale
+        self.panel = panel
+        self.limits = limits
+        self.confirm_delete = confirm_delete
+
+        self._build_view()
+
+    # -- construction ------------------------------------------------------ #
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container(accent_colour=discord.Colour(
+            self.panel.get('accent_color') or DEFAULT_ACCENT_COLOR))
+
+        container.add_item(ui.TextDisplay(
+            f"### {TICKET_PANEL} {self.panel['name']}"))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.tickets.panel.subtitle', locale=self.locale)}"))
+
+        if not self.panel.get('enabled', True):
+            container.add_item(ui.TextDisplay(
+                f"{WARNING} {t('modules.tickets.panel.paused_notice', locale=self.locale)}"))
+
+        if self.confirm_delete:
+            self._build_delete_confirmation(container)
+            self.add_item(container)
+            return
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # 1. Channel.
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.tickets.panel.channel_title', locale=self.locale)}**{REQUIRED_FIELDS}\n"
+            f"-# {t('modules.tickets.panel.channel_hint', locale=self.locale)}"))
+        channel = self.bot.get_channel(self.panel['channel_id']) \
+            if self.bot and self.panel.get('channel_id') else None
+        channel_row = ui.ActionRow()
+        channel_row.add_item(TicketPanelChannelSelect(
+            self.panel['id'],
+            placeholder=t('modules.tickets.panel.channel_placeholder',
+                          locale=self.locale),
+            channel=channel,
+        ))
+        container.add_item(channel_row)
+
+        # 2. Rendering style.
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.tickets.panel.style_title', locale=self.locale)}**\n"
+            f"-# {t('modules.tickets.panel.style_hint', locale=self.locale)}"))
+        style_row = ui.ActionRow()
+        style_row.add_item(TicketPanelSelect(
+            'style', self.panel['id'],
+            item=ui.Select(
+                options=[
+                    discord.SelectOption(
+                        label=t('modules.tickets.panel.style_buttons', locale=self.locale),
+                        value=STYLE_BUTTONS,
+                        description=t('modules.tickets.panel.style_buttons_hint',
+                                      locale=self.locale)[:100],
+                        default=self.panel['style'] == STYLE_BUTTONS,
+                    ),
+                    discord.SelectOption(
+                        label=t('modules.tickets.panel.style_select', locale=self.locale),
+                        value=STYLE_SELECT,
+                        description=t('modules.tickets.panel.style_select_hint',
+                                      locale=self.locale)[:100],
+                        default=self.panel['style'] == STYLE_SELECT,
+                    ),
+                ],
+                min_values=1, max_values=1,
+                custom_id=f"moddy:tickets:pnlsel:style:{self.panel['id']}",
+            ),
+        ))
+        container.add_item(style_row)
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # 3. Categories.
+        self._build_categories(container)
+
+        self.add_item(container)
+        self._build_buttons()
+
+    def _build_categories(self, container: ui.Container):
+        categories = self.panel.get('categories', [])
+        cap = max_categories_for_style(self.panel['style'],
+                                       self.limits.get('max_categories', 0))
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.tickets.panel.categories_title', locale=self.locale)}**{REQUIRED_FIELDS}\n"
+            f"-# {t('modules.tickets.panel.categories_hint', locale=self.locale, count=len(categories), max=cap)}"))
+        hint = premium_hint(self.locale, self.limits)
+        if hint:
+            container.add_item(ui.TextDisplay(hint))
+
+        if not categories:
+            container.add_item(ui.TextDisplay(
+                f"{INFO} {t('modules.tickets.panel.no_category', locale=self.locale)}"))
+            return
+
+        for category in categories:
+            container.add_item(ui.TextDisplay(self._render_category(category)))
+
+        row = ui.ActionRow()
+        row.add_item(TicketPanelSelect(
+            'category', self.panel['id'],
+            item=ui.Select(
+                placeholder=t('modules.tickets.panel.category_placeholder',
+                              locale=self.locale),
+                options=[
+                    discord.SelectOption(
+                        label=category['name'][:100], value=category['id'],
+                        description=(category.get('description') or None),
+                    ) for category in categories[:25]
+                ],
+                min_values=1, max_values=1,
+                custom_id=f"moddy:tickets:pnlsel:category:{self.panel['id']}",
+            ),
+        ))
+        container.add_item(row)
+
+    def _render_category(self, category: Dict[str, Any]) -> str:
+        parent = self.bot.get_channel(category['discord_category_id']) \
+            if self.bot and category.get('discord_category_id') else None
+        target = f"`{parent.name}`" if parent else \
+            f"{WARNING} {t('modules.tickets.panel.no_destination', locale=self.locale)}"
+
+        prefix = category.get('emoji') or TICKET_CATEGORY
+        line = f"{prefix} **{category['name']}** — {target}"
+        if not category.get('enabled', True):
+            line += f" · {t('modules.tickets.config.paused', locale=self.locale)}"
+
+        roles = len(category.get('permissions', {}))
+        line += (f"\n-# {t('modules.tickets.panel.category_summary', locale=self.locale, roles=roles, language=category['locale'])}")
+        return line
+
+    def _build_delete_confirmation(self, container: ui.Container):
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+        container.add_item(ui.TextDisplay(
+            f"{WARNING} **{t('modules.tickets.panel.delete_title', locale=self.locale)}**\n"
+            f"{t('modules.tickets.panel.delete_description', locale=self.locale, categories=len(self.panel.get('categories', [])))}"))
+
+        row = ui.ActionRow()
+        row.add_item(TicketPanelButton(
+            'back', self.panel['id'],
+            label=t('modules.config.buttons.cancel', locale=self.locale),
+            style=discord.ButtonStyle.secondary, emoji=BACK))
+        row.add_item(TicketPanelButton(
+            'delconfirm', self.panel['id'],
+            label=t('modules.tickets.panel.delete_confirm', locale=self.locale),
+            style=discord.ButtonStyle.danger, emoji=DELETE))
+        container.add_item(row)
+
+    def _build_buttons(self):
+        panel_id = self.panel['id']
+        enabled = self.panel.get('enabled', True)
+        cap = max_categories_for_style(self.panel['style'],
+                                       self.limits.get('max_categories', 0))
+
+        row = ui.ActionRow()
+        row.add_item(TicketPanelButton(
+            'back', panel_id,
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary, emoji=BACK))
+        row.add_item(TicketPanelButton(
+            'edit', panel_id,
+            label=t('modules.tickets.panel.edit', locale=self.locale),
+            style=discord.ButtonStyle.primary, emoji=EDIT))
+        row.add_item(TicketPanelButton(
+            'addcat', panel_id,
+            label=t('modules.tickets.panel.add_category', locale=self.locale),
+            style=discord.ButtonStyle.success, emoji=ADD,
+            disabled=len(self.panel.get('categories', [])) >= cap))
+        self.add_item(row)
+
+        row2 = ui.ActionRow()
+        row2.add_item(TicketPanelButton(
+            'repost', panel_id,
+            label=t('modules.tickets.panel.repost', locale=self.locale),
+            style=discord.ButtonStyle.secondary, emoji=SYNC,
+            disabled=not (enabled and self.panel.get('channel_id'))))
+        row2.add_item(TicketPanelButton(
+            'toggle', panel_id,
+            label=t('modules.tickets.panel.pause' if enabled
+                    else 'modules.tickets.panel.resume', locale=self.locale),
+            style=discord.ButtonStyle.secondary, emoji=PAUSE if enabled else PLAY))
+        row2.add_item(TicketPanelButton(
+            'delete', panel_id,
+            label=t('modules.tickets.panel.delete', locale=self.locale),
+            style=discord.ButtonStyle.danger, emoji=DELETE))
+        self.add_item(row2)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_guild_perms(interaction)

--- a/modules/module_manager.py
+++ b/modules/module_manager.py
@@ -385,6 +385,10 @@ class ModuleManager:
             except Exception as e:
                 logger.error(f"[FAIL] Error disabling {module_id} for guild {guild_id}: {e}")
             self.active_modules.get(guild_id, {}).pop(module_id, None)
+            # AFTER the instance is dropped: the command sync asks the cache
+            # whether the module is still enabled, and the outgoing instance
+            # would still answer yes.
+            await self._sync_module_commands(guild_id, module_id)
             logger.info(f"Module {module_id} unloaded for guild {guild_id} (external delete)")
             return {"ok": True, "action": action, "cleaned": True, **recap}
 
@@ -399,11 +403,29 @@ class ModuleManager:
             await module.disable()
 
         recap = await self._run_external_hook(module, action, guild_id, module_id)
+        await self._sync_module_commands(guild_id, module_id)
         logger.info(
             f"Module {module_id} reloaded from a pushed config for guild {guild_id} "
             f"(enabled: {module.enabled})"
         )
         return {"ok": True, "action": action, "enabled": module.enabled, **recap}
+
+    async def _sync_module_commands(self, guild_id: int, module_id: str) -> None:
+        """Publish/unpublish a module's slash commands after a config change.
+
+        A module can own guild commands that must only exist where it is
+        enabled (``/ticket``). Enabling or disabling it therefore changes the
+        guild's command tree, and nothing else in the save path would notice.
+        The bot skips the sync itself when the enabled set did not change, so
+        this is safe to call after every save.
+        """
+        if module_id not in getattr(self.bot, 'module_slash_commands', {}):
+            return
+        try:
+            await self.bot.resync_module_commands(guild_id)
+        except Exception as e:
+            logger.error(f"[FAIL] Could not re-sync {module_id} commands for guild "
+                         f"{guild_id}: {e}")
 
     async def _run_external_hook(self, module: ModuleBase, action: str,
                                  guild_id: int, module_id: str) -> Dict[str, Any]:
@@ -568,6 +590,10 @@ class ModuleManager:
                 await module_instance.disable()
 
             logger.info(f"Configuration saved for module {module_id} in guild {guild_id} (enabled: {module_instance.enabled})")
+
+            # A module that owns slash commands has just appeared in (or
+            # vanished from) this guild's command tree.
+            await self._sync_module_commands(guild_id, module_id)
             return True, None
 
         except Exception as e:
@@ -603,6 +629,9 @@ class ModuleManager:
             )
 
             logger.info(f"Configuration deleted for module {module_id} in guild {guild_id}")
+
+            # Its commands must disappear from the guild along with it.
+            await self._sync_module_commands(guild_id, module_id)
             return True
 
         except Exception as e:

--- a/modules/tickets.py
+++ b/modules/tickets.py
@@ -1,0 +1,723 @@
+"""
+Tickets module — configurable support tickets.
+
+Three levels, and keeping them apart is what makes the rest of the module
+simple:
+
+- **A panel** is one message posted in a channel. It carries its own title,
+  description and accent colour, and offers either **buttons** or a **select
+  menu**. A guild can have several panels (``max_panels``).
+- **A category** is one entry inside a panel: the button/option a member
+  clicks. It decides *where* the ticket channel is created, *who* may open it,
+  *what* each staff role may do inside it, in which *language* the ticket
+  speaks, and the *messages* the member sees.
+- **A ticket** is the channel a member ends up in. Its live state (owner,
+  number, participants, staff thread, escalation) lives in the ``tickets``
+  table — see ``db/repositories/tickets.py``. Runtime actions live in
+  ``services/ticket_service.py``.
+
+This file owns only the *configuration*: the schema, its normalisation, the
+free/premium limits, the permission model, and posting/refreshing the panel
+messages. It deliberately holds no ticket action, so the config surface and the
+runtime surface can be reasoned about (and tested) separately.
+
+Slash commands (``/ticket …``) are published **only in guilds where this
+module is enabled** — see ``cogs/tickets.py`` and
+``ModdyBot.register_module_commands``.
+
+See docs/TICKETS.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Any, Dict, List, Optional, Tuple
+
+import discord
+
+from modules.module_manager import ModuleBase, EXTERNAL_DELETED
+from utils.emojis import TICKET
+
+logger = logging.getLogger('moddy.modules.tickets')
+
+MODULE_ID = "tickets"
+
+# --------------------------------------------------------------------------- #
+# Limits (free vs premium)
+# --------------------------------------------------------------------------- #
+FREE_MAX_PANELS = 3
+PREMIUM_MAX_PANELS = 10
+FREE_MAX_CATEGORIES = 5
+PREMIUM_MAX_CATEGORIES = 15
+
+# Hard ceilings imposed by Discord, independent of the plan: five buttons per
+# ActionRow (a button panel uses at most three rows) and 25 options in a select.
+MAX_BUTTONS_PER_PANEL = 15
+MAX_SELECT_OPTIONS = 25
+
+# --------------------------------------------------------------------------- #
+# Field limits
+# --------------------------------------------------------------------------- #
+MAX_PANEL_NAME = 60
+MAX_PANEL_TITLE = 100
+MAX_PANEL_DESCRIPTION = 2000
+MAX_CATEGORY_NAME = 60          # also the button label / select option label
+MAX_CATEGORY_DESCRIPTION = 100  # select option description (Discord limit)
+MAX_TICKET_MESSAGE = 2000
+MAX_CHANNEL_NAME = 90           # Discord allows 100; leave room for prefixes
+
+DEFAULT_ACCENT_COLOR = 0x5865F2
+
+# --------------------------------------------------------------------------- #
+# Panel styles
+# --------------------------------------------------------------------------- #
+STYLE_BUTTONS = "buttons"
+STYLE_SELECT = "select"
+PANEL_STYLES = (STYLE_BUTTONS, STYLE_SELECT)
+
+# Button colours an admin may pick for a category (Discord's four styles; the
+# link style makes no sense for a ticket button).
+BUTTON_STYLES: Dict[str, discord.ButtonStyle] = {
+    "primary": discord.ButtonStyle.primary,
+    "secondary": discord.ButtonStyle.secondary,
+    "success": discord.ButtonStyle.success,
+    "danger": discord.ButtonStyle.danger,
+}
+DEFAULT_BUTTON_STYLE = "primary"
+
+# --------------------------------------------------------------------------- #
+# Ticket permissions
+#
+# One flat list, granted per role, per category. `admin` is the only implicit
+# one: it grants everything AND survives an escalation (see the service).
+# --------------------------------------------------------------------------- #
+PERM_VIEW = "view"                  # see and talk in the ticket
+PERM_CLOSE = "close"                # close / reopen it
+PERM_STAFF_THREAD = "staff_thread"  # open and join the private staff thread
+PERM_RENAME = "rename"              # rename the ticket channel
+PERM_MOVE = "move"                  # move it to another category
+PERM_PARTICIPANTS = "participants"  # add/remove members and roles
+PERM_ADMIN = "admin"                # everything above + kept on escalation
+
+TICKET_PERMISSIONS: Tuple[str, ...] = (
+    PERM_VIEW, PERM_CLOSE, PERM_STAFF_THREAD, PERM_RENAME,
+    PERM_MOVE, PERM_PARTICIPANTS, PERM_ADMIN,
+)
+
+# What a brand new role entry gets: enough to actually work the ticket, not
+# enough to reorganise the server.
+DEFAULT_ROLE_PERMISSIONS = (PERM_VIEW, PERM_CLOSE, PERM_STAFF_THREAD)
+
+# Languages a category can speak. Same set as the bot's own locale files, so a
+# ticket never falls back to a half-translated language.
+TICKET_LOCALES = ("en-US", "fr", "es-ES", "pt-BR", "de")
+DEFAULT_TICKET_LOCALE = "en-US"
+
+# Placeholders usable in the messages an admin writes.
+PLACEHOLDERS = (
+    "{user}", "{username}", "{display_name}", "{server}",
+    "{category}", "{number}", "{ticket}",
+)
+
+DEFAULT_NAME_FORMAT = "ticket-{number}"
+# Placeholders usable in the channel name (a subset: no mentions in a name).
+NAME_PLACEHOLDERS = ("{number}", "{username}", "{display_name}", "{category}")
+
+# Open tickets one member may hold in one category at the same time.
+DEFAULT_MAX_OPEN_PER_USER = 1
+MAX_OPEN_PER_USER_CEILING = 10
+
+# Channel types a panel message can be posted in.
+PANEL_CHANNEL_TYPES = [discord.ChannelType.text, discord.ChannelType.news]
+
+
+# --------------------------------------------------------------------------- #
+# Ids
+# --------------------------------------------------------------------------- #
+def new_panel_id() -> str:
+    """Short, url-safe id for a panel (custom_ids are capped at 100 chars)."""
+    return f"p_{secrets.token_hex(3)}"
+
+
+def new_category_id() -> str:
+    return f"c_{secrets.token_hex(3)}"
+
+
+# --------------------------------------------------------------------------- #
+# Normalisation
+#
+# Everything that reads the config goes through normalize_config(): a panel
+# written by the dashboard, an old config missing a key added later, and a
+# panel just built by the /config UI all come out with the exact same shape.
+# --------------------------------------------------------------------------- #
+def _as_int(value: Any) -> Optional[int]:
+    """Snowflakes arrive as int (from Discord) or str (from JSON/the API)."""
+    try:
+        return int(value) if value is not None and value != "" else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_id_list(value: Any) -> List[int]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    out = []
+    for item in value:
+        parsed = _as_int(item)
+        if parsed is not None and parsed not in out:
+            out.append(parsed)
+    return out
+
+
+def _as_text(value: Any, limit: int) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text[:limit] if text else None
+
+
+def normalize_permissions(value: Any) -> Dict[str, List[str]]:
+    """``{role_id: [perm, ...]}`` with unknown roles and perms dropped.
+
+    Keys stay **strings** because this dict is stored as JSON, where an int key
+    would come back as a string anyway.
+    """
+    if not isinstance(value, dict):
+        return {}
+    out: Dict[str, List[str]] = {}
+    for role_id, perms in value.items():
+        parsed_role = _as_int(role_id)
+        if parsed_role is None or not isinstance(perms, (list, tuple)):
+            continue
+        kept = [p for p in TICKET_PERMISSIONS if p in perms]
+        if kept:
+            out[str(parsed_role)] = kept
+    return out
+
+
+def normalize_category(raw: Any) -> Optional[Dict[str, Any]]:
+    """One category entry, or ``None`` if it is not usable at all."""
+    if not isinstance(raw, dict):
+        return None
+
+    name = _as_text(raw.get('name'), MAX_CATEGORY_NAME)
+    if not name:
+        return None
+
+    button_style = raw.get('button_style')
+    if button_style not in BUTTON_STYLES:
+        button_style = DEFAULT_BUTTON_STYLE
+
+    locale = raw.get('locale')
+    if locale not in TICKET_LOCALES:
+        locale = DEFAULT_TICKET_LOCALE
+
+    max_open = _as_int(raw.get('max_open_per_user'))
+    if max_open is None or max_open < 1:
+        max_open = DEFAULT_MAX_OPEN_PER_USER
+    max_open = min(max_open, MAX_OPEN_PER_USER_CEILING)
+
+    return {
+        'id': _as_text(raw.get('id'), 32) or new_category_id(),
+        'name': name,
+        'emoji': _as_text(raw.get('emoji'), 64),
+        'description': _as_text(raw.get('description'), MAX_CATEGORY_DESCRIPTION),
+        'button_style': button_style,
+        'discord_category_id': _as_int(raw.get('discord_category_id')),
+        'allowed_role_ids': _as_id_list(raw.get('allowed_role_ids')),
+        'denied_role_ids': _as_id_list(raw.get('denied_role_ids')),
+        'ping_role_ids': _as_id_list(raw.get('ping_role_ids')),
+        'permissions': normalize_permissions(raw.get('permissions')),
+        'locale': locale,
+        'open_message': _as_text(raw.get('open_message'), MAX_TICKET_MESSAGE),
+        'close_message': _as_text(raw.get('close_message'), MAX_TICKET_MESSAGE),
+        'name_format': _as_text(raw.get('name_format'), MAX_CHANNEL_NAME) or DEFAULT_NAME_FORMAT,
+        'max_open_per_user': max_open,
+        'enabled': bool(raw.get('enabled', True)),
+    }
+
+
+def normalize_panel(raw: Any) -> Optional[Dict[str, Any]]:
+    """One panel entry, or ``None`` if it is not usable at all."""
+    if not isinstance(raw, dict):
+        return None
+
+    name = _as_text(raw.get('name'), MAX_PANEL_NAME)
+    if not name:
+        return None
+
+    style = raw.get('style')
+    if style not in PANEL_STYLES:
+        style = STYLE_BUTTONS
+
+    categories = []
+    seen_ids = set()
+    for entry in raw.get('categories') or []:
+        category = normalize_category(entry)
+        if not category or category['id'] in seen_ids:
+            continue
+        seen_ids.add(category['id'])
+        categories.append(category)
+
+    accent = _as_int(raw.get('accent_color'))
+    if accent is not None:
+        accent = max(0, min(accent, 0xFFFFFF))
+
+    return {
+        'id': _as_text(raw.get('id'), 32) or new_panel_id(),
+        'name': name,
+        'channel_id': _as_int(raw.get('channel_id')),
+        'message_id': _as_int(raw.get('message_id')),
+        'title': _as_text(raw.get('title'), MAX_PANEL_TITLE),
+        'description': _as_text(raw.get('description'), MAX_PANEL_DESCRIPTION),
+        'accent_color': accent,
+        'style': style,
+        'placeholder': _as_text(raw.get('placeholder'), 150),
+        'enabled': bool(raw.get('enabled', True)),
+        'categories': categories,
+    }
+
+
+def normalize_config(raw: Any) -> Dict[str, Any]:
+    """The whole module config, always ``{'panels': [...]}``."""
+    if not isinstance(raw, dict):
+        return {'panels': []}
+
+    panels = []
+    seen_ids = set()
+    for entry in raw.get('panels') or []:
+        panel = normalize_panel(entry)
+        if not panel or panel['id'] in seen_ids:
+            continue
+        seen_ids.add(panel['id'])
+        panels.append(panel)
+
+    return {'panels': panels}
+
+
+# --------------------------------------------------------------------------- #
+# Limits
+# --------------------------------------------------------------------------- #
+async def get_limits(bot, guild_id: int) -> Dict[str, Any]:
+    """How many panels/categories this guild may have right now.
+
+    Premium is read at call time (never cached on a view): a panel can sit open
+    for hours, and a stale render must never grant an entitlement.
+    See docs/PREMIUM.md.
+    """
+    from utils.subscription import is_guild_premium
+
+    try:
+        premium = await is_guild_premium(bot, guild_id)
+    except Exception as e:
+        # Fail closed on the *limit*, not on the feature: a lookup error must
+        # not silently hand a free guild the premium quota.
+        logger.error(f"[Tickets] Premium check failed for guild {guild_id}: {e}")
+        premium = False
+
+    return {
+        'premium': premium,
+        'max_panels': PREMIUM_MAX_PANELS if premium else FREE_MAX_PANELS,
+        'max_categories': PREMIUM_MAX_CATEGORIES if premium else FREE_MAX_CATEGORIES,
+    }
+
+
+def max_categories_for_style(style: str, limit: int) -> int:
+    """The plan limit, capped by what the chosen rendering can actually show."""
+    ceiling = MAX_SELECT_OPTIONS if style == STYLE_SELECT else MAX_BUTTONS_PER_PANEL
+    return min(limit, ceiling)
+
+
+# --------------------------------------------------------------------------- #
+# Lookups
+# --------------------------------------------------------------------------- #
+def find_panel(config: Dict[str, Any], panel_id: str) -> Optional[Dict[str, Any]]:
+    return next((p for p in config.get('panels', []) if p['id'] == panel_id), None)
+
+
+def find_category(panel: Optional[Dict[str, Any]],
+                  category_id: str) -> Optional[Dict[str, Any]]:
+    if not panel:
+        return None
+    return next((c for c in panel.get('categories', []) if c['id'] == category_id), None)
+
+
+def locate_category(config: Dict[str, Any], panel_id: str,
+                    category_id: str) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """``(panel, category)`` — either may be ``None`` if it was deleted."""
+    panel = find_panel(config, panel_id)
+    return panel, find_category(panel, category_id)
+
+
+# --------------------------------------------------------------------------- #
+# Permission model
+# --------------------------------------------------------------------------- #
+def role_permissions(category: Dict[str, Any], role_id: int) -> List[str]:
+    """Permissions granted to one role, with ``admin`` expanded."""
+    perms = category.get('permissions', {}).get(str(role_id), [])
+    if PERM_ADMIN in perms:
+        return list(TICKET_PERMISSIONS)
+    return list(perms)
+
+
+def staff_role_ids(category: Dict[str, Any],
+                   *, permission: Optional[str] = None) -> List[int]:
+    """Roles with any permission in this category, or with a specific one."""
+    out = []
+    for role_id, perms in category.get('permissions', {}).items():
+        parsed = _as_int(role_id)
+        if parsed is None:
+            continue
+        granted = list(TICKET_PERMISSIONS) if PERM_ADMIN in perms else perms
+        if permission is None or permission in granted:
+            out.append(parsed)
+    return out
+
+
+def member_permissions(member: discord.Member, category: Dict[str, Any],
+                       ticket: Optional[Dict[str, Any]] = None) -> set:
+    """Everything ``member`` may do in a ticket of this category.
+
+    Three sources, deliberately in this order:
+
+    1. A guild administrator always has everything — locking the bot's own
+       config out of the people who own the server would be absurd.
+    2. Each of the member's roles contributes its granted permissions.
+    3. The ticket **owner**, and anyone added to the ticket by hand, may always
+       see it. That mirrors the channel overwrites exactly — someone who can
+       read the ticket but whom the permission model claims cannot see it would
+       be refused actions that are open to everyone in the ticket, such as
+       asking for it to be closed. Being in a ticket grants no *staff*
+       permission: closing your own ticket is the server's decision (grant
+       ``close`` to a members role for that); asking for it needs none.
+    """
+    if getattr(member, 'guild_permissions', None) and member.guild_permissions.administrator:
+        return set(TICKET_PERMISSIONS)
+
+    granted = set()
+    role_ids = {role.id for role in getattr(member, 'roles', [])}
+    for role_id in role_ids:
+        granted.update(role_permissions(category, role_id))
+
+    if ticket:
+        in_ticket = (
+            ticket.get('owner_id') == member.id
+            or member.id in (ticket.get('participants') or [])
+            or role_ids & set(ticket.get('participant_roles') or [])
+        )
+        if in_ticket:
+            granted.add(PERM_VIEW)
+
+    return granted
+
+
+def can_open(member: discord.Member, category: Dict[str, Any]) -> bool:
+    """Is this member allowed to open a ticket in this category?
+
+    ``denied_role_ids`` always wins over ``allowed_role_ids`` — a deny list
+    that could be defeated by also holding an allowed role would be a trap.
+    An empty allow list means "everyone", which is what an admin expects from
+    a field they never filled in.
+    """
+    role_ids = {role.id for role in getattr(member, 'roles', [])}
+
+    if role_ids & set(category.get('denied_role_ids', [])):
+        return False
+
+    allowed = category.get('allowed_role_ids', [])
+    if not allowed:
+        return True
+    if getattr(member, 'guild_permissions', None) and member.guild_permissions.administrator:
+        return True
+    return bool(role_ids & set(allowed))
+
+
+# --------------------------------------------------------------------------- #
+# Text rendering
+# --------------------------------------------------------------------------- #
+def render_text(template: str, *, member: discord.abc.User, guild: discord.Guild,
+                category: Dict[str, Any], number: int,
+                channel: Optional[discord.abc.GuildChannel] = None) -> str:
+    """Substitute the ``{placeholders}`` an admin may use in their messages.
+
+    ``str.format`` is deliberately NOT used: an admin who types a stray ``{``
+    would blow up the message for everyone.
+    """
+    values = {
+        "{user}": member.mention,
+        "{username}": member.name,
+        "{display_name}": getattr(member, 'display_name', member.name),
+        "{server}": guild.name,
+        "{category}": category.get('name', ''),
+        "{number}": str(number),
+        "{ticket}": channel.mention if channel else f"#{number}",
+    }
+    out = template
+    for key, value in values.items():
+        out = out.replace(key, str(value))
+    return out
+
+
+def render_channel_name(category: Dict[str, Any], *, member: discord.abc.User,
+                        number: int) -> str:
+    """Build the ticket channel name from the category's format."""
+    values = {
+        "{number}": f"{number:04d}",
+        "{username}": member.name,
+        "{display_name}": getattr(member, 'display_name', member.name),
+        "{category}": category.get('name', ''),
+    }
+    name = category.get('name_format') or DEFAULT_NAME_FORMAT
+    for key, value in values.items():
+        name = name.replace(key, str(value))
+
+    # Discord lowercases and mangles text channel names anyway; doing it here
+    # keeps the stored name and the real one identical.
+    cleaned = "".join(
+        c if (c.isalnum() or c in "-_") else "-"
+        for c in name.lower().replace(" ", "-")
+    ).strip("-")
+    while "--" in cleaned:
+        cleaned = cleaned.replace("--", "-")
+    return (cleaned or f"ticket-{number:04d}")[:MAX_CHANNEL_NAME]
+
+
+def parse_emoji(raw: Optional[str]) -> Optional[discord.PartialEmoji]:
+    """Turn a stored emoji string into something a Button/SelectOption accepts."""
+    if not raw:
+        return None
+    try:
+        emoji = discord.PartialEmoji.from_str(raw.strip())
+    except Exception:
+        return None
+    # from_str never fails on plain text: reject a "name" with no id that isn't
+    # a real unicode emoji, otherwise Discord rejects the whole message.
+    if emoji.id is None and (not emoji.name or emoji.name.isascii()):
+        return None
+    return emoji
+
+
+# --------------------------------------------------------------------------- #
+# The module
+# --------------------------------------------------------------------------- #
+class TicketsModule(ModuleBase):
+    """Per-guild ticket configuration and panel messages."""
+
+    MODULE_ID = MODULE_ID
+    MODULE_NAME = "Tickets"
+    MODULE_DESCRIPTION = "Support tickets with panels, categories and per-role permissions"
+    MODULE_EMOJI = TICKET
+    MODULE_ORDER = 25
+
+    def __init__(self, bot, guild_id: int):
+        super().__init__(bot, guild_id)
+        self.panels: List[Dict[str, Any]] = []
+
+    # -- ModuleBase ------------------------------------------------------- #
+    async def load_config(self, config_data: Dict[str, Any]) -> bool:
+        try:
+            normalized = normalize_config(config_data)
+            self.config = normalized
+            self.panels = normalized['panels']
+            # A guild "has tickets" as soon as one panel is switched on. That
+            # is also the condition under which /ticket is published in the
+            # guild, so it must not depend on anything transient.
+            self.enabled = any(p['enabled'] for p in self.panels)
+            return True
+        except Exception as e:
+            logger.error(f"[Tickets] Error loading config for guild {self.guild_id}: {e}",
+                         exc_info=True)
+            return False
+
+    def get_default_config(self) -> Dict[str, Any]:
+        return {'panels': []}
+
+    def get_required_fields(self) -> List[str]:
+        # Nothing is required to *store* the config: a guild that created a
+        # panel but has not picked its channel yet must be able to save and
+        # come back to it. What a panel needs to actually be posted is checked
+        # in validate_config below.
+        return []
+
+    async def validate_config(self, config_data: Dict[str, Any]) -> tuple[bool, Optional[str]]:
+        normalized = normalize_config(config_data)
+        guild = self.bot.get_guild(self.guild_id) if self.bot else None
+
+        limits = await get_limits(self.bot, self.guild_id) if self.bot else {
+            'max_panels': FREE_MAX_PANELS, 'max_categories': FREE_MAX_CATEGORIES,
+        }
+
+        if len(normalized['panels']) > limits['max_panels']:
+            return False, (f"Too many ticket panels "
+                           f"({len(normalized['panels'])}/{limits['max_panels']})")
+
+        for panel in normalized['panels']:
+            category_cap = max_categories_for_style(panel['style'], limits['max_categories'])
+            if len(panel['categories']) > category_cap:
+                return False, (f"Panel '{panel['name']}' has too many categories "
+                               f"({len(panel['categories'])}/{category_cap})")
+
+            if guild and panel['channel_id']:
+                channel = guild.get_channel(panel['channel_id'])
+                if channel is None:
+                    return False, f"Panel '{panel['name']}': channel not found"
+                if not isinstance(channel, (discord.TextChannel, discord.ForumChannel)):
+                    return False, f"Panel '{panel['name']}': not a text channel"
+
+            for category in panel['categories']:
+                if guild and category['discord_category_id']:
+                    parent = guild.get_channel(category['discord_category_id'])
+                    if parent is None:
+                        return False, (f"Category '{category['name']}': "
+                                       f"Discord category not found")
+                    if not isinstance(parent, discord.CategoryChannel):
+                        return False, (f"Category '{category['name']}': "
+                                       f"the destination is not a category")
+
+        return True, None
+
+    async def on_external_config_change(self, action: str) -> Dict[str, Any]:
+        """Re-post the panels after a dashboard-side change.
+
+        Reloading the config is not enough here: a panel is a *message* in
+        Discord. Its title, its buttons and its very existence are stored
+        state that only a re-post can bring in line — exactly what ``/config``
+        does on save. See docs/MODULE_SYSTEM.md §3bis.
+        """
+        if action == EXTERNAL_DELETED:
+            # The stored config is already gone: only clean Discord up, never
+            # write anything back (that would half-resurrect the module).
+            removed = await self.delete_all_panels(persist=False)
+            return {"panels_deleted": removed}
+
+        recap = await self.refresh_all_panels()
+        return {
+            "panels": len(self.panels),
+            "panels_posted": recap['posted'],
+            "panels_failed": recap['failed'],
+        }
+
+    # -- helpers ---------------------------------------------------------- #
+    @property
+    def guild(self) -> Optional[discord.Guild]:
+        return self.bot.get_guild(self.guild_id) if self.bot else None
+
+    def get_panel(self, panel_id: str) -> Optional[Dict[str, Any]]:
+        return find_panel({'panels': self.panels}, panel_id)
+
+    def get_category(self, panel_id: str, category_id: str):
+        return locate_category({'panels': self.panels}, panel_id, category_id)
+
+    def open_categories(self, panel: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Categories a panel actually renders (enabled, with a destination)."""
+        return [c for c in panel.get('categories', [])
+                if c['enabled'] and c.get('discord_category_id')]
+
+    async def _persist(self) -> None:
+        """Write the panel list back, keeping ``message_id`` in sync.
+
+        Goes straight to the DB rather than through ``save_module_config``:
+        this only ever writes ids the bot itself just produced, and the
+        module instance is already holding the authoritative state.
+        """
+        if not self.bot or not self.bot.db:
+            return
+        try:
+            await self.bot.db.update_guild_data(
+                self.guild_id, f"modules.{MODULE_ID}", {'panels': self.panels})
+        except Exception as e:
+            logger.error(f"[Tickets] Could not persist panels for guild "
+                         f"{self.guild_id}: {e}")
+
+    # -- panel messages --------------------------------------------------- #
+    async def refresh_panel(self, panel: Dict[str, Any], *,
+                            persist: bool = True) -> Optional[discord.Message]:
+        """(Re)post one panel message, replacing the previous one.
+
+        Always deleting and re-posting is the point: it repairs a panel someone
+        deleted, and it is the only way a title, a colour or a new category
+        reaches the message.
+        """
+        from utils.ticket_views import build_panel_view
+
+        guild = self.guild
+        if not guild or not panel.get('channel_id') or not panel.get('enabled'):
+            return None
+
+        channel = guild.get_channel(panel['channel_id'])
+        if not isinstance(channel, discord.TextChannel):
+            return None
+
+        if not self.open_categories(panel):
+            # A panel with nothing to click is worse than no panel: take the
+            # old message down rather than leaving dead buttons up.
+            await self.delete_panel(panel, persist=persist)
+            return None
+
+        await self.delete_panel(panel, persist=False)
+
+        try:
+            message = await channel.send(view=build_panel_view(panel))
+        except discord.Forbidden:
+            logger.warning(f"[Tickets] Cannot post panel {panel['id']} in guild "
+                           f"{self.guild_id} (missing permissions)")
+            return None
+        except discord.HTTPException as e:
+            logger.error(f"[Tickets] Failed to post panel {panel['id']} in guild "
+                         f"{self.guild_id}: {e}")
+            return None
+
+        panel['message_id'] = message.id
+        if persist:
+            await self._persist()
+        return message
+
+    async def refresh_all_panels(self) -> Dict[str, int]:
+        """Re-post every enabled panel. Returns a small recap for the dashboard."""
+        posted = failed = 0
+        for panel in self.panels:
+            if not panel['enabled']:
+                await self.delete_panel(panel, persist=False)
+                continue
+            message = await self.refresh_panel(panel, persist=False)
+            if message:
+                posted += 1
+            elif panel.get('channel_id'):
+                failed += 1
+        await self._persist()
+        return {'posted': posted, 'failed': failed}
+
+    async def delete_panel(self, panel: Dict[str, Any], *,
+                           persist: bool = True) -> bool:
+        """Take a panel message down. Returns True if a message was removed."""
+        message_id = panel.get('message_id')
+        if not message_id:
+            return False
+
+        guild = self.guild
+        channel = guild.get_channel(panel['channel_id']) if guild and panel.get('channel_id') else None
+        removed = False
+        if isinstance(channel, discord.TextChannel):
+            try:
+                await channel.get_partial_message(message_id).delete()
+                removed = True
+            except (discord.NotFound, discord.Forbidden):
+                pass
+            except discord.HTTPException as e:
+                logger.error(f"[Tickets] Could not delete panel message "
+                             f"{message_id} in guild {self.guild_id}: {e}")
+
+        panel['message_id'] = None
+        if persist:
+            await self._persist()
+        return removed
+
+    async def delete_all_panels(self, *, persist: bool = True) -> int:
+        removed = 0
+        for panel in self.panels:
+            if await self.delete_panel(panel, persist=False):
+                removed += 1
+        if persist:
+            await self._persist()
+        return removed

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -1,0 +1,687 @@
+"""
+Ticket service — every action a ticket can undergo, in one place.
+
+``modules/tickets.py`` owns the *configuration*; this owns the *verbs*. The
+slash commands (``cogs/tickets.py``) and the buttons on the ticket message
+(``utils/ticket_views.py``) are both thin shells over the methods here, which
+is what makes "every ticket action is available as a slash command" true by
+construction rather than by discipline.
+
+Reachable as ``bot.tickets``.
+
+Failures are raised as :class:`TicketError` carrying an **i18n key**, never a
+formatted string: the caller decides whether to answer in the actor's language
+(a slash command) or the ticket's (a message posted in the channel).
+
+See docs/TICKETS.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional, Tuple, Union
+
+import discord
+
+from modules.tickets import (
+    MODULE_ID,
+    PERM_ADMIN,
+    PERM_CLOSE,
+    PERM_MOVE,
+    PERM_PARTICIPANTS,
+    PERM_RENAME,
+    PERM_STAFF_THREAD,
+    PERM_VIEW,
+    can_open,
+    locate_category,
+    member_permissions,
+    render_channel_name,
+    render_text,
+    staff_role_ids,
+)
+from utils.i18n import t
+
+logger = logging.getLogger('moddy.services.tickets')
+
+# Permissions the ticket opener (and anyone added by hand) gets in the channel.
+_MEMBER_OVERWRITE = discord.PermissionOverwrite(
+    view_channel=True,
+    send_messages=True,
+    read_message_history=True,
+    attach_files=True,
+    embed_links=True,
+    add_reactions=True,
+)
+
+# Staff get the same plus the ability to tidy the channel up.
+_STAFF_OVERWRITE = discord.PermissionOverwrite(
+    view_channel=True,
+    send_messages=True,
+    read_message_history=True,
+    attach_files=True,
+    embed_links=True,
+    add_reactions=True,
+    manage_messages=True,
+)
+
+_HIDDEN_OVERWRITE = discord.PermissionOverwrite(view_channel=False)
+
+
+class TicketError(Exception):
+    """An action that could not be performed, with a translatable reason."""
+
+    def __init__(self, key: str, **params: Any):
+        super().__init__(key)
+        self.key = key
+        self.params = params
+
+    def message(self, locale: str) -> str:
+        return t(self.key, locale=locale, **self.params)
+
+
+class TicketService:
+    """Open, close, escalate, move, rename and staff a ticket."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    # ------------------------------------------------------------------ #
+    # Resolution
+    # ------------------------------------------------------------------ #
+    async def get_module(self, guild_id: int):
+        """The guild's Tickets module instance, or ``None`` when unconfigured."""
+        if not getattr(self.bot, 'module_manager', None):
+            return None
+        try:
+            return await self.bot.module_manager.get_module_instance(guild_id, MODULE_ID)
+        except Exception as e:
+            logger.error(f"[Tickets] Could not load module for guild {guild_id}: {e}")
+            return None
+
+    async def get_ticket(self, channel_id: int) -> Optional[Dict[str, Any]]:
+        if not self.bot.db:
+            return None
+        return await self.bot.db.get_ticket_by_channel(channel_id)
+
+    async def resolve(self, channel: discord.abc.GuildChannel
+                      ) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
+        """``(ticket, panel, category)`` for a ticket channel.
+
+        Raises :class:`TicketError` when the channel is not a ticket, or when
+        the category it was opened in has since been deleted from the config —
+        the two states every caller has to handle anyway.
+        """
+        ticket = await self.get_ticket(channel.id)
+        if not ticket:
+            raise TicketError('modules.tickets.errors.not_a_ticket')
+
+        module = await self.get_module(ticket['guild_id'])
+        if not module:
+            raise TicketError('modules.tickets.errors.module_disabled')
+
+        panel, category = locate_category(
+            {'panels': module.panels}, ticket['panel_id'], ticket['category_id'])
+        if not category:
+            raise TicketError('modules.tickets.errors.category_gone')
+        return ticket, panel, category
+
+    def ticket_locale(self, category: Dict[str, Any]) -> str:
+        return category.get('locale') or 'en-US'
+
+    # ------------------------------------------------------------------ #
+    # Authorization
+    # ------------------------------------------------------------------ #
+    def require(self, member: discord.Member, category: Dict[str, Any],
+                ticket: Dict[str, Any], permission: str) -> set:
+        """Assert ``member`` holds ``permission`` here; return all their perms."""
+        granted = member_permissions(member, category, ticket)
+        if permission not in granted:
+            raise TicketError('modules.tickets.errors.missing_permission')
+        return granted
+
+    # ------------------------------------------------------------------ #
+    # Channel permissions
+    # ------------------------------------------------------------------ #
+    def build_overwrites(self, guild: discord.Guild, category: Dict[str, Any],
+                         ticket: Dict[str, Any]
+                         ) -> Dict[Union[discord.Role, discord.Member],
+                                   discord.PermissionOverwrite]:
+        """The full overwrite map for a ticket channel, from scratch.
+
+        Rebuilding the whole map on every change (instead of patching it) is
+        what keeps escalation, closure and participant edits from drifting into
+        states nobody can explain.
+
+        - **Escalated** tickets only keep the roles holding ``admin``.
+        - **Closed** tickets keep staff and hide the channel from the member
+          side, so a closed ticket disappears from the opener's channel list
+          without losing anything: reopening restores it exactly.
+        """
+        escalated = bool(ticket.get('escalated'))
+        closed = ticket.get('status') == 'closed'
+
+        overwrites: Dict[Any, discord.PermissionOverwrite] = {
+            guild.default_role: _HIDDEN_OVERWRITE,
+        }
+        if guild.me:
+            overwrites[guild.me] = discord.PermissionOverwrite(
+                view_channel=True, send_messages=True, read_message_history=True,
+                manage_channels=True, manage_messages=True, embed_links=True,
+                attach_files=True, manage_threads=True, create_private_threads=True,
+            )
+
+        # Staff roles.
+        wanted = PERM_ADMIN if escalated else PERM_VIEW
+        for role_id in staff_role_ids(category, permission=wanted):
+            role = guild.get_role(role_id)
+            if role:
+                overwrites[role] = _STAFF_OVERWRITE
+
+        # Roles added by hand to this ticket keep their access through an
+        # escalation only when they are staff — otherwise escalating would be
+        # pointless. They are never hidden by a mere closure either.
+        for role_id in ticket.get('participant_roles', []):
+            role = guild.get_role(role_id)
+            if role and not escalated and not closed:
+                overwrites.setdefault(role, _MEMBER_OVERWRITE)
+
+        if not closed:
+            # The opener and everyone added by hand. Escalation deliberately
+            # keeps them (the opener has to stay, and the manual participants
+            # are an explicit staff decision — the escalate flow offers to
+            # drop them).
+            member_ids = [ticket['owner_id'], *ticket.get('participants', [])]
+            for user_id in member_ids:
+                member = guild.get_member(user_id)
+                if member and member not in overwrites:
+                    overwrites[member] = _MEMBER_OVERWRITE
+
+        return overwrites
+
+    async def sync_permissions(self, channel: discord.TextChannel,
+                               category: Dict[str, Any],
+                               ticket: Dict[str, Any]) -> bool:
+        """Push the rebuilt overwrite map onto the channel."""
+        try:
+            await channel.edit(
+                overwrites=self.build_overwrites(channel.guild, category, ticket),
+                reason="Moddy tickets: permission sync",
+            )
+            return True
+        except discord.Forbidden:
+            logger.warning(f"[Tickets] Missing permissions to sync overwrites on "
+                           f"channel {channel.id}")
+        except discord.HTTPException as e:
+            logger.error(f"[Tickets] Could not sync overwrites on {channel.id}: {e}")
+        return False
+
+    # ------------------------------------------------------------------ #
+    # Open
+    # ------------------------------------------------------------------ #
+    async def open_ticket(self, member: discord.Member, panel: Dict[str, Any],
+                          category: Dict[str, Any]) -> discord.TextChannel:
+        """Create the ticket channel and post its pinned control message."""
+        from utils.ticket_views import build_ticket_message
+
+        guild = member.guild
+
+        if not category.get('enabled'):
+            raise TicketError('modules.tickets.errors.category_disabled')
+        if not can_open(member, category):
+            raise TicketError('modules.tickets.errors.cannot_open')
+
+        parent = guild.get_channel(category['discord_category_id']) \
+            if category.get('discord_category_id') else None
+        if not isinstance(parent, discord.CategoryChannel):
+            raise TicketError('modules.tickets.errors.destination_missing')
+
+        if not self.bot.db:
+            raise TicketError('modules.tickets.errors.unavailable')
+
+        open_count = await self.bot.db.count_open_tickets(
+            guild.id, member.id, category['id'])
+        if open_count >= category.get('max_open_per_user', 1):
+            raise TicketError('modules.tickets.errors.too_many_open',
+                              max=category.get('max_open_per_user', 1))
+
+        # The number is predicted first so the channel can be created with its
+        # final name, its final overwrites and its topic in ONE call. Renaming
+        # afterwards would spend one of the two renames Discord allows per
+        # channel per 10 minutes, and a staffer's /ticket rename right after
+        # opening would then hang.
+        locale = self.ticket_locale(category)
+        number = await self.bot.db.next_ticket_number(guild.id)
+        draft = {'owner_id': member.id, 'status': 'open', 'escalated': False,
+                 'participants': [], 'participant_roles': []}
+        try:
+            channel = await guild.create_text_channel(
+                name=render_channel_name(category, member=member, number=number),
+                category=parent,
+                overwrites=self.build_overwrites(guild, category, draft),
+                topic=t('modules.tickets.channel.topic', locale=locale,
+                        user=str(member), category=category['name'])[:1024],
+                reason=f"Moddy ticket opened by {member} ({member.id})",
+            )
+        except discord.Forbidden:
+            raise TicketError('modules.tickets.errors.cannot_create_channel')
+        except discord.HTTPException as e:
+            logger.error(f"[Tickets] Channel creation failed in guild {guild.id}: {e}")
+            raise TicketError('modules.tickets.errors.cannot_create_channel')
+
+        # The channel id is part of the row, so the channel comes first and the
+        # row is written immediately after; a channel whose insert fails is
+        # deleted again rather than left dangling.
+        ticket = await self.bot.db.create_ticket(
+            guild_id=guild.id, channel_id=channel.id, panel_id=panel['id'],
+            category_id=category['id'], owner_id=member.id, number=number,
+        )
+        if not ticket:
+            await channel.delete(reason="Moddy tickets: could not register the ticket")
+            raise TicketError('modules.tickets.errors.unavailable')
+
+        # The control message: pinned, so it stays reachable however long the
+        # conversation gets.
+        body = category.get('open_message') or t(
+            'modules.tickets.channel.default_open_message', locale=locale)
+        rendered = render_text(body, member=member, guild=guild, category=category,
+                               number=ticket['number'], channel=channel)
+        try:
+            message = await channel.send(
+                content=self._ping_content(guild, category, member),
+                view=build_ticket_message(ticket, category, rendered, locale=locale),
+                allowed_mentions=discord.AllowedMentions(users=True, roles=True),
+            )
+            await message.pin(reason="Moddy tickets: control message")
+        except discord.HTTPException as e:
+            logger.warning(f"[Tickets] Could not post the control message in "
+                           f"{channel.id}: {e}")
+
+        logger.info(f"[Tickets] #{ticket['number']} opened in guild {guild.id} "
+                    f"by {member.id} (category {category['id']})")
+        return channel
+
+    def _ping_content(self, guild: discord.Guild, category: Dict[str, Any],
+                      member: discord.Member) -> Optional[str]:
+        """Mentions posted alongside the control message (opener + ping roles)."""
+        parts = [member.mention]
+        for role_id in category.get('ping_role_ids', []):
+            role = guild.get_role(role_id)
+            if role:
+                parts.append(role.mention)
+        return " ".join(parts) if parts else None
+
+    # ------------------------------------------------------------------ #
+    # Close / reopen
+    # ------------------------------------------------------------------ #
+    async def close_ticket(self, channel: discord.TextChannel, actor: discord.Member,
+                           reason: Optional[str] = None) -> Dict[str, Any]:
+        """Lock the ticket and post the closing card.
+
+        The channel is **kept**: nothing is destroyed by a click. Deleting it is
+        a separate, explicit action on the closing card.
+        """
+        from utils.ticket_views import build_closed_message
+
+        ticket, panel, category = await self.resolve(channel)
+        if ticket['status'] == 'closed':
+            raise TicketError('modules.tickets.errors.already_closed')
+        self.require(actor, category, ticket, PERM_CLOSE)
+
+        await self.bot.db.set_ticket_status(
+            channel.id, 'closed', actor_id=actor.id, reason=reason)
+        ticket = await self.get_ticket(channel.id) or ticket
+
+        await self.sync_permissions(channel, category, ticket)
+
+        locale = self.ticket_locale(category)
+        closing = category.get('close_message')
+        rendered = render_text(
+            closing, member=actor, guild=channel.guild, category=category,
+            number=ticket['number'], channel=channel,
+        ) if closing else None
+
+        try:
+            await channel.send(view=build_closed_message(
+                ticket, category, actor, reason, rendered, locale=locale))
+        except discord.HTTPException as e:
+            logger.warning(f"[Tickets] Could not post the closing card in "
+                           f"{channel.id}: {e}")
+
+        await self._notify_owner_closed(channel, ticket, category, actor, reason)
+        logger.info(f"[Tickets] #{ticket['number']} closed by {actor.id}")
+        return ticket
+
+    async def _notify_owner_closed(self, channel, ticket, category, actor, reason):
+        """DM the opener that their ticket is closed — best effort, never fatal."""
+        from utils.ticket_views import build_close_dm
+
+        owner = channel.guild.get_member(ticket['owner_id'])
+        if not owner or owner.bot:
+            return
+        try:
+            await owner.send(view=build_close_dm(
+                channel.guild, ticket, category, actor, reason,
+                locale=self.ticket_locale(category)))
+        except (discord.Forbidden, discord.HTTPException):
+            pass  # closed DMs are the norm, not an error
+
+    async def reopen_ticket(self, channel: discord.TextChannel,
+                            actor: discord.Member) -> Dict[str, Any]:
+        ticket, panel, category = await self.resolve(channel)
+        if ticket['status'] != 'closed':
+            raise TicketError('modules.tickets.errors.not_closed')
+        self.require(actor, category, ticket, PERM_CLOSE)
+
+        await self.bot.db.set_ticket_status(channel.id, 'open')
+        ticket = await self.get_ticket(channel.id) or ticket
+        await self.sync_permissions(channel, category, ticket)
+        logger.info(f"[Tickets] #{ticket['number']} reopened by {actor.id}")
+        return ticket
+
+    async def delete_ticket(self, channel: discord.TextChannel,
+                            actor: discord.Member) -> None:
+        """Delete the ticket channel for good. Requires ``admin``."""
+        ticket, panel, category = await self.resolve(channel)
+        self.require(actor, category, ticket, PERM_ADMIN)
+        await self.bot.db.delete_ticket(channel.id)
+        await channel.delete(reason=f"Moddy ticket deleted by {actor} ({actor.id})")
+
+    # ------------------------------------------------------------------ #
+    # Close request
+    # ------------------------------------------------------------------ #
+    async def request_close(self, channel: discord.TextChannel, actor: discord.Member,
+                            reason: Optional[str] = None) -> Dict[str, Any]:
+        """Ask the staff to close — the action for whoever cannot close.
+
+        Deliberately requires no permission: anyone who can see the ticket may
+        ask for it to end. Someone who *can* close is told to just close it,
+        rather than asking themselves.
+        """
+        from utils.ticket_views import build_close_request_message
+
+        ticket, panel, category = await self.resolve(channel)
+        if ticket['status'] == 'closed':
+            raise TicketError('modules.tickets.errors.already_closed')
+
+        granted = member_permissions(actor, category, ticket)
+        if PERM_VIEW not in granted:
+            raise TicketError('modules.tickets.errors.missing_permission')
+        if PERM_CLOSE in granted:
+            raise TicketError('modules.tickets.errors.can_close_directly')
+        if ticket.get('close_requested_by'):
+            raise TicketError('modules.tickets.errors.close_already_requested')
+
+        await self.bot.db.set_close_request(channel.id, actor.id, reason)
+        ticket = await self.get_ticket(channel.id) or ticket
+
+        locale = self.ticket_locale(category)
+        mentions = [r.mention for r in (
+            channel.guild.get_role(rid) for rid in staff_role_ids(category, permission=PERM_CLOSE)
+        ) if r]
+        try:
+            await channel.send(
+                content=" ".join(mentions) or None,
+                view=build_close_request_message(ticket, actor, reason, locale=locale),
+                allowed_mentions=discord.AllowedMentions(roles=True),
+            )
+        except discord.HTTPException as e:
+            logger.warning(f"[Tickets] Could not post the close request in "
+                           f"{channel.id}: {e}")
+        return ticket
+
+    async def cancel_close_request(self, channel: discord.TextChannel,
+                                   actor: discord.Member) -> Dict[str, Any]:
+        """Refuse a pending close request (staff) or withdraw it (requester)."""
+        ticket, panel, category = await self.resolve(channel)
+        if not ticket.get('close_requested_by'):
+            raise TicketError('modules.tickets.errors.no_close_request')
+
+        granted = member_permissions(actor, category, ticket)
+        if PERM_CLOSE not in granted and actor.id != ticket['close_requested_by']:
+            raise TicketError('modules.tickets.errors.missing_permission')
+
+        await self.bot.db.set_close_request(channel.id, None, None)
+        return await self.get_ticket(channel.id) or ticket
+
+    # ------------------------------------------------------------------ #
+    # Escalate
+    # ------------------------------------------------------------------ #
+    async def escalate(self, channel: discord.TextChannel, actor: discord.Member,
+                       *, reason: Optional[str] = None,
+                       keep_participants: bool = True) -> Dict[str, Any]:
+        """Restrict the ticket to the responsibles, its opener and (optionally)
+        the people added by hand.
+
+        Everyone else — every staff role that is not ``admin`` — loses access.
+        """
+        from utils.ticket_views import build_escalation_notice
+
+        ticket, panel, category = await self.resolve(channel)
+        if ticket['status'] == 'closed':
+            raise TicketError('modules.tickets.errors.already_closed')
+        if ticket.get('escalated'):
+            raise TicketError('modules.tickets.errors.already_escalated')
+        self.require(actor, category, ticket, PERM_ADMIN)
+
+        if not staff_role_ids(category, permission=PERM_ADMIN):
+            # Escalating with nobody to escalate *to* would lock the ticket
+            # down to its opener and the server admins alone.
+            raise TicketError('modules.tickets.errors.no_responsible_role')
+
+        if not keep_participants:
+            await self.bot.db.set_participants(channel.id, users=[], roles=[])
+        await self.bot.db.set_escalated(channel.id, True)
+        ticket = await self.get_ticket(channel.id) or ticket
+
+        await self.sync_permissions(channel, category, ticket)
+
+        locale = self.ticket_locale(category)
+        mentions = [r.mention for r in (
+            channel.guild.get_role(rid) for rid in staff_role_ids(category, permission=PERM_ADMIN)
+        ) if r]
+        try:
+            await channel.send(
+                content=" ".join(mentions) or None,
+                view=build_escalation_notice(ticket, actor, reason, locale=locale),
+                allowed_mentions=discord.AllowedMentions(roles=True),
+            )
+        except discord.HTTPException as e:
+            logger.warning(f"[Tickets] Could not post the escalation notice in "
+                           f"{channel.id}: {e}")
+
+        logger.info(f"[Tickets] #{ticket['number']} escalated by {actor.id}")
+        return ticket
+
+    async def deescalate(self, channel: discord.TextChannel,
+                         actor: discord.Member) -> Dict[str, Any]:
+        """Undo an escalation — the staff roles regain access."""
+        ticket, panel, category = await self.resolve(channel)
+        if not ticket.get('escalated'):
+            raise TicketError('modules.tickets.errors.not_escalated')
+        self.require(actor, category, ticket, PERM_ADMIN)
+
+        await self.bot.db.set_escalated(channel.id, False)
+        ticket = await self.get_ticket(channel.id) or ticket
+        await self.sync_permissions(channel, category, ticket)
+        return ticket
+
+    # ------------------------------------------------------------------ #
+    # Move
+    # ------------------------------------------------------------------ #
+    async def move_ticket(self, channel: discord.TextChannel, actor: discord.Member,
+                          panel_id: str, category_id: str) -> Dict[str, Any]:
+        """Move the ticket to another category (any panel of the guild).
+
+        The destination's permissions replace the current ones — that is the
+        point of moving — so the actor needs ``move`` **here**; a category they
+        could not work in is still a valid destination, exactly like handing a
+        ticket over to another team.
+        """
+        ticket, panel, category = await self.resolve(channel)
+        self.require(actor, category, ticket, PERM_MOVE)
+
+        module = await self.get_module(channel.guild.id)
+        target_panel, target = locate_category(
+            {'panels': module.panels if module else []}, panel_id, category_id)
+        if not target:
+            raise TicketError('modules.tickets.errors.unknown_category')
+        if target['id'] == category['id']:
+            raise TicketError('modules.tickets.errors.same_category')
+
+        parent = channel.guild.get_channel(target.get('discord_category_id')) \
+            if target.get('discord_category_id') else None
+        if not isinstance(parent, discord.CategoryChannel):
+            raise TicketError('modules.tickets.errors.destination_missing')
+
+        await self.bot.db.set_ticket_category(channel.id, target_panel['id'], target['id'])
+        ticket = await self.get_ticket(channel.id) or ticket
+
+        try:
+            await channel.edit(
+                category=parent,
+                overwrites=self.build_overwrites(channel.guild, target, ticket),
+                reason=f"Moddy ticket moved by {actor} ({actor.id})",
+            )
+        except discord.Forbidden:
+            raise TicketError('modules.tickets.errors.cannot_edit_channel')
+        except discord.HTTPException as e:
+            logger.error(f"[Tickets] Could not move channel {channel.id}: {e}")
+            raise TicketError('modules.tickets.errors.cannot_edit_channel')
+
+        logger.info(f"[Tickets] #{ticket['number']} moved to {target['id']} "
+                    f"by {actor.id}")
+        return ticket
+
+    # ------------------------------------------------------------------ #
+    # Rename
+    # ------------------------------------------------------------------ #
+    async def rename_ticket(self, channel: discord.TextChannel, actor: discord.Member,
+                            name: str) -> str:
+        ticket, panel, category = await self.resolve(channel)
+        self.require(actor, category, ticket, PERM_RENAME)
+
+        cleaned = render_channel_name(
+            {'name_format': name, 'name': category['name']},
+            member=actor, number=ticket['number'])
+        if not cleaned:
+            raise TicketError('modules.tickets.errors.invalid_name')
+
+        try:
+            await channel.edit(name=cleaned,
+                               reason=f"Moddy ticket renamed by {actor} ({actor.id})")
+        except discord.Forbidden:
+            raise TicketError('modules.tickets.errors.cannot_edit_channel')
+        except discord.HTTPException as e:
+            logger.error(f"[Tickets] Could not rename channel {channel.id}: {e}")
+            raise TicketError('modules.tickets.errors.cannot_edit_channel')
+        return cleaned
+
+    # ------------------------------------------------------------------ #
+    # Participants
+    # ------------------------------------------------------------------ #
+    async def add_participant(self, channel: discord.TextChannel, actor: discord.Member,
+                              target: Union[discord.Member, discord.Role]) -> Dict[str, Any]:
+        ticket, panel, category = await self.resolve(channel)
+        self.require(actor, category, ticket, PERM_PARTICIPANTS)
+
+        is_role = isinstance(target, discord.Role)
+        key = 'participant_roles' if is_role else 'participants'
+        current = list(ticket.get(key, []))
+
+        if not is_role and target.id == ticket['owner_id']:
+            raise TicketError('modules.tickets.errors.already_participant')
+        if target.id in current:
+            raise TicketError('modules.tickets.errors.already_participant')
+
+        current.append(target.id)
+        await self.bot.db.set_participants(
+            channel.id, **{'roles' if is_role else 'users': current})
+        ticket = await self.get_ticket(channel.id) or ticket
+        await self.sync_permissions(channel, category, ticket)
+        return ticket
+
+    async def remove_participant(self, channel: discord.TextChannel, actor: discord.Member,
+                                 target: Union[discord.Member, discord.Role]
+                                 ) -> Dict[str, Any]:
+        ticket, panel, category = await self.resolve(channel)
+        self.require(actor, category, ticket, PERM_PARTICIPANTS)
+
+        if not isinstance(target, discord.Role) and target.id == ticket['owner_id']:
+            # Removing the opener from their own ticket makes the ticket
+            # meaningless; closing it is the action they are looking for.
+            raise TicketError('modules.tickets.errors.cannot_remove_owner')
+
+        is_role = isinstance(target, discord.Role)
+        key = 'participant_roles' if is_role else 'participants'
+        current = list(ticket.get(key, []))
+        if target.id not in current:
+            raise TicketError('modules.tickets.errors.not_a_participant')
+
+        current.remove(target.id)
+        await self.bot.db.set_participants(
+            channel.id, **{'roles' if is_role else 'users': current})
+        ticket = await self.get_ticket(channel.id) or ticket
+        await self.sync_permissions(channel, category, ticket)
+        return ticket
+
+    # ------------------------------------------------------------------ #
+    # Staff thread
+    # ------------------------------------------------------------------ #
+    async def open_staff_thread(self, channel: discord.TextChannel,
+                                actor: discord.Member) -> discord.Thread:
+        """Create (or join) the ticket's private staff thread.
+
+        A **private** thread, so the opener never sees it. Discord has no
+        role-based membership for threads, so the thread is not pre-filled with
+        every staff member: each staffer joins by running the action once,
+        which is also what makes it cheap on a busy server.
+        """
+        ticket, panel, category = await self.resolve(channel)
+        self.require(actor, category, ticket, PERM_STAFF_THREAD)
+
+        locale = self.ticket_locale(category)
+        thread = None
+        if ticket.get('staff_thread_id'):
+            thread = channel.guild.get_channel_or_thread(ticket['staff_thread_id'])
+            if thread is None:
+                try:
+                    thread = await self.bot.fetch_channel(ticket['staff_thread_id'])
+                except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                    thread = None
+
+        if thread is None:
+            try:
+                thread = await channel.create_thread(
+                    name=t('modules.tickets.staff_thread.name', locale=locale,
+                           number=ticket['number'])[:100],
+                    type=discord.ChannelType.private_thread,
+                    invitable=False,
+                    reason=f"Moddy ticket staff thread opened by {actor} ({actor.id})",
+                )
+            except discord.Forbidden:
+                raise TicketError('modules.tickets.errors.cannot_create_thread')
+            except discord.HTTPException as e:
+                logger.error(f"[Tickets] Could not create staff thread in "
+                             f"{channel.id}: {e}")
+                raise TicketError('modules.tickets.errors.cannot_create_thread')
+
+            await self.bot.db.set_staff_thread(channel.id, thread.id)
+            try:
+                await thread.send(t('modules.tickets.staff_thread.intro',
+                                    locale=locale, number=ticket['number']))
+            except discord.HTTPException:
+                pass
+
+        try:
+            await thread.add_user(actor)
+        except discord.HTTPException:
+            pass
+        return thread
+
+    # ------------------------------------------------------------------ #
+    # Housekeeping
+    # ------------------------------------------------------------------ #
+    async def forget_channel(self, channel_id: int) -> None:
+        """Drop the row of a ticket whose channel no longer exists."""
+        if self.bot.db:
+            await self.bot.db.delete_ticket(channel_id)

--- a/tests/test_persistent_views.py
+++ b/tests/test_persistent_views.py
@@ -127,6 +127,14 @@ def _dynamic_item_cases():
     from staff.commands.manage.staff import (
         StaffPanelRolesSelect, StaffPanelScopeSelect, StaffPanelPermsSelect, StaffPanelActionButton,
     )
+    from utils.ticket_views import TicketOpenButton, TicketOpenSelect
+    from modules.configs.tickets_panel_config import (
+        TicketPanelButton, TicketPanelSelect, TicketPanelChannelSelect,
+    )
+    from modules.configs.tickets_category_config import (
+        TicketCategoryButton, TicketCategoryDestination, TicketCategoryRoles,
+        TicketCategoryLocale, TicketPermRoleSelect, TicketPermSelect, TicketPermButton,
+    )
     _U = "0f7d9c62-3b4e-4a1f-9c2d-5e6f70819a2b"
     _SNOWFLAKE = 123456789012345678
     _SNOWFLAKE2 = 987654321098765432
@@ -153,6 +161,20 @@ def _dynamic_item_cases():
         (StaffPanelScopeSelect, (_SNOWFLAKE, _SNOWFLAKE2)),
         (StaffPanelPermsSelect, (_SNOWFLAKE, _SNOWFLAKE2, "Supervisor_Mod")),
         (StaffPanelActionButton, ("save", _SNOWFLAKE, _SNOWFLAKE2)),
+        # Tickets — the public panel (whoever clicks opens a ticket)…
+        (TicketOpenButton, ("p_ab12cd", "c_ab12cd")),
+        (TicketOpenSelect, ("p_ab12cd",)),
+        # …and every /config screen below the module root.
+        (TicketPanelButton, ("repost", "p_ab12cd")),
+        (TicketPanelSelect, ("style", "p_ab12cd")),
+        (TicketPanelChannelSelect, ("p_ab12cd",)),
+        (TicketCategoryButton, ("perms", "p_ab12cd", "c_ab12cd")),
+        (TicketCategoryDestination, ("p_ab12cd", "c_ab12cd")),
+        (TicketCategoryRoles, ("allowed", "p_ab12cd", "c_ab12cd")),
+        (TicketCategoryLocale, ("p_ab12cd", "c_ab12cd")),
+        (TicketPermRoleSelect, ("p_ab12cd", "c_ab12cd")),
+        (TicketPermSelect, ("p_ab12cd", "c_ab12cd", _SNOWFLAKE)),
+        (TicketPermButton, ("clear", "p_ab12cd", "c_ab12cd", _SNOWFLAKE)),
     ]
 
 

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -1,0 +1,784 @@
+"""Tickets module — configuration schema, permission model and rendering.
+
+Everything here is pure Python: no gateway, no database. The Discord objects
+the permission code touches (guild, member, role) are replaced by the small
+stubs at the top of the file, which is exactly the surface the production code
+uses.
+
+    pytest tests/test_tickets.py -q
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from modules.tickets import (
+    DEFAULT_MAX_OPEN_PER_USER,
+    FREE_MAX_CATEGORIES,
+    FREE_MAX_PANELS,
+    MAX_BUTTONS_PER_PANEL,
+    MAX_SELECT_OPTIONS,
+    PERM_ADMIN,
+    PLACEHOLDERS,
+    PERM_CLOSE,
+    PERM_VIEW,
+    PREMIUM_MAX_CATEGORIES,
+    PREMIUM_MAX_PANELS,
+    STYLE_BUTTONS,
+    STYLE_SELECT,
+    TICKET_PERMISSIONS,
+    can_open,
+    find_category,
+    find_panel,
+    get_limits,
+    locate_category,
+    max_categories_for_style,
+    member_permissions,
+    normalize_category,
+    normalize_config,
+    normalize_permissions,
+    parse_emoji,
+    render_channel_name,
+    render_text,
+    role_permissions,
+    staff_role_ids,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Stubs
+# --------------------------------------------------------------------------- #
+class FakeRole:
+    def __init__(self, role_id: int, name: str = "role"):
+        self.id = role_id
+        self.name = name
+        self.mention = f"<@&{role_id}>"
+
+
+class FakeMember:
+    def __init__(self, user_id: int, roles=(), administrator: bool = False,
+                 name: str = "member", display_name: str = None):
+        self.id = user_id
+        self.roles = list(roles)
+        self.name = name
+        self.display_name = display_name or name
+        self.mention = f"<@{user_id}>"
+        self.guild_permissions = SimpleNamespace(administrator=administrator)
+
+
+def make_category(**overrides):
+    base = {
+        'name': "Support",
+        'discord_category_id': 100,
+        'permissions': {},
+        'allowed_role_ids': [],
+        'denied_role_ids': [],
+    }
+    base.update(overrides)
+    return normalize_category(base)
+
+
+# =========================================================================== #
+# Normalisation
+# =========================================================================== #
+class TestNormalisation:
+    def test_empty_config_is_a_panel_list(self):
+        assert normalize_config(None) == {'panels': []}
+        assert normalize_config({}) == {'panels': []}
+        assert normalize_config("nonsense") == {'panels': []}
+
+    def test_panel_without_a_name_is_dropped(self):
+        config = normalize_config({'panels': [{'id': 'p_a'}, {'name': "Kept"}]})
+        assert [p['name'] for p in config['panels']] == ["Kept"]
+
+    def test_ids_are_generated_when_missing(self):
+        config = normalize_config({'panels': [
+            {'name': "P", 'categories': [{'name': "C"}]},
+        ]})
+        panel = config['panels'][0]
+        assert panel['id'].startswith('p_')
+        assert panel['categories'][0]['id'].startswith('c_')
+
+    def test_duplicate_ids_are_dropped(self):
+        config = normalize_config({'panels': [
+            {'id': 'p_a', 'name': "First"},
+            {'id': 'p_a', 'name': "Shadow"},
+        ]})
+        assert [p['name'] for p in config['panels']] == ["First"]
+
+    def test_snowflakes_survive_a_json_round_trip_as_strings(self):
+        """The dashboard writes ids as strings; JSON has no 64-bit int."""
+        category = make_category(discord_category_id="123456789012345678",
+                                 allowed_role_ids=["1", 2, "1"])
+        assert category['discord_category_id'] == 123456789012345678
+        assert category['allowed_role_ids'] == [1, 2]
+
+    def test_unknown_style_falls_back_to_buttons(self):
+        config = normalize_config({'panels': [{'name': "P", 'style': "carousel"}]})
+        assert config['panels'][0]['style'] == STYLE_BUTTONS
+
+    def test_unknown_locale_falls_back_to_english(self):
+        assert make_category(locale="klingon")['locale'] == "en-US"
+
+    def test_max_open_per_user_is_clamped(self):
+        assert make_category(max_open_per_user=0)['max_open_per_user'] == \
+            DEFAULT_MAX_OPEN_PER_USER
+        assert make_category(max_open_per_user=999)['max_open_per_user'] == 10
+
+    def test_unknown_permissions_are_dropped(self):
+        permissions = normalize_permissions({
+            "42": ["view", "delete_the_server", "close"],
+            "not-a-role": ["view"],
+            "43": [],
+        })
+        assert permissions == {"42": ["view", "close"]}
+
+    def test_accent_colour_is_clamped_to_rgb(self):
+        config = normalize_config({'panels': [
+            {'name': "P", 'accent_color': 0xFFFFFFFF},
+        ]})
+        assert config['panels'][0]['accent_color'] == 0xFFFFFF
+
+
+# =========================================================================== #
+# Lookups
+# =========================================================================== #
+class TestLookups:
+    def setup_method(self):
+        self.config = normalize_config({'panels': [
+            {'id': 'p_a', 'name': "A", 'categories': [
+                {'id': 'c_1', 'name': "One"}, {'id': 'c_2', 'name': "Two"},
+            ]},
+        ]})
+
+    def test_find_panel_and_category(self):
+        panel = find_panel(self.config, 'p_a')
+        assert panel['name'] == "A"
+        assert find_category(panel, 'c_2')['name'] == "Two"
+
+    def test_missing_entries_are_none_not_an_error(self):
+        assert find_panel(self.config, 'p_nope') is None
+        assert find_category(None, 'c_1') is None
+        assert locate_category(self.config, 'p_nope', 'c_1') == (None, None)
+
+
+# =========================================================================== #
+# Limits
+# =========================================================================== #
+class TestLimits:
+    class _Bot:
+        def __init__(self, premium):
+            self._premium = premium
+
+    @pytest.fixture
+    def patched(self, monkeypatch):
+        def install(premium=False, raises=False):
+            async def fake(bot, guild_id):
+                if raises:
+                    raise RuntimeError("redis is down")
+                return premium
+            monkeypatch.setattr("utils.subscription.is_guild_premium", fake)
+        return install
+
+    async def test_free_limits(self, patched):
+        patched(premium=False)
+        limits = await get_limits(self._Bot(False), 1)
+        assert limits == {'premium': False,
+                          'max_panels': FREE_MAX_PANELS,
+                          'max_categories': FREE_MAX_CATEGORIES}
+
+    async def test_premium_limits(self, patched):
+        patched(premium=True)
+        limits = await get_limits(self._Bot(True), 1)
+        assert limits == {'premium': True,
+                          'max_panels': PREMIUM_MAX_PANELS,
+                          'max_categories': PREMIUM_MAX_CATEGORIES}
+
+    async def test_a_lookup_failure_never_grants_the_premium_quota(self, patched):
+        patched(raises=True)
+        limits = await get_limits(self._Bot(False), 1)
+        assert limits['premium'] is False
+        assert limits['max_panels'] == FREE_MAX_PANELS
+
+    def test_the_rendering_caps_the_plan(self):
+        # Premium allows 15 categories, but a dropdown could take 25 and a
+        # button panel only 15 — the plan is what binds here.
+        assert max_categories_for_style(STYLE_SELECT, PREMIUM_MAX_CATEGORIES) == \
+            PREMIUM_MAX_CATEGORIES
+        assert max_categories_for_style(STYLE_BUTTONS, PREMIUM_MAX_CATEGORIES) == \
+            PREMIUM_MAX_CATEGORIES
+        # …and a hypothetical plan above the rendering limit is capped by it.
+        assert max_categories_for_style(STYLE_BUTTONS, 99) == MAX_BUTTONS_PER_PANEL
+        assert max_categories_for_style(STYLE_SELECT, 99) == MAX_SELECT_OPTIONS
+
+
+# =========================================================================== #
+# Who may open a ticket
+# =========================================================================== #
+class TestCanOpen:
+    def test_empty_allow_list_means_everyone(self):
+        assert can_open(FakeMember(1), make_category()) is True
+
+    def test_allow_list_restricts(self):
+        category = make_category(allowed_role_ids=[10])
+        assert can_open(FakeMember(1), category) is False
+        assert can_open(FakeMember(1, [FakeRole(10)]), category) is True
+
+    def test_deny_list_wins_over_allow_list(self):
+        category = make_category(allowed_role_ids=[10], denied_role_ids=[11])
+        member = FakeMember(1, [FakeRole(10), FakeRole(11)])
+        assert can_open(member, category) is False
+
+    def test_deny_list_wins_over_administrator(self):
+        """A denied role that an admin could walk past would be a trap."""
+        category = make_category(denied_role_ids=[11])
+        member = FakeMember(1, [FakeRole(11)], administrator=True)
+        assert can_open(member, category) is False
+
+    def test_administrator_passes_an_allow_list(self):
+        category = make_category(allowed_role_ids=[10])
+        assert can_open(FakeMember(1, administrator=True), category) is True
+
+
+# =========================================================================== #
+# What a member may do inside a ticket
+# =========================================================================== #
+class TestMemberPermissions:
+    def test_admin_permission_expands_to_everything(self):
+        category = make_category(permissions={"10": [PERM_ADMIN]})
+        assert set(role_permissions(category, 10)) == set(TICKET_PERMISSIONS)
+
+    def test_roles_are_cumulative(self):
+        category = make_category(permissions={
+            "10": [PERM_VIEW], "11": [PERM_CLOSE],
+        })
+        member = FakeMember(1, [FakeRole(10), FakeRole(11)])
+        assert member_permissions(member, category) == {PERM_VIEW, PERM_CLOSE}
+
+    def test_guild_administrator_has_everything(self):
+        member = FakeMember(1, administrator=True)
+        assert member_permissions(member, make_category()) == set(TICKET_PERMISSIONS)
+
+    def test_the_opener_can_see_their_ticket_but_gets_no_staff_power(self):
+        ticket = {'owner_id': 7}
+        granted = member_permissions(FakeMember(7), make_category(), ticket)
+        assert granted == {PERM_VIEW}
+
+    def test_a_stranger_has_nothing(self):
+        assert member_permissions(FakeMember(9), make_category(), {'owner_id': 7}) == set()
+
+    def test_someone_added_by_hand_can_see_the_ticket(self):
+        """Must mirror the overwrites: they can read it, so they can act in it."""
+        ticket = {'owner_id': 7, 'participants': [9], 'participant_roles': []}
+        assert member_permissions(FakeMember(9), make_category(), ticket) == {PERM_VIEW}
+
+    def test_a_role_added_by_hand_can_see_the_ticket(self):
+        ticket = {'owner_id': 7, 'participants': [], 'participant_roles': [20]}
+        member = FakeMember(9, [FakeRole(20)])
+        assert member_permissions(member, make_category(), ticket) == {PERM_VIEW}
+
+    def test_staff_role_ids_filters_by_permission(self):
+        category = make_category(permissions={
+            "10": [PERM_VIEW],
+            "11": [PERM_VIEW, PERM_CLOSE],
+            "12": [PERM_ADMIN],
+        })
+        assert sorted(staff_role_ids(category)) == [10, 11, 12]
+        assert sorted(staff_role_ids(category, permission=PERM_CLOSE)) == [11, 12]
+        assert staff_role_ids(category, permission=PERM_ADMIN) == [12]
+
+
+# =========================================================================== #
+# Rendering
+# =========================================================================== #
+class TestRendering:
+    def test_channel_name_placeholders_and_sanitisation(self):
+        category = make_category(name="Général", name_format="ticket-{number}-{username}")
+        name = render_channel_name(category, member=FakeMember(1, name="Ada Lovelace"),
+                                   number=42)
+        assert name == "ticket-0042-ada-lovelace"
+
+    def test_channel_name_never_ends_up_empty(self):
+        category = make_category(name_format="!!!")
+        assert render_channel_name(category, member=FakeMember(1), number=7) == \
+            "ticket-0007"
+
+    def test_message_placeholders(self):
+        guild = SimpleNamespace(name="My Server")
+        category = make_category(name="Billing")
+        out = render_text("Hi {display_name}, ticket {number} on {server} — {category}",
+                          member=FakeMember(1, name="ada", display_name="Ada"),
+                          guild=guild, category=category, number=3)
+        assert out == "Hi Ada, ticket 3 on My Server — Billing"
+
+    def test_a_stray_brace_does_not_break_the_message(self):
+        """str.format would raise here and silence the whole ticket."""
+        guild = SimpleNamespace(name="S")
+        out = render_text("50% off {not_a_placeholder} {",
+                          member=FakeMember(1), guild=guild,
+                          category=make_category(), number=1)
+        assert out == "50% off {not_a_placeholder} {"
+
+    @pytest.mark.parametrize("raw", [None, "", "support", "not an emoji at all"])
+    def test_invalid_emoji_is_rejected(self, raw):
+        assert parse_emoji(raw) is None
+
+    def test_custom_emoji_is_accepted(self):
+        emoji = parse_emoji("<:support:1519797524813185164>")
+        assert emoji is not None and emoji.id == 1519797524813185164
+
+    def test_unicode_emoji_is_accepted(self):
+        assert parse_emoji("🎫") is not None
+
+
+# =========================================================================== #
+# Channel overwrites
+# =========================================================================== #
+class FakeGuild:
+    def __init__(self, roles=(), members=()):
+        self.default_role = FakeRole(0, "@everyone")
+        self.me = FakeMember(999, name="Moddy")
+        self._roles = {r.id: r for r in roles}
+        self._members = {m.id: m for m in members}
+
+    def get_role(self, role_id):
+        return self._roles.get(role_id)
+
+    def get_member(self, user_id):
+        return self._members.get(user_id)
+
+
+class TestOverwrites:
+    def setup_method(self):
+        from services.ticket_service import TicketService
+
+        self.service = TicketService(bot=None)
+        self.support = FakeRole(10, "Support")
+        self.lead = FakeRole(11, "Lead")
+        self.owner = FakeMember(7, name="opener")
+        self.helper = FakeMember(8, name="helper")
+        self.guild = FakeGuild(roles=[self.support, self.lead],
+                               members=[self.owner, self.helper])
+        self.category = make_category(permissions={
+            "10": [PERM_VIEW, PERM_CLOSE],
+            "11": [PERM_ADMIN],
+        })
+
+    def _ticket(self, **overrides):
+        base = {'owner_id': 7, 'status': 'open', 'escalated': False,
+                'participants': [], 'participant_roles': []}
+        base.update(overrides)
+        return base
+
+    def test_an_open_ticket_hides_from_everyone_else(self):
+        overwrites = self.service.build_overwrites(
+            self.guild, self.category, self._ticket())
+        assert overwrites[self.guild.default_role].view_channel is False
+        assert overwrites[self.support].view_channel is True
+        assert overwrites[self.lead].view_channel is True
+        assert overwrites[self.owner].view_channel is True
+
+    def test_participants_get_access(self):
+        overwrites = self.service.build_overwrites(
+            self.guild, self.category, self._ticket(participants=[8]))
+        assert overwrites[self.helper].view_channel is True
+
+    def test_escalation_keeps_only_the_responsibles_the_opener_and_manual_members(self):
+        overwrites = self.service.build_overwrites(
+            self.guild, self.category,
+            self._ticket(escalated=True, participants=[8]))
+        assert self.support not in overwrites      # plain staff role: out
+        assert overwrites[self.lead].view_channel is True   # admin role: in
+        assert overwrites[self.owner].view_channel is True  # opener: always in
+        assert overwrites[self.helper].view_channel is True  # added by hand: in
+
+    def test_escalation_after_dropping_participants(self):
+        overwrites = self.service.build_overwrites(
+            self.guild, self.category, self._ticket(escalated=True))
+        assert self.helper not in overwrites
+
+    def test_closing_hides_the_ticket_from_the_member_side_only(self):
+        overwrites = self.service.build_overwrites(
+            self.guild, self.category,
+            self._ticket(status='closed', participants=[8]))
+        assert self.owner not in overwrites
+        assert self.helper not in overwrites
+        assert overwrites[self.support].view_channel is True
+
+    def test_a_missing_role_is_skipped_not_crashed_on(self):
+        category = make_category(permissions={"404": [PERM_VIEW]})
+        overwrites = self.service.build_overwrites(
+            self.guild, category, self._ticket())
+        assert all(getattr(target, 'id', None) != 404 for target in overwrites)
+
+
+# =========================================================================== #
+# Panel message
+# =========================================================================== #
+class TestPanelView:
+    def _panel(self, style, count):
+        return normalize_config({'panels': [{
+            'id': 'p_a', 'name': "Support", 'style': style,
+            'categories': [
+                {'id': f'c_{i}', 'name': f"Cat {i}", 'discord_category_id': 100}
+                for i in range(count)
+            ],
+        }]})['panels'][0]
+
+    def _custom_ids(self, view):
+        return [getattr(item, 'custom_id', None) for item in view.walk_children()]
+
+    def test_buttons_are_rendered_one_per_category(self):
+        from utils.ticket_views import build_panel_view
+
+        view = build_panel_view(self._panel(STYLE_BUTTONS, 7))
+        ids = [cid for cid in self._custom_ids(view)
+               if cid and cid.startswith("moddy:tickets:open:")]
+        assert len(ids) == 7
+        assert ids[0] == "moddy:tickets:open:p_a:c_0"
+
+    def test_a_dropdown_panel_renders_one_select(self):
+        from utils.ticket_views import build_panel_view
+
+        view = build_panel_view(self._panel(STYLE_SELECT, 7))
+        ids = [cid for cid in self._custom_ids(view) if cid]
+        assert ids == ["moddy:tickets:opensel:p_a"]
+
+    def test_a_category_with_no_destination_is_not_offered(self):
+        from utils.ticket_views import build_panel_view
+
+        panel = self._panel(STYLE_BUTTONS, 3)
+        panel['categories'][1]['discord_category_id'] = None
+        panel['categories'][2]['enabled'] = False
+        view = build_panel_view(panel)
+        ids = [cid for cid in self._custom_ids(view)
+               if cid and cid.startswith("moddy:tickets:open:")]
+        assert ids == ["moddy:tickets:open:p_a:c_0"]
+
+    def test_the_panel_view_never_expires(self):
+        from utils.ticket_views import build_panel_view
+
+        assert build_panel_view(self._panel(STYLE_BUTTONS, 1)).timeout is None
+
+
+# =========================================================================== #
+# /config screens
+#
+# The panel, category and permission screens are deliberately NOT in the
+# persistent-view registry (their controls are dynamic items carrying the
+# entity ids), so tests/test_persistent_views.py never builds them. These
+# smoke tests are what stands in for that: they catch a screen that cannot be
+# rendered at all, which is the failure mode that matters.
+# =========================================================================== #
+class FakeBot:
+    """Just enough bot for a config screen: channel lookup and nothing else."""
+
+    def __init__(self, channels=()):
+        self._channels = {c.id: c for c in channels}
+
+    def get_channel(self, channel_id):
+        return self._channels.get(channel_id)
+
+
+class TestConfigScreens:
+    def setup_method(self):
+        self.config = normalize_config({'panels': [{
+            'id': 'p_a', 'name': "Support", 'channel_id': 500,
+            'categories': [{
+                'id': 'c_1', 'name': "General", 'discord_category_id': 100,
+                'permissions': {"10": [PERM_VIEW, PERM_CLOSE], "11": [PERM_ADMIN]},
+            }],
+        }]})
+        self.panel = self.config['panels'][0]
+        self.category = self.panel['categories'][0]
+        self.limits = {'premium': False, 'max_panels': FREE_MAX_PANELS,
+                       'max_categories': FREE_MAX_CATEGORIES}
+        self.bot = FakeBot()
+
+    def _ids(self, view):
+        return [cid for cid in
+                (getattr(i, 'custom_id', None) for i in view.walk_children()) if cid]
+
+    def test_panel_screen_renders(self):
+        from modules.configs.tickets_panel_config import TicketPanelConfigView
+
+        view = TicketPanelConfigView(self.bot, 1, "en-US", self.panel, self.limits)
+        ids = self._ids(view)
+        assert "moddy:tickets:pnlchan:p_a" in ids
+        assert "moddy:tickets:pnlsel:style:p_a" in ids
+        assert "moddy:tickets:pnlbtn:addcat:p_a" in ids
+        assert view.timeout is None
+
+    def test_panel_delete_confirmation_replaces_the_controls(self):
+        from modules.configs.tickets_panel_config import TicketPanelConfigView
+
+        view = TicketPanelConfigView(self.bot, 1, "en-US", self.panel, self.limits,
+                                     confirm_delete=True)
+        ids = self._ids(view)
+        assert "moddy:tickets:pnlbtn:delconfirm:p_a" in ids
+        # No way to keep configuring while the confirmation is up.
+        assert "moddy:tickets:pnlchan:p_a" not in ids
+
+    def test_category_screen_renders(self):
+        from modules.configs.tickets_category_config import TicketCategoryConfigView
+
+        view = TicketCategoryConfigView(self.bot, 1, "en-US", self.panel, self.category)
+        ids = self._ids(view)
+        assert "moddy:tickets:catdest:p_a:c_1" in ids
+        assert "moddy:tickets:catroles:allowed:p_a:c_1" in ids
+        assert "moddy:tickets:catroles:denied:p_a:c_1" in ids
+        assert "moddy:tickets:catlang:p_a:c_1" in ids
+        assert "moddy:tickets:catbtn:perms:p_a:c_1" in ids
+
+    def test_permissions_screen_without_a_role_selected(self):
+        from modules.configs.tickets_category_config import TicketPermissionsConfigView
+
+        view = TicketPermissionsConfigView(self.bot, 1, "en-US", self.panel,
+                                           self.category)
+        ids = self._ids(view)
+        assert "moddy:tickets:permrole:p_a:c_1" in ids
+        assert not any(cid.startswith("moddy:tickets:permset:") for cid in ids)
+
+    def test_permissions_screen_with_a_role_selected(self):
+        from modules.configs.tickets_category_config import TicketPermissionsConfigView
+
+        view = TicketPermissionsConfigView(self.bot, 1, "en-US", self.panel,
+                                           self.category, role_id=10)
+        ids = self._ids(view)
+        assert "moddy:tickets:permset:p_a:c_1:10" in ids
+        assert "moddy:tickets:permbtn:clear:p_a:c_1:10" in ids
+
+    def test_every_config_custom_id_fits_discords_limit(self):
+        from modules.configs.tickets_category_config import (
+            TicketCategoryConfigView, TicketPermissionsConfigView,
+        )
+        from modules.configs.tickets_panel_config import TicketPanelConfigView
+
+        views = [
+            TicketPanelConfigView(self.bot, 1, "en-US", self.panel, self.limits),
+            TicketCategoryConfigView(self.bot, 1, "en-US", self.panel, self.category),
+            TicketPermissionsConfigView(self.bot, 1, "en-US", self.panel,
+                                        self.category, role_id=123456789012345678),
+        ]
+        for view in views:
+            for cid in self._ids(view):
+                assert len(cid) <= 100, f"{cid} is {len(cid)} chars"
+
+
+# =========================================================================== #
+# i18n completeness
+# =========================================================================== #
+LOCALES = ("fr", "en-US", "es-ES", "pt-BR", "de")
+
+
+def _tickets_block(locale: str) -> dict:
+    import json
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    with open(root / "locales" / f"{locale}.json", encoding="utf-8") as handle:
+        return json.load(handle)["modules"]["tickets"]
+
+
+def _flatten(node, prefix=""):
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from _flatten(value, f"{prefix}.{key}" if prefix else key)
+    else:
+        yield prefix
+
+
+@pytest.mark.parametrize("locale", [l for l in LOCALES if l != "en-US"])
+def test_every_locale_has_the_same_ticket_keys(locale):
+    reference = set(_flatten(_tickets_block("en-US")))
+    translated = set(_flatten(_tickets_block(locale)))
+    assert reference - translated == set(), \
+        f"locales/{locale}.json is missing ticket keys"
+    assert translated - reference == set(), \
+        f"locales/{locale}.json has ticket keys English does not"
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_every_permission_is_named_and_described(locale):
+    block = _tickets_block(locale)["permissions"]
+    for permission in TICKET_PERMISSIONS:
+        assert block[permission]["name"], f"{locale}: {permission} has no name"
+        assert block[permission]["description"], \
+            f"{locale}: {permission} has no description"
+
+
+# =========================================================================== #
+# Modals
+#
+# A modal over five top-level components is rejected by Discord at send time,
+# with nothing in the logs to say which one — so the count is asserted here
+# rather than discovered in production.
+# =========================================================================== #
+async def _noop(*args, **kwargs):
+    pass
+
+
+class TestModals:
+    def setup_method(self):
+        self.category = normalize_category({'name': "Support", 'ping_role_ids': [1, 2]})
+        self.panel = normalize_config({'panels': [
+            {'id': 'p_a', 'name': "Support", 'style': STYLE_SELECT},
+        ]})['panels'][0]
+
+    def _modals(self):
+        from modules.configs.tickets_category_config import (
+            CategoryIdentityModal, CategoryMessagesModal, CategoryOptionsModal,
+        )
+        from modules.configs.tickets_config import PanelAppearanceModal
+        from utils.ticket_views import TicketReasonModal, TicketRenameModal
+
+        return [
+            PanelAppearanceModal("fr", None, _noop),
+            PanelAppearanceModal("fr", self.panel, _noop),
+            CategoryIdentityModal("fr", None, _noop),
+            CategoryIdentityModal("fr", self.category, _noop),
+            CategoryMessagesModal("fr", self.category, _noop),
+            CategoryOptionsModal("fr", self.category, _noop),
+            TicketReasonModal("fr", "close", _noop),
+            TicketRenameModal("fr", "ticket-0001", _noop),
+        ]
+
+    def test_every_modal_builds_within_discords_limits(self):
+        for modal in self._modals():
+            assert len(modal.children) <= 5, type(modal).__name__
+            assert len(modal.title) <= 45, type(modal).__name__
+
+    def test_modal_titles_are_translated_not_key_paths(self):
+        for modal in self._modals():
+            assert not modal.title.startswith("["), \
+                f"{type(modal).__name__}: missing translation {modal.title}"
+
+
+# =========================================================================== #
+# Ticket-channel views
+# =========================================================================== #
+class TestTicketChannelViews:
+    def setup_method(self):
+        self.category = normalize_category({'name': "Support", 'locale': "fr"})
+        self.ticket = {'number': 42, 'owner_id': 7, 'status': 'open',
+                       'escalated': False, 'participants': [8],
+                       'participant_roles': [10]}
+        self.actor = FakeMember(3, name="mod")
+
+    def _ids(self, view):
+        return [cid for cid in
+                (getattr(i, 'custom_id', None) for i in view.walk_children()) if cid]
+
+    def test_control_bar_offers_the_five_main_actions(self):
+        from utils.ticket_views import build_ticket_message
+
+        view = build_ticket_message(self.ticket, self.category, "Hello", "fr")
+        assert self._ids(view) == [
+            "moddy:tickets:ctrl:close",
+            "moddy:tickets:ctrl:close_request",
+            "moddy:tickets:ctrl:escalate",
+            "moddy:tickets:ctrl:staff_thread",
+            "moddy:tickets:ctrl:participants",
+        ]
+
+    def test_closing_card_offers_reopen_and_delete(self):
+        from utils.ticket_views import build_closed_message
+
+        view = build_closed_message(self.ticket, self.category, self.actor,
+                                    "solved", "Bye", "fr")
+        assert self._ids(view) == ["moddy:tickets:closed:reopen",
+                                   "moddy:tickets:closed:delete"]
+
+    def test_close_request_card(self):
+        from utils.ticket_views import build_close_request_message
+
+        view = build_close_request_message(self.ticket, self.actor, None, "fr")
+        assert self._ids(view) == ["moddy:tickets:request:accept",
+                                   "moddy:tickets:request:refuse"]
+
+    def test_escalation_notice_can_be_undone(self):
+        from utils.ticket_views import build_escalation_notice
+
+        view = build_escalation_notice(self.ticket, self.actor, "abuse", "fr")
+        assert self._ids(view) == ["moddy:tickets:escalated:cancel"]
+
+    def test_participants_panel_preselects_the_current_ones(self):
+        from utils.ticket_views import TicketParticipantsView
+
+        view = TicketParticipantsView(None, self.ticket, "fr")
+        selects = {getattr(i, 'custom_id', None): i for i in view.walk_children()}
+        users = selects["moddy:tickets:members:users"]
+        roles = selects["moddy:tickets:members:roles"]
+        assert [d.id for d in users.default_values] == [8]
+        assert [d.id for d in roles.default_values] == [10]
+
+    def test_the_closing_dm_has_nothing_to_click(self):
+        from types import SimpleNamespace
+
+        from utils.ticket_views import build_close_dm
+
+        view = build_close_dm(SimpleNamespace(name="S"), self.ticket, self.category,
+                              self.actor, "solved", "fr")
+        assert self._ids(view) == []
+
+
+# =========================================================================== #
+# Every translation key the code asks for actually exists
+#
+# A missing key does not raise — `t()` returns "[the.key.path]", which ships to
+# a user as visible gibberish. Scanning the source is the only way to catch it
+# before they do.
+# =========================================================================== #
+_SOURCE_FILES = (
+    "modules/tickets.py",
+    "services/ticket_service.py",
+    "utils/ticket_views.py",
+    "cogs/tickets.py",
+    "modules/configs/tickets_config.py",
+    "modules/configs/tickets_panel_config.py",
+    "modules/configs/tickets_category_config.py",
+)
+
+# Keys built with an f-string cannot be read off the source, so every value the
+# interpolation can take is listed here. A new permission or action added
+# without a line here is a gap this test cannot see — see docs/TICKETS.md
+# "Extending the module".
+_INTERPOLATED_KEYS = (
+    [f"modules.tickets.actions.{a}" for a in
+     ("close", "close_request", "escalate", "staff_thread", "participants",
+      "reopen", "delete", "deescalate", "rename")]
+    + [f"modules.tickets.permissions.{p}.{k}" for p in TICKET_PERMISSIONS
+       for k in ("name", "description")]
+    + [f"modules.tickets.status.{s}" for s in ("open", "closed", "escalated")]
+    + [f"modules.tickets.panel.style_{s}" for s in ("buttons", "select")]
+    + [f"modules.tickets.category.color_{c}" for c in
+       ("primary", "secondary", "success", "danger")]
+    + [f"modules.tickets.messages.ph_{p.strip('{}')}" for p in PLACEHOLDERS]
+    + [f"modules.tickets.participants.{k}_{s}" for k in ("added", "removed")
+       for s in ("title", "description")]
+)
+
+
+def _referenced_keys():
+    import re
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    pattern = re.compile(
+        r"""t\(\s*f?['"]((?:modules\.tickets|languages)[^'"{}]*)['"]""")
+    keys = set(_INTERPOLATED_KEYS)
+    for name in _SOURCE_FILES:
+        keys |= set(pattern.findall((root / name).read_text(encoding="utf-8")))
+    return sorted(keys)
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_every_referenced_key_resolves(locale):
+    from utils.i18n import t
+
+    keys = _referenced_keys()
+    assert len(keys) > 150, "the source scan found suspiciously few keys"
+
+    missing = [k for k in keys
+               if (v := t(k, locale=locale)).startswith("[") and v.endswith("]")]
+    assert not missing, f"locales/{locale}.json is missing: {missing}"

--- a/utils/emojis.py
+++ b/utils/emojis.py
@@ -98,6 +98,30 @@ ROCKET = "<a:Rocket:1535783839870353499>"  # bot customization bio attribution
 ALTGUARD = "<a:DisguisedFace:1539405255576657981>"  # AltGuard verification panel message
 
 # =============================================================================
+# TICKETS MODULE
+# -----------------------------------------------------------------------------
+# NOTE: these are ALIASES onto existing emojis, not dedicated ticket icons.
+# Everything in the Tickets module references these constants, so replacing an
+# id here propagates to the panels, the ticket control bar, the slash commands
+# and the /config screens at once. Replace them with dedicated artwork when it
+# exists — that is the only change needed.
+# =============================================================================
+TICKET = SUPPORT                # module icon + ticket cards      (placeholder)
+TICKET_PANEL = NOTE             # a ticket panel message          (placeholder)
+TICKET_CATEGORY = FOLDER        # a ticket category               (placeholder)
+TICKET_CLOSE = LOGOUT           # close a ticket                  (placeholder)
+TICKET_CLOSE_REQUEST = HAND     # ask the staff to close          (placeholder)
+TICKET_ESCALATE = SHIELD        # escalate to the responsibles    (placeholder)
+TICKET_STAFF_THREAD = MESSAGE   # private staff thread            (placeholder)
+TICKET_PARTICIPANTS = GROUPS    # manage who is in the ticket     (placeholder)
+TICKET_RENAME = EDIT            # rename the ticket               (placeholder)
+TICKET_MOVE = FOLDERS           # move to another category        (placeholder)
+TICKET_PERMISSIONS = LEGAL      # per-role ticket permissions     (placeholder)
+TICKET_ACCESS = MANAGE_USER     # who may open a ticket           (placeholder)
+TICKET_REOPEN = SYNC            # reopen a closed ticket          (placeholder)
+TICKET_LANGUAGE = TRANSLATE     # language of a category          (placeholder)
+
+# =============================================================================
 # SOCIAL PLATFORMS (Social Notifications module)
 # -----------------------------------------------------------------------------
 # NOTE: These are PLACEHOLDER ids — replace each one with the real custom emoji

--- a/utils/persistent_views.py
+++ b/utils/persistent_views.py
@@ -66,6 +66,13 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
         LogsConfigView, LogsOptionsView, LogsPersistence,
     )
     from utils.altguard_views import AltGuardPanelView
+    from modules.configs.tickets_config import TicketsConfigView
+    from modules.configs.tickets_category_config import TicketsConfigPersistence
+    from utils.ticket_views import (
+        TicketControlView, TicketClosedView, TicketCloseRequestView,
+        TicketEscalationView, TicketEscalateConfirmView, TicketParticipantsView,
+        TicketsPersistence,
+    )
 
     return [
         # Group 1 — /moddy (public informational, no user auth)
@@ -135,6 +142,23 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
         LogsConfigView,
         LogsOptionsView,
         LogsPersistence,
+        # Group 12g — Tickets. The /config root panel is a normal registered
+        # view (guild permission auth); the panel/category/permission screens
+        # are built from dynamic items carrying the entity ids, registered by
+        # TicketsConfigPersistence — see docs/PERSISTENT_VIEWS.md "Deliberate
+        # exclusions". The ticket-channel views need no id at all: the channel
+        # a click comes from IS the ticket.
+        TicketsConfigView,
+        TicketsConfigPersistence,
+        TicketControlView,
+        TicketClosedView,
+        TicketCloseRequestView,
+        TicketEscalationView,
+        TicketEscalateConfirmView,
+        TicketParticipantsView,
+        # Group 12h — the public ticket panel's open buttons / dropdown
+        # (dynamic items; public: whoever clicks is the member opening).
+        TicketsPersistence,
         # Group 13 — /config automod AI panel (guild permission auth;
         # AutomodAIPrecedentsView is deliberately excluded, see
         # docs/PERSISTENT_VIEWS.md Step 12)

--- a/utils/ticket_views.py
+++ b/utils/ticket_views.py
@@ -1,0 +1,1172 @@
+"""
+Every Discord surface of the Tickets module.
+
+Four kinds of message live here, and they have deliberately different
+persistence models:
+
+- **The panel** (posted in a public channel). Its buttons/options carry the
+  panel and category ids, so they are :class:`discord.ui.DynamicItem`\\ s
+  reconstructed from their ``custom_id`` on every click.
+- **The ticket control bar** (pinned in the ticket channel), **the closing
+  card**, **the close request** and **the escalation notice**. A ticket action
+  always happens *inside* its own channel, so ``interaction.channel_id`` is the
+  ticket's identity: these need no id in their custom_ids at all and are plain
+  registered persistent views with static ones.
+- **Ephemeral helper panels** (participants, escalation confirmation) — same
+  reasoning, same static ids.
+- **The closing DM**, which has no interactive child at all.
+
+Authorization is never carried by a view. Every callback resolves the ticket
+from the channel, the category from the guild's config, and the actor's
+permissions from their roles — see ``services/ticket_service.py``. A stale
+button clicked a month after a restart is therefore exactly as safe as a fresh
+one.
+
+See docs/TICKETS.md and docs/PERSISTENT_VIEWS.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseView, BaseModal
+from modules.tickets import (
+    BUTTON_STYLES,
+    DEFAULT_ACCENT_COLOR,
+    MAX_TICKET_MESSAGE,
+    PERM_ADMIN,
+    PERM_CLOSE,
+    PERM_PARTICIPANTS,
+    STYLE_SELECT,
+    find_category,
+    find_panel,
+    member_permissions,
+    parse_emoji,
+)
+from utils.components_v2 import create_error_message, create_success_message
+from utils.emojis import (
+    BACK, DELETE, GROUPS, INFO, TICKET, TICKET_CLOSE, TICKET_CLOSE_REQUEST,
+    TICKET_ESCALATE, TICKET_PARTICIPANTS, TICKET_REOPEN, TICKET_STAFF_THREAD,
+    UNDONE,
+)
+from utils.i18n import i18n, t
+
+logger = logging.getLogger('moddy.tickets.views')
+
+# --------------------------------------------------------------------------- #
+# custom_id constants.
+#
+# The ticket-scoped ones are static on purpose: the channel the click comes
+# from *is* the ticket. Adding an id would only create a second source of truth
+# that could disagree with the channel.
+# --------------------------------------------------------------------------- #
+_CID_CTRL_CLOSE = "moddy:tickets:ctrl:close"
+_CID_CTRL_CLOSE_REQUEST = "moddy:tickets:ctrl:close_request"
+_CID_CTRL_ESCALATE = "moddy:tickets:ctrl:escalate"
+_CID_CTRL_STAFF_THREAD = "moddy:tickets:ctrl:staff_thread"
+_CID_CTRL_PARTICIPANTS = "moddy:tickets:ctrl:participants"
+
+_CID_CLOSED_REOPEN = "moddy:tickets:closed:reopen"
+_CID_CLOSED_DELETE = "moddy:tickets:closed:delete"
+
+_CID_REQUEST_ACCEPT = "moddy:tickets:request:accept"
+_CID_REQUEST_REFUSE = "moddy:tickets:request:refuse"
+
+_CID_ESCALATED_CANCEL = "moddy:tickets:escalated:cancel"
+
+_CID_MEMBERS_USERS = "moddy:tickets:members:users"
+_CID_MEMBERS_ROLES = "moddy:tickets:members:roles"
+
+_CID_ESC_KEEP = "moddy:tickets:escalate:keep"
+_CID_ESC_DROP = "moddy:tickets:escalate:drop"
+
+# Panel ids are `p_xxxxxx` / `c_xxxxxx` (see modules/tickets.py).
+_ENTRY_ID = r"[a-z0-9_]+"
+
+
+# =========================================================================== #
+# Shared helpers
+# =========================================================================== #
+def _guarded(callback):
+    """Route a dynamic-item callback error to the central handler.
+
+    A ``DynamicItem`` dispatched through ``bot.add_dynamic_items`` has no live
+    ``BaseView``, so ``BaseView.on_error`` never fires and an unhandled
+    exception would simply vanish. See docs/PERSISTENT_VIEWS.md.
+    """
+    async def wrapper(self, interaction: discord.Interaction):
+        try:
+            await callback(self, interaction)
+        except Exception as e:  # noqa: BLE001
+            from cogs.error_handler import report_component_error
+            await report_component_error(interaction, e, self.__class__.__name__)
+    return wrapper
+
+
+async def send_error(interaction: discord.Interaction, description: str,
+                     locale: Optional[str] = None) -> None:
+    """Ephemeral error card, whatever state the interaction is in."""
+    locale = locale or i18n.get_user_locale(interaction)
+    view = create_error_message(
+        t('modules.tickets.errors.title', locale=locale), description)
+    if interaction.response.is_done():
+        await interaction.followup.send(view=view, ephemeral=True)
+    else:
+        await interaction.response.send_message(view=view, ephemeral=True)
+
+
+async def send_success(interaction: discord.Interaction, title: str,
+                       description: str) -> None:
+    view = create_success_message(title, description)
+    if interaction.response.is_done():
+        await interaction.followup.send(view=view, ephemeral=True)
+    else:
+        await interaction.response.send_message(view=view, ephemeral=True)
+
+
+async def handle_ticket_error(interaction: discord.Interaction, error) -> None:
+    """Turn a :class:`TicketError` into an ephemeral card in the actor's language."""
+    locale = i18n.get_user_locale(interaction)
+    await send_error(interaction, error.message(locale), locale)
+
+
+def _accent(panel: Dict[str, Any]) -> discord.Colour:
+    return discord.Colour(panel.get('accent_color') or DEFAULT_ACCENT_COLOR)
+
+
+def _category_label(category: Dict[str, Any]) -> str:
+    return (category.get('name') or '')[:80]
+
+
+# =========================================================================== #
+# 1. The panel (public message with the open buttons / select)
+# =========================================================================== #
+class TicketOpenButton(
+    ui.DynamicItem[ui.Button],
+    template=rf"moddy:tickets:open:(?P<panel_id>{_ENTRY_ID}):(?P<category_id>{_ENTRY_ID})",
+):
+    """One category button on a ticket panel. Auth: public (checked on click)."""
+
+    def __init__(self, panel_id: str, category_id: str,
+                 category: Optional[Dict[str, Any]] = None):
+        category = category or {}
+        super().__init__(
+            ui.Button(
+                label=_category_label(category) or "—",
+                style=BUTTON_STYLES.get(category.get('button_style'),
+                                        discord.ButtonStyle.primary),
+                emoji=parse_emoji(category.get('emoji')),
+                custom_id=f"moddy:tickets:open:{panel_id}:{category_id}",
+            )
+        )
+        self.panel_id = panel_id
+        self.category_id = category_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['panel_id'], match['category_id'])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        await _open_from_panel(interaction, self.panel_id, self.category_id)
+
+
+class TicketOpenSelect(
+    ui.DynamicItem[ui.Select],
+    template=rf"moddy:tickets:opensel:(?P<panel_id>{_ENTRY_ID})",
+):
+    """The category dropdown of a select-style panel. Auth: public."""
+
+    def __init__(self, panel_id: str, panel: Optional[Dict[str, Any]] = None,
+                 categories: Optional[List[Dict[str, Any]]] = None):
+        panel = panel or {}
+        options = [
+            discord.SelectOption(
+                label=_category_label(category) or "—",
+                value=category['id'],
+                description=(category.get('description') or None),
+                emoji=parse_emoji(category.get('emoji')),
+            )
+            for category in (categories or [])
+        ] or [discord.SelectOption(label="—", value="none")]
+
+        super().__init__(
+            ui.Select(
+                placeholder=panel.get('placeholder') or None,
+                options=options,
+                min_values=1, max_values=1,
+                custom_id=f"moddy:tickets:opensel:{panel_id}",
+            )
+        )
+        self.panel_id = panel_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match['panel_id'])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        values = interaction.data.get('values') or []
+        if not values or values[0] == "none":
+            await interaction.response.defer()
+            return
+        await _open_from_panel(interaction, self.panel_id, values[0])
+
+
+async def _open_from_panel(interaction: discord.Interaction, panel_id: str,
+                           category_id: str) -> None:
+    """Shared body of both panel controls: open a ticket, or say why not."""
+    from services.ticket_service import TicketError
+
+    locale = i18n.get_user_locale(interaction)
+    bot = interaction.client
+    service = getattr(bot, 'tickets', None)
+    if service is None or interaction.guild is None:
+        await send_error(interaction,
+                         t('modules.tickets.errors.unavailable', locale=locale), locale)
+        return
+
+    module = await service.get_module(interaction.guild_id)
+    if not module or not module.enabled:
+        await send_error(interaction,
+                         t('modules.tickets.errors.module_disabled', locale=locale), locale)
+        return
+
+    panel = find_panel({'panels': module.panels}, panel_id)
+    category = find_category(panel, category_id)
+    if not panel or not category:
+        await send_error(interaction,
+                         t('modules.tickets.errors.category_gone', locale=locale), locale)
+        return
+
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    try:
+        channel = await service.open_ticket(interaction.user, panel, category)
+    except TicketError as e:
+        await interaction.followup.send(
+            view=create_error_message(
+                t('modules.tickets.errors.title', locale=locale), e.message(locale)),
+            ephemeral=True)
+        return
+
+    await interaction.followup.send(
+        view=create_success_message(
+            t('modules.tickets.open.success_title', locale=locale),
+            t('modules.tickets.open.success_description', locale=locale,
+              channel=channel.mention)),
+        ephemeral=True)
+
+
+class TicketPanelView(BaseView):
+    """The panel message. Not registered: it is a shell around dynamic items.
+
+    Persistence lives entirely in :class:`TicketOpenButton` /
+    :class:`TicketOpenSelect`, registered through :class:`TicketsPersistence` —
+    same pattern as ``TranscribePromptView``. Registering the wrapper would be
+    meaningless: it cannot be built without a panel, and its children
+    reconstruct themselves from their custom_id on every click.
+    """
+
+    def __init__(self, panel: Dict[str, Any], categories: List[Dict[str, Any]]):
+        super().__init__()  # timeout=None
+        container = ui.Container(accent_colour=_accent(panel))
+
+        title = panel.get('title') or panel.get('name')
+        container.add_item(ui.TextDisplay(f"### {TICKET} {title}"))
+        if panel.get('description'):
+            container.add_item(ui.TextDisplay(panel['description']))
+
+        self.add_item(container)
+
+        if panel.get('style') == STYLE_SELECT:
+            row = ui.ActionRow()
+            row.add_item(TicketOpenSelect(panel['id'], panel, categories))
+            container.add_item(row)
+            return
+
+        # Buttons, five per row (Discord's limit).
+        for start in range(0, len(categories), 5):
+            row = ui.ActionRow()
+            for category in categories[start:start + 5]:
+                row.add_item(TicketOpenButton(panel['id'], category['id'], category))
+            container.add_item(row)
+
+
+def build_panel_view(panel: Dict[str, Any]) -> TicketPanelView:
+    """Render a panel from its stored configuration."""
+    categories = [c for c in panel.get('categories', [])
+                  if c.get('enabled') and c.get('discord_category_id')]
+    return TicketPanelView(panel, categories)
+
+
+# =========================================================================== #
+# 2. The ticket control bar (pinned in the ticket channel)
+# =========================================================================== #
+async def _resolve(interaction: discord.Interaction):
+    """``(service, ticket, panel, category)`` for the channel a click came from.
+
+    Answers the user and returns ``None`` when the channel is not (or is no
+    longer) a ticket, which is the only thing every caller does about it.
+    """
+    from services.ticket_service import TicketError
+
+    service = getattr(interaction.client, 'tickets', None)
+    locale = i18n.get_user_locale(interaction)
+    if service is None or not isinstance(interaction.channel, discord.TextChannel):
+        await send_error(interaction,
+                         t('modules.tickets.errors.not_a_ticket', locale=locale), locale)
+        return None
+    try:
+        ticket, panel, category = await service.resolve(interaction.channel)
+    except TicketError as e:
+        await handle_ticket_error(interaction, e)
+        return None
+    return service, ticket, panel, category
+
+
+class TicketControlView(BaseView):
+    """The pinned control bar of a ticket.
+
+    Persistent: yes. Auth: derived from the channel — the ticket is resolved
+    from ``interaction.channel_id`` and the actor's permissions from their
+    roles in the ticket's category, on every single click. The buttons are
+    shown to everyone who can see the ticket; each one refuses politely when
+    the clicker may not use it, which is what lets a member discover
+    *Request closure* instead of silently facing a bar with one button on it.
+    """
+
+    __persistent__ = True
+
+    def __init__(self, ticket: Optional[Dict[str, Any]] = None,
+                 category: Optional[Dict[str, Any]] = None,
+                 body: Optional[str] = None, locale: str = "en-US"):
+        super().__init__()  # timeout=None
+        self.ticket = ticket or {}
+        self.category = category or {}
+        self.body = body
+        self.locale = locale
+        self._build_view()
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container(accent_colour=discord.Colour(DEFAULT_ACCENT_COLOR))
+
+        number = self.ticket.get('number')
+        container.add_item(ui.TextDisplay(
+            f"### {TICKET} "
+            f"{t('modules.tickets.channel.title', locale=self.locale, number=number or '—')}"
+        ))
+        if self.ticket:
+            container.add_item(ui.TextDisplay(
+                f"-# {t('modules.tickets.channel.meta', locale=self.locale)} · "
+                f"<@{self.ticket.get('owner_id')}> · "
+                f"`{self.category.get('name', '—')}`"
+            ))
+        if self.body:
+            container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+            container.add_item(ui.TextDisplay(self.body))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.tickets.channel.commands_hint', locale=self.locale)}"))
+
+        row = ui.ActionRow()
+        row.add_item(self._button(
+            _CID_CTRL_CLOSE, 'close', TICKET_CLOSE,
+            discord.ButtonStyle.danger, self.on_close))
+        row.add_item(self._button(
+            _CID_CTRL_CLOSE_REQUEST, 'close_request', TICKET_CLOSE_REQUEST,
+            discord.ButtonStyle.secondary, self.on_close_request))
+        row.add_item(self._button(
+            _CID_CTRL_ESCALATE, 'escalate', TICKET_ESCALATE,
+            discord.ButtonStyle.secondary, self.on_escalate))
+        row.add_item(self._button(
+            _CID_CTRL_STAFF_THREAD, 'staff_thread', TICKET_STAFF_THREAD,
+            discord.ButtonStyle.secondary, self.on_staff_thread))
+        row.add_item(self._button(
+            _CID_CTRL_PARTICIPANTS, 'participants', TICKET_PARTICIPANTS,
+            discord.ButtonStyle.secondary, self.on_participants))
+        container.add_item(row)
+
+        self.add_item(container)
+
+    def _button(self, custom_id: str, key: str, emoji: str,
+                style: discord.ButtonStyle, callback) -> ui.Button:
+        button = ui.Button(
+            label=t(f'modules.tickets.actions.{key}', locale=self.locale)[:80],
+            style=style, custom_id=custom_id,
+            emoji=discord.PartialEmoji.from_str(emoji),
+        )
+        button.callback = callback
+        return button
+
+    # -- callbacks (everything re-derived from the interaction) ------------ #
+    async def on_close(self, interaction: discord.Interaction):
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service, ticket, panel, category = resolved
+        locale = i18n.get_user_locale(interaction)
+        granted = member_permissions(interaction.user, category, ticket)
+        if PERM_CLOSE not in granted:
+            # The one refusal that is really a redirection: tell them about
+            # the button that *is* theirs rather than just saying no.
+            await send_error(
+                interaction,
+                t('modules.tickets.errors.use_close_request', locale=locale), locale)
+            return
+        await interaction.response.send_modal(
+            TicketReasonModal(locale, 'close', self._do_close))
+
+    async def _do_close(self, interaction: discord.Interaction, reason: Optional[str]):
+        from services.ticket_service import TicketError
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service, ticket, panel, category = resolved
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            await service.close_ticket(interaction.channel, interaction.user, reason)
+        except TicketError as e:
+            await handle_ticket_error(interaction, e)
+            return
+        locale = i18n.get_user_locale(interaction)
+        await send_success(interaction,
+                           t('modules.tickets.close.done_title', locale=locale),
+                           t('modules.tickets.close.done_description', locale=locale))
+
+    async def on_close_request(self, interaction: discord.Interaction):
+        locale = i18n.get_user_locale(interaction)
+        await interaction.response.send_modal(
+            TicketReasonModal(locale, 'close_request', self._do_close_request))
+
+    async def _do_close_request(self, interaction: discord.Interaction,
+                                reason: Optional[str]):
+        from services.ticket_service import TicketError
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service, ticket, panel, category = resolved
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            await service.request_close(interaction.channel, interaction.user, reason)
+        except TicketError as e:
+            await handle_ticket_error(interaction, e)
+            return
+        locale = i18n.get_user_locale(interaction)
+        await send_success(
+            interaction,
+            t('modules.tickets.close_request.sent_title', locale=locale),
+            t('modules.tickets.close_request.sent_description', locale=locale))
+
+    async def on_escalate(self, interaction: discord.Interaction):
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service, ticket, panel, category = resolved
+        await start_escalation(interaction, service, ticket, category)
+
+    async def on_staff_thread(self, interaction: discord.Interaction):
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service, ticket, panel, category = resolved
+        await run_staff_thread(interaction, service)
+
+    async def on_participants(self, interaction: discord.Interaction):
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service, ticket, panel, category = resolved
+        locale = i18n.get_user_locale(interaction)
+        granted = member_permissions(interaction.user, category, ticket)
+        if PERM_PARTICIPANTS not in granted:
+            await send_error(
+                interaction,
+                t('modules.tickets.errors.missing_permission', locale=locale), locale)
+            return
+        await interaction.response.send_message(
+            view=TicketParticipantsView(interaction.guild, ticket, locale),
+            ephemeral=True)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: resolved from the ticket channel on every click."""
+        bot.add_view(cls())
+
+
+def build_ticket_message(ticket: Dict[str, Any], category: Dict[str, Any],
+                         body: Optional[str], locale: str) -> TicketControlView:
+    return TicketControlView(ticket, category, body, locale)
+
+
+# =========================================================================== #
+# 3. The closing card
+# =========================================================================== #
+class TicketClosedView(BaseView):
+    """Posted when a ticket closes: reopen it, or delete the channel for good.
+
+    Persistent: yes. Auth: resolved from the ticket channel (``close`` to
+    reopen, ``admin`` to delete — deletion destroys the conversation, so it is
+    never a permission a plain agent role gets by default).
+    """
+
+    __persistent__ = True
+
+    def __init__(self, ticket: Optional[Dict[str, Any]] = None,
+                 category: Optional[Dict[str, Any]] = None,
+                 actor: Optional[discord.abc.User] = None,
+                 reason: Optional[str] = None, body: Optional[str] = None,
+                 locale: str = "en-US"):
+        super().__init__()  # timeout=None
+        self.ticket = ticket or {}
+        self.category = category or {}
+        self.actor = actor
+        self.reason = reason
+        self.body = body
+        self.locale = locale
+        self._build_view()
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container(accent_colour=discord.Colour(0xED4245))
+
+        container.add_item(ui.TextDisplay(
+            f"### {TICKET_CLOSE} {t('modules.tickets.close.card_title', locale=self.locale)}"))
+        lines = []
+        if self.actor:
+            lines.append(
+                f"-# {t('modules.tickets.close.by', locale=self.locale)} "
+                f"{self.actor.mention}")
+        if self.reason:
+            lines.append(
+                f"**{t('modules.tickets.fields.reason', locale=self.locale)}**\n"
+                f"{self.reason}")
+        if lines:
+            container.add_item(ui.TextDisplay("\n".join(lines)))
+        if self.body:
+            container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+            container.add_item(ui.TextDisplay(self.body))
+
+        row = ui.ActionRow()
+        reopen = ui.Button(
+            label=t('modules.tickets.actions.reopen', locale=self.locale)[:80],
+            style=discord.ButtonStyle.success, custom_id=_CID_CLOSED_REOPEN,
+            emoji=discord.PartialEmoji.from_str(TICKET_REOPEN),
+        )
+        reopen.callback = self.on_reopen
+        row.add_item(reopen)
+
+        delete = ui.Button(
+            label=t('modules.tickets.actions.delete', locale=self.locale)[:80],
+            style=discord.ButtonStyle.danger, custom_id=_CID_CLOSED_DELETE,
+            emoji=discord.PartialEmoji.from_str(DELETE),
+        )
+        delete.callback = self.on_delete
+        row.add_item(delete)
+        container.add_item(row)
+
+        self.add_item(container)
+
+    async def on_reopen(self, interaction: discord.Interaction):
+        from services.ticket_service import TicketError
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service = resolved[0]
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            await service.reopen_ticket(interaction.channel, interaction.user)
+        except TicketError as e:
+            await handle_ticket_error(interaction, e)
+            return
+        locale = i18n.get_user_locale(interaction)
+        await send_success(interaction,
+                           t('modules.tickets.reopen.done_title', locale=locale),
+                           t('modules.tickets.reopen.done_description', locale=locale))
+
+    async def on_delete(self, interaction: discord.Interaction):
+        from services.ticket_service import TicketError
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service, ticket, panel, category = resolved
+        locale = i18n.get_user_locale(interaction)
+        if PERM_ADMIN not in member_permissions(interaction.user, category, ticket):
+            await send_error(
+                interaction,
+                t('modules.tickets.errors.missing_permission', locale=locale), locale)
+            return
+        await interaction.response.send_message(
+            view=create_success_message(
+                t('modules.tickets.delete.pending_title', locale=locale),
+                t('modules.tickets.delete.pending_description', locale=locale)),
+            ephemeral=True)
+        try:
+            await service.delete_ticket(interaction.channel, interaction.user)
+        except TicketError as e:
+            await interaction.followup.send(
+                view=create_error_message(
+                    t('modules.tickets.errors.title', locale=locale), e.message(locale)),
+                ephemeral=True)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: resolved from the ticket channel on every click."""
+        bot.add_view(cls())
+
+
+def build_closed_message(ticket: Dict[str, Any], category: Dict[str, Any],
+                         actor: discord.abc.User, reason: Optional[str],
+                         body: Optional[str], locale: str) -> TicketClosedView:
+    return TicketClosedView(ticket, category, actor, reason, body, locale)
+
+
+# =========================================================================== #
+# 4. The close request
+# =========================================================================== #
+class TicketCloseRequestView(BaseView):
+    """A member asked for the ticket to be closed; staff accepts or refuses.
+
+    Persistent: yes. Auth: resolved from the ticket channel — accepting needs
+    ``close``, refusing needs ``close`` or being the requester.
+    """
+
+    __persistent__ = True
+
+    def __init__(self, ticket: Optional[Dict[str, Any]] = None,
+                 requester: Optional[discord.abc.User] = None,
+                 reason: Optional[str] = None, locale: str = "en-US"):
+        super().__init__()  # timeout=None
+        self.ticket = ticket or {}
+        self.requester = requester
+        self.reason = reason
+        self.locale = locale
+        self._build_view()
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container(accent_colour=discord.Colour(0xFEE75C))
+
+        container.add_item(ui.TextDisplay(
+            f"### {TICKET_CLOSE_REQUEST} "
+            f"{t('modules.tickets.close_request.card_title', locale=self.locale)}"))
+        body = t('modules.tickets.close_request.card_description', locale=self.locale,
+                 user=self.requester.mention if self.requester else "—")
+        if self.reason:
+            body += (f"\n\n**{t('modules.tickets.fields.reason', locale=self.locale)}**\n"
+                     f"{self.reason}")
+        container.add_item(ui.TextDisplay(body))
+
+        row = ui.ActionRow()
+        accept = ui.Button(
+            label=t('modules.tickets.close_request.accept', locale=self.locale)[:80],
+            style=discord.ButtonStyle.danger, custom_id=_CID_REQUEST_ACCEPT,
+            emoji=discord.PartialEmoji.from_str(TICKET_CLOSE),
+        )
+        accept.callback = self.on_accept
+        row.add_item(accept)
+
+        refuse = ui.Button(
+            label=t('modules.tickets.close_request.refuse', locale=self.locale)[:80],
+            style=discord.ButtonStyle.secondary, custom_id=_CID_REQUEST_REFUSE,
+            emoji=discord.PartialEmoji.from_str(UNDONE),
+        )
+        refuse.callback = self.on_refuse
+        row.add_item(refuse)
+        container.add_item(row)
+
+        self.add_item(container)
+
+    async def on_accept(self, interaction: discord.Interaction):
+        from services.ticket_service import TicketError
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service = resolved[0]
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            await service.close_ticket(interaction.channel, interaction.user, None)
+        except TicketError as e:
+            await handle_ticket_error(interaction, e)
+            return
+        locale = i18n.get_user_locale(interaction)
+        await send_success(interaction,
+                           t('modules.tickets.close.done_title', locale=locale),
+                           t('modules.tickets.close.done_description', locale=locale))
+
+    async def on_refuse(self, interaction: discord.Interaction):
+        from services.ticket_service import TicketError
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service = resolved[0]
+        try:
+            await service.cancel_close_request(interaction.channel, interaction.user)
+        except TicketError as e:
+            await handle_ticket_error(interaction, e)
+            return
+        locale = i18n.get_user_locale(interaction)
+        await interaction.response.edit_message(
+            view=_close_request_resolved(interaction.user, locale))
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: resolved from the ticket channel on every click."""
+        bot.add_view(cls())
+
+
+def _close_request_resolved(actor: discord.abc.User, locale: str) -> ui.LayoutView:
+    """The close-request card once it has been refused (no buttons left)."""
+    view = ui.LayoutView(timeout=None)
+    container = ui.Container(accent_colour=discord.Colour(0x99AAB5))
+    container.add_item(ui.TextDisplay(
+        f"### {TICKET_CLOSE_REQUEST} "
+        f"{t('modules.tickets.close_request.card_title', locale=locale)}"))
+    container.add_item(ui.TextDisplay(
+        f"{INFO} {t('modules.tickets.close_request.refused', locale=locale, user=actor.mention)}"))
+    view.add_item(container)
+    return view
+
+
+def build_close_request_message(ticket: Dict[str, Any], requester: discord.abc.User,
+                                reason: Optional[str],
+                                locale: str) -> TicketCloseRequestView:
+    return TicketCloseRequestView(ticket, requester, reason, locale)
+
+
+# =========================================================================== #
+# 5. The escalation notice
+# =========================================================================== #
+class TicketEscalationView(BaseView):
+    """Posted when a ticket is escalated. Persistent: yes.
+
+    Auth: resolved from the ticket channel — cancelling needs ``admin``, the
+    same permission escalating needed.
+    """
+
+    __persistent__ = True
+
+    def __init__(self, ticket: Optional[Dict[str, Any]] = None,
+                 actor: Optional[discord.abc.User] = None,
+                 reason: Optional[str] = None, locale: str = "en-US"):
+        super().__init__()  # timeout=None
+        self.ticket = ticket or {}
+        self.actor = actor
+        self.reason = reason
+        self.locale = locale
+        self._build_view()
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container(accent_colour=discord.Colour(0x9B59B6))
+
+        container.add_item(ui.TextDisplay(
+            f"### {TICKET_ESCALATE} "
+            f"{t('modules.tickets.escalate.card_title', locale=self.locale)}"))
+        body = t('modules.tickets.escalate.card_description', locale=self.locale,
+                 user=self.actor.mention if self.actor else "—")
+        if self.reason:
+            body += (f"\n\n**{t('modules.tickets.fields.reason', locale=self.locale)}**\n"
+                     f"{self.reason}")
+        container.add_item(ui.TextDisplay(body))
+
+        row = ui.ActionRow()
+        cancel = ui.Button(
+            label=t('modules.tickets.actions.deescalate', locale=self.locale)[:80],
+            style=discord.ButtonStyle.secondary, custom_id=_CID_ESCALATED_CANCEL,
+            emoji=discord.PartialEmoji.from_str(BACK),
+        )
+        cancel.callback = self.on_cancel
+        row.add_item(cancel)
+        container.add_item(row)
+
+        self.add_item(container)
+
+    async def on_cancel(self, interaction: discord.Interaction):
+        from services.ticket_service import TicketError
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service = resolved[0]
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            await service.deescalate(interaction.channel, interaction.user)
+        except TicketError as e:
+            await handle_ticket_error(interaction, e)
+            return
+        locale = i18n.get_user_locale(interaction)
+        await send_success(
+            interaction,
+            t('modules.tickets.escalate.cancelled_title', locale=locale),
+            t('modules.tickets.escalate.cancelled_description', locale=locale))
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: resolved from the ticket channel on every click."""
+        bot.add_view(cls())
+
+
+def build_escalation_notice(ticket: Dict[str, Any], actor: discord.abc.User,
+                            reason: Optional[str], locale: str) -> TicketEscalationView:
+    return TicketEscalationView(ticket, actor, reason, locale)
+
+
+# =========================================================================== #
+# 6. Escalation confirmation (ephemeral)
+# =========================================================================== #
+async def start_escalation(interaction: discord.Interaction, service,
+                           ticket: Dict[str, Any], category: Dict[str, Any],
+                           reason: Optional[str] = None) -> None:
+    """Escalate, asking first what to do with the manually added participants.
+
+    Skipping the question when there is nobody to ask about is the whole point
+    of asking it: a confirmation that always appears stops being read.
+    """
+    from services.ticket_service import TicketError
+
+    locale = i18n.get_user_locale(interaction)
+    if PERM_ADMIN not in member_permissions(interaction.user, category, ticket):
+        await send_error(interaction,
+                         t('modules.tickets.errors.missing_permission', locale=locale),
+                         locale)
+        return
+
+    manual = list(ticket.get('participants', [])) + list(ticket.get('participant_roles', []))
+    if manual:
+        await interaction.response.send_message(
+            view=TicketEscalateConfirmView(ticket, reason, locale), ephemeral=True)
+        return
+
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    try:
+        await service.escalate(interaction.channel, interaction.user, reason=reason)
+    except TicketError as e:
+        await handle_ticket_error(interaction, e)
+        return
+    await send_success(interaction,
+                       t('modules.tickets.escalate.done_title', locale=locale),
+                       t('modules.tickets.escalate.done_description', locale=locale))
+
+
+class TicketEscalateConfirmView(BaseView):
+    """Keep or drop the manually added participants when escalating.
+
+    Persistent: yes (ephemeral messages survive a restart too, and a dead
+    button on one is just as broken). Auth: resolved from the ticket channel.
+
+    The escalation reason typed in the slash command is not carried across a
+    restart — the shell escalates without one rather than refusing, which is
+    the harmless half of the trade.
+    """
+
+    __persistent__ = True
+
+    def __init__(self, ticket: Optional[Dict[str, Any]] = None,
+                 reason: Optional[str] = None, locale: str = "en-US"):
+        super().__init__()  # timeout=None
+        self.ticket = ticket or {}
+        self.reason = reason
+        self.locale = locale
+        self._build_view()
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container(accent_colour=discord.Colour(0x9B59B6))
+
+        container.add_item(ui.TextDisplay(
+            f"### {TICKET_ESCALATE} "
+            f"{t('modules.tickets.escalate.confirm_title', locale=self.locale)}"))
+        container.add_item(ui.TextDisplay(
+            t('modules.tickets.escalate.confirm_description', locale=self.locale)))
+
+        listed = [f"<@{uid}>" for uid in self.ticket.get('participants', [])]
+        listed += [f"<@&{rid}>" for rid in self.ticket.get('participant_roles', [])]
+        if listed:
+            container.add_item(ui.TextDisplay(
+                f"-# {t('modules.tickets.fields.participants', locale=self.locale)} : "
+                f"{', '.join(listed)}"))
+
+        row = ui.ActionRow()
+        keep = ui.Button(
+            label=t('modules.tickets.escalate.keep', locale=self.locale)[:80],
+            style=discord.ButtonStyle.primary, custom_id=_CID_ESC_KEEP,
+            emoji=discord.PartialEmoji.from_str(GROUPS),
+        )
+        keep.callback = self.on_keep
+        row.add_item(keep)
+
+        drop = ui.Button(
+            label=t('modules.tickets.escalate.drop', locale=self.locale)[:80],
+            style=discord.ButtonStyle.danger, custom_id=_CID_ESC_DROP,
+            emoji=discord.PartialEmoji.from_str(DELETE),
+        )
+        drop.callback = self.on_drop
+        row.add_item(drop)
+        container.add_item(row)
+
+        self.add_item(container)
+
+    async def on_keep(self, interaction: discord.Interaction):
+        await self._escalate(interaction, keep=True)
+
+    async def on_drop(self, interaction: discord.Interaction):
+        await self._escalate(interaction, keep=False)
+
+    async def _escalate(self, interaction: discord.Interaction, *, keep: bool):
+        from services.ticket_service import TicketError
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service = resolved[0]
+        locale = i18n.get_user_locale(interaction)
+        await interaction.response.defer()
+        try:
+            await service.escalate(interaction.channel, interaction.user,
+                                   reason=self.reason, keep_participants=keep)
+        except TicketError as e:
+            await handle_ticket_error(interaction, e)
+            return
+        await interaction.edit_original_response(view=create_success_message(
+            t('modules.tickets.escalate.done_title', locale=locale),
+            t('modules.tickets.escalate.done_description', locale=locale)))
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: resolved from the ticket channel on every click."""
+        bot.add_view(cls())
+
+
+# =========================================================================== #
+# 7. Participants (ephemeral)
+# =========================================================================== #
+class TicketParticipantsView(BaseView):
+    """Who is in this ticket, on top of its opener and the staff roles.
+
+    Persistent: yes. Auth: resolved from the ticket channel + the
+    ``participants`` permission, re-checked on every change.
+
+    Both selects **replace** the list rather than adding to it: a picker that
+    already shows the current members as selected reads as "this is who is in",
+    and unselecting is then the obvious way to remove someone. An add-only
+    picker would need a second, mirror-image remove control for no gain.
+    """
+
+    __persistent__ = True
+
+    def __init__(self, guild: Optional[discord.Guild] = None,
+                 ticket: Optional[Dict[str, Any]] = None, locale: str = "en-US"):
+        super().__init__()  # timeout=None
+        self.guild = guild
+        self.ticket = ticket or {}
+        self.locale = locale
+        self._build_view()
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container(accent_colour=discord.Colour(DEFAULT_ACCENT_COLOR))
+
+        container.add_item(ui.TextDisplay(
+            f"### {TICKET_PARTICIPANTS} "
+            f"{t('modules.tickets.participants.title', locale=self.locale)}"))
+        container.add_item(ui.TextDisplay(
+            t('modules.tickets.participants.description', locale=self.locale)))
+
+        if self.ticket.get('owner_id'):
+            container.add_item(ui.TextDisplay(
+                f"-# {t('modules.tickets.participants.owner_note', locale=self.locale)} "
+                f"<@{self.ticket['owner_id']}>"))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.tickets.participants.members_title', locale=self.locale)}**\n"
+            f"-# {t('modules.tickets.participants.members_description', locale=self.locale)}"))
+        user_row = ui.ActionRow()
+        user_select = ui.UserSelect(
+            placeholder=t('modules.tickets.participants.members_placeholder',
+                          locale=self.locale),
+            min_values=0, max_values=25, custom_id=_CID_MEMBERS_USERS,
+        )
+        user_select.default_values = [
+            discord.Object(id=uid) for uid in self.ticket.get('participants', [])
+        ]
+        user_select.callback = self.on_users
+        user_row.add_item(user_select)
+        container.add_item(user_row)
+
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.tickets.participants.roles_title', locale=self.locale)}**\n"
+            f"-# {t('modules.tickets.participants.roles_description', locale=self.locale)}"))
+        role_row = ui.ActionRow()
+        role_select = ui.RoleSelect(
+            placeholder=t('modules.tickets.participants.roles_placeholder',
+                          locale=self.locale),
+            min_values=0, max_values=10, custom_id=_CID_MEMBERS_ROLES,
+        )
+        role_select.default_values = [
+            discord.Object(id=rid) for rid in self.ticket.get('participant_roles', [])
+        ]
+        role_select.callback = self.on_roles
+        role_row.add_item(role_select)
+        container.add_item(role_row)
+
+        self.add_item(container)
+
+    async def on_users(self, interaction: discord.Interaction):
+        await self._apply(interaction, users=[
+            int(v) for v in (interaction.data.get('values') or [])
+        ])
+
+    async def on_roles(self, interaction: discord.Interaction):
+        await self._apply(interaction, roles=[
+            int(v) for v in (interaction.data.get('values') or [])
+        ])
+
+    async def _apply(self, interaction: discord.Interaction, **selection):
+        resolved = await _resolve(interaction)
+        if not resolved:
+            return
+        service, ticket, panel, category = resolved
+        locale = i18n.get_user_locale(interaction)
+
+        if PERM_PARTICIPANTS not in member_permissions(interaction.user, category, ticket):
+            await send_error(
+                interaction,
+                t('modules.tickets.errors.missing_permission', locale=locale), locale)
+            return
+
+        users = selection.get('users')
+        if users is not None:
+            # The opener is in the ticket by definition; keeping them out of
+            # the manual list stops "remove the owner" from being one click.
+            users = [uid for uid in users if uid != ticket['owner_id']]
+
+        await interaction.client.db.set_participants(
+            interaction.channel.id, users=users, roles=selection.get('roles'))
+        ticket = await service.get_ticket(interaction.channel.id) or ticket
+        await service.sync_permissions(interaction.channel, category, ticket)
+
+        await interaction.response.edit_message(
+            view=TicketParticipantsView(interaction.guild, ticket, locale))
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: resolved from the ticket channel on every click."""
+        bot.add_view(cls())
+
+
+# =========================================================================== #
+# 8. Modals
+# =========================================================================== #
+class TicketReasonModal(BaseModal):
+    """One optional free-text reason, reused by close / close request / escalate."""
+
+    def __init__(self, locale: str, action: str, callback_func):
+        super().__init__(
+            title=t(f'modules.tickets.actions.{action}', locale=locale)[:45],
+            timeout=None,
+        )
+        self.callback_func = callback_func
+        self.reason_input = ui.TextInput(
+            style=discord.TextStyle.paragraph,
+            required=False,
+            max_length=MAX_TICKET_MESSAGE,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.fields.reason', locale=locale)[:45],
+            description=t('modules.tickets.fields.reason_hint', locale=locale)[:100],
+            component=self.reason_input,
+        ))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        value = (self.reason_input.value or "").strip()
+        await self.callback_func(interaction, value or None)
+
+
+class TicketRenameModal(BaseModal):
+    """Rename the ticket channel."""
+
+    def __init__(self, locale: str, current: str, callback_func):
+        super().__init__(
+            title=t('modules.tickets.actions.rename', locale=locale)[:45],
+            timeout=None,
+        )
+        self.callback_func = callback_func
+        self.name_input = ui.TextInput(
+            style=discord.TextStyle.short,
+            default=current,
+            max_length=90,
+            required=True,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.fields.channel_name', locale=locale)[:45],
+            description=t('modules.tickets.fields.channel_name_hint', locale=locale)[:100],
+            component=self.name_input,
+        ))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await self.callback_func(interaction, (self.name_input.value or "").strip())
+
+
+# =========================================================================== #
+# 9. Shared action bodies (used by the buttons AND the slash commands)
+# =========================================================================== #
+async def run_staff_thread(interaction: discord.Interaction, service) -> None:
+    """Open/join the staff thread and answer with a link to it."""
+    from services.ticket_service import TicketError
+
+    locale = i18n.get_user_locale(interaction)
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    try:
+        thread = await service.open_staff_thread(interaction.channel, interaction.user)
+    except TicketError as e:
+        await handle_ticket_error(interaction, e)
+        return
+    await send_success(
+        interaction,
+        t('modules.tickets.staff_thread.done_title', locale=locale),
+        t('modules.tickets.staff_thread.done_description', locale=locale,
+          thread=thread.mention))
+
+
+# =========================================================================== #
+# 10. The closing DM (no interactive child)
+# =========================================================================== #
+def build_close_dm(guild: discord.Guild, ticket: Dict[str, Any],
+                   category: Dict[str, Any], actor: discord.abc.User,
+                   reason: Optional[str], locale: str) -> ui.LayoutView:
+    """Tell the opener their ticket is closed. Zero interactive children."""
+    view = ui.LayoutView(timeout=None)
+    container = ui.Container(accent_colour=discord.Colour(0xED4245))
+
+    container.add_item(ui.TextDisplay(
+        f"### {TICKET_CLOSE} {t('modules.tickets.close.dm_title', locale=locale)}"))
+    container.add_item(ui.TextDisplay(
+        t('modules.tickets.close.dm_description', locale=locale,
+          server=guild.name, number=ticket.get('number', '—'),
+          category=category.get('name', '—'))))
+    if reason:
+        container.add_item(ui.TextDisplay(
+            f"**{t('modules.tickets.fields.reason', locale=locale)}**\n{reason}"))
+
+    view.add_item(container)
+    return view
+
+
+# =========================================================================== #
+# 11. Persistence marker
+# =========================================================================== #
+class TicketsPersistence(BaseView):
+    """Marker view: registers the ticket panel's dynamic items at startup."""
+
+    __persistent__ = True
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        bot.add_dynamic_items(TicketOpenButton, TicketOpenSelect)


### PR DESCRIPTION
## Summary

Implements the complete **Tickets** server module, enabling guilds to create configurable support ticket systems with panels, categories, per-role permissions, and a full ticket lifecycle (open, close, escalate, rename, move, staff threads).

## Key Changes

### Core Module Implementation
- **`modules/tickets.py`** — Configuration schema, normalization, free/premium limits (3/10 panels, 5/15 categories), permission model, and panel rendering
- **`services/ticket_service.py`** — All ticket actions (open, close, escalate, move, rename, staff threads, participants) with translatable error handling
- **`db/repositories/tickets.py`** — Live ticket state persistence (channel_id, owner, number, participants, escalation, status)

### Configuration UI (Components V2)
- **`modules/configs/tickets_config.py`** — Panel list and panel editor (appearance, channel, style)
- **`modules/configs/tickets_panel_config.py`** — Panel-level configuration (categories, repost, toggle)
- **`modules/configs/tickets_category_config.py`** — Category editor with identity, messages, options, and per-role permissions screens

### Discord Integration
- **`cogs/tickets.py`** — `/ticket` command group (close, escalate, move, rename, staff-thread, participants) published only in guilds where the module is enabled
- **`utils/ticket_views.py`** — All interactive components: panel buttons/select, ticket control bar, closing cards, escalation confirmations, participant/role pickers (1172 lines)

### Testing & Documentation
- **`tests/test_tickets.py`** — 784 lines of pure Python tests covering schema normalization, permission model, rendering, and limits
- **`docs/TICKETS.md`** — Complete specification (three levels, schema, permission model, actions, persistence, i18n)
- **`docs/sessions/2026-08-23_tickets-module.md`** — Implementation session notes

### Localization
- Added `modules.tickets.*` i18n keys to all 5 supported locales (en-US, fr, es-ES, pt-BR, de)
- Added `/ticket` command translations to 25 language files (command names and parameter descriptions)

### Integration Points
- **`bot.py`** — Added `TicketService` instance as `bot.tickets`
- **`db/base.py`** — Registered `TicketsRepository`
- **`cogs/config.py`** — Wired `/config` → Tickets entry point
- **`utils/persistent_views.py`** — Registered all persistent view classes
- **`utils/emojis.py`** — Added ticket-related emoji constants
- **`docs/PERSISTENT_VIEWS.md`** — Documented dynamic-item persistence pattern for tickets
- **`docs/MODULE_SYSTEM.md`** — Documented module-scoped slash command registration
- **`CLAUDE.md`** — Updated project structure

## Notable Implementation Details

- **Authorization model**: Every callback resolves the ticket from channel_id, category from guild config, and actor permissions from roles — no auth carried by views
- **Persistence strategy**: Panel uses `DynamicItem`s (reconstructed on click); ticket actions use static custom_ids (channel_id is the identity)
- **Error handling**: `TicketError` carries i18n keys, not formatted strings — caller chooses language context
- **Limits**: Free tier (3 panels, 5 categories); Premium (10 panels, 15 categories); hard Discord ceilings (15 buttons, 25 select options)
- **Slash commands**: Published per-guild via `ModuleManager.register_module_commands()` — only visible where module is enabled
- **i18n**: Supports 5 locales with full command translations in 25 language files

https://claude.ai/code/session_01FDJGYe74yUFnK8gv2UrGBc