### PR TITLE
Tickets: fix the shadowed set_claim, make the participants form safe, use the claim icon

### DIFF
--- a/db/repositories/tickets.py
+++ b/db/repositories/tickets.py
@@ -269,9 +269,15 @@ class TicketsRepository:
                     WHERE channel_id = $1
                 """, channel_id)
 
-    async def set_claim(self, channel_id: int,
-                        claimer_id: Optional[int]) -> None:
-        """Assign the ticket to a staffer, or release it with ``None``."""
+    async def set_ticket_claim(self, channel_id: int,
+                               claimer_id: Optional[int]) -> None:
+        """Assign the ticket to a staffer, or release it with ``None``.
+
+        Named ``set_ticket_claim`` and not ``set_claim`` because every
+        repository is mixed into one ``ModdyDatabase``: a plain ``set_claim``
+        collided with ``AppealRepository.set_claim``, which sits earlier in the
+        MRO and silently won. See ``tests/test_database_repositories.py``.
+        """
         async with self.pool.acquire() as conn:
             await conn.execute("""
                 UPDATE tickets

--- a/docs/EMOJIS.md
+++ b/docs/EMOJIS.md
@@ -140,6 +140,7 @@
 <:server:1519788576420921476>
 <:ticket:1541216667420594257>
 <:threads:1541216661699436675>
+<:claim:1541239118888181770>
 
 
 ## Server logs icon set — `utils/emojis.py::LOG_EMOJIS`

--- a/docs/sessions/2026-08-23_tickets-claim-and-message-overhaul.md
+++ b/docs/sessions/2026-08-23_tickets-claim-and-message-overhaul.md
@@ -46,14 +46,15 @@ Optional per category (`claim_enabled`).
 
 `TICKET` is now the real `<:ticket:…>`, `TICKET_STAFF_THREAD` the real
 `<:threads:…>`. `TICKET_CLOSE` → `UNDONE` (a plain cross),
-`TICKET_PARTICIPANTS` → `MANAGE_USER`, new `TICKET_CLAIM` → `QUESTIONS`.
+`TICKET_PARTICIPANTS` → `MANAGE_USER`, new `TICKET_CLAIM` → `<:claim:…>`.
 
-### 6. Participants open on who is already in
+### 6. Participants is a Modal V2
 
-`TicketParticipantsView` became **`TicketParticipantsModal`** (Modal V2), with
-both pickers pre-filled with the current members and roles. One submit applies
-the whole picture, which is what makes unselecting the obvious way to remove
-somebody.
+`TicketParticipantsView` became **`TicketParticipantsModal`**. It prints the
+current participants as text and asks what to do with the selection — add
+(default), remove, or replace. See the follow-up below: Discord does not render
+pre-selected values inside a modal, so the form could not be a straight
+"edit the list in place".
 
 ### 7. The staff thread stays staff-only
 
@@ -116,9 +117,9 @@ back to the channel that had vanished from their list (`build_reopen_dm`).
 | `utils/ticket_views.py` | Rewritten: buttons outside containers, configurable button set, claim notice, participants modal, reopen DM |
 | `cogs/tickets.py` | `/ticket claim`, `/ticket unclaim`, participants modal, `on_thread_member_join` guard, claim in `/ticket info` |
 | `db/base.py` | 4 claim columns + idempotent migration |
-| `db/repositories/tickets.py` | `set_claim`, claim-aware `set_escalated` |
+| `db/repositories/tickets.py` | `set_ticket_claim`, claim-aware `set_escalated` |
 | `modules/configs/tickets_category_config.py` | Button picker, `---` hint, behaviour `CheckboxGroup`, claim in the summary |
-| `utils/emojis.py`, `docs/EMOJIS.md` | `TICKET`, `THREADS`, `QUESTIONS`, `TICKET_CLAIM` |
+| `utils/emojis.py`, `docs/EMOJIS.md` | `TICKET`, `THREADS`, `CLAIM`, `TICKET_CLAIM` |
 | `utils/persistent_views.py` | `TicketParticipantsView` dropped (now a modal) |
 | `locales/*.json` (5) | ~80 keys each |
 | `locales/commands/*.json` (32) | `/ticket claim`, `/ticket unclaim` |
@@ -149,6 +150,46 @@ back to the channel that had vanished from their list (`build_reopen_dm`).
   runs `str.format` over the whole string as soon as it gets a kwarg, which
   would eat the `{number}` / `{user}` placeholders the admin keeps.
 
+## Follow-up fixes, same session
+
+### `set_claim` was silently shadowed
+
+`ModdyDatabase` inherits from ~24 repositories, so two of them picking the same
+method name do not clash loudly — the one earlier in the MRO wins. My
+`TicketsRepository.set_claim` was shadowed by `AppealRepository.set_claim`, and
+claiming a ticket raised `TypeError: takes 2 positional arguments but 3 were
+given` in production rather than failing at import.
+
+Renamed to **`set_ticket_claim`**, and `tests/test_database_repositories.py`
+now asserts that no repository method name is defined twice. It was the only
+collision in the project — the rule is: when two repositories describe the same
+verb on different things, qualify the name.
+
+### The participants modal came up empty, and that was destructive
+
+Discord does not render `default_values` for a select inside a modal (the
+payload is correct — verified by dumping `Modal.to_dict()` — it is simply
+ignored). The pickers therefore opened empty, while `_apply_participants`
+**replaced** the list with whatever was submitted: a staffer opening the form to
+add one person wiped every existing participant.
+
+Fixed by not depending on a pre-fill the platform does not guarantee:
+
+- the current participants are printed as **text** (the one thing that always
+  renders);
+- a mode select says what happens to the selection — **Add** (the default, and
+  the only one that can never destroy anything), Remove, or Replace;
+- `default_values` is still sent, so the form pre-fills the day Discord honours
+  it, but nothing depends on it.
+
+`TestParticipantMerge` covers the three modes, including the exact failure: an
+empty selection is a no-op in add and remove.
+
+### The claim icon
+
+`TICKET_CLAIM` now points at the dedicated `<:claim:1541239118888181770>`
+rather than borrowing `questions`.
+
 ## Known issues / follow-ups
 
 - `on_thread_member_join` needs the members intent (the bot has it). A member
@@ -159,7 +200,11 @@ back to the channel that had vanished from their list (`build_reopen_dm`).
   design; nothing else depends on it.
 - `MAX_TICKET_MESSAGE` stays at 2000 characters now that `open_message` is the
   whole message. Raise it if a server hits the ceiling.
+- The participants form is not the "edit the list in place" UX originally
+  asked for, because a modal cannot pre-select. If that UX matters more than
+  the modal, the only Discord surface that supports it is a Components V2
+  panel — switching back is a contained change.
 
 ## Tests
 
-`python3 -m pytest tests/ -q` — 1198 passed.
+`python3 -m pytest tests/ -q` — 1207 passed.

--- a/locales/de.json
+++ b/locales/de.json
@@ -3074,7 +3074,7 @@
       },
       "participants": {
         "title": "Teilnehmer des Tickets",
-        "description": "Alle hier ausgewählten Personen haben Zugriff auf das Ticket, zusätzlich zum Ersteller und den Team-Rollen. Wähle jemanden ab, um ihn zu entfernen.",
+        "description": "Wähle, wen du hinzufügen, entfernen oder als vollständige Liste setzen willst — zusätzlich zum Ersteller des Tickets und den Team-Rollen.",
         "members_title": "Mitglieder",
         "members_description": "Einzeln hinzugefügt",
         "members_placeholder": "Wähle die Mitglieder",
@@ -3086,7 +3086,14 @@
         "removed_title": "Entfernt",
         "removed_description": "{target} hat keinen Zugriff mehr auf dieses Ticket.",
         "saved_title": "Teilnehmer aktualisiert",
-        "saved_description": "In diesem Ticket, zusätzlich zum Ersteller und zum Team: {participants}"
+        "saved_description": "In diesem Ticket, zusätzlich zum Ersteller und zum Team: {participants}",
+        "current": "Aktuell in diesem Ticket:",
+        "nobody": "noch niemand",
+        "mode_label": "Was mit deiner Auswahl geschehen soll",
+        "mode_hint": "Hinzufügen ist die Vorgabe und entfernt nie jemanden",
+        "mode_add": "Sie zum Ticket hinzufügen",
+        "mode_remove": "Sie aus dem Ticket entfernen",
+        "mode_replace": "Die ganze Liste durch sie ersetzen"
       },
       "staff_thread": {
         "name": "staff-{number}",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -3074,7 +3074,7 @@
       },
       "participants": {
         "title": "Ticket participants",
-        "description": "Everyone selected here has access to the ticket, on top of its opener and the staff roles. Unselect someone to remove them.",
+        "description": "Pick who to add, remove, or set as the full list — on top of the ticket's opener and the staff roles.",
         "members_title": "Members",
         "members_description": "Added one by one",
         "members_placeholder": "Select the members",
@@ -3086,7 +3086,14 @@
         "removed_title": "Removed",
         "removed_description": "{target} no longer has access to this ticket.",
         "saved_title": "Participants updated",
-        "saved_description": "Now in this ticket, on top of its opener and the staff: {participants}"
+        "saved_description": "Now in this ticket, on top of its opener and the staff: {participants}",
+        "current": "Currently in this ticket:",
+        "nobody": "nobody yet",
+        "mode_label": "What to do with your selection",
+        "mode_hint": "Add is the default and never removes anyone",
+        "mode_add": "Add them to the ticket",
+        "mode_remove": "Remove them from the ticket",
+        "mode_replace": "Replace the whole list with them"
       },
       "staff_thread": {
         "name": "staff-{number}",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -3074,7 +3074,7 @@
       },
       "participants": {
         "title": "Participantes del ticket",
-        "description": "Todas las personas seleccionadas aquí tienen acceso al ticket, además de quien lo abrió y de los roles del staff. Deselecciona a alguien para quitarlo.",
+        "description": "Elige a quién añadir, quitar o fijar como lista completa — además del autor del ticket y de los roles del staff.",
         "members_title": "Miembros",
         "members_description": "Añadidos uno a uno",
         "members_placeholder": "Selecciona los miembros",
@@ -3086,7 +3086,14 @@
         "removed_title": "Quitado",
         "removed_description": "{target} ya no tiene acceso a este ticket.",
         "saved_title": "Participantes actualizados",
-        "saved_description": "En este ticket, además de su autor y del staff: {participants}"
+        "saved_description": "En este ticket, además de su autor y del staff: {participants}",
+        "current": "Actualmente en este ticket:",
+        "nobody": "nadie todavía",
+        "mode_label": "Qué hacer con tu selección",
+        "mode_hint": "Añadir es la opción por defecto y nunca quita a nadie",
+        "mode_add": "Añadirlos al ticket",
+        "mode_remove": "Quitarlos del ticket",
+        "mode_replace": "Sustituir toda la lista por ellos"
       },
       "staff_thread": {
         "name": "staff-{number}",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3073,7 +3073,7 @@
       },
       "participants": {
         "title": "Participants du ticket",
-        "description": "Toutes les personnes sélectionnées ici ont accès au ticket, en plus de son auteur et des rôles du staff. Désélectionnez quelqu'un pour le retirer.",
+        "description": "Choisissez qui ajouter, retirer, ou définir comme liste complète — en plus de l'auteur du ticket et des rôles du staff.",
         "members_title": "Membres",
         "members_description": "Ajoutés un par un",
         "members_placeholder": "Sélectionnez les membres",
@@ -3085,7 +3085,14 @@
         "removed_title": "Retiré",
         "removed_description": "{target} n'a plus accès à ce ticket.",
         "saved_title": "Participants mis à jour",
-        "saved_description": "Dans ce ticket, en plus de son auteur et du staff : {participants}"
+        "saved_description": "Dans ce ticket, en plus de son auteur et du staff : {participants}",
+        "current": "Actuellement dans ce ticket :",
+        "nobody": "personne pour l'instant",
+        "mode_label": "Que faire de votre sélection",
+        "mode_hint": "Ajouter est le choix par défaut et ne retire jamais personne",
+        "mode_add": "Les ajouter au ticket",
+        "mode_remove": "Les retirer du ticket",
+        "mode_replace": "Remplacer toute la liste par eux"
       },
       "staff_thread": {
         "name": "staff-{number}",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -3074,7 +3074,7 @@
       },
       "participants": {
         "title": "Participantes do ticket",
-        "description": "Todas as pessoas selecionadas aqui têm acesso ao ticket, além de quem o abriu e dos cargos da equipe. Desmarque alguém para removê-lo.",
+        "description": "Escolha quem adicionar, remover ou definir como lista completa — além do autor do ticket e dos cargos da equipe.",
         "members_title": "Membros",
         "members_description": "Adicionados um a um",
         "members_placeholder": "Selecione os membros",
@@ -3086,7 +3086,14 @@
         "removed_title": "Removido",
         "removed_description": "{target} não tem mais acesso a este ticket.",
         "saved_title": "Participantes atualizados",
-        "saved_description": "Neste ticket, além do autor e da equipe: {participants}"
+        "saved_description": "Neste ticket, além do autor e da equipe: {participants}",
+        "current": "Atualmente neste ticket:",
+        "nobody": "ninguém ainda",
+        "mode_label": "O que fazer com a sua seleção",
+        "mode_hint": "Adicionar é o padrão e nunca remove ninguém",
+        "mode_add": "Adicioná-los ao ticket",
+        "mode_remove": "Removê-los do ticket",
+        "mode_replace": "Substituir toda a lista por eles"
       },
       "staff_thread": {
         "name": "staff-{number}",

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -641,7 +641,7 @@ class TicketService:
             raise TicketError('modules.tickets.errors.already_claimed',
                               user=f"<@{holder}>")
 
-        await self.bot.db.set_claim(channel.id, actor.id)
+        await self.bot.db.set_ticket_claim(channel.id, actor.id)
         ticket = await self.get_ticket(channel.id) or ticket
         await self.sync_permissions(channel, category, ticket)
         await self.sync_status_prefix(channel, category, ticket)
@@ -688,7 +688,7 @@ class TicketService:
         if holder == actor.id and self.claim_permission(ticket) not in granted:
             raise TicketError('modules.tickets.errors.missing_permission')
 
-        await self.bot.db.set_claim(channel.id, None)
+        await self.bot.db.set_ticket_claim(channel.id, None)
         ticket = await self.get_ticket(channel.id) or ticket
         await self.sync_permissions(channel, category, ticket)
         await self.sync_status_prefix(channel, category, ticket)

--- a/tests/test_database_repositories.py
+++ b/tests/test_database_repositories.py
@@ -1,0 +1,56 @@
+"""``ModdyDatabase`` mixes every repository into one class — so names collide.
+
+`db/base.py::ModdyDatabase` inherits from ~24 repositories at once, which means
+two repositories that happen to pick the same method name do **not** produce an
+error: the one earlier in the MRO silently wins, and every call meant for the
+other one lands on it. That is not a hypothetical — `TicketsRepository.set_claim`
+shipped and was shadowed by `AppealRepository.set_claim`, so claiming a ticket
+raised ``TypeError: takes 2 positional arguments but 3 were given`` in
+production instead of failing at import.
+
+The rule this file enforces: **a repository method name is unique across all
+repositories.** When two of them describe the same verb on different things,
+qualify the name (``set_ticket_claim``, not ``set_claim``).
+
+    pytest tests/test_database_repositories.py -q
+"""
+
+import collections
+import inspect
+
+
+def _repository_methods():
+    """``{method_name: [repository class name, ...]}`` over every mixin."""
+    from db.base import ModdyDatabase
+
+    owners = collections.defaultdict(list)
+    for repository in ModdyDatabase.__bases__:
+        for name, value in vars(repository).items():
+            if name.startswith('_'):
+                continue
+            if not (inspect.isfunction(value) or isinstance(value, property)):
+                continue
+            owners[name].append(repository.__name__)
+    return owners
+
+
+def test_no_two_repositories_define_the_same_method():
+    clashes = {
+        name: sorted(owners)
+        for name, owners in _repository_methods().items()
+        if len(owners) > 1
+    }
+    assert not clashes, (
+        "these method names are defined by more than one repository, so the "
+        "one earliest in ModdyDatabase's MRO silently shadows the others — "
+        "qualify the name (e.g. `set_ticket_claim` rather than `set_claim`):\n"
+        + "\n".join(f"  {name}: {owners}" for name, owners in clashes.items())
+    )
+
+
+def test_the_ticket_claim_method_is_reachable_from_the_database():
+    """The exact regression: `bot.db.set_ticket_claim` must be the ticket one."""
+    from db.base import ModdyDatabase
+    from db.repositories.tickets import TicketsRepository
+
+    assert ModdyDatabase.set_ticket_claim is TicketsRepository.set_ticket_claim

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -542,6 +542,36 @@ class TestStatusDot:
         assert strip_status_prefix("ticket-0003") == "ticket-0003"
 
 
+class TestParticipantMerge:
+    """The three modes of the participants form."""
+
+    def _merge(self, current, selected, mode):
+        from utils.ticket_views import _merge_participants
+
+        return _merge_participants(current, selected, mode)
+
+    def test_add_never_removes_anyone(self):
+        assert self._merge([1, 2], [3], "add") == [1, 2, 3]
+
+    def test_add_is_idempotent(self):
+        assert self._merge([1, 2], [2, 3], "add") == [1, 2, 3]
+
+    def test_remove_takes_only_the_selection_out(self):
+        assert self._merge([1, 2, 3], [2], "remove") == [1, 3]
+
+    def test_removing_someone_who_is_not_in_changes_nothing(self):
+        assert self._merge([1, 2], [9], "remove") == [1, 2]
+
+    def test_replace_is_the_only_destructive_mode(self):
+        assert self._merge([1, 2, 3], [9], "replace") == [9]
+        assert self._merge([1, 2, 3], [], "replace") == []
+
+    def test_an_empty_selection_is_a_no_op_in_the_safe_modes(self):
+        """The failure this guards: the pickers come up empty in a modal."""
+        assert self._merge([1, 2], [], "add") == [1, 2]
+        assert self._merge([1, 2], [], "remove") == [1, 2]
+
+
 class TestMessageBlocks:
     def test_a_dashes_line_cuts_the_message(self):
         assert split_message_blocks("Top\n---\nBottom") == ["Top", "Bottom"]
@@ -929,14 +959,28 @@ class TestTicketChannelViews:
         view = build_escalation_notice(self.ticket, self.actor, "abuse", "fr")
         assert self._ids(view) == ["moddy:tickets:escalated:cancel"]
 
-    def test_the_participants_form_opens_on_who_is_already_in(self):
-        """A picker showing the current members reads as "this is who is in",
-        which is what makes unselecting the obvious way to remove someone."""
+    def test_the_participants_form_shows_who_is_already_in(self):
+        """Discord does not render pre-selected values inside a modal, so the
+        current list is printed as text — the one thing that always shows."""
         from utils.ticket_views import TicketParticipantsModal
 
         modal = TicketParticipantsModal("fr", self.ticket, _noop)
+        rendered = "\n".join(
+            getattr(child, 'content', '') or '' for child in modal.children)
+        assert "<@8>" in rendered and "<@&10>" in rendered
+
+        # Still sent, so the form pre-fills the day Discord honours it.
         assert [d.id for d in modal.user_select.default_values] == [8]
         assert [d.id for d in modal.role_select.default_values] == [10]
+
+    def test_the_participants_form_defaults_to_the_harmless_mode(self):
+        """The pickers come up empty, so "replace" as a silent default would
+        wipe the list of a staffer who only wanted to add one person."""
+        from utils.ticket_views import TicketParticipantsModal
+
+        modal = TicketParticipantsModal("fr", self.ticket, _noop)
+        selected = [o.value for o in modal.mode_select.options if o.default]
+        assert selected == [TicketParticipantsModal.MODE_ADD]
 
     def test_the_closing_dm_has_nothing_to_click(self):
         from types import SimpleNamespace
@@ -990,6 +1034,8 @@ _INTERPOLATED_KEYS = (
     + [f"modules.tickets.messages.ph_{p.strip('{}')}" for p in PLACEHOLDERS]
     + [f"modules.tickets.participants.{k}_{s}" for k in ("added", "removed")
        for s in ("title", "description")]
+    + [f"modules.tickets.participants.mode_{m}" for m in
+       ("add", "remove", "replace")]
 )
 
 

--- a/utils/emojis.py
+++ b/utils/emojis.py
@@ -96,8 +96,8 @@ LINK = "<:link:1521517863607734385>"       # appeal "invite" button
 PENDING = "<:pending:1521282587962900611>"  # appeal "pending" status
 ROCKET = "<a:Rocket:1535783839870353499>"  # bot customization bio attribution
 ALTGUARD = "<a:DisguisedFace:1539405255576657981>"  # AltGuard verification panel message
-QUESTIONS = "<:questions:1540890130854838272>"  # ticket claim button
-THREADS = "<:threads:1541216661699436675>"      # private staff thread
+CLAIM = "<:claim:1541239118888181770>"      # take a ticket in charge
+THREADS = "<:threads:1541216661699436675>"  # private staff thread
 
 # =============================================================================
 # TICKETS MODULE
@@ -112,7 +112,7 @@ TICKET = "<:ticket:1541216667420594257>"   # module icon + ticket cards
 TICKET_STAFF_THREAD = THREADS              # private staff thread
 TICKET_CLOSE = UNDONE                      # close a ticket (a plain cross)
 TICKET_PARTICIPANTS = MANAGE_USER          # manage who is in the ticket
-TICKET_CLAIM = QUESTIONS                   # claim / release a ticket
+TICKET_CLAIM = CLAIM                       # claim / release a ticket
 TICKET_PANEL = NOTE             # a ticket panel message          (placeholder)
 TICKET_CATEGORY = FOLDER        # a ticket category               (placeholder)
 TICKET_CLOSE_REQUEST = HAND     # ask the staff to close          (placeholder)
@@ -262,7 +262,7 @@ EMOJIS = {
     "download": DOWNLOAD,
     "emoji": EMOJI,
     "manage_user": MANAGE_USER,
-    "questions": QUESTIONS,
+    "claim": CLAIM,
     "threads": THREADS,
     "ticket": TICKET,
     "banner": BANNER,

--- a/utils/ticket_views.py
+++ b/utils/ticket_views.py
@@ -1023,15 +1023,23 @@ def build_claim_notice(actor: discord.abc.User, *,
 class TicketParticipantsModal(BaseModal):
     """Who is in this ticket, on top of its opener and the staff roles.
 
-    A modal rather than a panel of selects: both pickers open **pre-filled with
-    the current participants**, and one submit applies the whole picture at
-    once. That is what makes unselecting the obvious way to remove somebody —
-    the form shows who is in, not a queue of additions.
+    **The current participants are printed as text, and the form says what it
+    will do with the selection.** Both pickers still carry ``default_values``,
+    but nothing here depends on them: Discord does not render pre-selected
+    values for a select inside a modal, so a form that silently meant "replace
+    everyone with what you picked" would wipe the list of a staffer who only
+    wanted to add one person. The mode is therefore explicit, and it defaults
+    to **Add** — the answer that can never destroy anything.
 
     Modals are the one surface that is deliberately not persistent (see
     docs/PERSISTENT_VIEWS.md "Deliberate exclusions"): they are answered in the
     moment, and Discord closes them on a restart anyway.
     """
+
+    MODE_ADD = "add"
+    MODE_REMOVE = "remove"
+    MODE_REPLACE = "replace"
+    MODES = (MODE_ADD, MODE_REMOVE, MODE_REPLACE)
 
     def __init__(self, locale: str, ticket: Dict[str, Any], callback_func):
         super().__init__(
@@ -1040,8 +1048,33 @@ class TicketParticipantsModal(BaseModal):
         )
         self.callback_func = callback_func
 
+        # The one thing that always renders — and the only way the staffer can
+        # see who is in before deciding what to do about it.
+        listed = [f"<@{uid}>" for uid in ticket.get('participants', [])]
+        listed += [f"<@&{rid}>" for rid in ticket.get('participant_roles', [])]
         self.add_item(ui.TextDisplay(
-            t('modules.tickets.participants.description', locale=locale)))
+            t('modules.tickets.participants.description', locale=locale) + "\n"
+            + t('modules.tickets.participants.current', locale=locale) + " "
+            + (", ".join(listed)
+               or t('modules.tickets.participants.nobody', locale=locale))))
+
+        self.mode_select = ui.Select(
+            options=[
+                discord.SelectOption(
+                    label=t(f'modules.tickets.participants.mode_{mode}',
+                            locale=locale)[:100],
+                    value=mode,
+                    default=mode == self.MODE_ADD,
+                ) for mode in self.MODES
+            ],
+            min_values=1, max_values=1,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.tickets.participants.mode_label', locale=locale)[:45],
+            description=t('modules.tickets.participants.mode_hint',
+                          locale=locale)[:100],
+            component=self.mode_select,
+        ))
 
         self.user_select = ui.UserSelect(
             placeholder=t('modules.tickets.participants.members_placeholder',
@@ -1074,8 +1107,10 @@ class TicketParticipantsModal(BaseModal):
         ))
 
     async def on_submit(self, interaction: discord.Interaction):
+        values = self.mode_select.values
         await self.callback_func(
             interaction,
+            values[0] if values else self.MODE_ADD,
             [target.id for target in self.user_select.values],
             [role.id for role in self.role_select.values],
         )
@@ -1097,9 +1132,19 @@ async def open_participants_modal(interaction: discord.Interaction,
     await interaction.response.send_modal(modal)
 
 
-async def _apply_participants(interaction: discord.Interaction,
+def _merge_participants(current: List[int], selected: List[int],
+                        mode: str) -> List[int]:
+    """Apply one of the three modes to a participant list, order preserved."""
+    if mode == TicketParticipantsModal.MODE_REPLACE:
+        return list(dict.fromkeys(selected))
+    if mode == TicketParticipantsModal.MODE_REMOVE:
+        return [item for item in current if item not in selected]
+    return list(dict.fromkeys([*current, *selected]))
+
+
+async def _apply_participants(interaction: discord.Interaction, mode: str,
                               users: List[int], roles: List[int]) -> None:
-    """Replace the ticket's manual participants with what the form returned."""
+    """Add, remove or replace the ticket's manual participants."""
     resolved = await _resolve(interaction)
     if not resolved:
         return
@@ -1114,8 +1159,11 @@ async def _apply_participants(interaction: discord.Interaction,
                          locale)
         return
 
+    users = _merge_participants(list(ticket.get('participants', [])), users, mode)
+    roles = _merge_participants(list(ticket.get('participant_roles', [])), roles, mode)
+
     # The opener is in the ticket by definition; keeping them out of the manual
-    # list stops "remove the owner" from being one click.
+    # list stops "remove the owner" from being one submit.
     users = [uid for uid in users if uid != ticket['owner_id']]
 
     await interaction.response.defer(ephemeral=True, thinking=True)


### PR DESCRIPTION
Follow-up to #351, which is already merged. Two bugs found by testing the merged code on a live bot, plus an icon swap.

## 1. Claiming a ticket crashed

```
TypeError: AppealRepository.set_claim() takes 2 positional arguments but 3 were given
  File "services/ticket_service.py", line 644, in claim_ticket
    await self.bot.db.set_claim(channel.id, actor.id)
```

`ModdyDatabase` inherits from ~24 repositories at once, so two of them picking the same method name do **not** clash loudly — the one earlier in the MRO silently wins and every call meant for the other lands on it. `TicketsRepository.set_claim` was shadowed by `AppealRepository.set_claim`, so the failure surfaced at runtime instead of at import.

- Renamed to **`set_ticket_claim`**.
- Added `tests/test_database_repositories.py`, which asserts no repository method name is defined twice. It was the only collision in the project.

The rule it encodes: when two repositories describe the same verb on different things, qualify the name.

## 2. The participants modal came up empty — and that was destructive

Discord does not render `default_values` for a select inside a modal. The payload discord.py sends is correct (verified by dumping `Modal.to_dict()` — right ids, right types); it is simply ignored.

The pickers therefore opened empty while `_apply_participants` **replaced** the list with whatever was submitted, so a staffer opening the form to add one person wiped every existing participant.

Fixed by not depending on a pre-fill the platform does not guarantee:

- the current participants are printed as **text**, the one thing that always renders;
- a mode select says what happens to the selection — **Add** (the default, and the only mode that can never destroy anything), Remove, or Replace;
- `default_values` is still sent, so the form pre-fills the day Discord honours it, but nothing depends on it.

`TestParticipantMerge` covers the three modes, including the exact failure: an empty selection is a no-op in add and remove.

⚠️ This departs from the UX originally asked for ("the pickers should open pre-selected"). A modal cannot do that today. If that matters more than having participants be a modal, the only Discord surface that supports pre-selection is a Components V2 panel — switching back is a contained change.

## 3. The claim icon

`TICKET_CLAIM` borrowed `questions`; it now points at the dedicated `<:claim:1541239118888181770>`. The alias it was the only user of is gone with it.

## Testing

`python3 -m pytest tests/ -q` — 1207 passed. New coverage: repository name collisions, the three participant modes, the participants form showing the current list and defaulting to the harmless mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C9jpgK224KhNXABXxZJsF

---
_Generated by [Claude Code](https://claude.ai/code/session_019C9jpgK224KhNXABXxZJsF)_