### PR TITLE
Centralized notification system with attribution and abuse reporting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,11 @@ moddy/
 │                              #   invites, assets, scheduled_events, stage, polls,
 │                              #   integrations, automod, moderation
 │
+├── notifications/             # Centralized notifications (EVERY DM goes through it)
+│   ├── models.py              #   Uniform payload + source + service registry + hashing
+│   ├── render.py              #   Payload → Components V2 + attribution context
+│   └── service.py             #   NotificationService (bot.notifications)
+│
 ├── automod/                   # Automod AI DETECTION pipeline (decides only; no side effects)
 │   ├── engine.py              #   Shared per-bot orchestrator (funnel entry)
 │   ├── relations.py / routing.py / precedents.py / bareme.py
@@ -135,6 +140,9 @@ moddy/
 │   ├── commands/dev/          #   /dev commands (one file each)
 │   ├── commands/team/         #   /team commands (incl. help)
 │   ├── commands/mod/          #   /mod commands + case/, global/ and altguard/ sub-groups
+│   │                          #   (incl. /mod notif — notification lookup by uuid)
+│   ├── commands/com/          #   /com commands (/com send — notification to a user,
+│   │                          #   a server, or thousands of them)
 │   ├── commands/manage/       #   /manage commands (staff panel, badge, redirect/, banner/…)
 │   ├── support_commands.py    #   sup. commands — legacy (not yet migrated)
 │   └── communication_commands.py  # com. commands — legacy (not yet migrated)
@@ -153,6 +161,7 @@ moddy/
 │       ├── precedents.py        #   Automod server precedents (automod_precedents, RAG)
 │       ├── token_alerts.py, token_secrets.py
 │       ├── subscription.py    #   Subscription read-only queries (incl. is_guild_premium)
+│       ├── notifications.py   #   Notifications, deliveries, abuse reports
 │       ├── social.py          #   Social notifications subscriptions
 │       └── _utils.py
 │
@@ -172,6 +181,7 @@ moddy/
 │   ├── altguard_views.py      #   AltGuard panel (persistent), consent Modal V2, link + log cards
 │   ├── automod_shadow_views.py #  Automod shadow-mode (dry_run) SIMULATION card + annotation buttons (persistent)
 │   ├── automod_render.py      #   Shared automod card helpers (barème breakdown, sanction name/accent)
+│   ├── notification_views.py  #   Notification attribution row, report Modal V2, staff review panels
 │   ├── ticket_views.py        #   Ticket panel, ticket message, cards, claim, participants modal
 │   ├── transcription_views.py #   Voice transcription cards + persistent Transcribe button
 │   ├── appeal_views.py        #   Automod appeal UI (DM buttons + reviewer panels, persistent)
@@ -245,6 +255,7 @@ moddy/
     ├── test_task_signature.py #   moddy:tasks HMAC contract (canonicalization, replay, dedup)
     ├── test_tickets.py        #   Tickets: schema, permissions, claim, overwrites, screens, i18n
     ├── test_transcription.py  #   Voice transcription helpers, guard rails, cards
+    ├── test_notifications.py  #   Notifications: hashing, attribution, report rules, i18n
     ├── test_logs.py           #   Server logs: registry, routing, rendering, delivery
     └── test_logs_i18n.py      #   Server logs: i18n completeness on the 5 locales
 ```
@@ -375,6 +386,23 @@ moddy/
 - Code comments, commits, PRs: **English only**
 - User-facing strings: via i18n (French + English)
 
+### 11. Every message to a human goes through the notification system
+- **NEVER call `user.send(...)` / `member.send(...)` directly.** Every DM — and
+  every server-wide notice Moddy posts on its own behalf — goes through
+  `bot.notifications` so that it is stored, attributable, and reportable when
+  someone other than Moddy wrote it.
+- Pass a uniform `NotificationContent` **and** a `NotificationSource` that tells
+  the truth about who wrote the words. A feature that already has its own card
+  passes it as `view=` — the uniform content is still required, because it is
+  what the dashboard, the mail pipeline and the staff preview render.
+- Keep `{placeholders}` in the content and pass their values as `variables`:
+  that is what lets thousands of identical DMs share one stored body while each
+  one stays reproducible to the character.
+- The only exception is a sender with a genuinely exotic delivery path (the
+  token detector opens the DM channel with the user's own token). It still calls
+  `record()` and then `mark_delivered()` / `mark_failed()`.
+- See → [docs/NOTIFICATIONS.md](docs/NOTIFICATIONS.md)
+
 ---
 
 ## Documentation Index
@@ -410,6 +438,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/BOT_CUSTOMIZATION.md](docs/BOT_CUSTOMIZATION.md) | Bot Customization — per-guild nickname/avatar/banner/bio + name styles, Redis dashboard contract |
 | [docs/PREMIUM.md](docs/PREMIUM.md) | **Premium gating** — how to check whether a server (or a user) is premium |
 | [docs/STAFF_SYSTEM.md](docs/STAFF_SYSTEM.md) | Staff/dev commands, permissions, roles |
+| [docs/NOTIFICATIONS.md](docs/NOTIFICATIONS.md) | **Centralized notifications** — every DM/mail/dashboard message, attribution buttons, abuse reports, `/com send`, `/mod notif` |
 | [docs/LOGS.md](docs/LOGS.md) | **Advanced server logs** — 163 events, registry, rendering, webhook delivery, stored config & dashboard contract |
 | [docs/MODERATION_CASES.md](docs/MODERATION_CASES.md) | Moderation cases/sanctions, the case service & sources, auto-sync |
 | [docs/GLOBAL_SANCTIONS.md](docs/GLOBAL_SANCTIONS.md) | **Global sanctions** — Moddy-team warn / limited / suspended, on users *and* servers |

--- a/bot.py
+++ b/bot.py
@@ -131,6 +131,10 @@ class ModdyBot(ModdyFrameworkBot):
         self.altguard = AltGuardClient(self)
         from services.ticket_service import TicketService
         self.tickets = TicketService(self)  # ticket lifecycle (open/close/escalate…)
+        from notifications import NotificationService
+        # Every DM / server notice Moddy sends goes through this: stored,
+        # attributed, reportable (see docs/NOTIFICATIONS.md).
+        self.notifications = NotificationService(self)
         from gateway import Gateway
         self.gateway = Gateway()
         self.redis = None  # Redis client (shared with backend)

--- a/cogs/moderation_commands.py
+++ b/cogs/moderation_commands.py
@@ -21,6 +21,7 @@ from discord.ext import commands
 
 from cogs.error_handler import BaseModal, BaseView
 from config import COLORS
+from notifications.models import NotificationContent, NotificationSource
 from utils import emojis
 from utils.i18n import t, get_locale
 
@@ -109,6 +110,7 @@ def _parse_iso(value: Optional[str]) -> Optional[datetime]:
 
 
 async def _send_sanction_dm(
+    bot,
     guild: discord.Guild,
     mod_id: int,
     action: str,
@@ -122,7 +124,9 @@ async def _send_sanction_dm(
     """Send a sanction DM notification to the sanctioned user.
 
     Shared by the manual /ban /mute /warn modal and the backend-dashboard
-    sanction handler so both produce an identical DM.
+    sanction handler so both produce an identical DM. It goes out through
+    ``bot.notifications`` like every other DM, attributed to the sanctioning
+    server (docs/NOTIFICATIONS.md).
     """
     try:
         accent = {
@@ -174,7 +178,22 @@ async def _send_sanction_dm(
             )
             dm_view.add_item(gallery)
 
-        await user.send(view=dm_view)
+        # Through the notification system: the wording (the reason) is the
+        # moderator's own, so the DM is attributed to the server and is
+        # reportable. See docs/NOTIFICATIONS.md.
+        await bot.notifications.send_dm(
+            user,
+            content=NotificationContent(
+                title=title,
+                body=text,
+                icon=sanction_emoji,
+                accent_color=accent,
+                template_id=f"moderation.dm.{action}",
+            ),
+            source=NotificationSource.guild(guild_id, actor_id=mod_id),
+            view=dm_view,
+            locale=dm_locale,
+        )
     except discord.Forbidden:
         pass  # DMs disabled
     except Exception as exc:
@@ -734,7 +753,7 @@ class SanctionModal(BaseModal):
     ):
         """Send a sanction DM notification to the sanctioned user."""
         await _send_sanction_dm(
-            self.guild, self.mod.id, self.action,
+            self.bot, self.guild, self.mod.id, self.action,
             user, reason, expires_at, reference, dm_locale, attachments,
         )
 
@@ -1170,7 +1189,7 @@ class ModerationCommands(commands.Cog):
                 dm_target = None
         if dm_target is not None and issuer_id:
             await _send_sanction_dm(
-                guild, int(issuer_id), action, dm_target,
+                self.bot, guild, int(issuer_id), action, dm_target,
                 case_row["reason"], expires_at, case_row["reference"],
                 _guild_locale(guild),
             )

--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -917,8 +917,26 @@ class Reminder(commands.Cog):
                     container_dm.add_item(TextDisplay(f"-# {t('commands.reminder.notification.footer', locale='en', time=format_discord_timestamp(created_at, 'R'))}"))
 
                 view_dm.add_item(container_dm)
-                await user.send(view=view_dm)
-                sent = True
+                # Through the notification system: the text is the user's own
+                # reminder, sent by a Moddy service — attributed, not reportable.
+                from notifications.models import NotificationContent, NotificationSource
+                from utils.emojis import TIME
+                result = await self.bot.notifications.send_dm(
+                    user,
+                    content=NotificationContent(
+                        title=t("commands.reminder.notification.title", locale="en"),
+                        body="> {message}",
+                        icon=TIME,
+                        template_id="reminder.notification",
+                    ),
+                    source=NotificationSource.service("reminder"),
+                    variables={"message": reminder['message']},
+                    view=view_dm,
+                    locale="en-US",
+                )
+                sent = result.delivered
+                if result.forbidden:
+                    logger.warning(f"Could not DM user {user_id}")
             except discord.Forbidden:
                 logger.warning(f"Could not DM user {user_id}")
                 sent = False

--- a/cogs/token_detector.py
+++ b/cogs/token_detector.py
@@ -1075,20 +1075,66 @@ def _build_bot_alert_view(
 # DM SENDER
 # =============================================================================
 
+async def _record_alert(bot, user_id: int, kind: str) -> Optional[dict]:
+    """Register the alert as an official notification before sending it.
+
+    A leaked-token alert is Moddy speaking as an institution: it deliberately
+    carries **no** attribution or report buttons (docs/NOTIFICATIONS.md), but it
+    is stored and counted like every other notification, and the delivery is
+    marked below once one of the two send paths succeeds.
+    """
+    notifications = getattr(bot, "notifications", None)
+    if notifications is None:
+        return None
+    from notifications.models import (
+        NotificationContent, NotificationSource, RecipientType,
+    )
+    from utils.emojis import SHIELD
+    return await notifications.record(
+        content=NotificationContent(
+            title="Token detected",
+            body="A Discord token belonging to {subject} was found in a public "
+                 "message and must be regenerated immediately.",
+            icon=SHIELD,
+            accent_color=0xED4245,
+            links=[{"label": "Learn more",
+                    "url": "https://docs.moddy.app/articles/token-detector"}],
+            template_id=f"token_detector.{kind}",
+        ),
+        source=NotificationSource.official("token_detector"),
+        recipient_type=RecipientType.DISCORD_USER,
+        recipient_id=user_id,
+        variables={"subject": kind},
+    )
+
+
 async def _send_dm(
     bot: commands.Bot,
     session: aiohttp.ClientSession,
     user_id: int,
     view: BaseView,
     user_token: Optional[str] = None,
+    kind: str = "user",
 ) -> Optional[discord.Message]:
     """Send a DM to *user_id*. Falls back to opening DM via the user's token.
     Returns the sent Message on success, None otherwise."""
+
+    record = await _record_alert(bot, user_id, kind)
+
+    async def _mark(message: Optional[discord.Message], error: Optional[str] = None):
+        notifications = getattr(bot, "notifications", None)
+        if notifications is None or record is None:
+            return
+        if message is not None:
+            await notifications.mark_delivered(record, message)
+        else:
+            await notifications.mark_failed(record, error)
 
     # Attempt 1: normal bot DM
     try:
         user = bot.get_user(user_id) or await bot.fetch_user(user_id)
         msg = await user.send(view=view)
+        await _mark(msg)
         return msg
     except (discord.Forbidden, discord.HTTPException):
         pass
@@ -1102,10 +1148,12 @@ async def _send_dm(
             if ch_id:
                 channel = bot.get_channel(ch_id) or await bot.fetch_channel(ch_id)
                 msg = await channel.send(view=view)
+                await _mark(msg)
                 return msg
         except Exception as exc:
             logger.debug(f"Fallback DM (user token) failed for {user_id}: {exc}")
 
+    await _mark(None, "dm_unreachable")
     return None
 
 
@@ -1350,7 +1398,8 @@ class TokenDetector(commands.Cog):
                 targets.append(int(owner["id"]))
 
         for uid in targets:
-            sent_msg = await _send_dm(self.bot, session, uid, view, user_token=None)
+            sent_msg = await _send_dm(self.bot, session, uid, view,
+                                      user_token=None, kind="bot")
             if sent_msg:
                 payload["dm_message_id"] = sent_msg.id
                 payload["dm_channel_id"] = sent_msg.channel.id

--- a/config.py
+++ b/config.py
@@ -30,6 +30,14 @@ DEVELOPER_IDS: List[int] = [int(id.strip()) for id in dev_ids_str.split(",") if 
 MODDY_TEAM_GUILD_ID: int = int(os.environ.get("MODDY_GUILD_ID", "1394001780148535387"))
 MODDY_APPEAL_CHANNEL_ID: int = int(os.environ.get("MODDY_APPEAL_CHANNEL_ID", "1521246998127317114"))
 
+# Centralized notifications (docs/NOTIFICATIONS.md): where abuse reports filed
+# from a DM's flag button are reviewed, and where every step of their handling
+# is logged. Both live in the Moddy team guild.
+MODDY_NOTIF_REPORT_CHANNEL_ID: int = int(
+    os.environ.get("MODDY_NOTIF_REPORT_CHANNEL_ID", "1541231528754028594"))
+MODDY_NOTIF_REPORT_LOG_CHANNEL_ID: int = int(
+    os.environ.get("MODDY_NOTIF_REPORT_LOG_CHANNEL_ID", "1541233478522241034"))
+
 # =============================================================================
 # BASE DE DONNÉES
 # =============================================================================

--- a/db/base.py
+++ b/db/base.py
@@ -35,6 +35,7 @@ from db.repositories.forms import FormsRepository
 from db.repositories.social import SocialSubscriptionsRepository
 from db.repositories.altguard import AltGuardRepository
 from db.repositories.tickets import TicketsRepository
+from db.repositories.notifications import NotificationRepository
 
 logger = logging.getLogger('moddy.database')
 
@@ -71,6 +72,7 @@ class ModdyDatabase(
     SocialSubscriptionsRepository,
     AltGuardRepository,
     TicketsRepository,
+    NotificationRepository,
 ):
     """Gestionnaire principal de la base de données"""
 
@@ -866,6 +868,108 @@ class ModdyDatabase(
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_tickets_owner "
                 "ON tickets (guild_id, owner_id, status)")
+
+            # ---------------------------------------------------------------
+            # Centralized notifications (docs/NOTIFICATIONS.md)
+            # Every message Moddy sends to a human is one row in
+            # `notifications`. The wording itself lives once in
+            # `notification_contents`, keyed by the hash of its TEMPLATE
+            # (placeholders unresolved), so ten thousand identical welcome DMs
+            # store one body and ten thousand small rows pointing at it; the
+            # `variables` column carries what each one substituted, which is
+            # what makes an exact preview reproducible months later.
+            # ---------------------------------------------------------------
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS notification_contents (
+                    hash          TEXT PRIMARY KEY,
+                    payload       JSONB NOT NULL,
+                    uses          BIGINT NOT NULL DEFAULT 0,
+                    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    last_seen_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS notifications (
+                    id              UUID PRIMARY KEY,
+                    batch_id        UUID,
+                    kind            TEXT NOT NULL
+                        CHECK (kind IN ('official','service','guild','service_guild')),
+                    author          TEXT NOT NULL DEFAULT 'moddy'
+                        CHECK (author IN ('moddy','guild','staff')),
+                    source_service  TEXT,
+                    source_guild_id BIGINT,
+                    actor_id        BIGINT,
+                    recipient_type  TEXT NOT NULL,
+                    recipient_id    BIGINT,
+                    recipient_ref   TEXT,
+                    content_hash    TEXT NOT NULL REFERENCES notification_contents(hash),
+                    variables       JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    platforms       TEXT[] NOT NULL DEFAULT ARRAY['discord'],
+                    reportable      BOOLEAN NOT NULL DEFAULT FALSE,
+                    locale          TEXT,
+                    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_notifications_recipient "
+                "ON notifications (recipient_id, created_at DESC)")
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_notifications_guild "
+                "ON notifications (source_guild_id, created_at DESC)")
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_notifications_batch "
+                "ON notifications (batch_id)")
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_notifications_content "
+                "ON notifications (content_hash)")
+
+            # One row per (notification, platform): Discord may be sent while
+            # the mail failed. Primary-keyed on the pair so a retry updates.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS notification_deliveries (
+                    notification_id UUID NOT NULL
+                        REFERENCES notifications(id) ON DELETE CASCADE,
+                    platform        TEXT NOT NULL
+                        CHECK (platform IN ('discord','email','dashboard')),
+                    status          TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending','sent','failed','skipped')),
+                    channel_id      BIGINT,
+                    message_id      BIGINT,
+                    error           TEXT,
+                    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    PRIMARY KEY (notification_id, platform)
+                )
+            """)
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_notification_deliveries_status "
+                "ON notification_deliveries (platform, status)")
+
+            # Abuse reports filed by a recipient. UNIQUE(notification, reporter)
+            # because a recipient reports a given DM once — a second click must
+            # show them the status of their report, not open a new one.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS notification_reports (
+                    id                UUID PRIMARY KEY,
+                    notification_id   UUID NOT NULL
+                        REFERENCES notifications(id) ON DELETE CASCADE,
+                    reporter_id       BIGINT NOT NULL,
+                    reason            TEXT NOT NULL,
+                    status            TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending','claimed','accepted','refused')),
+                    claimed_by        BIGINT,
+                    claimed_at        TIMESTAMPTZ,
+                    decided_by        BIGINT,
+                    decided_at        TIMESTAMPTZ,
+                    decision_note     TEXT,
+                    review_channel_id BIGINT,
+                    review_message_id BIGINT,
+                    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    CONSTRAINT notification_reports_unique UNIQUE (notification_id, reporter_id)
+                )
+            """)
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_notification_reports_status "
+                "ON notification_reports (status, created_at DESC)")
 
             # Table des rôles sauvegardés (Auto Restore Roles module)
             await conn.execute("""

--- a/db/repositories/notifications.py
+++ b/db/repositories/notifications.py
@@ -1,0 +1,358 @@
+"""
+Notifications repository — every message Moddy sends to a human.
+
+Four tables, one idea per table:
+
+``notification_contents``
+    The **template** bodies, keyed by their SHA-256. Ten thousand welcome DMs
+    configured with the same text write this row once; ``uses`` counts how
+    often it has been sent. Placeholders are *not* resolved here, which is what
+    makes the de-duplication work (see ``notifications/models.py``).
+
+``notifications``
+    One row per (message, recipient): its uuid — the reference a user or a
+    staffer quotes — who sent it, who receives it, which platforms it targets,
+    and the ``variables`` needed to rebuild the exact wording later.
+
+``notification_deliveries``
+    One row per (notification, platform): did Discord accept it, which message
+    id did it get, why did the mail fail. Primary-keyed on the pair so a retry
+    updates instead of duplicating.
+
+``notification_reports``
+    Abuse reports filed by recipients, with the review-panel message they were
+    posted to and the staff decision.
+
+See docs/NOTIFICATIONS.md.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid as uuid_module
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger('moddy.database')
+
+
+def _as_uuid(value: Any) -> Optional[uuid_module.UUID]:
+    """Coerce a str/UUID into a UUID, or ``None`` when it is not one."""
+    if value is None:
+        return None
+    if isinstance(value, uuid_module.UUID):
+        return value
+    try:
+        return uuid_module.UUID(str(value))
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+class NotificationRepository:
+    """CRUD for the notification tables."""
+
+    # ------------------------------------------------------------------ #
+    # Content
+    # ------------------------------------------------------------------ #
+
+    async def store_notification_content(self, content_hash: str, payload: Dict[str, Any]) -> None:
+        """Insert the template body, or bump its counters if already known."""
+        async with self.pool.acquire() as conn:
+            await conn.execute("""
+                INSERT INTO notification_contents (hash, payload, uses)
+                VALUES ($1, $2::jsonb, 1)
+                ON CONFLICT (hash) DO UPDATE
+                    SET uses = notification_contents.uses + 1,
+                        last_seen_at = now()
+            """, content_hash, json.dumps(payload, ensure_ascii=False))
+
+    async def get_notification_content(self, content_hash: str) -> Optional[Dict[str, Any]]:
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT * FROM notification_contents WHERE hash = $1", content_hash)
+            if not row:
+                return None
+            return {
+                "hash": row["hash"],
+                "payload": self._parse_jsonb(row["payload"]),
+                "uses": row["uses"],
+                "first_seen_at": row["first_seen_at"],
+                "last_seen_at": row["last_seen_at"],
+            }
+
+    # ------------------------------------------------------------------ #
+    # Notifications
+    # ------------------------------------------------------------------ #
+
+    async def create_notification(
+        self,
+        *,
+        kind: str,
+        author: str,
+        recipient_type: str,
+        content_hash: str,
+        content_payload: Dict[str, Any],
+        variables: Optional[Dict[str, Any]] = None,
+        platforms: Sequence[str] = ("discord",),
+        source_service: Optional[str] = None,
+        source_guild_id: Optional[int] = None,
+        actor_id: Optional[int] = None,
+        recipient_id: Optional[int] = None,
+        recipient_ref: Optional[str] = None,
+        reportable: bool = False,
+        locale: Optional[str] = None,
+        batch_id: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        """Write the notification row (and its content) and return it.
+
+        The uuid is generated here so the caller can put it on the message it is
+        about to send — the button custom_ids carry it, and a recipient quoting
+        "notification `…`" to support must land on this row.
+        """
+        await self.store_notification_content(content_hash, content_payload)
+
+        notification_id = uuid_module.uuid4()
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                INSERT INTO notifications (
+                    id, batch_id, kind, author, source_service, source_guild_id,
+                    actor_id, recipient_type, recipient_id, recipient_ref,
+                    content_hash, variables, platforms, reportable, locale
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15)
+                RETURNING *
+            """,
+                notification_id, _as_uuid(batch_id), kind, author, source_service,
+                source_guild_id, actor_id, recipient_type, recipient_id, recipient_ref,
+                content_hash, json.dumps(variables or {}, ensure_ascii=False),
+                list(platforms), reportable, locale,
+            )
+
+            # Every targeted platform starts pending; the sender flips its own.
+            for platform in platforms:
+                await conn.execute("""
+                    INSERT INTO notification_deliveries (notification_id, platform, status)
+                    VALUES ($1, $2, 'pending')
+                    ON CONFLICT (notification_id, platform) DO NOTHING
+                """, notification_id, platform)
+
+        return self._notification_row(row)
+
+    def _notification_row(self, row) -> Dict[str, Any]:
+        return {
+            "id": row["id"],
+            "batch_id": row["batch_id"],
+            "kind": row["kind"],
+            "author": row["author"],
+            "source_service": row["source_service"],
+            "source_guild_id": row["source_guild_id"],
+            "actor_id": row["actor_id"],
+            "recipient_type": row["recipient_type"],
+            "recipient_id": row["recipient_id"],
+            "recipient_ref": row["recipient_ref"],
+            "content_hash": row["content_hash"],
+            "variables": self._parse_jsonb(row["variables"]),
+            "platforms": list(row["platforms"] or []),
+            "reportable": row["reportable"],
+            "locale": row["locale"],
+            "created_at": row["created_at"],
+        }
+
+    async def get_notification(self, notification_id: Any) -> Optional[Dict[str, Any]]:
+        """The full notification: row + template payload + every delivery."""
+        nid = _as_uuid(notification_id)
+        if nid is None:
+            return None
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT * FROM notifications WHERE id = $1", nid)
+            if not row:
+                return None
+            data = self._notification_row(row)
+            content = await conn.fetchrow(
+                "SELECT payload, uses FROM notification_contents WHERE hash = $1",
+                data["content_hash"])
+            data["content"] = self._parse_jsonb(content["payload"]) if content else {}
+            data["content_uses"] = content["uses"] if content else 0
+            deliveries = await conn.fetch("""
+                SELECT * FROM notification_deliveries
+                WHERE notification_id = $1 ORDER BY platform
+            """, nid)
+            data["deliveries"] = [{
+                "platform": d["platform"],
+                "status": d["status"],
+                "channel_id": d["channel_id"],
+                "message_id": d["message_id"],
+                "error": d["error"],
+                "updated_at": d["updated_at"],
+            } for d in deliveries]
+        return data
+
+    async def set_notification_delivery(
+        self,
+        notification_id: Any,
+        platform: str,
+        status: str,
+        *,
+        channel_id: Optional[int] = None,
+        message_id: Optional[int] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """Record the outcome of one platform's delivery attempt."""
+        nid = _as_uuid(notification_id)
+        if nid is None:
+            return
+        async with self.pool.acquire() as conn:
+            await conn.execute("""
+                INSERT INTO notification_deliveries
+                    (notification_id, platform, status, channel_id, message_id, error, updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6, now())
+                ON CONFLICT (notification_id, platform) DO UPDATE
+                    SET status = EXCLUDED.status,
+                        channel_id = COALESCE(EXCLUDED.channel_id, notification_deliveries.channel_id),
+                        message_id = COALESCE(EXCLUDED.message_id, notification_deliveries.message_id),
+                        error = EXCLUDED.error,
+                        updated_at = now()
+            """, nid, platform, status, channel_id, message_id,
+                 (error[:500] if error else None))
+
+    async def list_notifications(
+        self,
+        *,
+        recipient_id: Optional[int] = None,
+        source_guild_id: Optional[int] = None,
+        batch_id: Optional[Any] = None,
+        limit: int = 25,
+    ) -> List[Dict[str, Any]]:
+        """Recent notifications for a recipient, a server, or a batch."""
+        clauses, params = [], []
+        if recipient_id is not None:
+            params.append(recipient_id)
+            clauses.append(f"recipient_id = ${len(params)}")
+        if source_guild_id is not None:
+            params.append(source_guild_id)
+            clauses.append(f"source_guild_id = ${len(params)}")
+        if batch_id is not None:
+            params.append(_as_uuid(batch_id))
+            clauses.append(f"batch_id = ${len(params)}")
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(max(1, min(limit, 200)))
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"SELECT * FROM notifications {where} "
+                f"ORDER BY created_at DESC LIMIT ${len(params)}", *params)
+        return [self._notification_row(r) for r in rows]
+
+    async def get_batch_stats(self, batch_id: Any) -> Dict[str, int]:
+        """How a broadcast went: one count per delivery status."""
+        bid = _as_uuid(batch_id)
+        if bid is None:
+            return {}
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch("""
+                SELECT d.status, COUNT(*) AS total
+                FROM notifications n
+                JOIN notification_deliveries d ON d.notification_id = n.id
+                WHERE n.batch_id = $1
+                GROUP BY d.status
+            """, bid)
+        return {r["status"]: r["total"] for r in rows}
+
+    # ------------------------------------------------------------------ #
+    # Reports
+    # ------------------------------------------------------------------ #
+
+    async def create_notification_report(
+        self, *, notification_id: Any, reporter_id: int, reason: str,
+    ) -> Optional[Dict[str, Any]]:
+        """File an abuse report. Returns ``None`` if this user already filed one."""
+        nid = _as_uuid(notification_id)
+        if nid is None:
+            return None
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                INSERT INTO notification_reports (id, notification_id, reporter_id, reason)
+                VALUES ($1, $2, $3, $4)
+                ON CONFLICT (notification_id, reporter_id) DO NOTHING
+                RETURNING *
+            """, uuid_module.uuid4(), nid, reporter_id, reason[:1000])
+        return self._report_row(row) if row else None
+
+    def _report_row(self, row) -> Dict[str, Any]:
+        return {
+            "id": row["id"],
+            "notification_id": row["notification_id"],
+            "reporter_id": row["reporter_id"],
+            "reason": row["reason"],
+            "status": row["status"],
+            "claimed_by": row["claimed_by"],
+            "claimed_at": row["claimed_at"],
+            "decided_by": row["decided_by"],
+            "decided_at": row["decided_at"],
+            "decision_note": row["decision_note"],
+            "review_channel_id": row["review_channel_id"],
+            "review_message_id": row["review_message_id"],
+            "created_at": row["created_at"],
+        }
+
+    async def get_notification_report(self, report_id: Any) -> Optional[Dict[str, Any]]:
+        rid = _as_uuid(report_id)
+        if rid is None:
+            return None
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT * FROM notification_reports WHERE id = $1", rid)
+        return self._report_row(row) if row else None
+
+    async def get_reports_for_notification(self, notification_id: Any) -> List[Dict[str, Any]]:
+        nid = _as_uuid(notification_id)
+        if nid is None:
+            return []
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch("""
+                SELECT * FROM notification_reports
+                WHERE notification_id = $1 ORDER BY created_at
+            """, nid)
+        return [self._report_row(r) for r in rows]
+
+    async def set_report_review_message(
+        self, report_id: Any, channel_id: int, message_id: int
+    ) -> None:
+        """Remember where the review panel lives so decisions can edit it."""
+        rid = _as_uuid(report_id)
+        if rid is None:
+            return
+        async with self.pool.acquire() as conn:
+            await conn.execute("""
+                UPDATE notification_reports
+                SET review_channel_id = $2, review_message_id = $3
+                WHERE id = $1
+            """, rid, channel_id, message_id)
+
+    async def claim_notification_report(self, report_id: Any, staff_id: int) -> Optional[Dict[str, Any]]:
+        """Assign a pending report. Returns ``None`` when someone got there first."""
+        rid = _as_uuid(report_id)
+        if rid is None:
+            return None
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                UPDATE notification_reports
+                SET status = 'claimed', claimed_by = $2, claimed_at = now()
+                WHERE id = $1 AND status = 'pending'
+                RETURNING *
+            """, rid, staff_id)
+        return self._report_row(row) if row else None
+
+    async def decide_notification_report(
+        self, report_id: Any, staff_id: int, status: str, note: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Accept or refuse a report that has not been decided yet."""
+        rid = _as_uuid(report_id)
+        if rid is None or status not in ("accepted", "refused"):
+            return None
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                UPDATE notification_reports
+                SET status = $3, decided_by = $2, decided_at = now(), decision_note = $4
+                WHERE id = $1 AND status IN ('pending', 'claimed')
+                RETURNING *
+            """, rid, staff_id, status, (note or None))
+        return self._report_row(row) if row else None

--- a/db/repositories/users.py
+++ b/db/repositories/users.py
@@ -46,6 +46,18 @@ class UserRepository:
         """Met à jour une partie spécifique de la data utilisateur"""
         await self._update_entity_data('users', 'user_id', user_id, path, value)
 
+    async def get_all_user_ids(self, limit: int = 100000) -> List[int]:
+        """Every user Moddy knows about.
+
+        The audience of a bot-wide announcement (see the notification system's
+        broadcasts). Capped rather than unbounded so a mistyped segment cannot
+        pull the whole table into memory at once.
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT user_id FROM users ORDER BY user_id LIMIT $1", limit)
+            return [row['user_id'] for row in rows]
+
     async def get_users_with_attribute(self, attribute: str, value: Any = None) -> List[int]:
         """Récupère tous les utilisateurs ayant un attribut spécifique
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -556,6 +556,137 @@ Voir → [TICKETS.md](TICKETS.md).
 
 ---
 
+### 13. Table `notification_contents`
+
+The **template bodies** of everything Moddy sends to a human, stored once each.
+
+A notification's wording is hashed **as a template**, with its `{placeholders}`
+left unresolved (`NotificationContent.template_hash()` — SHA-256 of the
+canonical JSON payload). Ten thousand members receiving the same welcome DM of
+the same server therefore share **one** row here: the body is written once, and
+each `notifications` row only points at its hash. The values that were
+substituted for that particular recipient live in `notifications.variables`, so
+the exact wording of any single notification stays reproducible months later
+(`content.render(variables)`) — that is what the staff preview and the abuse
+report show as evidence.
+
+**Columns:**
+- `hash` (TEXT, PRIMARY KEY) — SHA-256 of the canonical template payload
+- `payload` (JSONB) — the `NotificationContent` template: `title`, `body`,
+  `icon`, `accent_color`, `sections`, `links`, `footer`, `template_id`
+- `uses` (BIGINT) — how many notifications have used this exact wording,
+  incremented on conflict at insert time
+- `first_seen_at` / `last_seen_at` (TIMESTAMPTZ)
+
+**Repository:** `db/repositories/notifications.py` — `NotificationRepository`
+
+See → [NOTIFICATIONS.md](NOTIFICATIONS.md).
+
+---
+
+### 14. Table `notifications`
+
+One row per **(message, recipient)**. The `id` is the uuid a recipient reads at
+the bottom of a Moddy DM and quotes to support, and the uuid the attribution and
+report buttons carry in their `custom_id`.
+
+A broadcast is exploded into one row per recipient, all sharing the same
+`batch_id`, so "who did this campaign reach, and how did it go" is a single
+query. `recipient_type` values `all_users` / `all_guilds` / `segment` describe
+the *audience* a batch was aimed at, not a delivered row.
+
+**Columns:**
+- `id` (UUID, PRIMARY KEY) — the public reference of the notification
+- `batch_id` (UUID) — groups the rows of one broadcast
+- `kind` (TEXT) — `official` | `service` | `guild` | `service_guild`
+- `author` (TEXT) — who wrote the words: `moddy` | `guild` | `staff`
+- `source_service` (TEXT) — service id (`reminder`, `tickets`…), if any
+- `source_guild_id` (BIGINT) — the server on whose behalf it was sent, if any
+- `actor_id` (BIGINT) — the human who triggered the send, if any
+- `recipient_type` (TEXT) — `discord_user` | `discord_guild` | `all_users` |
+  `all_guilds` | `segment` | `email`
+- `recipient_id` (BIGINT) / `recipient_ref` (TEXT) — the Discord id, or a
+  non-Discord reference (email address, segment name)
+- `content_hash` (TEXT) — FK → `notification_contents(hash)`
+- `variables` (JSONB) — the values substituted into the template for *this* row
+- `platforms` (TEXT[]) — what the notification targets (default `{discord}`)
+- `reportable` (BOOLEAN) — frozen at send time; the row can only make a
+  notification *less* reportable later, never more
+- `locale` (TEXT) — the locale the message was rendered in
+- `created_at` (TIMESTAMPTZ)
+
+**Index:**
+- `idx_notifications_recipient` on `(recipient_id, created_at DESC)`
+- `idx_notifications_guild` on `(source_guild_id, created_at DESC)`
+- `idx_notifications_batch` on `(batch_id)`
+- `idx_notifications_content` on `(content_hash)`
+
+**Repository:** `db/repositories/notifications.py` — `NotificationRepository`
+
+See → [NOTIFICATIONS.md](NOTIFICATIONS.md).
+
+---
+
+### 15. Table `notification_deliveries`
+
+One row per **(notification, platform)**: `notifications.platforms` is what a
+notification *targets*, this table is what actually happened on each one —
+Discord may have been accepted while the mail failed. The pair is the
+**PRIMARY KEY `(notification_id, platform)`**, so a retry updates the row
+instead of duplicating it.
+
+The bot delivers Discord; the `email` and `dashboard` rows stay `pending` for
+the backend to pick up and mark.
+
+**Columns:**
+- `notification_id` (UUID) — FK → `notifications(id)`, `ON DELETE CASCADE`
+- `platform` (TEXT) — `discord` | `email` | `dashboard`
+- `status` (TEXT) — `pending` | `sent` | `failed` | `skipped`
+- `channel_id` / `message_id` (BIGINT) — where it landed, for Discord
+- `error` (TEXT) — why it failed (closed DMs, HTTP error…)
+- `updated_at` (TIMESTAMPTZ)
+- PRIMARY KEY `(notification_id, platform)`
+
+**Index:**
+- `idx_notification_deliveries_status` on `(platform, status)`
+
+**Repository:** `db/repositories/notifications.py` — `NotificationRepository`
+
+See → [NOTIFICATIONS.md](NOTIFICATIONS.md).
+
+---
+
+### 16. Table `notification_reports`
+
+The **abuse reports** filed by recipients against a notification whose wording
+came from a server, plus the staff review that followed.
+
+`UNIQUE (notification_id, reporter_id)` (`notification_reports_unique`): a
+recipient reports a given message **once**. A second click on the flag shows
+them the status of their existing report instead of opening a new one.
+
+**Columns:**
+- `id` (UUID, PRIMARY KEY) — the report reference, accepted by `/mod notif`
+- `notification_id` (UUID) — FK → `notifications(id)`, `ON DELETE CASCADE`
+- `reporter_id` (BIGINT) — the recipient who filed it
+- `reason` (TEXT) — the text typed in the report modal
+- `status` (TEXT) — `pending` | `claimed` | `accepted` | `refused`
+- `claimed_by` / `claimed_at` — the reviewer who took it
+- `decided_by` / `decided_at` / `decision_note` — the outcome
+- `review_channel_id` / `review_message_id` (BIGINT) — the review panel it was
+  posted to
+- `created_at` (TIMESTAMPTZ)
+- `CONSTRAINT notification_reports_unique UNIQUE (notification_id, reporter_id)`
+
+**Index:**
+- `idx_notification_reports_status` on `(status, created_at DESC)`
+
+**Repository:** `db/repositories/notifications.py` — `NotificationRepository`
+
+See → [NOTIFICATIONS.md](NOTIFICATIONS.md).
+
+---
+
 ## Système d'attributs et de données
 
 Moddy utilise deux types de champs JSONB pour stocker les informations:

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -1,0 +1,317 @@
+# Centralized Notifications
+
+> Every message Moddy sends to a human — a DM, a mail, a card on the dashboard —
+> is a **notification**: stored, attributable, and (when someone other than
+> Moddy wrote it) reportable.
+
+**Nothing in the bot calls `user.send(...)` directly any more.** A feature says
+*what* it wants to say and *who is behind it*; the system does the rest.
+
+---
+
+## Why
+
+Before this, a member who received an abusive welcome DM had no way to know
+which server sent it, and no way to tell us. And nothing was recorded: we could
+not answer "what did we send this person, and when".
+
+Three answers, one system:
+
+1. **Provenance.** Under every DM, a button carries the name and icon of the
+   server or the Moddy service that sent it. Clicking it identifies the sender,
+   links into the server, and shows the notification's uuid.
+2. **Reporting.** Next to it, a red flag opens a Modal V2 that recaps the
+   message, asks why, and requires an explicit "this report is legitimate"
+   confirmation. The report lands in a staff review channel with Claim / See the
+   message / Accept / Decline, and every step is logged.
+3. **Memory.** Every notification is a row: uuid, sender, recipient, target
+   platforms, per-platform delivery status, and enough to rebuild the exact
+   wording months later.
+
+---
+
+## The three shapes of a notification
+
+| Source | Buttons under the message | Report flag |
+|---|---|---|
+| **Official** — account suspension, leaked-token alert | *none at all* | — |
+| **Service** — a Moddy feature acting alone (reminder) | `[ Service ]` `[ 🚩 ]` | greyed out (Moddy wrote it) |
+| **Server** — a server's own words (welcome DM, sanction reason) | `[ Server ]` `[ 🚩 ]` | **live** |
+| **Service + server** — a feature acting for a server (AltGuard, tickets, automod) | `[ Service ]` `[ Server ]` `[ 🚩 ]` | greyed out unless the server wrote the words |
+
+Two rules decide the flag, and they are re-checked on **every click**, not only
+at send time:
+
+- **Who wrote the words** (`ContentAuthor`). Only `GUILD`-authored content can
+  be abusive. A sanction notice worded by Moddy on a server's behalf is not
+  reportable — its exit is the appeal, not the flag.
+- **Whose server it is.** A message from a server carrying the `OFFICIAL`
+  attribute (one of Moddy's own) is never reportable: reporting Moddy to Moddy
+  is a loop with no exit. The flag is rendered disabled, and the identity panel
+  says *why* — a dead button with no explanation is a bug.
+
+A verified server (`VERIFIED`, `VERIFIED_ORG` or `PARTNER`) shows the
+verification check next to its name, hyperlinked like everywhere else in Moddy
+(CLAUDE.md rule #7). An official Moddy server shows it too, plus an explicit
+"Official Moddy server" line.
+
+> **Button icons.** A Discord button emoji must be a real emoji — a server icon
+> URL cannot go on one. The button therefore carries a generic server icon (or
+> the verification check), and the **real** server icon is shown in the panel
+> the button opens.
+
+---
+
+## Sending a notification
+
+```python
+from notifications import NotificationContent, NotificationSource
+
+result = await bot.notifications.send_dm(
+    member,
+    content=NotificationContent(
+        title=guild.name,
+        body="Welcome {user} on {server}!",   # placeholders LEFT IN
+        icon=WAVING_HAND,
+        accent_color=0x5865F2,
+        template_id="welcome_dm.wdm_a1b2",
+    ),
+    source=NotificationSource.guild(guild.id),  # the server wrote this
+    variables={"user": member.mention, "server": guild.name},
+    locale="fr",
+)
+
+if result.forbidden:      # DMs closed — every other send would fail the same
+    return
+```
+
+`send_dm` returns a `DeliveryResult` (`notification_id`, `message`, `status`,
+`error`, plus `delivered` / `forbidden`). It never raises on a delivery
+failure: closed DMs are the norm, not an exception.
+
+### Keeping your own card
+
+Features with an established card (a sanction notice, a ticket transcript, the
+automod DM with its appeal buttons) pass it as `view=`; the attribution row is
+appended to it:
+
+```python
+await bot.notifications.send_dm(
+    member, content=content, source=source, view=my_view, files=files)
+```
+
+The uniform `content` is **still required** even then. It is what the dashboard
+renders, what the mail pipeline sends, and what a staff reviewer sees when they
+click *See the message*. A `view` without a `content` would be a Discord-only
+message that no other surface can show.
+
+### Source constructors
+
+```python
+NotificationSource.official("token_detector")            # no buttons at all
+NotificationSource.service("reminder")                   # service button only
+NotificationSource.guild(guild_id)                       # server + live flag
+NotificationSource.service_guild("tickets", guild_id)    # service + server
+```
+
+`author=ContentAuthor.GUILD` marks the wording as the server's (reportable);
+`ContentAuthor.STAFF` marks a Moddy-team broadcast; the default is
+`ContentAuthor.MODDY`. `actor_id=` records the human who triggered the send.
+
+### Other destinations
+
+```python
+# A server-wide notice: moddy-updates → Community Updates → system channel,
+# optionally the owner too (and always the owner if no channel is usable).
+await bot.notifications.notify_guild(guild, content=…, source=…, dm_owner=True)
+
+# Thousands of recipients, one batch_id, paced and resilient.
+stats = await bot.notifications.broadcast_users(user_ids, content=…, source=…,
+                                                segment="PREMIUM", progress=cb)
+stats = await bot.notifications.broadcast_guilds(guild_ids, content=…, source=…)
+```
+
+### Exotic senders
+
+The token detector opens the DM channel with the *user's own token* when the
+bot cannot. Such a sender records first and marks the outcome itself:
+
+```python
+record = await bot.notifications.record(content=…, source=…,
+                                        recipient_type=RecipientType.DISCORD_USER,
+                                        recipient_id=user_id)
+...
+await bot.notifications.mark_delivered(record, message)   # or mark_failed(record, "…")
+```
+
+---
+
+## The uniform payload
+
+`NotificationContent` is the same object on every platform, which is what makes
+"a suspension notice reads the same in Discord, in an inbox and on the
+dashboard" true rather than aspirational.
+
+| Field | Discord | Mail | Dashboard |
+|---|---|---|---|
+| `title` | `### <icon> title` | subject | card title |
+| `body` | markdown | text | markdown |
+| `sections[]` | `**title**` + body | labelled blocks | blocks |
+| `links[]` | link buttons | link list | buttons |
+| `footer` | `-# footer` | last line | footer |
+| `icon` | custom emoji | *stripped* | emoji string |
+| `accent_color` | container accent | header colour | accent |
+
+`to_email()` strips custom emojis (`<:done:123>` is literal noise in an inbox);
+`to_dashboard()` keeps the markdown as-is.
+
+### Placeholders and the content hash
+
+**Strings keep their `{placeholders}`; the resolved values travel next to them
+as `variables`.** This is the single most important convention in the system:
+
+- `template_hash()` is the SHA-256 of the *unresolved* template, so ten thousand
+  welcome DMs of the same server share **one** `notification_contents` row.
+- The exact wording of any single notification is `content.render(variables)`,
+  reproducible months later — that is the staff preview and the report evidence.
+
+Substitution is `notifications.models.substitute()`, never `str.format`: server
+text is arbitrary and a stray `{` must not raise mid-delivery. Unknown
+placeholders are left visible rather than silently blanked.
+
+---
+
+## Database
+
+Four tables (DDL in `db/base.py::_init_tables`, queries in
+`db/repositories/notifications.py`):
+
+| Table | One row per | Notable columns |
+|---|---|---|
+| `notification_contents` | template body | `hash` (PK), `payload`, `uses` |
+| `notifications` | (message, recipient) | `id` (uuid), `batch_id`, `kind`, `author`, `source_service`, `source_guild_id`, `actor_id`, `recipient_type`, `recipient_id`, `recipient_ref`, `content_hash`, `variables`, `platforms[]`, `reportable`, `locale` |
+| `notification_deliveries` | (notification, platform) | PK `(notification_id, platform)`, `status`, `channel_id`, `message_id`, `error` |
+| `notification_reports` | abuse report | `id`, `notification_id`, `reporter_id`, `reason`, `status`, `claimed_by`, `decided_by`, `decision_note`, `review_channel_id`, `review_message_id`; `UNIQUE (notification_id, reporter_id)` |
+
+`recipient_type` is `discord_user` | `discord_guild` | `all_users` | `all_guilds`
+| `segment` | `email`. A broadcast is exploded into one row per recipient sharing
+a `batch_id`, so "who did this campaign reach, and how did it go" is one query
+(`get_batch_stats`).
+
+`platforms[]` is what the notification *targets*; `notification_deliveries` is
+what actually happened on each. The bot delivers Discord; the mail and dashboard
+rows stay `pending` for the backend to pick up and mark.
+
+`reportable` is frozen on the row at send time. The row's flag can only ever
+make a notification *less* reportable, never more: a server marked official
+later must not resurrect old flags.
+
+---
+
+## Reporting flow
+
+1. The recipient clicks 🚩 on their DM. Authorization: the addressee, and only
+   them (`may_report`) — for a server-wide notice, that means a member with
+   Manage Server.
+2. A Modal V2 recaps the source, the uuid and an excerpt, asks for a reason
+   (15–1000 chars) and requires a `CheckboxGroup` confirmation.
+3. The report is written and posted to `MODDY_NOTIF_REPORT_CHANNEL_ID` as a
+   review panel: **Claim**, **See the message**, **Accept**, **Decline**.
+4. Every step (created / claimed / accepted / declined) is mirrored to
+   `MODDY_NOTIF_REPORT_LOG_CHANNEL_ID`.
+5. On a decision, the reporter receives the outcome — as an official
+   notification, through this same system.
+
+Reviewer rules, re-checked on every click: the `notif_review` permission node,
+and never your own report. A second click on the flag by the same person shows
+the status of their existing report instead of opening a new one
+(`UNIQUE (notification_id, reporter_id)`).
+
+Configuration:
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `MODDY_NOTIF_REPORT_CHANNEL_ID` | `1541231528754028594` | where reports are reviewed |
+| `MODDY_NOTIF_REPORT_LOG_CHANNEL_ID` | `1541233478522241034` | where every step is logged |
+
+---
+
+## Staff commands
+
+### `/mod notif <reference>` — look one up
+
+Takes a notification uuid **or** a report reference (staff copy whichever id is
+in front of them) and shows everything: origin, reportability and why, recipient
+and batch, per-platform delivery with message ids, the resolved content, the
+template hash and how many times that exact wording has been sent, plus every
+report filed against it. Node: `notif_lookup`.
+
+### `/com send <target> <recipient> [dm_owner]` — send one
+
+| `target` | `recipient` | Result |
+|---|---|---|
+| `user` | a user id | one DM |
+| `guild` | a server id | the server's Moddy channel, optionally its owner |
+| `users` | `all`, or an attribute (`PREMIUM`, `BETA`…) | a DM per user |
+| `guilds` | `all`, or an attribute (`OFFICIAL`, `PARTNER`…) | a notice per server |
+
+The wording is written in a Modal V2 (title, body, optional button label + URL)
+and stored as a uniform payload, so the same announcement can be rendered by the
+dashboard and the mail pipeline without being retyped. Group sends are confirmed
+first (with a warning past 500 recipients), then run in the background with a
+live progress panel, paced by `BROADCAST_DELAY`. Node: `broadcast`.
+
+---
+
+## Persistence
+
+Every button is a `discord.ui.DynamicItem` whose `custom_id` carries the
+notification (or report) uuid, registered through `NotificationsPersistence`:
+
+| custom_id | Item | Auth |
+|---|---|---|
+| `moddy:notif:svc:<uuid>` | service identity panel | public |
+| `moddy:notif:src:<uuid>` | server identity panel | public |
+| `moddy:notif:flag:<uuid>` | report | the addressee |
+| `moddy:notif:rvclaim:<uuid>` | claim | `notif_review`, not the reporter |
+| `moddy:notif:rvshow:<uuid>` | see the message | `notif_review`, not the reporter |
+| `moddy:notif:rvdec:<accept\|refuse>:<uuid>` | decide | `notif_review`, not the reporter |
+
+A DM sent today must still be reportable after next week's deploy, so nothing
+may rely on in-memory state: every callback re-derives the notification from its
+uuid and the database. See [PERSISTENT_VIEWS.md](PERSISTENT_VIEWS.md).
+
+---
+
+## Files
+
+```
+notifications/
+├── __init__.py       # public surface
+├── models.py         # content, source, enums, service registry, hashing
+├── render.py         # content → Components V2, attribution context
+└── service.py        # NotificationService (bot.notifications)
+
+utils/notification_views.py     # attribution row, report modal, review panels
+db/repositories/notifications.py
+staff/commands/mod/notification.py   # /mod notif
+staff/commands/com/send.py           # /com send
+tests/test_notifications.py
+```
+
+---
+
+## Adding a sender
+
+1. Register the service in `notifications/models.py::SERVICES` (one line) and
+   add its name under `notifications.services.<id>` in the five locale files.
+2. Build a `NotificationContent` — **keep the placeholders in**, pass the values
+   as `variables`.
+3. Pick the source constructor that tells the truth about who wrote the words.
+   If in doubt: did a human outside Moddy type this text? If yes,
+   `ContentAuthor.GUILD`; if no, the default.
+4. Call `bot.notifications.send_dm(...)` and act on the `DeliveryResult`.
+
+Never call `.send()` on a user object directly. If a delivery path genuinely
+cannot go through `send_dm`, use `record()` + `mark_delivered()` /
+`mark_failed()` so the notification still exists in the record.

--- a/docs/PERSISTENT_VIEWS.md
+++ b/docs/PERSISTENT_VIEWS.md
@@ -511,7 +511,12 @@ Registered persistent views live in
 the `/moddy` views, `/config` and every `modules/configs/*` panel, social
 notifications, `/cases` & `/mycases`, automod appeals and shadow-mode
 annotations, reminders, preferences, saved messages, and the staff
-help/server-list/manager panels.
+help/server-list/manager panels, and the notification attribution + abuse
+report buttons (`NotificationsPersistence`, see
+[NOTIFICATIONS.md](NOTIFICATIONS.md)) — a DM sent today must still be
+reportable after next week's deploy, so every one of its buttons carries the
+notification (or report) uuid in its custom_id and rebuilds from the database
+on each click.
 
 **`staff/commands/manage/staff.py::StaffManagerPanel`** grants and revokes
 staff roles/permissions. Making it persistent required changing its

--- a/docs/RAILWAY.md
+++ b/docs/RAILWAY.md
@@ -100,6 +100,22 @@ AltGuard — sans lui, le bouton de vérification répond « service indisponibl
 Les canaux Redis `altguard:verdict` / `altguard:membership` passent par le Redis
 déjà configuré (`REDIS_URL`), rien à ajouter — voir [ALTGUARD.md](ALTGUARD.md)
 
+## Notifications centralisées
+
+Les deux salons vivent dans le serveur de l'équipe Moddy. Défauts dans
+`config.py` — voir [NOTIFICATIONS.md](NOTIFICATIONS.md).
+
+### MODDY_NOTIF_REPORT_CHANNEL_ID
+**Valeur :** id de salon (défaut : `1541231528754028594`)
+**Description :** Salon où sont postés les signalements d'abus déposés depuis le
+bouton drapeau d'une notification, avec le panneau de revue (Claim / Voir le
+message / Accepter / Refuser)
+
+### MODDY_NOTIF_REPORT_LOG_CHANNEL_ID
+**Valeur :** id de salon (défaut : `1541233478522241034`)
+**Description :** Salon où chaque étape du traitement d'un signalement (créé,
+pris en charge, accepté, refusé) est journalisée
+
 ## Checklist Railway
 
 - [ ] `DISCORD_TOKEN`
@@ -114,6 +130,8 @@ déjà configuré (`REDIS_URL`), rien à ajouter — voir [ALTGUARD.md](ALTGUARD
 - [ ] `BOT_STATUS` (optionnel)
 - [ ] `ALTGUARD_BOT_TOKEN` (optionnel, requis pour le module AltGuard)
 - [ ] `ALTGUARD_API_URL` (optionnel, défaut `https://verify.moddy.app`)
+- [ ] `MODDY_NOTIF_REPORT_CHANNEL_ID` (optionnel, défaut en dur dans `config.py`)
+- [ ] `MODDY_NOTIF_REPORT_LOG_CHANNEL_ID` (optionnel, défaut en dur dans `config.py`)
 
 ## Dépannage
 
@@ -131,3 +149,4 @@ déjà configuré (`REDIS_URL`), rien à ajouter — voir [ALTGUARD.md](ALTGUARD
 ## Documentation connexe
 
 - [BACKEND-INTEGRATION.md](BACKEND-INTEGRATION.md) — Architecture complète bot ↔ backend
+- [NOTIFICATIONS.md](NOTIFICATIONS.md) — Système de notifications centralisées

--- a/docs/STAFF_COMMANDS_FRAMEWORK.md
+++ b/docs/STAFF_COMMANDS_FRAMEWORK.md
@@ -23,7 +23,7 @@ option, and error handling.
 | Management | `/manage` | `m.` | `staff/commands/manage/` |
 | Moderator | `/mod` | `mod.` | `staff/commands/mod/` |
 | Support | `/support` | `sup.` | `staff/commands/support/` *(no commands yet)* |
-| Communication | `/com` | `com.` | `staff/commands/com/` *(no commands yet)* |
+| Communication | `/com` | `com.` | `staff/commands/com/` |
 
 Slash commands are **ephemeral by default**. Every staff slash command carries
 an auto-injected `incognito` boolean option (default `true` = ephemeral). Pass
@@ -155,9 +155,9 @@ Permission checks are centralized in the dispatcher (`staff/framework/cog.py`):
    (`utils/staff_role_permissions.py`) — devs and super-admin bypass all nodes.
 
 Available permission nodes: `stripe_manage`, `redirect_manage`, `banner_manage`,
-`official_manage`, `global_sanction`, `global_enforcement`. Nodes let a command
-live in a non-dev department (e.g. `/manage`) while still being gated beyond the
-base role check.
+`official_manage`, `global_sanction`, `global_enforcement`, `notif_review`,
+`notif_lookup`, `broadcast`. Nodes let a command live in a non-dev department
+(e.g. `/manage`) while still being gated beyond the base role check.
 
 The node check lives in `utils/staff_permissions.has_staff_node(bot, user_id,
 node)`, shared with persistent components that must re-derive authorization on
@@ -231,10 +231,25 @@ arguments (used by `sql` and `jsk`). **Commands must not log themselves.**
 | `case create/view/list/edit/close/note` | Moderation case management |
 | `global apply/view/halt/resume/lift/pending` | Moddy-team global sanctions (grouped cases, appeal countdown) |
 | `altguard verify/unverify/refusal` | AltGuard gate overrides + refusal details (`altguard_manage`) — see [ALTGUARD.md](ALTGUARD.md) |
+| `notif` | Look a notification (or a report filed on it) up by its uuid (`notif_lookup`) — see [NOTIFICATIONS.md](NOTIFICATIONS.md) |
 
-### `/support` / `/com`
+### `/com` (Communication)
 
-No framework commands yet. Legacy placeholder `help` command exists on both.
+| Command | Message alias | Description |
+|---------|--------------|-------------|
+| `send` | `com.send` | Send a Moddy notification to a user, a server, or a group of them (`broadcast`) |
+
+`/com send <target> <recipient> [dm_owner]` — `target` is `user`, `guild`,
+`users` or `guilds`; `recipient` is a Discord id for the single targets, or a
+segment (`all`, or an attribute such as `PREMIUM` / `OFFICIAL`) for the group
+ones. The wording is written in a **Modal V2** (title, body, optional button
+label + URL) and stored as a uniform notification payload. Group sends are
+confirmed first, then run in the background with a live progress panel, every
+row sharing one `batch_id` — see [NOTIFICATIONS.md](NOTIFICATIONS.md).
+
+### `/support`
+
+No framework commands yet. A legacy placeholder `help` command exists.
 
 ---
 
@@ -256,7 +271,8 @@ staff/
 │   ├── dev/               # /dev commands (one file each)
 │   ├── team/              # /team commands
 │   ├── manage/            # /manage commands (+ redirect/ and banner/ sub-dirs)
-│   └── mod/               # /mod commands (+ case/ and global_sanction/ sub-dirs)
+│   ├── mod/               # /mod commands (+ case/ and global_sanction/ sub-dirs)
+│   └── com/               # /com commands (send + its compose modal)
 ├── base.py                # StaffCommandsCog base (auto-delete tracking)
 ├── staff_commands.py      # Entry point extension loaded by the bot
 ├── support_commands.py    # /sup legacy placeholder

--- a/docs/WELCOME_DM.md
+++ b/docs/WELCOME_DM.md
@@ -29,8 +29,9 @@ configuration order. Rendering is a `ui.LayoutView` holding a single
 `ui.Container` (accent-coloured) with the formatted text — no `discord.Embed`
 anywhere.
 
-A member with DMs closed raises `discord.Forbidden` on the first send; the
-module stops there instead of retrying the remaining entries.
+A member with DMs closed makes the first send come back `forbidden`; the module
+stops there instead of retrying the remaining entries (see §7 — delivery goes
+through the notification system, which does not raise on a closed DM).
 
 Mentions are constrained to the joining member: `AllowedMentions(everyone=False,
 roles=False, users=[member])`. A DM cannot mass-ping in the first place, but the
@@ -195,3 +196,36 @@ Main panel ──► Add message (Modal V2) ──► saved
   registered in `utils/persistent_views.py`. The manage view's current entry is
   not persisted across a restart — same accepted loss as
   `ManageWelcomeMessageView`, see [PERSISTENT_VIEWS.md](PERSISTENT_VIEWS.md).
+
+---
+
+## 7. Delivery: through the notification system
+
+Welcome DMs are not sent with `member.send(...)`. They go through
+`bot.notifications.send_dm()` — see [NOTIFICATIONS.md](NOTIFICATIONS.md) — which
+changes three things:
+
+- **Every DM is recorded.** One `notifications` row per member, carrying the
+  uuid the recipient can quote to support, the delivery result, and the
+  `variables` that were substituted (`message_variables()`), so the exact
+  wording sent to a given member can be rebuilt later. The body itself is
+  stored **as a template**, placeholders unresolved (`welcome_content()` keeps
+  `{server}` / `{user}` in the text), so all the members of one server share a
+  single stored content row.
+- **It is attributed to the server.** A button under the message carries the
+  server's name and opens a panel identifying it — the recipient can always
+  tell which server DMed them.
+- **It is reportable.** The source is `NotificationSource.guild(guild.id)`,
+  whose default author is `ContentAuthor.GUILD`: the text is the server's own
+  words, which is exactly what can be abused, so the red flag next to the
+  attribution button is live and files an abuse report to the Moddy team.
+
+`send_dm()` returns a `DeliveryResult` instead of raising: `result.forbidden`
+means the member's DMs are closed (the module stops there), `result.delivered`
+that the message went out, and `result.notification_id` is what the module logs.
+
+The rendered container is unchanged — the module still builds its own
+Components V2 view holding only the guild's text — and is passed as `view=`;
+the attribution row is appended to it. The uniform `content` is still required:
+it is what the dashboard and the mail pipeline render, and what a staff reviewer
+sees when handling a report.

--- a/docs/sessions/2026-08-24_centralized-notifications.md
+++ b/docs/sessions/2026-08-24_centralized-notifications.md
@@ -1,0 +1,121 @@
+# Session: Centralized notification system
+
+**Date:** 2026-08-24
+**Agent:** Claude Code
+
+## Summary
+
+Every message Moddy sends to a human now goes through one system
+(`bot.notifications`). A notification is stored, carries the identity of
+whoever is behind it, and — when someone other than Moddy wrote the words —
+can be reported by its recipient.
+
+What shipped:
+
+- **Uniform payload.** `NotificationContent` renders to Discord, to a mail
+  shape and to a dashboard shape, so a suspension notice reads the same
+  everywhere. Titles, body, sections, links, footer, icon, accent.
+- **Attribution row** under every non-official DM: `[ Service ] [ Server ] [ 🚩 ]`.
+  The first two open an ephemeral identity panel (server icon, verification
+  badge, member count, link into the server, the notification's uuid, a support
+  link). The flag opens a report Modal V2 (recap + reason + explicit legitimacy
+  confirmation).
+- **Abuse reports** posted to the staff review channel with Claim / See the
+  message / Accept / Decline, every step mirrored to the report log channel, and
+  the reporter told the outcome — through this same system.
+- **Storage**: four tables. The wording is stored once per *template* (hashed
+  before placeholder substitution), each notification storing its own
+  `variables`, so ten thousand identical welcome DMs cost one body row and every
+  one of them stays reproducible to the character.
+- **Staff commands**: `/mod notif <uuid>` (everything about one notification or
+  report) and `/com send` (one user, one server, or thousands of either).
+- **Eleven senders migrated** off `user.send(...)`.
+
+## Changes Made
+
+### New
+
+- `notifications/models.py` — payload, source, enums, service registry, template
+  hashing, placeholder substitution, mail/dashboard shapes
+- `notifications/render.py` — payload → Components V2, attribution context
+  (verified / official / reportable)
+- `notifications/service.py` — `NotificationService`: record, deliver, mark,
+  server notices, broadcasts, the whole report lifecycle
+- `notifications/__init__.py` — public surface
+- `utils/notification_views.py` — attribution row, identity panels, report Modal
+  V2, staff review panel, report log card, six persistent `DynamicItem`s
+- `db/repositories/notifications.py` — CRUD for the four tables
+- `staff/commands/mod/notification.py` — `/mod notif`
+- `staff/commands/com/send.py`, `staff/commands/com/_send_modal.py` — `/com send`
+- `tests/test_notifications.py` — 39 tests (hashing, reproducibility,
+  attribution rules, report authorization, i18n completeness on 5 locales)
+- `docs/NOTIFICATIONS.md`
+
+### Modified
+
+- `db/base.py` — DDL for `notification_contents`, `notifications`,
+  `notification_deliveries`, `notification_reports` + indexes
+- `db/repositories/users.py` — `get_all_user_ids()` (broadcast audience)
+- `bot.py` — `self.notifications = NotificationService(self)`
+- `config.py` — `MODDY_NOTIF_REPORT_CHANNEL_ID`, `MODDY_NOTIF_REPORT_LOG_CHANNEL_ID`
+- `utils/persistent_views.py` — registers `NotificationsPersistence`
+- `utils/staff_role_permissions.py` — nodes `notif_review`, `notif_lookup`
+- Senders migrated: `modules/welcome_dm.py`, `modules/altguard.py`,
+  `modules/interserver.py`, `modules/automod_ai.py`, `cogs/moderation_commands.py`,
+  `cogs/reminder.py`, `cogs/token_detector.py`, `services/ticket_service.py`,
+  `services/appeal_service.py`, `services/expiration_notifier.py`,
+  `services/global_sanction_service.py`
+- `locales/{fr,en-US,es-ES,pt-BR,de}.json` — `notifications.*`, `staff.notif.*`,
+  `staff.com.*`
+- `tests/test_persistent_views.py`, `tests/test_altguard.py`,
+  `tests/test_expiration_notifications.py`, `tests/test_tickets.py`
+- `CLAUDE.md` (rule #11), `docs/PERSISTENT_VIEWS.md`, `docs/DATABASE.md`,
+  `docs/STAFF_COMMANDS_FRAMEWORK.md`, `docs/RAILWAY.md`, `docs/WELCOME_DM.md`
+
+## Decisions & Rationale
+
+- **Content is stored as a template, not as a finished message.** Hashing before
+  substitution is what makes de-duplication real (one row per configured welcome
+  DM, not one per member) while `variables` keeps each notification exactly
+  reproducible. `str.format` was rejected for substitution: server text is
+  arbitrary and a stray `{` must never raise mid-delivery.
+- **Reportability is decided by who wrote the words, not by the message type.**
+  `ContentAuthor.GUILD` → live flag; Moddy's own wording → greyed out, with the
+  reason spelled out in the identity panel (a dead button with no explanation is
+  a bug). Messages from `OFFICIAL` Moddy servers are never reportable.
+- **`reportable` is frozen on the row**, and the runtime check can only make a
+  notification *less* reportable. A server marked official later must not
+  resurrect old flags.
+- **Callers keep their own card.** Features with an established design (sanction
+  DMs with appeal buttons, ticket cards, transcriptions) pass `view=`; the
+  uniform content is still required because the dashboard, the mail pipeline and
+  the staff preview all read it. A view-only message would be Discord-only.
+- **Official notices carry no attribution at all** — a suspension is Moddy
+  speaking as an institution; offering to "report" it is nonsense. They are
+  still stored and counted.
+- **Every button is a `DynamicItem` keyed by uuid.** A DM sent today must still
+  be reportable after next week's deploy, so no callback may rely on in-memory
+  state.
+- **Attribution button icons are Moddy emojis, not server icons.** Discord
+  button emojis must be real emojis; the *actual* server icon is shown in the
+  panel the button opens.
+- **Broadcasts explode into one row per recipient** sharing a `batch_id`. Per-
+  recipient delivery status is the whole point of the table, and "how did this
+  campaign go" is still one query.
+- **A database outage degrades to an unattributed DM**, never to a swallowed
+  message. Recording is best-effort; delivery is not.
+
+## Known Issues / Follow-ups
+
+- [ ] The **mail** and **dashboard** platforms are declared, stored and rendered
+      (`to_email()` / `to_dashboard()`) but nothing sends them: their delivery
+      rows stay `pending` for the backend to pick up and mark. Needs the
+      backend-side contract.
+- [ ] Accepting a report records the decision and tells the reporter; it takes
+      **no automatic action** against the server. Wiring it to the global
+      sanction / case system is a deliberate next step, not an oversight.
+- [ ] `/com send` progress edits stop if the interaction token expires (15 min);
+      the batch keeps running and stays queryable by `batch_id`. A long campaign
+      would be better served by a status message in a staff channel.
+- [ ] Recipient locale is the guild's (or the caller's), never the user's own —
+      Moddy stores no per-user language preference yet.

--- a/locales/de.json
+++ b/locales/de.json
@@ -3715,6 +3715,118 @@
         "confirm_title": "Banner löschen?",
         "confirm": "Banner {id} dauerhaft löschen?"
       }
+    },
+    "notif": {
+      "title": "Benachrichtigung",
+      "created_at": "Gesendet am",
+      "kind": "Art",
+      "author": "Verfasst von",
+      "service": "Dienst",
+      "guild": "Server",
+      "actor": "Ausgelöst von",
+      "reportable": "Meldbar",
+      "recipient": "Empfänger",
+      "batch": "Kampagne",
+      "delivery": "Zustellung",
+      "no_delivery": "Keine Zustellung erfasst",
+      "content": "Inhalt",
+      "hash": "Prüfsumme",
+      "occurrences": "Identische Sendungen",
+      "template": "Vorlage",
+      "reports": "Meldungen",
+      "not_found": {
+        "title": "Benachrichtigung nicht gefunden",
+        "description": "Keine Benachrichtigung und keine Meldung passt zu `{uuid}`."
+      },
+      "unavailable": {
+        "title": "System nicht verfügbar",
+        "description": "Das Benachrichtigungssystem ist nicht initialisiert."
+      }
+    },
+    "com": {
+      "send": {
+        "compose": "Nachricht verfassen",
+        "compose_hint": "Empfänger: {audience}",
+        "default_link_label": "Mehr erfahren",
+        "audience": {
+          "user": "Nutzer",
+          "guild": "Server",
+          "users": "Nutzer",
+          "guilds": "Server"
+        },
+        "modal": {
+          "title": "Neue Benachrichtigung",
+          "title_field": {
+            "label": "Titel",
+            "placeholder": "Titel, der oben in der Nachricht angezeigt wird"
+          },
+          "body": {
+            "label": "Nachricht",
+            "description": "Markdown wird unterstützt. Schreibe sie als finale Nachricht.",
+            "placeholder": "Der Inhalt der Benachrichtigung…"
+          },
+          "link_label": {
+            "label": "Button-Text (optional)",
+            "placeholder": "Mehr erfahren"
+          },
+          "link_url": {
+            "label": "Button-Link (optional)",
+            "description": "Muss mit https:// beginnen"
+          }
+        },
+        "confirm": {
+          "title": "Senden bestätigen",
+          "description": "Die Nachricht wird an `{count}` {kind} gesendet (Segment `{segment}`).",
+          "large": "Massenversand: Er kann nach dem Start nicht abgebrochen werden.",
+          "button": "Senden"
+        },
+        "progress": {
+          "title": "Senden läuft",
+          "description": "`{done}` / `{total}` verarbeitet — `{sent}` gesendet, `{failed}` fehlgeschlagen."
+        },
+        "done": {
+          "title": "Senden abgeschlossen",
+          "description": "`{total}` Empfänger — `{sent}` gesendet, `{failed}` fehlgeschlagen."
+        },
+        "user_done": {
+          "title": "Benachrichtigung gesendet",
+          "description": "Die Nachricht wurde an **{user}** gesendet."
+        },
+        "guild_done": {
+          "title": "Benachrichtigung gesendet",
+          "description": "Die Nachricht wurde auf **{guild}** veröffentlicht (`{count}` Zustellung(en))."
+        },
+        "errors": {
+          "bad_id": {
+            "title": "Ungültige ID",
+            "description": "Gib eine gültige Discord-ID an (nur Ziffern)."
+          },
+          "unknown_user": {
+            "title": "Nutzer nicht gefunden",
+            "description": "Kein Nutzer passt zu `{id}`."
+          },
+          "unknown_guild": {
+            "title": "Server nicht gefunden",
+            "description": "Moddy ist nicht auf dem Server `{id}`."
+          },
+          "empty_segment": {
+            "title": "Leeres Segment",
+            "description": "Kein Empfänger passt zum Segment `{segment}`."
+          },
+          "no_channel": {
+            "title": "Senden nicht möglich",
+            "description": "Kein nutzbarer Kanal auf **{guild}**."
+          },
+          "dms_closed": {
+            "title": "Direktnachrichten deaktiviert",
+            "description": "**{user}** nimmt keine Direktnachrichten an."
+          },
+          "failed": {
+            "title": "Senden nicht möglich",
+            "description": "Die Nachricht konnte nicht an **{user}** gesendet werden."
+          }
+        }
+      }
     }
   },
   "transcription": {
@@ -3876,6 +3988,178 @@
       "title": "Dein Einspruch wurde abgelehnt",
       "description": "Unser Team hat deinen Einspruch geprüft und abgelehnt. Die Sanktion **{level}** bleibt bestehen, und die ausgesetzten Maßnahmen sind wieder eingeplant.",
       "deadline": "Sie treten nun am **{date}** (**{rel}**) in Kraft."
+    }
+  },
+  "notifications": {
+    "services": {
+      "moddy": "Moddy",
+      "welcome_dm": "Willkommensnachricht",
+      "moderation": "Moderation",
+      "automod_ai": "Automod KI",
+      "appeals": "Einsprüche",
+      "altguard": "AltGuard",
+      "tickets": "Tickets",
+      "reminder": "Erinnerungen",
+      "interserver": "Serverübergreifend",
+      "token_detector": "Token-Erkennung",
+      "global_sanctions": "Globale Sanktionen",
+      "expirations": "Sanktionsende"
+    },
+    "attribution": {
+      "unknown_guild": "Unbekannter Server"
+    },
+    "source": {
+      "title": "Herkunft dieser Benachrichtigung",
+      "guild_label": "Server:",
+      "service_label": "Dienst:",
+      "id_label": "ID:",
+      "members": "Mitglieder:",
+      "created": "Erstellt am:",
+      "verified": "Verifizierter Server",
+      "official": "Offizieller Moddy-Server",
+      "open_server": "Server öffnen",
+      "uuid_label": "Benachrichtigung:",
+      "sent_at": "Gesendet am:",
+      "support_hint": "Ein Problem mit dieser Benachrichtigung? [Support kontaktieren]({url})",
+      "not_reportable": {
+        "moddy_authored": "Diese Nachricht stammt von Moddy: Es gibt nichts zu melden.",
+        "official_guild": "Diese Nachricht kommt von einem offiziellen Moddy-Server: Sie kann nicht gemeldet werden."
+      }
+    },
+    "service": {
+      "title": "Herkunft dieser Benachrichtigung",
+      "description": "Diese Nachricht wurde dir von einem Moddy-Dienst gesendet."
+    },
+    "errors": {
+      "unknown": {
+        "title": "Benachrichtigung nicht gefunden",
+        "description": "Die Benachrichtigung `{uuid}` existiert nicht mehr in unseren Aufzeichnungen."
+      },
+      "unknown_report": {
+        "description": "Die Meldung `{uuid}` existiert nicht mehr."
+      }
+    },
+    "report": {
+      "modal": {
+        "title": "Diese Benachrichtigung melden",
+        "recap": "**Herkunft:** {source}\n**Benachrichtigung:** `{uuid}`\n\n> {excerpt}",
+        "reason": {
+          "label": "Warum meldest du diese Nachricht?",
+          "description": "Beschreibe das Problem so genau wie möglich.",
+          "placeholder": "Diese Nachricht enthält…"
+        },
+        "confirm": {
+          "label": "Bestätigung",
+          "option": "Ich bestätige, dass diese Meldung berechtigt ist"
+        }
+      },
+      "sent": {
+        "title": "Meldung gesendet",
+        "description": "Das Moddy-Team wird diese Nachricht prüfen. Danke für deine Hilfe."
+      },
+      "already": {
+        "title": "Meldung bereits gesendet",
+        "description": "Du hast diese Benachrichtigung bereits gemeldet."
+      },
+      "status_label": "Status:",
+      "status": {
+        "pending": "Ausstehend",
+        "claimed": "In Prüfung",
+        "accepted": "Angenommen",
+        "refused": "Abgelehnt"
+      },
+      "reference": "Meldung:",
+      "decision_note": "Hinweis des Teams:",
+      "errors": {
+        "not_recipient": {
+          "title": "Melden nicht möglich",
+          "description": "Nur der Empfänger dieser Benachrichtigung kann sie melden."
+        },
+        "not_reportable": {
+          "title": "Melden nicht möglich"
+        },
+        "failed": {
+          "title": "Melden nicht möglich",
+          "description": "Die Meldung konnte nicht gespeichert werden. Versuche es gleich noch einmal."
+        }
+      },
+      "outcome": {
+        "accepted": {
+          "title": "Meldung angenommen",
+          "description": "Deine Meldung wurde vom Moddy-Team geprüft und angenommen. Die nötigen Maßnahmen wurden ergriffen."
+        },
+        "refused": {
+          "title": "Meldung abgelehnt",
+          "description": "Deine Meldung wurde vom Moddy-Team geprüft, aber nicht angenommen."
+        },
+        "footer": "Meldung {report}"
+      }
+    },
+    "review": {
+      "title": "Meldung einer Benachrichtigung",
+      "reporter": "Gemeldet von",
+      "source": "Herkunft",
+      "service": "Dienst",
+      "recipient": "Empfänger",
+      "sent_at": "Gesendet am",
+      "occurrences": "Sendungen dieses Inhalts",
+      "reason": "Meldegrund",
+      "content": "Gesendete Nachricht",
+      "note": "Notiz",
+      "claimed_by": "Übernommen von",
+      "decided_by": "Entschieden von",
+      "buttons": {
+        "claim": "Übernehmen",
+        "claimed": "Übernommen",
+        "preview": "Nachricht ansehen",
+        "accept": "Annehmen",
+        "refuse": "Ablehnen"
+      },
+      "no_permission": {
+        "title": "Zugriff verweigert",
+        "description": "Du hast keine Berechtigung, Meldungen zu Benachrichtigungen zu prüfen."
+      },
+      "own_report": {
+        "title": "Aktion nicht möglich",
+        "description": "Du kannst deine eigene Meldung nicht prüfen."
+      },
+      "already_decided": {
+        "title": "Meldung bereits bearbeitet",
+        "description": "Über diese Meldung wurde bereits entschieden."
+      },
+      "decision": {
+        "accept": {
+          "title": "Meldung annehmen",
+          "recap": "Die Meldung wird als **angenommen** markiert und die meldende Person wird informiert.",
+          "done": {
+            "title": "Meldung angenommen",
+            "description": "Die Entscheidung wurde gespeichert und die meldende Person wurde benachrichtigt."
+          }
+        },
+        "refuse": {
+          "title": "Meldung ablehnen",
+          "recap": "Die Meldung wird als **abgelehnt** markiert und die meldende Person wird informiert.",
+          "done": {
+            "title": "Meldung abgelehnt",
+            "description": "Die Entscheidung wurde gespeichert und die meldende Person wurde benachrichtigt."
+          }
+        },
+        "note": {
+          "label": "Notiz zur Entscheidung",
+          "description": "Wird der meldenden Person mitgeteilt und in den Logs gespeichert.",
+          "placeholder": "Optional: Erkläre die Entscheidung."
+        }
+      }
+    },
+    "log": {
+      "title": {
+        "created": "Neue Meldung",
+        "claimed": "Meldung übernommen",
+        "accepted": "Meldung angenommen",
+        "refused": "Meldung abgelehnt"
+      },
+      "actor": "Staff",
+      "jump": "Meldung ansehen"
     }
   }
 }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -3715,6 +3715,118 @@
         "confirm_title": "Delete Banner?",
         "confirm": "Permanently delete banner {id}?"
       }
+    },
+    "notif": {
+      "title": "Notification",
+      "created_at": "Sent",
+      "kind": "Kind",
+      "author": "Written by",
+      "service": "Service",
+      "guild": "Server",
+      "actor": "Triggered by",
+      "reportable": "Reportable",
+      "recipient": "Recipient",
+      "batch": "Batch",
+      "delivery": "Delivery",
+      "no_delivery": "No delivery recorded",
+      "content": "Content",
+      "hash": "Hash",
+      "occurrences": "Identical sends",
+      "template": "Template",
+      "reports": "Reports",
+      "not_found": {
+        "title": "Notification not found",
+        "description": "No notification or report matches `{uuid}`."
+      },
+      "unavailable": {
+        "title": "System unavailable",
+        "description": "The notification system is not initialized."
+      }
+    },
+    "com": {
+      "send": {
+        "compose": "Write the message",
+        "compose_hint": "Recipients: {audience}",
+        "default_link_label": "Learn more",
+        "audience": {
+          "user": "user",
+          "guild": "server",
+          "users": "users",
+          "guilds": "servers"
+        },
+        "modal": {
+          "title": "New notification",
+          "title_field": {
+            "label": "Title",
+            "placeholder": "Title shown at the top of the message"
+          },
+          "body": {
+            "label": "Message",
+            "description": "Markdown supported. Write it as the final message.",
+            "placeholder": "The notification content…"
+          },
+          "link_label": {
+            "label": "Button label (optional)",
+            "placeholder": "Learn more"
+          },
+          "link_url": {
+            "label": "Button link (optional)",
+            "description": "Must start with https://"
+          }
+        },
+        "confirm": {
+          "title": "Confirm the send",
+          "description": "The message will be sent to `{count}` {kind} (segment `{segment}`).",
+          "large": "Mass send: it cannot be cancelled once started.",
+          "button": "Send"
+        },
+        "progress": {
+          "title": "Sending",
+          "description": "`{done}` / `{total}` processed — `{sent}` sent, `{failed}` failed."
+        },
+        "done": {
+          "title": "Send finished",
+          "description": "`{total}` recipients — `{sent}` sent, `{failed}` failed."
+        },
+        "user_done": {
+          "title": "Notification sent",
+          "description": "The message was sent to **{user}**."
+        },
+        "guild_done": {
+          "title": "Notification sent",
+          "description": "The message was posted on **{guild}** (`{count}` delivery/deliveries)."
+        },
+        "errors": {
+          "bad_id": {
+            "title": "Invalid id",
+            "description": "Provide a valid Discord id (digits only)."
+          },
+          "unknown_user": {
+            "title": "User not found",
+            "description": "No user matches `{id}`."
+          },
+          "unknown_guild": {
+            "title": "Server not found",
+            "description": "Moddy is not on server `{id}`."
+          },
+          "empty_segment": {
+            "title": "Empty segment",
+            "description": "No recipient matches the segment `{segment}`."
+          },
+          "no_channel": {
+            "title": "Cannot send",
+            "description": "No usable channel on **{guild}**."
+          },
+          "dms_closed": {
+            "title": "DMs closed",
+            "description": "**{user}** does not accept direct messages."
+          },
+          "failed": {
+            "title": "Cannot send",
+            "description": "The message could not be sent to **{user}**."
+          }
+        }
+      }
     }
   },
   "transcription": {
@@ -3876,6 +3988,178 @@
       "title": "Your appeal was refused",
       "description": "Our team has reviewed your appeal and refused it. The **{level}** sanction stands, and the measures that were on hold are scheduled again.",
       "deadline": "They now take effect on **{date}** (**{rel}**)."
+    }
+  },
+  "notifications": {
+    "services": {
+      "moddy": "Moddy",
+      "welcome_dm": "Welcome message",
+      "moderation": "Moderation",
+      "automod_ai": "Automod AI",
+      "appeals": "Appeals",
+      "altguard": "AltGuard",
+      "tickets": "Tickets",
+      "reminder": "Reminders",
+      "interserver": "Inter-server",
+      "token_detector": "Token detector",
+      "global_sanctions": "Global sanctions",
+      "expirations": "Sanction expiry"
+    },
+    "attribution": {
+      "unknown_guild": "Unknown server"
+    },
+    "source": {
+      "title": "Where this notification comes from",
+      "guild_label": "Server:",
+      "service_label": "Service:",
+      "id_label": "ID:",
+      "members": "Members:",
+      "created": "Created:",
+      "verified": "Verified server",
+      "official": "Official Moddy server",
+      "open_server": "Open the server",
+      "uuid_label": "Notification:",
+      "sent_at": "Sent:",
+      "support_hint": "Something wrong with this notification? [Contact support]({url})",
+      "not_reportable": {
+        "moddy_authored": "This message is written by Moddy: there is nothing to report.",
+        "official_guild": "This message comes from an official Moddy server: it cannot be reported."
+      }
+    },
+    "service": {
+      "title": "Where this notification comes from",
+      "description": "This message was sent to you by a Moddy service."
+    },
+    "errors": {
+      "unknown": {
+        "title": "Notification not found",
+        "description": "Notification `{uuid}` no longer exists in our records."
+      },
+      "unknown_report": {
+        "description": "Report `{uuid}` no longer exists."
+      }
+    },
+    "report": {
+      "modal": {
+        "title": "Report this notification",
+        "recap": "**From:** {source}\n**Notification:** `{uuid}`\n\n> {excerpt}",
+        "reason": {
+          "label": "Why are you reporting this message?",
+          "description": "Describe the problem as precisely as you can.",
+          "placeholder": "This message contains…"
+        },
+        "confirm": {
+          "label": "Confirmation",
+          "option": "I confirm this report is legitimate"
+        }
+      },
+      "sent": {
+        "title": "Report sent",
+        "description": "The Moddy team will review this message. Thank you for your help."
+      },
+      "already": {
+        "title": "Report already sent",
+        "description": "You have already reported this notification."
+      },
+      "status_label": "Status:",
+      "status": {
+        "pending": "Pending",
+        "claimed": "Under review",
+        "accepted": "Accepted",
+        "refused": "Declined"
+      },
+      "reference": "Report:",
+      "decision_note": "Team note:",
+      "errors": {
+        "not_recipient": {
+          "title": "Cannot report",
+          "description": "Only the recipient of this notification can report it."
+        },
+        "not_reportable": {
+          "title": "Cannot report"
+        },
+        "failed": {
+          "title": "Cannot report",
+          "description": "The report could not be saved. Please try again in a moment."
+        }
+      },
+      "outcome": {
+        "accepted": {
+          "title": "Report accepted",
+          "description": "Your report was reviewed and upheld by the Moddy team. The necessary action has been taken."
+        },
+        "refused": {
+          "title": "Report declined",
+          "description": "Your report was reviewed but was not upheld by the Moddy team."
+        },
+        "footer": "Report {report}"
+      }
+    },
+    "review": {
+      "title": "Notification report",
+      "reporter": "Reported by",
+      "source": "Origin",
+      "service": "Service",
+      "recipient": "Recipient",
+      "sent_at": "Sent",
+      "occurrences": "Times this content was sent",
+      "reason": "Report reason",
+      "content": "Message sent",
+      "note": "Note",
+      "claimed_by": "Claimed by",
+      "decided_by": "Decided by",
+      "buttons": {
+        "claim": "Claim",
+        "claimed": "Claimed",
+        "preview": "See the message",
+        "accept": "Accept",
+        "refuse": "Decline"
+      },
+      "no_permission": {
+        "title": "Access denied",
+        "description": "You do not have permission to review notification reports."
+      },
+      "own_report": {
+        "title": "Not allowed",
+        "description": "You cannot review your own report."
+      },
+      "already_decided": {
+        "title": "Report already handled",
+        "description": "A decision has already been made on this report."
+      },
+      "decision": {
+        "accept": {
+          "title": "Accept the report",
+          "recap": "The report will be marked **accepted** and the reporter will be told.",
+          "done": {
+            "title": "Report accepted",
+            "description": "The decision was recorded and the reporter was notified."
+          }
+        },
+        "refuse": {
+          "title": "Decline the report",
+          "recap": "The report will be marked **declined** and the reporter will be told.",
+          "done": {
+            "title": "Report declined",
+            "description": "The decision was recorded and the reporter was notified."
+          }
+        },
+        "note": {
+          "label": "Decision note",
+          "description": "Sent to the reporter and kept in the logs.",
+          "placeholder": "Optional: explain the decision."
+        }
+      }
+    },
+    "log": {
+      "title": {
+        "created": "New report",
+        "claimed": "Report claimed",
+        "accepted": "Report accepted",
+        "refused": "Report declined"
+      },
+      "actor": "Staff",
+      "jump": "Open the report"
     }
   }
 }

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -3715,6 +3715,118 @@
         "confirm_title": "¿Eliminar banner?",
         "confirm": "¿Eliminar permanentemente el banner {id}?"
       }
+    },
+    "notif": {
+      "title": "Notificación",
+      "created_at": "Enviada el",
+      "kind": "Tipo",
+      "author": "Redactado por",
+      "service": "Servicio",
+      "guild": "Servidor",
+      "actor": "Desencadenante",
+      "reportable": "Reportable",
+      "recipient": "Destinatario",
+      "batch": "Campaña",
+      "delivery": "Entrega",
+      "no_delivery": "Ninguna entrega registrada",
+      "content": "Contenido",
+      "hash": "Huella",
+      "occurrences": "Envíos idénticos",
+      "template": "Plantilla",
+      "reports": "Reportes",
+      "not_found": {
+        "title": "Notificación no encontrada",
+        "description": "Ninguna notificación ni reporte corresponde a `{uuid}`."
+      },
+      "unavailable": {
+        "title": "Sistema no disponible",
+        "description": "El sistema de notificaciones no está inicializado."
+      }
+    },
+    "com": {
+      "send": {
+        "compose": "Redactar el mensaje",
+        "compose_hint": "Destinatarios: {audience}",
+        "default_link_label": "Más información",
+        "audience": {
+          "user": "usuario",
+          "guild": "servidor",
+          "users": "usuarios",
+          "guilds": "servidores"
+        },
+        "modal": {
+          "title": "Nueva notificación",
+          "title_field": {
+            "label": "Título",
+            "placeholder": "Título mostrado en la parte superior del mensaje"
+          },
+          "body": {
+            "label": "Mensaje",
+            "description": "Se admite Markdown. Redáctalo como el mensaje final.",
+            "placeholder": "El contenido de la notificación…"
+          },
+          "link_label": {
+            "label": "Texto del botón (opcional)",
+            "placeholder": "Más información"
+          },
+          "link_url": {
+            "label": "Enlace del botón (opcional)",
+            "description": "Debe empezar por https://"
+          }
+        },
+        "confirm": {
+          "title": "Confirmar el envío",
+          "description": "El mensaje se enviará a `{count}` {kind} (segmento `{segment}`).",
+          "large": "Envío masivo: no se podrá cancelar una vez iniciado.",
+          "button": "Enviar"
+        },
+        "progress": {
+          "title": "Envío en curso",
+          "description": "`{done}` / `{total}` procesados — `{sent}` enviados, `{failed}` fallidos."
+        },
+        "done": {
+          "title": "Envío finalizado",
+          "description": "`{total}` destinatarios — `{sent}` enviados, `{failed}` fallidos."
+        },
+        "user_done": {
+          "title": "Notificación enviada",
+          "description": "El mensaje se ha enviado a **{user}**."
+        },
+        "guild_done": {
+          "title": "Notificación enviada",
+          "description": "El mensaje se ha publicado en **{guild}** (`{count}` envío(s))."
+        },
+        "errors": {
+          "bad_id": {
+            "title": "Identificador inválido",
+            "description": "Proporciona un identificador de Discord válido (solo cifras)."
+          },
+          "unknown_user": {
+            "title": "Usuario no encontrado",
+            "description": "Ningún usuario corresponde a `{id}`."
+          },
+          "unknown_guild": {
+            "title": "Servidor no encontrado",
+            "description": "Moddy no está en el servidor `{id}`."
+          },
+          "empty_segment": {
+            "title": "Segmento vacío",
+            "description": "Ningún destinatario corresponde al segmento `{segment}`."
+          },
+          "no_channel": {
+            "title": "No se puede enviar",
+            "description": "Ningún canal utilizable en **{guild}**."
+          },
+          "dms_closed": {
+            "title": "Mensajes privados cerrados",
+            "description": "**{user}** no acepta mensajes privados."
+          },
+          "failed": {
+            "title": "No se puede enviar",
+            "description": "El mensaje no se ha podido enviar a **{user}**."
+          }
+        }
+      }
     }
   },
   "transcription": {
@@ -3876,6 +3988,178 @@
       "title": "Tu apelación ha sido rechazada",
       "description": "Nuestro equipo ha revisado tu apelación y la ha rechazado. La sanción **{level}** se mantiene, y las medidas en espera vuelven a programarse.",
       "deadline": "Ahora surtirán efecto el **{date}** (**{rel}**)."
+    }
+  },
+  "notifications": {
+    "services": {
+      "moddy": "Moddy",
+      "welcome_dm": "Mensaje de bienvenida",
+      "moderation": "Moderación",
+      "automod_ai": "Automod IA",
+      "appeals": "Apelaciones",
+      "altguard": "AltGuard",
+      "tickets": "Tickets",
+      "reminder": "Recordatorios",
+      "interserver": "Interservidor",
+      "token_detector": "Detector de tokens",
+      "global_sanctions": "Sanciones globales",
+      "expirations": "Fin de sanción"
+    },
+    "attribution": {
+      "unknown_guild": "Servidor desconocido"
+    },
+    "source": {
+      "title": "Origen de esta notificación",
+      "guild_label": "Servidor:",
+      "service_label": "Servicio:",
+      "id_label": "Identificador:",
+      "members": "Miembros:",
+      "created": "Creado el:",
+      "verified": "Servidor verificado",
+      "official": "Servidor oficial de Moddy",
+      "open_server": "Abrir el servidor",
+      "uuid_label": "Notificación:",
+      "sent_at": "Enviada el:",
+      "support_hint": "¿Algún problema con esta notificación? [Contactar con el soporte]({url})",
+      "not_reportable": {
+        "moddy_authored": "Este mensaje está redactado por Moddy: no hay nada que reportar.",
+        "official_guild": "Este mensaje proviene de un servidor oficial de Moddy: no se puede reportar."
+      }
+    },
+    "service": {
+      "title": "Origen de esta notificación",
+      "description": "Este mensaje te lo ha enviado un servicio de Moddy."
+    },
+    "errors": {
+      "unknown": {
+        "title": "Notificación no encontrada",
+        "description": "La notificación `{uuid}` ya no existe en nuestros registros."
+      },
+      "unknown_report": {
+        "description": "El reporte `{uuid}` ya no existe."
+      }
+    },
+    "report": {
+      "modal": {
+        "title": "Reportar esta notificación",
+        "recap": "**Origen:** {source}\n**Notificación:** `{uuid}`\n\n> {excerpt}",
+        "reason": {
+          "label": "¿Por qué reportas este mensaje?",
+          "description": "Describe el problema con la mayor precisión posible.",
+          "placeholder": "Este mensaje contiene…"
+        },
+        "confirm": {
+          "label": "Confirmación",
+          "option": "Confirmo que este reporte es legítimo"
+        }
+      },
+      "sent": {
+        "title": "Reporte enviado",
+        "description": "El equipo de Moddy va a revisar este mensaje. Gracias por tu ayuda."
+      },
+      "already": {
+        "title": "Reporte ya enviado",
+        "description": "Ya has reportado esta notificación."
+      },
+      "status_label": "Estado:",
+      "status": {
+        "pending": "Pendiente",
+        "claimed": "En revisión",
+        "accepted": "Aceptado",
+        "refused": "Rechazado"
+      },
+      "reference": "Reporte:",
+      "decision_note": "Nota del equipo:",
+      "errors": {
+        "not_recipient": {
+          "title": "No se puede reportar",
+          "description": "Solo el destinatario de esta notificación puede reportarla."
+        },
+        "not_reportable": {
+          "title": "No se puede reportar"
+        },
+        "failed": {
+          "title": "No se puede reportar",
+          "description": "No se ha podido guardar el reporte. Inténtalo de nuevo en un momento."
+        }
+      },
+      "outcome": {
+        "accepted": {
+          "title": "Reporte aceptado",
+          "description": "Tu reporte ha sido revisado y aceptado por el equipo de Moddy. Se han tomado las medidas necesarias."
+        },
+        "refused": {
+          "title": "Reporte rechazado",
+          "description": "Tu reporte ha sido revisado, pero el equipo de Moddy no lo ha aceptado."
+        },
+        "footer": "Reporte {report}"
+      }
+    },
+    "review": {
+      "title": "Reporte de notificación",
+      "reporter": "Reportado por",
+      "source": "Origen",
+      "service": "Servicio",
+      "recipient": "Destinatario",
+      "sent_at": "Enviada el",
+      "occurrences": "Envíos de este contenido",
+      "reason": "Motivo del reporte",
+      "content": "Mensaje enviado",
+      "note": "Nota",
+      "claimed_by": "Gestionado por",
+      "decided_by": "Decisión de",
+      "buttons": {
+        "claim": "Encargarse",
+        "claimed": "Gestionado",
+        "preview": "Ver el mensaje",
+        "accept": "Aceptar",
+        "refuse": "Rechazar"
+      },
+      "no_permission": {
+        "title": "Acceso denegado",
+        "description": "No tienes permiso para revisar los reportes de notificaciones."
+      },
+      "own_report": {
+        "title": "Acción imposible",
+        "description": "No puedes revisar tu propio reporte."
+      },
+      "already_decided": {
+        "title": "Reporte ya tratado",
+        "description": "Ya se ha tomado una decisión sobre este reporte."
+      },
+      "decision": {
+        "accept": {
+          "title": "Aceptar el reporte",
+          "recap": "El reporte se marcará como **aceptado** y se informará a quien lo envió.",
+          "done": {
+            "title": "Reporte aceptado",
+            "description": "La decisión se ha registrado y se ha avisado a quien envió el reporte."
+          }
+        },
+        "refuse": {
+          "title": "Rechazar el reporte",
+          "recap": "El reporte se marcará como **rechazado** y se informará a quien lo envió.",
+          "done": {
+            "title": "Reporte rechazado",
+            "description": "La decisión se ha registrado y se ha avisado a quien envió el reporte."
+          }
+        },
+        "note": {
+          "label": "Nota de la decisión",
+          "description": "Se envía a quien reportó y se conserva en los registros.",
+          "placeholder": "Opcional: explica la decisión."
+        }
+      }
+    },
+    "log": {
+      "title": {
+        "created": "Nuevo reporte",
+        "claimed": "Reporte gestionado",
+        "accepted": "Reporte aceptado",
+        "refused": "Reporte rechazado"
+      },
+      "actor": "Staff",
+      "jump": "Ver el reporte"
     }
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3714,6 +3714,118 @@
         "confirm_title": "Supprimer la bannière ?",
         "confirm": "Supprimer définitivement la bannière {id} ?"
       }
+    },
+    "notif": {
+      "title": "Notification",
+      "created_at": "Envoyée le",
+      "kind": "Type",
+      "author": "Rédacteur",
+      "service": "Service",
+      "guild": "Serveur",
+      "actor": "Déclencheur",
+      "reportable": "Signalable",
+      "recipient": "Destinataire",
+      "batch": "Campagne",
+      "delivery": "Livraison",
+      "no_delivery": "Aucune livraison enregistrée",
+      "content": "Contenu",
+      "hash": "Empreinte",
+      "occurrences": "Envois identiques",
+      "template": "Modèle",
+      "reports": "Signalements",
+      "not_found": {
+        "title": "Notification introuvable",
+        "description": "Aucune notification ni signalement ne correspond à `{uuid}`."
+      },
+      "unavailable": {
+        "title": "Système indisponible",
+        "description": "Le système de notifications n'est pas initialisé."
+      }
+    },
+    "com": {
+      "send": {
+        "compose": "Rédiger le message",
+        "compose_hint": "Destinataires : {audience}",
+        "default_link_label": "En savoir plus",
+        "audience": {
+          "user": "utilisateur",
+          "guild": "serveur",
+          "users": "utilisateurs",
+          "guilds": "serveurs"
+        },
+        "modal": {
+          "title": "Nouvelle notification",
+          "title_field": {
+            "label": "Titre",
+            "placeholder": "Titre affiché en haut du message"
+          },
+          "body": {
+            "label": "Message",
+            "description": "Markdown accepté. Rédige-le comme un message final.",
+            "placeholder": "Le contenu de la notification…"
+          },
+          "link_label": {
+            "label": "Libellé du bouton (facultatif)",
+            "placeholder": "En savoir plus"
+          },
+          "link_url": {
+            "label": "Lien du bouton (facultatif)",
+            "description": "Doit commencer par https://"
+          }
+        },
+        "confirm": {
+          "title": "Confirmer l'envoi",
+          "description": "Le message va être envoyé à `{count}` {kind} (segment `{segment}`).",
+          "large": "Envoi massif : il ne pourra pas être annulé une fois lancé.",
+          "button": "Envoyer"
+        },
+        "progress": {
+          "title": "Envoi en cours",
+          "description": "`{done}` / `{total}` traités — `{sent}` envoyés, `{failed}` échecs."
+        },
+        "done": {
+          "title": "Envoi terminé",
+          "description": "`{total}` destinataires — `{sent}` envoyés, `{failed}` échecs."
+        },
+        "user_done": {
+          "title": "Notification envoyée",
+          "description": "Le message a été envoyé à **{user}**."
+        },
+        "guild_done": {
+          "title": "Notification envoyée",
+          "description": "Le message a été publié sur **{guild}** (`{count}` envoi(s))."
+        },
+        "errors": {
+          "bad_id": {
+            "title": "Identifiant invalide",
+            "description": "Fournis un identifiant Discord valide (uniquement des chiffres)."
+          },
+          "unknown_user": {
+            "title": "Utilisateur introuvable",
+            "description": "Aucun utilisateur ne correspond à `{id}`."
+          },
+          "unknown_guild": {
+            "title": "Serveur introuvable",
+            "description": "Moddy n'est pas présent sur le serveur `{id}`."
+          },
+          "empty_segment": {
+            "title": "Segment vide",
+            "description": "Aucun destinataire ne correspond au segment `{segment}`."
+          },
+          "no_channel": {
+            "title": "Envoi impossible",
+            "description": "Aucun salon utilisable sur **{guild}**."
+          },
+          "dms_closed": {
+            "title": "Messages privés fermés",
+            "description": "**{user}** n'accepte pas les messages privés."
+          },
+          "failed": {
+            "title": "Envoi impossible",
+            "description": "Le message n'a pas pu être envoyé à **{user}**."
+          }
+        }
+      }
     }
   },
   "transcription": {
@@ -3875,6 +3987,178 @@
       "title": "Ton appel a été refusé",
       "description": "Notre équipe a examiné ton appel et l'a refusé. La sanction **{level}** est maintenue, et les mesures suspendues sont de nouveau programmées.",
       "deadline": "Elles prendront désormais effet le **{date}** (**{rel}**)."
+    }
+  },
+  "notifications": {
+    "services": {
+      "moddy": "Moddy",
+      "welcome_dm": "Message de bienvenue",
+      "moderation": "Modération",
+      "automod_ai": "Automod IA",
+      "appeals": "Appels",
+      "altguard": "AltGuard",
+      "tickets": "Tickets",
+      "reminder": "Rappels",
+      "interserver": "Inter-serveurs",
+      "token_detector": "Détecteur de tokens",
+      "global_sanctions": "Sanctions globales",
+      "expirations": "Fin de sanction"
+    },
+    "attribution": {
+      "unknown_guild": "Serveur inconnu"
+    },
+    "source": {
+      "title": "Origine de cette notification",
+      "guild_label": "Serveur :",
+      "service_label": "Service :",
+      "id_label": "Identifiant :",
+      "members": "Membres :",
+      "created": "Créé le :",
+      "verified": "Serveur vérifié",
+      "official": "Serveur officiel Moddy",
+      "open_server": "Ouvrir le serveur",
+      "uuid_label": "Notification :",
+      "sent_at": "Envoyée le :",
+      "support_hint": "Un problème avec cette notification ? [Contacter le support]({url})",
+      "not_reportable": {
+        "moddy_authored": "Ce message est rédigé par Moddy : il n'y a rien à signaler.",
+        "official_guild": "Ce message provient d'un serveur officiel Moddy : il ne peut pas être signalé."
+      }
+    },
+    "service": {
+      "title": "Origine de cette notification",
+      "description": "Ce message t'a été envoyé par un service de Moddy."
+    },
+    "errors": {
+      "unknown": {
+        "title": "Notification introuvable",
+        "description": "La notification `{uuid}` n'existe plus dans nos registres."
+      },
+      "unknown_report": {
+        "description": "Le signalement `{uuid}` n'existe plus."
+      }
+    },
+    "report": {
+      "modal": {
+        "title": "Signaler cette notification",
+        "recap": "**Origine :** {source}\n**Notification :** `{uuid}`\n\n> {excerpt}",
+        "reason": {
+          "label": "Pourquoi signales-tu ce message ?",
+          "description": "Décris le problème le plus précisément possible.",
+          "placeholder": "Ce message contient…"
+        },
+        "confirm": {
+          "label": "Confirmation",
+          "option": "Je confirme que ce signalement est légitime"
+        }
+      },
+      "sent": {
+        "title": "Signalement envoyé",
+        "description": "L'équipe Moddy va examiner ce message. Merci de ton aide."
+      },
+      "already": {
+        "title": "Signalement déjà envoyé",
+        "description": "Tu as déjà signalé cette notification."
+      },
+      "status_label": "Statut :",
+      "status": {
+        "pending": "En attente",
+        "claimed": "En cours d'examen",
+        "accepted": "Accepté",
+        "refused": "Refusé"
+      },
+      "reference": "Signalement :",
+      "decision_note": "Note de l'équipe :",
+      "errors": {
+        "not_recipient": {
+          "title": "Signalement impossible",
+          "description": "Seul le destinataire de cette notification peut la signaler."
+        },
+        "not_reportable": {
+          "title": "Signalement impossible"
+        },
+        "failed": {
+          "title": "Signalement impossible",
+          "description": "Le signalement n'a pas pu être enregistré. Réessaie dans un instant."
+        }
+      },
+      "outcome": {
+        "accepted": {
+          "title": "Signalement accepté",
+          "description": "Ton signalement a été examiné et retenu par l'équipe Moddy. Les mesures nécessaires ont été prises."
+        },
+        "refused": {
+          "title": "Signalement refusé",
+          "description": "Ton signalement a été examiné mais n'a pas été retenu par l'équipe Moddy."
+        },
+        "footer": "Signalement {report}"
+      }
+    },
+    "review": {
+      "title": "Signalement de notification",
+      "reporter": "Signalé par",
+      "source": "Origine",
+      "service": "Service",
+      "recipient": "Destinataire",
+      "sent_at": "Envoyée le",
+      "occurrences": "Envois de ce contenu",
+      "reason": "Motif du signalement",
+      "content": "Contenu envoyé",
+      "note": "Note",
+      "claimed_by": "Pris en charge par",
+      "decided_by": "Décision de",
+      "buttons": {
+        "claim": "Prendre en charge",
+        "claimed": "Pris en charge",
+        "preview": "Voir le message",
+        "accept": "Accepter",
+        "refuse": "Refuser"
+      },
+      "no_permission": {
+        "title": "Accès refusé",
+        "description": "Tu n'as pas la permission d'examiner les signalements de notifications."
+      },
+      "own_report": {
+        "title": "Action impossible",
+        "description": "Tu ne peux pas examiner ton propre signalement."
+      },
+      "already_decided": {
+        "title": "Signalement déjà traité",
+        "description": "Une décision a déjà été rendue sur ce signalement."
+      },
+      "decision": {
+        "accept": {
+          "title": "Accepter le signalement",
+          "recap": "Le signalement sera marqué comme **accepté** et le signaleur en sera informé.",
+          "done": {
+            "title": "Signalement accepté",
+            "description": "La décision a été enregistrée et le signaleur a été prévenu."
+          }
+        },
+        "refuse": {
+          "title": "Refuser le signalement",
+          "recap": "Le signalement sera marqué comme **refusé** et le signaleur en sera informé.",
+          "done": {
+            "title": "Signalement refusé",
+            "description": "La décision a été enregistrée et le signaleur a été prévenu."
+          }
+        },
+        "note": {
+          "label": "Note de décision",
+          "description": "Transmise au signaleur et conservée dans les logs.",
+          "placeholder": "Facultatif : explique la décision."
+        }
+      }
+    },
+    "log": {
+      "title": {
+        "created": "Nouveau signalement",
+        "claimed": "Signalement pris en charge",
+        "accepted": "Signalement accepté",
+        "refused": "Signalement refusé"
+      },
+      "actor": "Staff",
+      "jump": "Voir le signalement"
     }
   }
 }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -3715,6 +3715,118 @@
         "confirm_title": "Excluir Banner?",
         "confirm": "Excluir permanentemente o banner {id}?"
       }
+    },
+    "notif": {
+      "title": "Notificação",
+      "created_at": "Enviada em",
+      "kind": "Tipo",
+      "author": "Escrita por",
+      "service": "Serviço",
+      "guild": "Servidor",
+      "actor": "Acionada por",
+      "reportable": "Denunciável",
+      "recipient": "Destinatário",
+      "batch": "Campanha",
+      "delivery": "Entrega",
+      "no_delivery": "Nenhuma entrega registrada",
+      "content": "Conteúdo",
+      "hash": "Impressão",
+      "occurrences": "Envios idênticos",
+      "template": "Modelo",
+      "reports": "Denúncias",
+      "not_found": {
+        "title": "Notificação não encontrada",
+        "description": "Nenhuma notificação ou denúncia corresponde a `{uuid}`."
+      },
+      "unavailable": {
+        "title": "Sistema indisponível",
+        "description": "O sistema de notificações não está inicializado."
+      }
+    },
+    "com": {
+      "send": {
+        "compose": "Escrever a mensagem",
+        "compose_hint": "Destinatários: {audience}",
+        "default_link_label": "Saiba mais",
+        "audience": {
+          "user": "usuário",
+          "guild": "servidor",
+          "users": "usuários",
+          "guilds": "servidores"
+        },
+        "modal": {
+          "title": "Nova notificação",
+          "title_field": {
+            "label": "Título",
+            "placeholder": "Título exibido no topo da mensagem"
+          },
+          "body": {
+            "label": "Mensagem",
+            "description": "Markdown é aceito. Escreva-a como a mensagem final.",
+            "placeholder": "O conteúdo da notificação…"
+          },
+          "link_label": {
+            "label": "Texto do botão (opcional)",
+            "placeholder": "Saiba mais"
+          },
+          "link_url": {
+            "label": "Link do botão (opcional)",
+            "description": "Deve começar com https://"
+          }
+        },
+        "confirm": {
+          "title": "Confirmar o envio",
+          "description": "A mensagem será enviada para `{count}` {kind} (segmento `{segment}`).",
+          "large": "Envio em massa: não poderá ser cancelado depois de iniciado.",
+          "button": "Enviar"
+        },
+        "progress": {
+          "title": "Envio em andamento",
+          "description": "`{done}` / `{total}` processados — `{sent}` enviados, `{failed}` falhas."
+        },
+        "done": {
+          "title": "Envio concluído",
+          "description": "`{total}` destinatários — `{sent}` enviados, `{failed}` falhas."
+        },
+        "user_done": {
+          "title": "Notificação enviada",
+          "description": "A mensagem foi enviada para **{user}**."
+        },
+        "guild_done": {
+          "title": "Notificação enviada",
+          "description": "A mensagem foi publicada em **{guild}** (`{count}` envio(s))."
+        },
+        "errors": {
+          "bad_id": {
+            "title": "Identificador inválido",
+            "description": "Forneça um identificador do Discord válido (apenas números)."
+          },
+          "unknown_user": {
+            "title": "Usuário não encontrado",
+            "description": "Nenhum usuário corresponde a `{id}`."
+          },
+          "unknown_guild": {
+            "title": "Servidor não encontrado",
+            "description": "O Moddy não está no servidor `{id}`."
+          },
+          "empty_segment": {
+            "title": "Segmento vazio",
+            "description": "Nenhum destinatário corresponde ao segmento `{segment}`."
+          },
+          "no_channel": {
+            "title": "Não é possível enviar",
+            "description": "Nenhum canal utilizável em **{guild}**."
+          },
+          "dms_closed": {
+            "title": "Mensagens diretas fechadas",
+            "description": "**{user}** não aceita mensagens diretas."
+          },
+          "failed": {
+            "title": "Não é possível enviar",
+            "description": "A mensagem não pôde ser enviada para **{user}**."
+          }
+        }
+      }
     }
   },
   "transcription": {
@@ -3876,6 +3988,178 @@
       "title": "O seu recurso foi recusado",
       "description": "A nossa equipa analisou o seu recurso e recusou-o. A sanção **{level}** mantém-se, e as medidas suspensas voltam a estar agendadas.",
       "deadline": "Produzem agora efeito a **{date}** (**{rel}**)."
+    }
+  },
+  "notifications": {
+    "services": {
+      "moddy": "Moddy",
+      "welcome_dm": "Mensagem de boas-vindas",
+      "moderation": "Moderação",
+      "automod_ai": "Automod IA",
+      "appeals": "Recursos",
+      "altguard": "AltGuard",
+      "tickets": "Tickets",
+      "reminder": "Lembretes",
+      "interserver": "Interservidor",
+      "token_detector": "Detector de tokens",
+      "global_sanctions": "Sanções globais",
+      "expirations": "Fim de sanção"
+    },
+    "attribution": {
+      "unknown_guild": "Servidor desconhecido"
+    },
+    "source": {
+      "title": "Origem desta notificação",
+      "guild_label": "Servidor:",
+      "service_label": "Serviço:",
+      "id_label": "Identificador:",
+      "members": "Membros:",
+      "created": "Criado em:",
+      "verified": "Servidor verificado",
+      "official": "Servidor oficial da Moddy",
+      "open_server": "Abrir o servidor",
+      "uuid_label": "Notificação:",
+      "sent_at": "Enviada em:",
+      "support_hint": "Algum problema com esta notificação? [Falar com o suporte]({url})",
+      "not_reportable": {
+        "moddy_authored": "Esta mensagem foi escrita pelo Moddy: não há nada a denunciar.",
+        "official_guild": "Esta mensagem vem de um servidor oficial da Moddy: ela não pode ser denunciada."
+      }
+    },
+    "service": {
+      "title": "Origem desta notificação",
+      "description": "Esta mensagem foi enviada a você por um serviço do Moddy."
+    },
+    "errors": {
+      "unknown": {
+        "title": "Notificação não encontrada",
+        "description": "A notificação `{uuid}` não existe mais em nossos registros."
+      },
+      "unknown_report": {
+        "description": "A denúncia `{uuid}` não existe mais."
+      }
+    },
+    "report": {
+      "modal": {
+        "title": "Denunciar esta notificação",
+        "recap": "**Origem:** {source}\n**Notificação:** `{uuid}`\n\n> {excerpt}",
+        "reason": {
+          "label": "Por que você está denunciando isto?",
+          "description": "Descreva o problema da forma mais precisa possível.",
+          "placeholder": "Esta mensagem contém…"
+        },
+        "confirm": {
+          "label": "Confirmação",
+          "option": "Confirmo que esta denúncia é legítima"
+        }
+      },
+      "sent": {
+        "title": "Denúncia enviada",
+        "description": "A equipe do Moddy vai analisar esta mensagem. Obrigado pela sua ajuda."
+      },
+      "already": {
+        "title": "Denúncia já enviada",
+        "description": "Você já denunciou esta notificação."
+      },
+      "status_label": "Status:",
+      "status": {
+        "pending": "Pendente",
+        "claimed": "Em análise",
+        "accepted": "Aceita",
+        "refused": "Recusada"
+      },
+      "reference": "Denúncia:",
+      "decision_note": "Nota da equipe:",
+      "errors": {
+        "not_recipient": {
+          "title": "Não é possível denunciar",
+          "description": "Somente o destinatário desta notificação pode denunciá-la."
+        },
+        "not_reportable": {
+          "title": "Não é possível denunciar"
+        },
+        "failed": {
+          "title": "Não é possível denunciar",
+          "description": "A denúncia não pôde ser salva. Tente novamente em instantes."
+        }
+      },
+      "outcome": {
+        "accepted": {
+          "title": "Denúncia aceita",
+          "description": "Sua denúncia foi analisada e aceita pela equipe do Moddy. As medidas necessárias foram tomadas."
+        },
+        "refused": {
+          "title": "Denúncia recusada",
+          "description": "Sua denúncia foi analisada, mas não foi aceita pela equipe do Moddy."
+        },
+        "footer": "Denúncia {report}"
+      }
+    },
+    "review": {
+      "title": "Denúncia de notificação",
+      "reporter": "Denunciado por",
+      "source": "Origem",
+      "service": "Serviço",
+      "recipient": "Destinatário",
+      "sent_at": "Enviada em",
+      "occurrences": "Envios deste conteúdo",
+      "reason": "Motivo da denúncia",
+      "content": "Mensagem enviada",
+      "note": "Nota",
+      "claimed_by": "Assumida por",
+      "decided_by": "Decisão de",
+      "buttons": {
+        "claim": "Assumir",
+        "claimed": "Assumida",
+        "preview": "Ver a mensagem",
+        "accept": "Aceitar",
+        "refuse": "Recusar"
+      },
+      "no_permission": {
+        "title": "Acesso negado",
+        "description": "Você não tem permissão para analisar denúncias de notificações."
+      },
+      "own_report": {
+        "title": "Ação impossível",
+        "description": "Você não pode analisar a sua própria denúncia."
+      },
+      "already_decided": {
+        "title": "Denúncia já tratada",
+        "description": "Uma decisão já foi tomada sobre esta denúncia."
+      },
+      "decision": {
+        "accept": {
+          "title": "Aceitar a denúncia",
+          "recap": "A denúncia será marcada como **aceita** e quem a enviou será avisado.",
+          "done": {
+            "title": "Denúncia aceita",
+            "description": "A decisão foi registrada e quem enviou a denúncia foi avisado."
+          }
+        },
+        "refuse": {
+          "title": "Recusar a denúncia",
+          "recap": "A denúncia será marcada como **recusada** e quem a enviou será avisado.",
+          "done": {
+            "title": "Denúncia recusada",
+            "description": "A decisão foi registrada e quem enviou a denúncia foi avisado."
+          }
+        },
+        "note": {
+          "label": "Nota da decisão",
+          "description": "Enviada a quem denunciou e mantida nos logs.",
+          "placeholder": "Opcional: explique a decisão."
+        }
+      }
+    },
+    "log": {
+      "title": {
+        "created": "Nova denúncia",
+        "claimed": "Denúncia assumida",
+        "accepted": "Denúncia aceita",
+        "refused": "Denúncia recusada"
+      },
+      "actor": "Staff",
+      "jump": "Ver a denúncia"
     }
   }
 }

--- a/modules/altguard.py
+++ b/modules/altguard.py
@@ -688,12 +688,32 @@ class AltGuardModule(ModuleBase):
         if view is None:
             return
 
+        from notifications.models import NotificationContent, NotificationSource
+        from utils.emojis import ALTGUARD
+        from utils.i18n import t
+
         try:
-            await member.send(view=view)
-        except discord.Forbidden:
-            logger.info(
-                f"[AltGuard] Cannot DM {member.id} in guild {self.guild_id} (DMs closed)"
+            # Through the notification system: AltGuard's wording is Moddy's,
+            # so the DM is attributed (service + server) but not reportable.
+            result = await self.bot.notifications.send_dm(
+                member,
+                content=NotificationContent(
+                    title=t(f'modules.altguard.dm.{kind}.title', locale=self.panel_locale),
+                    body=t(f'modules.altguard.dm.{kind}.description',
+                           locale=self.panel_locale,
+                           server=f"**{guild.name}**" if guild else ""),
+                    icon=ALTGUARD,
+                    footer=t(f'modules.altguard.dm.{kind}.footer', locale=self.panel_locale),
+                    template_id=f"altguard.dm.{kind}",
+                ),
+                source=NotificationSource.service_guild("altguard", self.guild_id),
+                view=view,
+                locale=self.panel_locale,
             )
+            if result.forbidden:
+                logger.info(
+                    f"[AltGuard] Cannot DM {member.id} in guild {self.guild_id} (DMs closed)"
+                )
         except Exception as e:
             logger.error(f"[AltGuard] DM failed for {member.id} in guild {self.guild_id}: {e}")
 

--- a/modules/automod_ai.py
+++ b/modules/automod_ai.py
@@ -1115,7 +1115,36 @@ class AutomodModule(ModuleBase):
             proof_ts=int(message.created_at.timestamp()) if message else None,
         )
         try:
-            await member.send(view=view, files=files)
+            # Through the notification system: the sanction is worded by Moddy
+            # (the appeal buttons are the way to contest it), so the DM is
+            # attributed to the automod service + the server, flag greyed out.
+            from notifications.models import NotificationContent, NotificationSource
+            from utils.emojis import get_sanction_dm_emoji, get_sanction_accent
+            await self.bot.notifications.send_dm(
+                member,
+                content=NotificationContent(
+                    title=t(f"modules.automod_ai.dm.title_{primary_action}",
+                            locale=locale),
+                    body="{reason}",
+                    icon=get_sanction_dm_emoji(primary_action),
+                    accent_color=get_sanction_accent(primary_action),
+                    sections=[{"title": "{explication_title}", "body": "{explication}"}],
+                    footer="{case_ref}",
+                    template_id=f"automod_ai.sanction.{primary_action}",
+                ),
+                source=NotificationSource.service_guild(
+                    "automod_ai", guild.id if guild else 0),
+                variables={
+                    "reason": decision.raison or "",
+                    "explication_title": t("modules.automod_ai.dm.explanation",
+                                           locale=locale),
+                    "explication": decision.explication or "",
+                    "case_ref": case_ref or "—",
+                },
+                view=view,
+                files=files,
+                locale=locale,
+            )
         except (discord.Forbidden, discord.HTTPException):
             pass  # closed DMs — the case + channel notification still stand
 

--- a/modules/interserver.py
+++ b/modules/interserver.py
@@ -453,8 +453,23 @@ class InterServerModule(ModuleBase):
 
             view = WelcomeView()
 
-            # Envoie le DM
-            await user.send(view=view)
+            # Through the notification system: Moddy's own wording, so the DM
+            # carries the service attribution button and no report flag.
+            from notifications.models import (
+                NotificationContent, NotificationSource,
+            )
+            await self.bot.notifications.send_dm(
+                user,
+                content=NotificationContent(
+                    title=welcome_title,
+                    body=welcome_body,
+                    icon=GROUPS,
+                    template_id=f"interserver.welcome.{self.interserver_type}",
+                ),
+                source=NotificationSource.service_guild("interserver", self.guild_id),
+                view=view,
+                locale=locale,
+            )
 
             # Marque l'utilisateur comme accueilli en DB
             await self.bot.db.set_attribute(

--- a/modules/welcome_dm.py
+++ b/modules/welcome_dm.py
@@ -28,6 +28,7 @@ import discord
 from discord import ui
 
 from modules.module_manager import ModuleBase
+from notifications.models import NotificationContent, NotificationSource
 from utils.emojis import WAVING_HAND
 from utils.i18n import t
 
@@ -155,23 +156,49 @@ def entry_accent_color(entry: Dict[str, Any]) -> int:
 # --------------------------------------------------------------------------- #
 # Rendering (Components V2)
 # --------------------------------------------------------------------------- #
+def message_variables(member: discord.Member, guild: discord.Guild) -> Dict[str, str]:
+    """The placeholder values for one member joining one guild.
+
+    Keys are bare (``server``, not ``{server}``) because this same dict is
+    stored as the notification's ``variables`` — that is what lets the exact
+    wording of a welcome DM be rebuilt months later from the template alone
+    (see docs/NOTIFICATIONS.md).
+    """
+    joined_at = getattr(member, 'joined_at', None)
+    timestamp = int(joined_at.timestamp()) if joined_at else int(time.time())
+    return {
+        "server": guild.name,
+        "user": member.mention,
+        "display_name": member.display_name,
+        "username": member.name,
+        "member_count": str(guild.member_count or 0),
+        "timestamp": str(timestamp),
+    }
+
+
 def format_message(template: str, member: discord.Member,
                    guild: discord.Guild) -> str:
     """Substitute the supported placeholders inside a message template."""
-    joined_at = getattr(member, 'joined_at', None)
-    timestamp = int(joined_at.timestamp()) if joined_at else int(time.time())
-
-    replacements = {
-        "{server}": guild.name,
-        "{user}": member.mention,
-        "{display_name}": member.display_name,
-        "{username}": member.name,
-        "{member_count}": str(guild.member_count or 0),
-        "{timestamp}": str(timestamp),
-    }
-    for key, value in replacements.items():
-        template = template.replace(key, str(value))
+    for key, value in message_variables(member, guild).items():
+        template = template.replace("{" + key + "}", str(value))
     return template
+
+
+def welcome_content(entry: Dict[str, Any], guild_name: str) -> NotificationContent:
+    """The uniform notification payload behind one welcome DM.
+
+    The body keeps its ``{placeholders}``: every member of a given server
+    receives the *same* template, so all of their notifications share one stored
+    content row. The guild name is part of the title, which is what the mail and
+    the dashboard show as the heading.
+    """
+    return NotificationContent(
+        title=guild_name,
+        body=entry.get('message') or '',
+        icon=WAVING_HAND,
+        accent_color=entry_accent_color(entry),
+        template_id=f"welcome_dm.{entry.get('id')}",
+    )
 
 
 def build_welcome_view(entry: Dict[str, Any], member: discord.Member,
@@ -272,23 +299,38 @@ class WelcomeDmModule(ModuleBase):
         if not guild:
             return
 
+        variables = message_variables(member, guild)
+        locale = self._locale()
+
         for entry in self.messages:
             if not entry.get('enabled', True):
                 continue
             try:
                 view, allowed = build_welcome_view(entry, member, guild)
-                await member.send(view=view, allowed_mentions=allowed)
-                logger.info(
-                    f"DM welcome sent to {member.id} (guild {self.guild_id}, "
-                    f"message {entry['id']})"
+                # Through the notification system: the DM is recorded,
+                # attributed to this server, and reportable — the text is the
+                # server's own words, which is exactly what can be abused.
+                result = await self.bot.notifications.send_dm(
+                    member,
+                    content=welcome_content(entry, guild.name),
+                    source=NotificationSource.guild(guild.id),
+                    variables=variables,
+                    view=view,
+                    allowed_mentions=allowed,
+                    locale=locale,
                 )
-            except discord.Forbidden:
-                # DMs are closed for this member: every other entry would fail
-                # the same way, so stop here instead of hammering the API.
-                logger.warning(
-                    f"Cannot send DM welcome to {member.id} (guild {self.guild_id}) "
-                    "— DMs disabled"
-                )
-                return
+                if result.forbidden:
+                    # DMs are closed for this member: every other entry would
+                    # fail the same way, so stop instead of hammering the API.
+                    logger.warning(
+                        f"Cannot send DM welcome to {member.id} (guild {self.guild_id}) "
+                        "— DMs disabled"
+                    )
+                    return
+                if result.delivered:
+                    logger.info(
+                        f"DM welcome sent to {member.id} (guild {self.guild_id}, "
+                        f"message {entry['id']}, notification {result.notification_id})"
+                    )
             except Exception as e:
                 logger.error(f"Error sending DM welcome: {e}", exc_info=True)

--- a/notifications/__init__.py
+++ b/notifications/__init__.py
@@ -1,0 +1,47 @@
+"""
+Centralized notification system.
+
+Every message Moddy sends to a human — a DM, a mail, a dashboard card — is
+created here, so that it is stored, attributable and (when someone else wrote
+it) reportable. ``bot.notifications`` is the service; the model is uniform
+across platforms.
+
+    from notifications import NotificationContent, NotificationSource
+
+    await bot.notifications.send_dm(
+        member,
+        content=NotificationContent(title="…", body="…", icon=WAVING_HAND),
+        source=NotificationSource.guild(guild.id),
+        variables={"user": member.mention},
+    )
+
+See docs/NOTIFICATIONS.md.
+"""
+
+from notifications.models import (
+    SERVICES, ContentAuthor, DeliveryStatus, NotificationContent,
+    NotificationSource, Platform, RecipientType, ReportStatus, ServiceInfo,
+    SourceKind, get_service, strip_custom_emojis, substitute,
+)
+from notifications.render import build_content_view, resolve_source_context
+from notifications.service import DeliveryResult, NotificationService
+
+__all__ = [
+    "SERVICES",
+    "ContentAuthor",
+    "DeliveryResult",
+    "DeliveryStatus",
+    "NotificationContent",
+    "NotificationService",
+    "NotificationSource",
+    "Platform",
+    "RecipientType",
+    "ReportStatus",
+    "ServiceInfo",
+    "SourceKind",
+    "build_content_view",
+    "get_service",
+    "resolve_source_context",
+    "strip_custom_emojis",
+    "substitute",
+]

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -1,0 +1,420 @@
+"""
+Data model of the centralized notification system.
+
+Everything Moddy sends to a human — a DM, a mail, a card on the dashboard —
+is one **notification**: a uniform, platform-agnostic payload plus the
+identity of whoever caused it to be sent. This module holds that model and
+nothing else (no Discord calls, no database), so it can be imported from the
+render layer, the service, the staff commands and the tests alike.
+
+Three ideas carry the whole design:
+
+* :class:`NotificationContent` is a **template**, not a finished message. Its
+  strings keep their ``{placeholders}``; the resolved values travel next to it
+  as ``variables``. That is what lets thousands of identical welcome DMs share
+  a single stored body (hashed by :meth:`NotificationContent.template_hash`)
+  while each notification stays reproducible to the character.
+* :class:`NotificationSource` says **who** is behind the message: a Moddy
+  service, a server, both, or Moddy itself speaking officially. The DM's
+  attribution buttons and whether it can be reported are derived from it, and
+  from nothing else.
+* The same content renders to Discord, to an email and to the dashboard
+  (:meth:`NotificationContent.to_email` / :meth:`to_dashboard`), so a
+  suspension notice reads the same wherever the recipient sees it.
+
+See docs/NOTIFICATIONS.md.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+# --------------------------------------------------------------------------- #
+# Enums
+# --------------------------------------------------------------------------- #
+
+
+class SourceKind(str, Enum):
+    """What sort of actor is behind a notification.
+
+    ``OFFICIAL`` is the only kind that carries **no** attribution buttons at
+    all: an account suspension or a leaked-token alert is Moddy speaking as an
+    institution, and offering to "report" it would be nonsense. It is still
+    stored and counted like every other notification.
+    """
+
+    OFFICIAL = "official"            # Moddy itself, institutional
+    SERVICE = "service"              # a Moddy service acting on its own
+    GUILD = "guild"                  # a server, through Moddy
+    SERVICE_GUILD = "service_guild"  # a Moddy service acting for a server
+
+
+class ContentAuthor(str, Enum):
+    """Who actually wrote the words the recipient reads.
+
+    This — not :class:`SourceKind` — decides whether the report button works.
+    A welcome DM is written by the server (``GUILD``) and can be abused, so it
+    is reportable. A sanction notice is worded by Moddy on the server's behalf
+    (``MODDY``): there is nothing for the abuse team to judge, the button is
+    rendered disabled and the source panel says why.
+    """
+
+    MODDY = "moddy"
+    GUILD = "guild"
+    STAFF = "staff"
+
+
+class RecipientType(str, Enum):
+    """Who a notification is addressed to.
+
+    Broadcasts are exploded into one row per recipient (they share a
+    ``batch_id``), so ``ALL_USERS`` / ``SEGMENT`` never appear on a delivered
+    row — they describe the *audience* a batch was aimed at.
+    """
+
+    DISCORD_USER = "discord_user"
+    DISCORD_GUILD = "discord_guild"
+    ALL_USERS = "all_users"
+    ALL_GUILDS = "all_guilds"
+    SEGMENT = "segment"
+    EMAIL = "email"
+
+
+class Platform(str, Enum):
+    """Where a notification must be delivered or displayed."""
+
+    DISCORD = "discord"
+    EMAIL = "email"
+    DASHBOARD = "dashboard"
+
+
+class DeliveryStatus(str, Enum):
+    """State of one (notification, platform) pair."""
+
+    PENDING = "pending"    # queued, not attempted yet
+    SENT = "sent"          # accepted by the platform
+    FAILED = "failed"      # attempted, refused (closed DMs, HTTP error…)
+    SKIPPED = "skipped"    # deliberately not attempted (no email on file…)
+
+
+class ReportStatus(str, Enum):
+    """State of an abuse report filed against a notification."""
+
+    PENDING = "pending"
+    CLAIMED = "claimed"
+    ACCEPTED = "accepted"
+    REFUSED = "refused"
+
+
+#: Platforms a notification defaults to when the caller says nothing.
+DEFAULT_PLATFORMS = (Platform.DISCORD,)
+
+
+# --------------------------------------------------------------------------- #
+# Services
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ServiceInfo:
+    """A Moddy feature allowed to send notifications.
+
+    ``emoji`` is a custom Moddy emoji (see ``utils/emojis.py``) shown on the
+    attribution button; ``i18n_key`` resolves the human name shown next to it.
+    Registering a service here is what makes it addressable — the service id is
+    stored on every notification row and is what a staff lookup shows.
+    """
+
+    id: str
+    i18n_key: str
+    emoji_name: str   # attribute name in utils.emojis, resolved lazily
+
+    @property
+    def emoji(self) -> str:
+        from utils import emojis as _emojis
+        return getattr(_emojis, self.emoji_name, _emojis.MODDY)
+
+
+def _svc(sid: str, emoji_name: str) -> ServiceInfo:
+    return ServiceInfo(id=sid, i18n_key=f"notifications.services.{sid}", emoji_name=emoji_name)
+
+
+#: service id -> ServiceInfo. Adding a sender means adding one line here.
+SERVICES: Dict[str, ServiceInfo] = {
+    s.id: s for s in (
+        _svc("moddy", "MODDY"),                      # Moddy itself / staff broadcasts
+        _svc("welcome_dm", "WAVING_HAND"),           # modules/welcome_dm.py
+        _svc("moderation", "LEGAL"),                 # manual sanctions
+        _svc("automod_ai", "SHIELD"),                # modules/automod_ai.py
+        _svc("appeals", "BALANCE"),                  # services/appeal_service.py
+        _svc("altguard", "ALTGUARD"),                # modules/altguard.py
+        _svc("tickets", "TICKET"),                   # services/ticket_service.py
+        _svc("reminder", "TIME"),                    # cogs/reminder.py
+        _svc("interserver", "GROUPS"),               # modules/interserver.py
+        _svc("token_detector", "SHIELD"),            # cogs/token_detector.py
+        _svc("global_sanctions", "EXCLAMATION"),     # services/global_sanction_service.py
+        _svc("expirations", "TIME"),                 # services/expiration_notifier.py
+    )
+}
+
+
+def get_service(service_id: Optional[str]) -> Optional[ServiceInfo]:
+    """Look a service up, tolerating an unknown id (returns ``None``)."""
+    if not service_id:
+        return None
+    return SERVICES.get(service_id)
+
+
+# --------------------------------------------------------------------------- #
+# Source
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class NotificationSource:
+    """Where a notification comes from, and whether it can be reported.
+
+    Build one with the constructors below rather than by hand — they encode
+    the four legal shapes:
+
+    ``official()``        no attribution at all (suspension, token alert)
+    ``service()``         one button: the Moddy service
+    ``guild()``           two buttons: the server, and the report flag
+    ``service_guild()``   three buttons: the service, the server, the flag
+    """
+
+    kind: SourceKind
+    service_id: Optional[str] = None
+    guild_id: Optional[int] = None
+    author: ContentAuthor = ContentAuthor.MODDY
+    #: staff member who triggered the send, when a human did
+    actor_id: Optional[int] = None
+
+    # -- constructors ------------------------------------------------------ #
+
+    @classmethod
+    def official(cls, service_id: str = "moddy", *, actor_id: Optional[int] = None) -> "NotificationSource":
+        return cls(kind=SourceKind.OFFICIAL, service_id=service_id,
+                   author=ContentAuthor.MODDY, actor_id=actor_id)
+
+    @classmethod
+    def service(cls, service_id: str, *, author: ContentAuthor = ContentAuthor.MODDY,
+                actor_id: Optional[int] = None) -> "NotificationSource":
+        return cls(kind=SourceKind.SERVICE, service_id=service_id,
+                   author=author, actor_id=actor_id)
+
+    @classmethod
+    def guild(cls, guild_id: int, *, author: ContentAuthor = ContentAuthor.GUILD,
+              actor_id: Optional[int] = None) -> "NotificationSource":
+        return cls(kind=SourceKind.GUILD, guild_id=guild_id,
+                   author=author, actor_id=actor_id)
+
+    @classmethod
+    def service_guild(cls, service_id: str, guild_id: int, *,
+                      author: ContentAuthor = ContentAuthor.MODDY,
+                      actor_id: Optional[int] = None) -> "NotificationSource":
+        return cls(kind=SourceKind.SERVICE_GUILD, service_id=service_id,
+                   guild_id=guild_id, author=author, actor_id=actor_id)
+
+    # -- derived properties ------------------------------------------------ #
+
+    @property
+    def is_official(self) -> bool:
+        return self.kind is SourceKind.OFFICIAL
+
+    @property
+    def has_attribution(self) -> bool:
+        """Whether the DM carries the attribution row at all."""
+        return not self.is_official
+
+    @property
+    def base_reportable(self) -> bool:
+        """Reportability from the source alone.
+
+        Only words a human outside Moddy chose can be abusive, so only
+        ``GUILD``/``STAFF``-authored content is reportable. The final answer
+        also depends on the guild being an official Moddy server, which needs a
+        database read — see ``NotificationService.is_reportable``.
+        """
+        if self.is_official:
+            return False
+        return self.author is ContentAuthor.GUILD
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "service_id": self.service_id,
+            "guild_id": self.guild_id,
+            "author": self.author.value,
+            "actor_id": self.actor_id,
+        }
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any]) -> "NotificationSource":
+        """Rebuild a source from a stored ``notifications`` row."""
+        return cls(
+            kind=SourceKind(row["kind"]),
+            service_id=row.get("source_service"),
+            guild_id=row.get("source_guild_id"),
+            author=ContentAuthor(row.get("author") or "moddy"),
+            actor_id=row.get("actor_id"),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Content
+# --------------------------------------------------------------------------- #
+
+_PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z0-9_]+)\}")
+
+
+def substitute(text: Optional[str], variables: Dict[str, Any]) -> str:
+    """Resolve ``{placeholders}`` in ``text`` from ``variables``.
+
+    Deliberately not ``str.format``: notification bodies carry arbitrary
+    server-written text, and a stray ``{`` must never raise in the middle of a
+    delivery. Unknown placeholders are left untouched so a mistake is visible
+    rather than silently blank.
+    """
+    if not text:
+        return ""
+    if not variables:
+        return text
+
+    def _replace(match: "re.Match") -> str:
+        key = match.group(1)
+        if key in variables:
+            value = variables[key]
+            return "" if value is None else str(value)
+        return match.group(0)
+
+    return _PLACEHOLDER_RE.sub(_replace, text)
+
+
+@dataclass
+class NotificationContent:
+    """One notification's payload, in template form.
+
+    The fields are deliberately generic so every platform knows what to do with
+    them: ``title`` is the heading (a mail subject, a dashboard card title),
+    ``body`` the main markdown, ``sections`` optional labelled blocks,
+    ``links`` the call-to-action buttons, ``footer`` a discreet closing line.
+
+    ``icon`` is a Moddy custom emoji (Discord only — the other platforms get
+    the raw name via :meth:`to_dashboard`), and ``accent_color`` an ``0xRRGGBB``
+    int used as the container accent / mail header colour.
+    """
+
+    title: str
+    body: str
+    icon: str = ""
+    accent_color: Optional[int] = None
+    sections: List[Dict[str, str]] = field(default_factory=list)
+    links: List[Dict[str, str]] = field(default_factory=list)
+    footer: Optional[str] = None
+    #: stable id of the template this content came from, e.g. "welcome_dm.entry"
+    template_id: Optional[str] = None
+
+    # -- serialization ----------------------------------------------------- #
+
+    def to_dict(self) -> Dict[str, Any]:
+        """The stored template — placeholders unresolved."""
+        return {
+            "title": self.title,
+            "body": self.body,
+            "icon": self.icon,
+            "accent_color": self.accent_color,
+            "sections": self.sections,
+            "links": self.links,
+            "footer": self.footer,
+            "template_id": self.template_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "NotificationContent":
+        return cls(
+            title=data.get("title") or "",
+            body=data.get("body") or "",
+            icon=data.get("icon") or "",
+            accent_color=data.get("accent_color"),
+            sections=list(data.get("sections") or []),
+            links=list(data.get("links") or []),
+            footer=data.get("footer"),
+            template_id=data.get("template_id"),
+        )
+
+    def template_hash(self) -> str:
+        """SHA-256 of the canonical template.
+
+        Two welcome DMs configured with the same text hash the same however
+        many members receive them, which is what keeps the content table small:
+        the row is written once and every notification points at it. The hash is
+        taken **before** substitution, so ``Bienvenue {user}`` is one body, not
+        one per member.
+        """
+        payload = json.dumps(self.to_dict(), sort_keys=True, ensure_ascii=False,
+                             separators=(",", ":"))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    # -- rendering --------------------------------------------------------- #
+
+    def render(self, variables: Optional[Dict[str, Any]] = None) -> "NotificationContent":
+        """Return a copy with every placeholder resolved."""
+        variables = variables or {}
+        return NotificationContent(
+            title=substitute(self.title, variables),
+            body=substitute(self.body, variables),
+            icon=self.icon,
+            accent_color=self.accent_color,
+            sections=[{
+                "title": substitute(s.get("title"), variables),
+                "body": substitute(s.get("body"), variables),
+            } for s in self.sections],
+            links=[{
+                "label": substitute(l.get("label"), variables),
+                "url": substitute(l.get("url"), variables),
+            } for l in self.links],
+            footer=substitute(self.footer, variables) if self.footer else None,
+            template_id=self.template_id,
+        )
+
+    def to_email(self, variables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """The mail shape: a subject plus a plain-text body and the CTA links.
+
+        Moddy does not send the mail itself — the backend does — so this is the
+        contract handed over, not an SMTP call. Discord custom emojis are
+        stripped: they render as literal ``<:name:id>`` outside Discord.
+        """
+        resolved = self.render(variables)
+        blocks = [resolved.body]
+        for section in resolved.sections:
+            heading = section.get("title") or ""
+            blocks.append(f"{heading}\n{section.get('body') or ''}".strip())
+        if resolved.footer:
+            blocks.append(resolved.footer)
+        text = "\n\n".join(b for b in blocks if b)
+        return {
+            "subject": strip_custom_emojis(resolved.title),
+            "text": strip_custom_emojis(text),
+            "links": resolved.links,
+        }
+
+    def to_dashboard(self, variables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """The dashboard shape: the resolved payload, markdown kept as-is."""
+        resolved = self.render(variables)
+        data = resolved.to_dict()
+        data["icon"] = self.icon
+        return data
+
+
+_CUSTOM_EMOJI_RE = re.compile(r"<a?:[a-zA-Z0-9_]+:\d+>")
+
+
+def strip_custom_emojis(text: str) -> str:
+    """Remove Discord custom emojis and collapse the space they leave."""
+    return re.sub(r"[ \t]{2,}", " ", _CUSTOM_EMOJI_RE.sub("", text or "")).strip()

--- a/notifications/render.py
+++ b/notifications/render.py
@@ -1,0 +1,183 @@
+"""
+Rendering half of the notification system: content → Discord, and the
+attribution context every DM needs.
+
+Two things live here because both are pure functions of a notification and its
+source — no database writes, no sending:
+
+* :func:`build_content_view` turns a :class:`~notifications.models.NotificationContent`
+  into the Components V2 panel a recipient sees. Callers that already build
+  their own rich view (a sanction card, a ticket transcript) skip this and keep
+  theirs; the attribution row is appended either way.
+* :func:`resolve_source_context` answers "what is written on the attribution
+  buttons": the service's name and icon, the server's name, whether that server
+  is verified or an official Moddy server, and — the one decision everything
+  else hangs off — whether the report button is live.
+
+The actual buttons are built in ``utils/notification_views.py`` (they are
+persistent components and belong with the rest of the views).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseView
+from notifications.models import (
+    ContentAuthor, NotificationContent, NotificationSource, get_service,
+)
+from utils.emojis import GROUPS, MODDY, VERIFIED, format_verification_badge
+from utils.i18n import t
+
+logger = logging.getLogger("moddy.notifications.render")
+
+#: Guild attributes that earn the verification check on the attribution panel.
+VERIFIED_GUILD_ATTRIBUTES = ("VERIFIED", "VERIFIED_ORG", "PARTNER")
+
+#: Guild attribute marking one of Moddy's own servers. Reporting a message from
+#: Moddy's own server to Moddy's abuse team is a loop with no exit, so the flag
+#: button is rendered greyed out there.
+OFFICIAL_GUILD_ATTRIBUTE = "OFFICIAL"
+
+
+def build_content_view(
+    content: NotificationContent,
+    variables: Optional[Dict[str, Any]] = None,
+    *,
+    locale: str = "en-US",
+) -> BaseView:
+    """Render a uniform notification payload as a Components V2 panel.
+
+    This is the *default* look — a titled container, the body, optional
+    labelled sections, a discreet footer, then the call-to-action links as a
+    row of link buttons. Features with their own established card (sanctions,
+    tickets, transcriptions) pass their view to the service instead.
+    """
+    resolved = content.render(variables)
+
+    view = BaseView()
+    container = ui.Container(
+        accent_colour=discord.Colour(resolved.accent_color)
+        if resolved.accent_color is not None else None
+    )
+
+    heading = f"### {resolved.icon} {resolved.title}".replace("###  ", "### ")
+    container.add_item(ui.TextDisplay(heading))
+    if resolved.body:
+        container.add_item(ui.TextDisplay(resolved.body))
+
+    for section in resolved.sections:
+        title = (section.get("title") or "").strip()
+        body = (section.get("body") or "").strip()
+        if not title and not body:
+            continue
+        block = f"**{title}**\n{body}" if title else body
+        container.add_item(ui.TextDisplay(block))
+
+    if resolved.footer:
+        container.add_item(ui.TextDisplay(f"-# {resolved.footer}"))
+
+    view.add_item(container)
+
+    links = [l for l in resolved.links if l.get("url")][:5]
+    if links:
+        row = ui.ActionRow()
+        for link in links:
+            row.add_item(ui.Button(
+                label=(link.get("label") or link["url"])[:80],
+                url=link["url"],
+                style=discord.ButtonStyle.link,
+            ))
+        view.add_item(row)
+
+    return view
+
+
+async def resolve_source_context(
+    bot, source: NotificationSource, *, locale: str = "en-US"
+) -> Dict[str, Any]:
+    """Everything the attribution row and panel need about a source.
+
+    Returns a plain dict (never raises — a missing guild or a database hiccup
+    degrades to "Unknown server" rather than blocking a DM):
+
+    ``service`` / ``service_name`` / ``service_emoji``
+        The Moddy feature behind the message, when there is one.
+    ``guild_name`` / ``guild_icon_url`` / ``guild_id``
+        The server, when the message was sent on one's behalf.
+    ``verified`` / ``official`` / ``badge``
+        Whether that server carries the check, and whether it is Moddy's own.
+    ``reportable``
+        The final answer, source *and* guild attributes taken into account.
+    ``report_block``
+        Why the flag is greyed out, when it is: ``"moddy_authored"``,
+        ``"official_guild"`` or ``None``.
+    """
+    service = get_service(source.service_id)
+    ctx: Dict[str, Any] = {
+        "kind": source.kind.value,
+        "author": source.author.value,
+        "service_id": source.service_id,
+        "service_name": t(service.i18n_key, locale=locale) if service else None,
+        "service_emoji": service.emoji if service else MODDY,
+        "guild_id": source.guild_id,
+        "guild_name": None,
+        "guild_icon_url": None,
+        "guild_member_count": None,
+        "guild_created_at": None,
+        "verified": False,
+        "official": False,
+        "badge": "",
+        "reportable": source.base_reportable,
+        "report_block": None if source.base_reportable else "moddy_authored",
+    }
+
+    if source.guild_id:
+        guild = bot.get_guild(source.guild_id) if bot else None
+        if guild is not None:
+            ctx["guild_name"] = guild.name
+            ctx["guild_icon_url"] = guild.icon.url if guild.icon else None
+            ctx["guild_member_count"] = guild.member_count
+            ctx["guild_created_at"] = guild.created_at
+        else:
+            ctx["guild_name"] = t("notifications.attribution.unknown_guild", locale=locale)
+
+        attributes = {}
+        try:
+            if bot is not None and getattr(bot, "db", None):
+                guild_data = await bot.db.get_guild(source.guild_id)
+                attributes = (guild_data or {}).get("attributes", {}) or {}
+        except Exception as exc:  # noqa: BLE001 — attribution must never block a DM
+            logger.warning("Could not read guild attributes for %s: %s", source.guild_id, exc)
+
+        ctx["official"] = bool(attributes.get(OFFICIAL_GUILD_ATTRIBUTE))
+        ctx["verified"] = ctx["official"] or any(
+            attributes.get(attr) for attr in VERIFIED_GUILD_ATTRIBUTES
+        )
+        if ctx["verified"]:
+            ctx["badge"] = format_verification_badge(VERIFIED)
+
+        # Moddy's own servers are not reportable to Moddy.
+        if ctx["official"] and ctx["reportable"]:
+            ctx["reportable"] = False
+            ctx["report_block"] = "official_guild"
+
+    return ctx
+
+
+def source_button_emoji(ctx: Dict[str, Any]) -> str:
+    """The emoji shown on the *server* attribution button.
+
+    Buttons can only carry a real Discord emoji, never a server icon URL — the
+    icon itself is shown as the thumbnail of the panel the button opens.
+    """
+    return VERIFIED if ctx.get("verified") else GROUPS
+
+
+def author_is_guild(source: NotificationSource) -> bool:
+    """Whether the wording came from the server rather than from Moddy."""
+    return source.author is ContentAuthor.GUILD

--- a/notifications/service.py
+++ b/notifications/service.py
@@ -1,0 +1,680 @@
+"""
+NotificationService — the single door every Moddy notification goes through.
+
+Nothing in the bot should call ``user.send(...)`` directly any more. A feature
+hands this service *what* it wants to say (a uniform
+:class:`~notifications.models.NotificationContent`, optionally alongside its own
+rich Components V2 card) and *who* is behind it
+(:class:`~notifications.models.NotificationSource`); the service:
+
+1. writes the notification row — uuid, sender, recipient, platforms, and the
+   template hash that lets thousands of identical DMs share one stored body;
+2. appends the attribution row (service / server / report flag) unless the
+   message is an official Moddy notice, which carries none;
+3. delivers it and records the outcome per platform, message id included;
+4. owns the abuse-report lifecycle: open, claim, decide, log, notify.
+
+``bot.notifications`` is the instance. Everything here is defensive by design:
+a database outage degrades a DM to "sent without attribution", it never
+swallows the message itself.
+
+See docs/NOTIFICATIONS.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid as uuid_module
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+
+import discord
+
+import config
+from notifications.models import (
+    DeliveryStatus, NotificationContent, NotificationSource,
+    Platform, RecipientType, ReportStatus,
+)
+from notifications.render import build_content_view, resolve_source_context
+
+logger = logging.getLogger("moddy.notifications")
+
+#: Pause between two sends of a broadcast. Discord's global limit is far
+#: higher, but a 4 000-server announcement has no reason to burn the whole
+#: budget the rest of the bot shares.
+BROADCAST_DELAY = 0.35
+
+#: Staff review panels and report logs are rendered in a single language, the
+#: same convention the appeal review panels follow.
+STAFF_PANEL_LOCALE = "en-US"
+
+#: Name of the channel `utils/announcement_setup.py` creates when a server has
+#: no community-updates channel. Preferred destination for a server-wide notice.
+MODDY_UPDATES_CHANNEL_NAME = "moddy-updates"
+
+
+@dataclass
+class DeliveryResult:
+    """Outcome of one delivery attempt, from the caller's point of view."""
+
+    notification_id: Optional[str] = None
+    message: Optional[discord.Message] = None
+    status: DeliveryStatus = DeliveryStatus.PENDING
+    error: Optional[Exception] = None
+
+    @property
+    def delivered(self) -> bool:
+        return self.status is DeliveryStatus.SENT
+
+    @property
+    def forbidden(self) -> bool:
+        """The recipient refuses DMs — every further send would fail the same."""
+        return isinstance(self.error, discord.Forbidden)
+
+
+class NotificationService:
+    """Records, renders, delivers and polices every notification."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @property
+    def db(self):
+        return getattr(self.bot, "db", None)
+
+    # ------------------------------------------------------------------ #
+    # Reading
+    # ------------------------------------------------------------------ #
+
+    async def get(self, notification_id: Any) -> Optional[Dict[str, Any]]:
+        """One notification, with its template payload and its deliveries."""
+        if not self.db:
+            return None
+        try:
+            return await self.db.get_notification(notification_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to load notification %s: %s", notification_id, exc)
+            return None
+
+    async def get_report(self, report_id: Any) -> Optional[Dict[str, Any]]:
+        if not self.db:
+            return None
+        return await self.db.get_notification_report(report_id)
+
+    async def existing_report(self, notification_id: Any, reporter_id: int) -> Optional[Dict[str, Any]]:
+        """The report this user already filed against this notification, if any."""
+        if not self.db:
+            return None
+        for report in await self.db.get_reports_for_notification(notification_id):
+            if report["reporter_id"] == reporter_id:
+                return report
+        return None
+
+    async def source_context(self, record: Dict[str, Any], *, locale: str = "en-US") -> Dict[str, Any]:
+        """Attribution context for a stored notification row."""
+        source = NotificationSource.from_row(record)
+        ctx = await resolve_source_context(self.bot, source, locale=locale)
+        # The row's own flag wins when it is stricter: a notification recorded
+        # as non-reportable must never become reportable later.
+        if not record.get("reportable"):
+            ctx["reportable"] = False
+            ctx["report_block"] = ctx.get("report_block") or "moddy_authored"
+        return ctx
+
+    async def may_report(self, record: Dict[str, Any], interaction: discord.Interaction) -> bool:
+        """Only the addressee may report a notification.
+
+        For a DM that is the recipient themselves. For a notice delivered into a
+        server's channel, the addressee is the server, so the check becomes
+        "can this member manage the server".
+        """
+        recipient_type = record.get("recipient_type")
+        if recipient_type == RecipientType.DISCORD_USER.value:
+            return interaction.user.id == record.get("recipient_id")
+        if recipient_type == RecipientType.DISCORD_GUILD.value:
+            if interaction.guild_id != record.get("recipient_id"):
+                return False
+            perms = getattr(interaction.user, "guild_permissions", None)
+            return bool(perms and (perms.manage_guild or perms.administrator))
+        return False
+
+    # ------------------------------------------------------------------ #
+    # Recording
+    # ------------------------------------------------------------------ #
+
+    async def record(
+        self,
+        *,
+        content: NotificationContent,
+        source: NotificationSource,
+        recipient_type: RecipientType,
+        recipient_id: Optional[int] = None,
+        recipient_ref: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        platforms: Sequence[Platform] = (Platform.DISCORD,),
+        locale: Optional[str] = None,
+        batch_id: Optional[Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Persist a notification and return the stored row (``None`` if the
+        database is unavailable — the caller still sends, just unattributed)."""
+        if not self.db:
+            return None
+
+        reportable = source.base_reportable
+        if reportable and source.guild_id:
+            # A message from one of Moddy's own servers is not reportable to
+            # Moddy. Resolved once, at send time, and frozen on the row.
+            ctx = await resolve_source_context(self.bot, source)
+            reportable = bool(ctx.get("reportable"))
+
+        try:
+            return await self.db.create_notification(
+                kind=source.kind.value,
+                author=source.author.value,
+                source_service=source.service_id,
+                source_guild_id=source.guild_id,
+                actor_id=source.actor_id,
+                recipient_type=recipient_type.value,
+                recipient_id=recipient_id,
+                recipient_ref=recipient_ref,
+                content_hash=content.template_hash(),
+                content_payload=content.to_dict(),
+                variables=variables or {},
+                platforms=[p.value for p in platforms],
+                reportable=reportable,
+                locale=locale,
+                batch_id=batch_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — never block a delivery on the DB
+            logger.error("Failed to record notification: %s", exc, exc_info=True)
+            return None
+
+    async def _mark(self, notification_id, platform: Platform, status: DeliveryStatus,
+                    **kwargs) -> None:
+        if not self.db or not notification_id:
+            return
+        try:
+            await self.db.set_notification_delivery(
+                notification_id, platform.value, status.value, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to update delivery status: %s", exc)
+
+    async def mark_delivered(self, record: Optional[Dict[str, Any]],
+                             message: Optional[discord.Message] = None,
+                             platform: Platform = Platform.DISCORD) -> None:
+        """Mark a recorded notification as delivered.
+
+        For the rare senders that cannot use :meth:`send_dm` because they own an
+        exotic delivery path — the token detector opens the DM channel with the
+        *user's* own token when the bot cannot — record the notification, send
+        it your way, then call this.
+        """
+        if not record:
+            return
+        await self._mark(
+            record["id"], platform, DeliveryStatus.SENT,
+            channel_id=getattr(getattr(message, "channel", None), "id", None),
+            message_id=getattr(message, "id", None),
+        )
+
+    async def mark_failed(self, record: Optional[Dict[str, Any]],
+                          error: Optional[str] = None,
+                          platform: Platform = Platform.DISCORD) -> None:
+        """Counterpart of :meth:`mark_delivered` for a delivery that failed."""
+        if not record:
+            return
+        await self._mark(record["id"], platform, DeliveryStatus.FAILED, error=error)
+
+    # ------------------------------------------------------------------ #
+    # Sending
+    # ------------------------------------------------------------------ #
+
+    async def send_dm(
+        self,
+        user: discord.abc.Snowflake,
+        *,
+        content: NotificationContent,
+        source: NotificationSource,
+        variables: Optional[Dict[str, Any]] = None,
+        view: Optional[discord.ui.LayoutView] = None,
+        files: Optional[List[discord.File]] = None,
+        allowed_mentions: Optional[discord.AllowedMentions] = None,
+        platforms: Sequence[Platform] = (Platform.DISCORD,),
+        locale: Optional[str] = None,
+        batch_id: Optional[Any] = None,
+    ) -> DeliveryResult:
+        """Send one notification as a DM.
+
+        ``view`` lets a feature keep the card it already designed (a sanction
+        notice, a ticket transcript); the uniform ``content`` is still required
+        because it is what the dashboard, the mail and the staff preview read.
+        When ``view`` is omitted the content renders itself.
+        """
+        record = await self.record(
+            content=content, source=source,
+            recipient_type=RecipientType.DISCORD_USER,
+            recipient_id=getattr(user, "id", None),
+            variables=variables, platforms=platforms, locale=locale, batch_id=batch_id,
+        )
+        payload = await self._build_view(record, content, source, variables, view, locale)
+        return await self._deliver(
+            destination=user, record=record, view=payload,
+            files=files, allowed_mentions=allowed_mentions,
+        )
+
+    async def send_channel(
+        self,
+        channel: discord.abc.Messageable,
+        *,
+        content: NotificationContent,
+        source: NotificationSource,
+        guild_id: Optional[int] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        view: Optional[discord.ui.LayoutView] = None,
+        allowed_mentions: Optional[discord.AllowedMentions] = None,
+        platforms: Sequence[Platform] = (Platform.DISCORD,),
+        locale: Optional[str] = None,
+        batch_id: Optional[Any] = None,
+    ) -> DeliveryResult:
+        """Send one notification into a server channel (a server-wide notice)."""
+        record = await self.record(
+            content=content, source=source,
+            recipient_type=RecipientType.DISCORD_GUILD,
+            recipient_id=guild_id or getattr(getattr(channel, "guild", None), "id", None),
+            variables=variables, platforms=platforms, locale=locale, batch_id=batch_id,
+        )
+        payload = await self._build_view(record, content, source, variables, view, locale)
+        return await self._deliver(
+            destination=channel, record=record, view=payload,
+            allowed_mentions=allowed_mentions,
+        )
+
+    async def _build_view(self, record, content, source, variables, view, locale):
+        """Render (or take) the view and bolt the attribution row onto it."""
+        payload = view if view is not None else build_content_view(
+            content, variables, locale=locale or "en-US")
+
+        if not source.has_attribution:
+            return payload  # official notices carry no attribution at all
+        if not record:
+            # No uuid means no working custom_id: better an unattributed DM
+            # than dead buttons.
+            logger.warning("Notification not recorded — sending without attribution row")
+            return payload
+
+        from utils.notification_views import attach_attribution
+        ctx = await self.source_context(record, locale=locale or record.get("locale") or "en-US")
+        return attach_attribution(payload, str(record["id"]), ctx,
+                                  locale=locale or "en-US")
+
+    async def _deliver(self, *, destination, record, view, files=None,
+                       allowed_mentions=None) -> DeliveryResult:
+        notification_id = str(record["id"]) if record else None
+        kwargs: Dict[str, Any] = {"view": view}
+        if files:
+            kwargs["files"] = files
+        if allowed_mentions is not None:
+            kwargs["allowed_mentions"] = allowed_mentions
+
+        try:
+            message = await destination.send(**kwargs)
+        except discord.Forbidden as exc:
+            await self._mark(notification_id, Platform.DISCORD, DeliveryStatus.FAILED,
+                             error="forbidden")
+            return DeliveryResult(notification_id, None, DeliveryStatus.FAILED, exc)
+        except discord.HTTPException as exc:
+            await self._mark(notification_id, Platform.DISCORD, DeliveryStatus.FAILED,
+                             error=str(exc))
+            return DeliveryResult(notification_id, None, DeliveryStatus.FAILED, exc)
+
+        # ``message`` is always a Message from a real Discord send; guard
+        # anyway so a stubbed destination cannot turn a successful delivery
+        # into an AttributeError.
+        await self._mark(
+            notification_id, Platform.DISCORD, DeliveryStatus.SENT,
+            channel_id=getattr(getattr(message, "channel", None), "id", None),
+            message_id=getattr(message, "id", None),
+        )
+        # The mail and the dashboard are served by the backend from the stored
+        # row; the bot only declares them as targeted and leaves them pending.
+        return DeliveryResult(notification_id, message, DeliveryStatus.SENT, None)
+
+    # ------------------------------------------------------------------ #
+    # Server-wide notices
+    # ------------------------------------------------------------------ #
+
+    def resolve_guild_channel(self, guild: discord.Guild) -> Optional[discord.TextChannel]:
+        """Where a server-wide Moddy notice should land.
+
+        Priority, best first: the ``moddy-updates`` channel Moddy creates for
+        exactly this, the server's Community Updates channel, its system
+        channel, then any channel Moddy can actually talk in.
+        """
+        me = guild.me
+        if me is None:
+            return None
+
+        def usable(channel) -> bool:
+            return (isinstance(channel, discord.TextChannel)
+                    and channel.permissions_for(me).send_messages)
+
+        named = discord.utils.get(guild.text_channels, name=MODDY_UPDATES_CHANNEL_NAME)
+        for candidate in (named, guild.public_updates_channel, guild.system_channel):
+            if candidate is not None and usable(candidate):
+                return candidate
+        return next((c for c in guild.text_channels if usable(c)), None)
+
+    async def notify_guild(
+        self,
+        guild: discord.Guild,
+        *,
+        content: NotificationContent,
+        source: NotificationSource,
+        variables: Optional[Dict[str, Any]] = None,
+        dm_owner: bool = False,
+        locale: Optional[str] = None,
+        batch_id: Optional[Any] = None,
+    ) -> List[DeliveryResult]:
+        """Notify a whole server: its Moddy channel, and optionally its owner.
+
+        Returns one :class:`DeliveryResult` per attempt. When no channel is
+        usable, the owner DM is attempted even if it was not requested — a
+        server with no reachable channel is exactly the case where the owner is
+        the only way through.
+        """
+        locale = locale or (str(guild.preferred_locale) if guild.preferred_locale else "en-US")
+        results: List[DeliveryResult] = []
+
+        channel = self.resolve_guild_channel(guild)
+        if channel is not None:
+            results.append(await self.send_channel(
+                channel, content=content, source=source, guild_id=guild.id,
+                variables=variables, locale=locale, batch_id=batch_id,
+                allowed_mentions=discord.AllowedMentions.none(),
+            ))
+
+        if dm_owner or channel is None:
+            owner = guild.owner or (await self._fetch_owner(guild))
+            if owner is not None:
+                results.append(await self.send_dm(
+                    owner, content=content, source=source, variables=variables,
+                    locale=locale, batch_id=batch_id,
+                ))
+        return results
+
+    async def _fetch_owner(self, guild: discord.Guild) -> Optional[discord.abc.User]:
+        try:
+            return await self.bot.fetch_user(guild.owner_id) if guild.owner_id else None
+        except discord.HTTPException:
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Broadcasts
+    # ------------------------------------------------------------------ #
+
+    async def broadcast_users(
+        self,
+        user_ids: Iterable[int],
+        *,
+        content: NotificationContent,
+        source: NotificationSource,
+        variables: Optional[Dict[str, Any]] = None,
+        segment: Optional[str] = None,
+        locale: Optional[str] = None,
+        progress: Optional[Callable[[Dict[str, int]], Any]] = None,
+    ) -> Dict[str, Any]:
+        """DM a group of users — potentially thousands of them.
+
+        One notification row per recipient (they share a ``batch_id``, so the
+        whole campaign is queryable), paced by :data:`BROADCAST_DELAY`, and
+        resilient: a user with closed DMs is a ``failed`` delivery, not the end
+        of the run. ``progress`` is called every 25 recipients so a staff
+        command can keep its status message alive.
+        """
+        batch_id = uuid_module.uuid4()
+        stats = {"total": 0, "sent": 0, "failed": 0}
+
+        for user_id in user_ids:
+            stats["total"] += 1
+            user = self.bot.get_user(user_id)
+            if user is None:
+                try:
+                    user = await self.bot.fetch_user(user_id)
+                except discord.HTTPException:
+                    user = None
+            if user is None:
+                await self.record(
+                    content=content, source=source,
+                    recipient_type=RecipientType.DISCORD_USER, recipient_id=user_id,
+                    recipient_ref=segment, variables=variables, locale=locale,
+                    batch_id=batch_id,
+                )
+                stats["failed"] += 1
+            else:
+                result = await self.send_dm(
+                    user, content=content, source=source, variables=variables,
+                    locale=locale, batch_id=batch_id,
+                )
+                stats["sent" if result.delivered else "failed"] += 1
+
+            if progress and stats["total"] % 25 == 0:
+                await _maybe_await(progress(dict(stats)))
+            await asyncio.sleep(BROADCAST_DELAY)
+
+        if progress:
+            await _maybe_await(progress(dict(stats)))
+        return {"batch_id": str(batch_id), **stats}
+
+    async def broadcast_guilds(
+        self,
+        guild_ids: Iterable[int],
+        *,
+        content: NotificationContent,
+        source: NotificationSource,
+        variables: Optional[Dict[str, Any]] = None,
+        dm_owner: bool = False,
+        segment: Optional[str] = None,
+        progress: Optional[Callable[[Dict[str, int]], Any]] = None,
+    ) -> Dict[str, Any]:
+        """Post a notice in a group of servers — potentially thousands."""
+        batch_id = uuid_module.uuid4()
+        stats = {"total": 0, "sent": 0, "failed": 0}
+
+        for guild_id in guild_ids:
+            stats["total"] += 1
+            guild = self.bot.get_guild(guild_id)
+            if guild is None:
+                stats["failed"] += 1
+            else:
+                results = await self.notify_guild(
+                    guild, content=content, source=source, variables=variables,
+                    dm_owner=dm_owner, batch_id=batch_id,
+                )
+                stats["sent" if any(r.delivered for r in results) else "failed"] += 1
+
+            if progress and stats["total"] % 25 == 0:
+                await _maybe_await(progress(dict(stats)))
+            await asyncio.sleep(BROADCAST_DELAY)
+
+        if progress:
+            await _maybe_await(progress(dict(stats)))
+        return {"batch_id": str(batch_id), **stats}
+
+    # ------------------------------------------------------------------ #
+    # Reports
+    # ------------------------------------------------------------------ #
+
+    async def open_report(
+        self, *, notification_id: Any, reporter: discord.abc.User, reason: str,
+        locale: str = "en-US",
+    ) -> Optional[Dict[str, Any]]:
+        """File a report, post the review panel, log it. Returns the report row."""
+        if not self.db:
+            return None
+        report = await self.db.create_notification_report(
+            notification_id=notification_id, reporter_id=reporter.id, reason=reason)
+        if report is None:
+            # Racing double-submit: hand back the existing one so the reporter
+            # sees their status rather than an error.
+            return await self.existing_report(notification_id, reporter.id)
+
+        record = await self.get(notification_id)
+        if record:
+            await self._post_review(report, record)
+            await self._log_report("created", report, record, actor=reporter)
+        return report
+
+    async def claim_report(
+        self, *, report_id: Any, staff: discord.abc.User,
+        interaction: Optional[discord.Interaction] = None,
+    ) -> bool:
+        """Assign a pending report and refresh its panel."""
+        if not self.db:
+            return False
+        report = await self.db.claim_notification_report(report_id, staff.id)
+        if report is None:
+            if interaction is not None and not interaction.response.is_done():
+                await interaction.response.defer()
+            return False
+
+        record = await self.get(report["notification_id"])
+        if interaction is not None and not interaction.response.is_done():
+            await interaction.response.defer()
+        if record:
+            await self._refresh_review(report, record)
+            await self._log_report("claimed", report, record, actor=staff)
+        return True
+
+    async def decide_report(
+        self, *, report_id: Any, staff: discord.abc.User, status: str,
+        note: Optional[str] = None, locale: str = "en-US",
+    ) -> bool:
+        """Accept or refuse a report, refresh the panel, log it, tell the reporter."""
+        if not self.db:
+            return False
+        report = await self.db.decide_notification_report(report_id, staff.id, status, note)
+        if report is None:
+            return False
+
+        record = await self.get(report["notification_id"])
+        if record:
+            await self._refresh_review(report, record)
+            await self._log_report(status, report, record, actor=staff)
+            await self._notify_reporter(report, record)
+        return True
+
+    # -- report plumbing --------------------------------------------------- #
+
+    def _channel(self, channel_id: int) -> Optional[discord.abc.Messageable]:
+        return self.bot.get_channel(channel_id) if channel_id else None
+
+    async def _post_review(self, report: Dict[str, Any], record: Dict[str, Any]) -> None:
+        from utils.notification_views import build_review_panel
+
+        channel = self._channel(config.MODDY_NOTIF_REPORT_CHANNEL_ID)
+        if channel is None:
+            logger.warning("Notification report channel unavailable — report %s not posted",
+                           report["id"])
+            return
+        ctx = await self.source_context(record, locale=self._staff_locale())
+        try:
+            message = await channel.send(
+                view=build_review_panel(report=report, record=record, ctx=ctx,
+                                        locale=self._staff_locale()),
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+        except discord.HTTPException as exc:
+            logger.warning("Could not post notification report panel: %s", exc)
+            return
+        await self.db.set_report_review_message(report["id"], channel.id, message.id)
+        # Keep the caller's dict in step so the "created" log entry can already
+        # link to the panel it just posted.
+        report["review_channel_id"] = channel.id
+        report["review_message_id"] = message.id
+
+    async def _refresh_review(self, report: Dict[str, Any], record: Dict[str, Any]) -> None:
+        """Edit the stored panel — never the interaction's own message, which
+        may be an ephemeral follow-up."""
+        from utils.notification_views import build_review_panel
+
+        channel_id, message_id = report.get("review_channel_id"), report.get("review_message_id")
+        if not channel_id or not message_id:
+            return
+        channel = self._channel(channel_id)
+        if channel is None:
+            return
+        ctx = await self.source_context(record, locale=self._staff_locale())
+        try:
+            message = await channel.fetch_message(message_id)
+            await message.edit(view=build_review_panel(
+                report=report, record=record, ctx=ctx, locale=self._staff_locale()))
+        except discord.HTTPException as exc:
+            logger.warning("Could not refresh notification report panel: %s", exc)
+
+    async def _log_report(self, event: str, report: Dict[str, Any],
+                          record: Dict[str, Any], *, actor=None) -> None:
+        from utils.notification_views import build_report_log
+
+        channel = self._channel(config.MODDY_NOTIF_REPORT_LOG_CHANNEL_ID)
+        if channel is None:
+            return
+        jump_url = None
+        if report.get("review_channel_id") and report.get("review_message_id"):
+            jump_url = (f"https://discord.com/channels/{config.MODDY_TEAM_GUILD_ID}/"
+                        f"{report['review_channel_id']}/{report['review_message_id']}")
+        try:
+            await channel.send(
+                view=build_report_log(event=event, report=report, record=record,
+                                      actor=actor, jump_url=jump_url,
+                                      locale=self._staff_locale()),
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+        except discord.HTTPException as exc:
+            logger.warning("Could not log notification report event: %s", exc)
+
+    async def _notify_reporter(self, report: Dict[str, Any], record: Dict[str, Any]) -> None:
+        """Close the loop: the reporter hears back, through this same system."""
+        from utils.i18n import t
+
+        user = self.bot.get_user(report["reporter_id"])
+        if user is None:
+            try:
+                user = await self.bot.fetch_user(report["reporter_id"])
+            except discord.HTTPException:
+                return
+
+        locale = record.get("locale") or "en-US"
+        status = report["status"]
+        from utils.emojis import DONE, UNDONE
+        content = NotificationContent(
+            title=t(f"notifications.report.outcome.{status}.title", locale=locale),
+            body=t(f"notifications.report.outcome.{status}.description", locale=locale),
+            icon=DONE if status == ReportStatus.ACCEPTED.value else UNDONE,
+            accent_color=0x57F287 if status == ReportStatus.ACCEPTED.value else 0x99AAB5,
+            footer=t("notifications.report.outcome.footer", locale=locale,
+                     report="{report}"),
+            template_id="notifications.report.outcome",
+        )
+        if report.get("decision_note"):
+            content.sections = [{
+                "title": t("notifications.review.note", locale=locale),
+                "body": "{note}",
+            }]
+        await self.send_dm(
+            user, content=content,
+            source=NotificationSource.official("moddy"),
+            variables={"report": str(report["id"]), "note": report.get("decision_note") or ""},
+            locale=locale,
+        )
+
+    def _staff_locale(self) -> str:
+        """Staff-facing panels are rendered in one language, like the appeal
+        review panels (``services/appeal_service._PANEL_LOCALE``)."""
+        return STAFF_PANEL_LOCALE
+
+
+async def _maybe_await(value):
+    if asyncio.iscoroutine(value):
+        return await value
+    return value

--- a/services/appeal_service.py
+++ b/services/appeal_service.py
@@ -531,14 +531,34 @@ class AppealService:
             await self._dm_outcome(int(appeal["subject_id"]), appeal, decided, dm_locale)
 
     async def _dm_outcome(self, user_id: int, appeal: dict, decided: dict, locale: str):
+        from notifications.models import NotificationContent, NotificationSource
         from utils.components_v2 import create_info_message
+        from utils.emojis import BALANCE
         try:
             user = self.bot.get_user(user_id) or await self.bot.fetch_user(user_id)
             key = f"modules.automod_ai.appeal.status.{decided['status']}"
             body = t("modules.automod_ai.appeal.dm_outcome", locale=locale,
                      status=t(key, locale=locale), guild=self._guild_name(appeal))
-            await user.send(view=create_info_message(
-                t("modules.automod_ai.appeal.dm_outcome_title", locale=locale), body))
+            # Through the notification system: Moddy's own wording about an
+            # appeal on a server, so it is attributed but not reportable.
+            guild_id = appeal.get("guild_id")
+            await self.bot.notifications.send_dm(
+                user,
+                content=NotificationContent(
+                    title=t("modules.automod_ai.appeal.dm_outcome_title", locale=locale),
+                    body=t("modules.automod_ai.appeal.dm_outcome", locale=locale,
+                           status="{status}", guild="{guild}"),
+                    icon=BALANCE,
+                    template_id=f"appeals.outcome.{decided['status']}",
+                ),
+                source=(NotificationSource.service_guild("appeals", int(guild_id))
+                        if guild_id else NotificationSource.service("appeals")),
+                variables={"status": t(key, locale=locale),
+                           "guild": self._guild_name(appeal)},
+                view=create_info_message(
+                    t("modules.automod_ai.appeal.dm_outcome_title", locale=locale), body),
+                locale=locale,
+            )
         except (discord.Forbidden, discord.HTTPException):
             pass
 

--- a/services/expiration_notifier.py
+++ b/services/expiration_notifier.py
@@ -138,11 +138,34 @@ class ExpirationNotifier:
             expired_at=row.get("expires_at"),
             invite_url=invite_url,
         )
+        from notifications.models import NotificationContent, NotificationSource
+        from utils.emojis import TIME
+        from utils.i18n import t
+
         try:
-            await user.send(view=view)
-            return True
-        except discord.Forbidden:
-            return False  # DMs closed — the case timeline still records it
+            # Through the notification system: Moddy telling the subject a
+            # server sanction is over — attributed to the server, not reportable.
+            result = await self.bot.notifications.send_dm(
+                user,
+                content=NotificationContent(
+                    title=t("commands.moderation.expiry_dm.title",
+                            locale=self.guild_locale(guild)),
+                    body=t("commands.moderation.expiry_dm.body",
+                           locale=self.guild_locale(guild)),
+                    icon=TIME,
+                    sections=[{"title": t("commands.moderation.expiry_dm.case_id",
+                                          locale=self.guild_locale(guild)),
+                               "body": "`{reference}`"}],
+                    footer="{server}",
+                    template_id=f"expirations.{row.get('action')}",
+                ),
+                source=NotificationSource.service_guild("expirations", guild.id),
+                variables={"server": guild.name,
+                           "reference": str(row.get("reference") or "—")},
+                view=view,
+                locale=self.guild_locale(guild),
+            )
+            return result.delivered
         except discord.HTTPException as exc:
             logger.warning("Expiration DM to %s failed: %s", subject_id, exc)
             return False

--- a/services/global_sanction_service.py
+++ b/services/global_sanction_service.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import discord
 
+from notifications.models import NotificationContent, NotificationSource
 from utils import global_sanctions as gs
 from utils.global_sanctions import GlobalLevel
 from utils.moderation_cases import SubjectType
@@ -415,14 +416,50 @@ class GlobalSanctionService:
             deadline=(enforcement or {}).get("deadline"), premium=premium,
             has_servers=has_servers,
         )
-        try:
-            await user.send(view=view)
+        # Official Moddy notice: recorded and counted like every other
+        # notification, but it deliberately carries no attribution or report
+        # buttons — this IS Moddy speaking (docs/NOTIFICATIONS.md).
+        result = await self.bot.notifications.send_dm(
+            user,
+            content=self._notice_content(level, reason),
+            source=NotificationSource.official("global_sanctions"),
+            variables={"reason": reason or "", "level": level},
+            view=view,
+        )
+        if result.delivered:
             return True
-        except discord.Forbidden:
+        if result.forbidden:
             logger.info("[GlobalSanction] Cannot DM user %s (DMs closed)", user_id)
-        except discord.HTTPException as exc:
-            logger.error("[GlobalSanction] Notice DM to %s failed: %s", user_id, exc)
+        elif result.error is not None:
+            logger.error("[GlobalSanction] Notice DM to %s failed: %s",
+                         user_id, result.error)
         return False
+
+    def _notice_content(self, level: str, reason: Optional[str]) -> "NotificationContent":
+        """The uniform payload behind a global-sanction notice.
+
+        Same text the dashboard and the mail pipeline render — a suspension has
+        to reach the person even if they never open Discord again.
+        """
+        from utils.emojis import EXCLAMATION
+        from utils.i18n import t
+        locale = "en-US"
+        return NotificationContent(
+            title=t("global_sanctions.notice.title", locale=locale),
+            body=t("global_sanctions.notice.intro", locale=locale,
+                   url="https://moddy.app/violations"),
+            icon=EXCLAMATION,
+            accent_color=0xED4245,
+            sections=[
+                {"title": t("global_sanctions.notice.field_level", locale=locale),
+                 "body": "`{level}`"},
+                {"title": t("global_sanctions.notice.field_reason", locale=locale),
+                 "body": "{reason}"},
+            ],
+            links=[{"label": t("global_sanctions.notice.button_appeal", locale=locale),
+                    "url": "https://moddy.app/support"}],
+            template_id=f"global_sanctions.notice.{level}",
+        )
 
     async def _notify_halt(self, row: Dict[str, Any], group_cases: List[Dict[str, Any]]) -> None:
         """Tell the subject their countdown was stopped while the appeal runs."""
@@ -430,9 +467,17 @@ class GlobalSanctionService:
 
         try:
             user = await self.bot.fetch_user(int(row["subject_id"]))
-            await user.send(view=build_halt_notice(
-                level=self._level_of(row), cases=[self._case_summary(c) for c in group_cases],
-            ))
+            await self.bot.notifications.send_dm(
+                user,
+                content=self._notice_content(self._level_of(row), row.get("reason")),
+                source=NotificationSource.official("global_sanctions"),
+                variables={"reason": row.get("reason") or "",
+                           "level": self._level_of(row)},
+                view=build_halt_notice(
+                    level=self._level_of(row),
+                    cases=[self._case_summary(c) for c in group_cases],
+                ),
+            )
         except (discord.HTTPException, ValueError, TypeError):
             pass
 
@@ -446,12 +491,19 @@ class GlobalSanctionService:
 
         try:
             user = await self.bot.fetch_user(int(row["subject_id"]))
-            await user.send(view=build_resume_notice(
-                level=self._level_of(row),
-                cases=[self._case_summary(c) for c in group_cases],
-                deadline=row.get("deadline"),
-                premium=bool(row.get("premium")),
-            ))
+            await self.bot.notifications.send_dm(
+                user,
+                content=self._notice_content(self._level_of(row), row.get("reason")),
+                source=NotificationSource.official("global_sanctions"),
+                variables={"reason": row.get("reason") or "",
+                           "level": self._level_of(row)},
+                view=build_resume_notice(
+                    level=self._level_of(row),
+                    cases=[self._case_summary(c) for c in group_cases],
+                    deadline=row.get("deadline"),
+                    premium=bool(row.get("premium")),
+                ),
+            )
         except (discord.HTTPException, ValueError, TypeError):
             pass
 

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -513,18 +513,46 @@ class TicketService:
         """DM the opener that their ticket is closed — best effort, never fatal."""
         from utils.ticket_views import build_close_dm
 
-        await self._dm_owner(channel, ticket, build_close_dm(
-            channel.guild, ticket, category, actor, reason,
-            locale=self.ticket_locale(category)))
+        await self._dm_owner(
+            channel, ticket,
+            build_close_dm(channel.guild, ticket, category, actor, reason,
+                           locale=self.ticket_locale(category)),
+            kind="close", category=category, locale=self.ticket_locale(category))
 
     async def _dm_owner(self, channel: discord.TextChannel,
-                        ticket: Dict[str, Any], view) -> None:
-        """Send one card to the ticket's opener. Closed DMs are not an error."""
+                        ticket: Dict[str, Any], view, *,
+                        kind: str = "close", category: Optional[Dict[str, Any]] = None,
+                        locale: str = "en-US") -> None:
+        """Send one card to the ticket's opener. Closed DMs are not an error.
+
+        Routed through the notification system like every other DM: the card is
+        Moddy's own wording about a ticket on that server, so it carries the
+        service + server attribution and a greyed-out report flag.
+        """
         owner = channel.guild.get_member(ticket['owner_id'])
         if not owner or owner.bot:
             return
+        from notifications.models import NotificationContent, NotificationSource
+        from utils.emojis import TICKET
         try:
-            await owner.send(view=view)
+            await self.bot.notifications.send_dm(
+                owner,
+                content=NotificationContent(
+                    title=t(f"modules.tickets.{kind}.dm_title", locale=locale),
+                    body=t(f"modules.tickets.{kind}.dm_description", locale=locale,
+                           server="{server}", number="{number}", category="{category}"),
+                    icon=TICKET,
+                    template_id=f"tickets.dm.{kind}",
+                ),
+                variables={
+                    "server": channel.guild.name,
+                    "number": str(ticket.get("number", "—")),
+                    "category": (category or {}).get("name", "—"),
+                },
+                source=NotificationSource.service_guild("tickets", channel.guild.id),
+                view=view,
+                locale=locale,
+            )
         except (discord.Forbidden, discord.HTTPException):
             pass  # closed DMs are the norm, not an error
 
@@ -545,9 +573,11 @@ class TicketService:
         # The closure was announced in a DM, so its cancellation has to be too:
         # a member told their ticket was over has no reason to look at a
         # channel that had disappeared from their list.
-        await self._dm_owner(channel, ticket, build_reopen_dm(
-            channel.guild, ticket, category, actor, channel,
-            locale=self.ticket_locale(category)))
+        await self._dm_owner(
+            channel, ticket,
+            build_reopen_dm(channel.guild, ticket, category, actor, channel,
+                            locale=self.ticket_locale(category)),
+            kind="reopen", category=category, locale=self.ticket_locale(category))
 
         logger.info(f"[Tickets] #{ticket['number']} reopened by {actor.id}")
         return ticket

--- a/staff/commands/com/__init__.py
+++ b/staff/commands/com/__init__.py
@@ -1,0 +1,1 @@
+"""Communication staff commands (`/com` · `com.`)."""

--- a/staff/commands/com/_send_modal.py
+++ b/staff/commands/com/_send_modal.py
@@ -1,0 +1,75 @@
+"""Modal V2 for composing a Moddy notification sent by the team.
+
+One screen writes the message; the command that opened it decides who receives
+it. The fields map one-to-one onto
+:class:`~notifications.models.NotificationContent`, so the same text renders as
+a Discord panel, a mail subject + body, and a dashboard card without anyone
+rewriting it per platform.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseModal
+from utils.i18n import t
+
+
+class NotificationComposeModal(BaseModal):
+    """Compose a notification. ``on_submit_content`` receives the payload."""
+
+    def __init__(self, *, locale: str,
+                 on_content: Callable[[discord.Interaction, Dict[str, Any]], Any]):
+        super().__init__(title=t("staff.com.send.modal.title", locale=locale)[:45])
+        self.locale = locale
+        self.on_content = on_content
+
+        self.title_input = ui.TextInput(
+            style=discord.TextStyle.short, max_length=200, required=True,
+            placeholder=t("staff.com.send.modal.title_field.placeholder", locale=locale)[:100],
+        )
+        self.body_input = ui.TextInput(
+            style=discord.TextStyle.paragraph, max_length=3000, required=True,
+            placeholder=t("staff.com.send.modal.body.placeholder", locale=locale)[:100],
+        )
+        self.link_label_input = ui.TextInput(
+            style=discord.TextStyle.short, max_length=80, required=False,
+            placeholder=t("staff.com.send.modal.link_label.placeholder", locale=locale)[:100],
+        )
+        self.link_url_input = ui.TextInput(
+            style=discord.TextStyle.short, max_length=300, required=False,
+            placeholder="https://moddy.app/…",
+        )
+
+        self.add_item(ui.Label(
+            text=t("staff.com.send.modal.title_field.label", locale=locale)[:45],
+            component=self.title_input))
+        self.add_item(ui.Label(
+            text=t("staff.com.send.modal.body.label", locale=locale)[:45],
+            description=t("staff.com.send.modal.body.description", locale=locale)[:100],
+            component=self.body_input))
+        self.add_item(ui.Label(
+            text=t("staff.com.send.modal.link_label.label", locale=locale)[:45],
+            component=self.link_label_input))
+        self.add_item(ui.Label(
+            text=t("staff.com.send.modal.link_url.label", locale=locale)[:45],
+            description=t("staff.com.send.modal.link_url.description", locale=locale)[:100],
+            component=self.link_url_input))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        url = (self.link_url_input.value or "").strip()
+        links = []
+        if url.startswith("https://"):
+            links.append({
+                "label": (self.link_label_input.value or "").strip()
+                         or t("staff.com.send.default_link_label", locale=self.locale),
+                "url": url,
+            })
+        await self.on_content(interaction, {
+            "title": (self.title_input.value or "").strip(),
+            "body": (self.body_input.value or "").strip(),
+            "links": links,
+        })

--- a/staff/commands/com/send.py
+++ b/staff/commands/com/send.py
@@ -1,0 +1,305 @@
+"""`/com send` — send a Moddy notification to a user, a server, or thousands.
+
+Four audiences from one command:
+
+``user``    one Discord user, by id — a DM.
+``guild``   one server: its Moddy channel (``moddy-updates`` → Community
+            Updates → system channel), optionally its owner too.
+``users``   a group of users: ``all``, or every user carrying an attribute
+            (``PREMIUM``, ``BETA``…). Can be thousands.
+``guilds``  a group of servers, same segment syntax (``OFFICIAL``, ``PARTNER``…).
+
+The wording is written in a Modal V2 and stored as a uniform notification
+payload, so the same announcement can be rendered by the dashboard and the mail
+pipeline without being retyped. Group sends are confirmed first, then run in the
+background with a live progress panel; everything is recorded under one
+``batch_id``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import discord
+
+from cogs.error_handler import BaseView
+from notifications.models import ContentAuthor, NotificationContent, NotificationSource
+from staff.framework import StaffCommand, SlashOption, staff_command, design, CommandType
+from staff.commands.com._send_modal import NotificationComposeModal
+from staff.framework.views import ConfirmView
+from utils import emojis
+from utils.i18n import t
+
+logger = logging.getLogger("moddy.staff.com.send")
+
+#: Audience keyword meaning "everyone Moddy knows".
+SEGMENT_ALL = "all"
+
+#: Above this many recipients the confirmation panel carries a warning: a
+#: broadcast cannot be recalled, and it paces itself at ~3 sends a second.
+LARGE_AUDIENCE = 500
+
+
+@staff_command
+class ComSendCommand(StaffCommand):
+    command_type = CommandType.COMMUNICATION
+    name = "send"
+    permission = "broadcast"
+    description = "Send a Moddy notification to a user, a server, or a group of them."
+    options = [
+        SlashOption("target", "string", "Who receives it.", required=True,
+                    choices=["user", "guild", "users", "guilds"]),
+        SlashOption("recipient", "string",
+                    "A Discord id, or a segment: 'all' or an attribute (PREMIUM, OFFICIAL…).",
+                    required=True),
+        SlashOption("dm_owner", "boolean",
+                    "Server targets: also DM the server owner.", required=False, default=False),
+    ]
+
+    def parse_message(self, raw: str) -> dict:
+        parts = (raw or "").split()
+        return {
+            "target": parts[0] if parts else None,
+            "recipient": parts[1] if len(parts) > 1 else None,
+            "dm_owner": len(parts) > 2 and parts[2].lower() in ("true", "yes", "1"),
+        }
+
+    async def execute(self, ctx):
+        target = (ctx.opt("target") or "").lower()
+        recipient = (ctx.opt("recipient") or "").strip()
+        dm_owner = bool(ctx.opt("dm_owner", False))
+
+        if target not in ("user", "guild", "users", "guilds") or not recipient:
+            await ctx.send(view=design.invalid_usage(
+                ctx.locale, "com.send <user|guild|users|guilds> <id|segment> [dm_owner]"))
+            return
+
+        audience, error = await _resolve_audience(ctx.bot, target, recipient, ctx.locale)
+        if error is not None:
+            await ctx.send(view=error)
+            return
+
+        async def _composed(interaction: discord.Interaction, payload: Dict[str, Any]):
+            await _handle_composed(
+                interaction, ctx, target=target, recipient=recipient,
+                audience=audience, dm_owner=dm_owner, payload=payload)
+
+        await ctx.open_modal(
+            lambda: NotificationComposeModal(locale=ctx.locale, on_content=_composed),
+            label=t("staff.com.send.compose", locale=ctx.locale), emoji=emojis.MESSAGE,
+            prompt_title=t("staff.com.send.compose", locale=ctx.locale),
+            prompt_description=t("staff.com.send.compose_hint", locale=ctx.locale,
+                                 audience=_audience_label(target, recipient, audience)),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Audience
+# --------------------------------------------------------------------------- #
+
+async def _resolve_audience(bot, target: str, recipient: str, locale: str
+                            ) -> Tuple[Optional[Any], Optional[BaseView]]:
+    """Turn ``target`` + ``recipient`` into something sendable, or an error panel."""
+    if target in ("user", "guild"):
+        if not recipient.isdigit():
+            return None, design.error(
+                t("staff.com.send.errors.bad_id.title", locale=locale),
+                t("staff.com.send.errors.bad_id.description", locale=locale))
+        entity_id = int(recipient)
+        if target == "user":
+            user = bot.get_user(entity_id)
+            if user is None:
+                try:
+                    user = await bot.fetch_user(entity_id)
+                except discord.HTTPException:
+                    user = None
+            if user is None:
+                return None, design.error(
+                    t("staff.com.send.errors.unknown_user.title", locale=locale),
+                    t("staff.com.send.errors.unknown_user.description", locale=locale,
+                      id=entity_id))
+            return user, None
+
+        guild = bot.get_guild(entity_id)
+        if guild is None:
+            return None, design.error(
+                t("staff.com.send.errors.unknown_guild.title", locale=locale),
+                t("staff.com.send.errors.unknown_guild.description", locale=locale,
+                  id=entity_id))
+        return guild, None
+
+    segment = recipient.strip()
+    if target == "users":
+        if segment.lower() == SEGMENT_ALL:
+            ids = await bot.db.get_all_user_ids()
+        else:
+            ids = await bot.db.get_users_with_attribute(segment.upper())
+    else:
+        known = {g.id for g in bot.guilds}
+        if segment.lower() == SEGMENT_ALL:
+            ids = sorted(known)
+        else:
+            ids = [gid for gid in await bot.db.get_guilds_with_attribute(segment.upper())
+                   if gid in known]
+
+    if not ids:
+        return None, design.error(
+            t("staff.com.send.errors.empty_segment.title", locale=locale),
+            t("staff.com.send.errors.empty_segment.description", locale=locale,
+              segment=segment))
+    return ids, None
+
+
+def _audience_label(target: str, recipient: str, audience: Any) -> str:
+    if target in ("user", "guild"):
+        name = getattr(audience, "name", None) or getattr(audience, "display_name", recipient)
+        return f"{name} (`{getattr(audience, 'id', recipient)}`)"
+    return f"`{len(audience)}` · `{recipient}`"
+
+
+# --------------------------------------------------------------------------- #
+# Composition -> send
+# --------------------------------------------------------------------------- #
+
+def _build_content(payload: Dict[str, Any]) -> NotificationContent:
+    """The staff-written announcement, as a uniform notification payload."""
+    return NotificationContent(
+        title=payload["title"],
+        body=payload["body"],
+        icon=emojis.MODDY,
+        accent_color=0x3661FF,
+        links=payload.get("links") or [],
+        template_id="staff.com.send",
+    )
+
+
+async def _handle_composed(interaction: discord.Interaction, ctx, *, target: str,
+                           recipient: str, audience: Any, dm_owner: bool,
+                           payload: Dict[str, Any]) -> None:
+    """Single targets go out immediately; group targets are confirmed first."""
+    locale = ctx.locale
+    content = _build_content(payload)
+    source = NotificationSource.service(
+        "moddy", author=ContentAuthor.STAFF, actor_id=interaction.user.id)
+
+    if target == "user":
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        result = await ctx.bot.notifications.send_dm(
+            audience, content=content, source=source, locale=locale)
+        await interaction.followup.send(view=_single_result(
+            result, name=str(audience), locale=locale), ephemeral=True)
+        return
+
+    if target == "guild":
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        results = await ctx.bot.notifications.notify_guild(
+            audience, content=content, source=source, dm_owner=dm_owner)
+        delivered = [r for r in results if r.delivered]
+        await interaction.followup.send(view=design.panel(
+            "success" if delivered else "error",
+            t("staff.com.send.guild_done.title" if delivered
+              else "staff.com.send.errors.no_channel.title", locale=locale),
+            t("staff.com.send.guild_done.description" if delivered
+              else "staff.com.send.errors.no_channel.description",
+              locale=locale, guild=audience.name, count=len(delivered)),
+            footer=(f"{t('staff.notif.title', locale=locale)}: "
+                    f"{', '.join(r.notification_id or '—' for r in results)}"),
+        ), ephemeral=True)
+        return
+
+    # --- group targets ---------------------------------------------------- #
+    total = len(audience)
+    confirm = ConfirmView(
+        bot=ctx.bot, author_id=interaction.user.id, locale=locale,
+        title=t("staff.com.send.confirm.title", locale=locale),
+        description=t("staff.com.send.confirm.description", locale=locale,
+                      count=total, segment=recipient,
+                      kind=t(f"staff.com.send.audience.{target}", locale=locale))
+        + (f"\n\n{emojis.WARNING} **"
+           f"{t('staff.com.send.confirm.large', locale=locale)}**"
+           if total >= LARGE_AUDIENCE else "")
+        + f"\n\n**{payload['title']}**\n-# {payload['body'][:300]}",
+        confirm_label=t("staff.com.send.confirm.button", locale=locale),
+        danger=True, emoji=emojis.MESSAGE,
+        on_confirm=lambda i: _start_broadcast(
+            i, ctx, target=target, recipient=recipient, audience=audience,
+            content=content, source=source, dm_owner=dm_owner, locale=locale),
+    )
+    await interaction.response.send_message(view=confirm, ephemeral=True)
+
+
+def _single_result(result, *, name: str, locale: str) -> BaseView:
+    if result.delivered:
+        return design.success(
+            t("staff.com.send.user_done.title", locale=locale),
+            t("staff.com.send.user_done.description", locale=locale, user=name),
+            footer=f"`{result.notification_id}`")
+    key = "dms_closed" if result.forbidden else "failed"
+    return design.error(
+        t(f"staff.com.send.errors.{key}.title", locale=locale),
+        t(f"staff.com.send.errors.{key}.description", locale=locale, user=name))
+
+
+async def _start_broadcast(interaction: discord.Interaction, ctx, *, target: str,
+                           recipient: str, audience: List[int],
+                           content: NotificationContent, source: NotificationSource,
+                           dm_owner: bool, locale: str) -> BaseView:
+    """Kick the broadcast off in the background and hand back a live panel.
+
+    ``ConfirmView`` edits the message with whatever this returns, so the first
+    panel is "started"; the task then keeps editing it as recipients are
+    processed. A broadcast outliving the interaction token simply stops
+    updating — the batch itself keeps running and stays queryable by id.
+    """
+    async def _progress(stats: Dict[str, int]) -> None:
+        try:
+            await interaction.edit_original_response(
+                view=_progress_panel(stats, total=len(audience), locale=locale))
+        except discord.HTTPException:
+            pass  # token expired on a long run: the batch continues regardless
+
+    async def _run() -> None:
+        try:
+            if target == "users":
+                stats = await ctx.bot.notifications.broadcast_users(
+                    audience, content=content, source=source, segment=recipient,
+                    progress=_progress)
+            else:
+                stats = await ctx.bot.notifications.broadcast_guilds(
+                    audience, content=content, source=source, segment=recipient,
+                    dm_owner=dm_owner, progress=_progress)
+            logger.info("Broadcast %s finished: %s", stats.get("batch_id"), stats)
+            try:
+                await interaction.edit_original_response(
+                    view=_done_panel(stats, locale=locale))
+            except discord.HTTPException:
+                pass
+        except Exception as exc:  # noqa: BLE001 — a background task must not die silently
+            logger.error("Broadcast failed: %s", exc, exc_info=True)
+
+    asyncio.create_task(_run())
+    return _progress_panel({"total": 0, "sent": 0, "failed": 0},
+                           total=len(audience), locale=locale)
+
+
+def _progress_panel(stats: Dict[str, int], *, total: int, locale: str) -> BaseView:
+    done = stats.get("total", 0)
+    return design.panel(
+        "loading",
+        t("staff.com.send.progress.title", locale=locale),
+        t("staff.com.send.progress.description", locale=locale,
+          done=done, total=total, sent=stats.get("sent", 0),
+          failed=stats.get("failed", 0)),
+    )
+
+
+def _done_panel(stats: Dict[str, int], *, locale: str) -> BaseView:
+    return design.success(
+        t("staff.com.send.done.title", locale=locale),
+        t("staff.com.send.done.description", locale=locale,
+          total=stats.get("total", 0), sent=stats.get("sent", 0),
+          failed=stats.get("failed", 0)),
+        footer=f"batch `{stats.get('batch_id')}`",
+    )

--- a/staff/commands/mod/notification.py
+++ b/staff/commands/mod/notification.py
@@ -1,0 +1,175 @@
+"""`/mod notif` — everything Moddy knows about one notification.
+
+Takes the uuid a recipient reads at the bottom of any Moddy DM (or the
+reference of an abuse report filed against one) and reconstructs the full
+picture: who sent it and on whose behalf, who received it, on which platforms
+it was delivered and with what result, how many times that exact wording has
+been sent, and the state of every report against it.
+"""
+
+from typing import Any, Dict, List
+
+import discord
+from discord import ui
+
+from staff.framework import StaffCommand, SlashOption, staff_command, design, CommandType
+from cogs.error_handler import BaseView
+from notifications.models import NotificationContent, ReportStatus
+from utils import emojis
+from utils.i18n import t
+
+#: Delivery status -> the dot shown in front of it.
+_STATUS_DOT = {
+    "sent": emojis.GREEN_STATUS,
+    "pending": emojis.YELLOW_STATUS,
+    "failed": emojis.RED_STATUS,
+    "skipped": emojis.YELLOW_STATUS,
+}
+
+_REPORT_EMOJI = {
+    ReportStatus.PENDING.value: emojis.PENDING,
+    ReportStatus.CLAIMED.value: emojis.HAND,
+    ReportStatus.ACCEPTED.value: emojis.DONE,
+    ReportStatus.REFUSED.value: emojis.UNDONE,
+}
+
+
+@staff_command
+class NotificationInfoCommand(StaffCommand):
+    command_type = CommandType.MODERATOR
+    name = "notif"
+    permission = "notif_lookup"
+    description = "Look up a notification (or an abuse report) by its uuid."
+    options = [
+        SlashOption("reference", "string",
+                    "Notification uuid, or the reference of a report on it.",
+                    required=True),
+    ]
+
+    async def execute(self, ctx):
+        reference = (ctx.opt("reference") or "").strip()
+        if not reference:
+            await ctx.send(view=design.invalid_usage(ctx.locale, "mod.notif <uuid>"))
+            return
+
+        notifications = getattr(ctx.bot, "notifications", None)
+        if notifications is None:
+            await ctx.send(view=design.error(
+                t("staff.notif.unavailable.title", locale=ctx.locale),
+                t("staff.notif.unavailable.description", locale=ctx.locale)))
+            return
+
+        # A staffer copies whichever id they have in front of them, so accept
+        # both: try the notification first, fall back to a report reference.
+        record = await notifications.get(reference)
+        if record is None:
+            report = await notifications.get_report(reference)
+            record = await notifications.get(report["notification_id"]) if report else None
+
+        if record is None:
+            await ctx.send(view=design.error(
+                t("staff.notif.not_found.title", locale=ctx.locale),
+                t("staff.notif.not_found.description", locale=ctx.locale, uuid=reference)))
+            return
+
+        ctx_source = await notifications.source_context(record, locale=ctx.locale)
+        reports = await ctx.bot.db.get_reports_for_notification(record["id"])
+
+        await ctx.send(view=_build_panel(record, ctx_source, reports, locale=ctx.locale))
+
+
+def _build_panel(record: Dict[str, Any], source_ctx: Dict[str, Any],
+                 reports: List[Dict[str, Any]], *, locale: str) -> BaseView:
+    """The staff card: identity, routing, delivery, content, reports."""
+    view = BaseView()
+    container = design.make_container("info")
+
+    container.add_item(ui.TextDisplay(design.title_line(
+        emojis.MESSAGE, t("staff.notif.title", locale=locale))))
+    container.add_item(ui.TextDisplay(
+        f"`{record['id']}`\n"
+        f"-# {t('staff.notif.created_at', locale=locale)} "
+        f"<t:{int(record['created_at'].timestamp())}:f>"))
+
+    container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+    # --- origin ---------------------------------------------------------- #
+    origin = [
+        f"**{t('staff.notif.kind', locale=locale)}** `{record['kind']}`",
+        f"**{t('staff.notif.author', locale=locale)}** `{record['author']}`",
+    ]
+    if source_ctx.get("service_name"):
+        origin.append(f"**{t('staff.notif.service', locale=locale)}** "
+                      f"{source_ctx.get('service_emoji') or ''} {source_ctx['service_name']} "
+                      f"(`{record['source_service']}`)")
+    if record.get("source_guild_id"):
+        origin.append(f"**{t('staff.notif.guild', locale=locale)}** "
+                      f"{source_ctx.get('guild_name') or '?'}{source_ctx.get('badge') or ''} "
+                      f"(`{record['source_guild_id']}`)")
+    if record.get("actor_id"):
+        origin.append(f"**{t('staff.notif.actor', locale=locale)}** "
+                      f"<@{record['actor_id']}> (`{record['actor_id']}`)")
+    origin.append(
+        f"**{t('staff.notif.reportable', locale=locale)}** "
+        + (f"{emojis.DONE} `true`" if record.get("reportable")
+           else f"{emojis.UNDONE} `false`"
+                + (f" — `{source_ctx.get('report_block')}`" if source_ctx.get("report_block") else ""))
+    )
+    container.add_item(ui.TextDisplay("\n".join(origin)))
+
+    # --- recipient + delivery -------------------------------------------- #
+    container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+    recipient = [f"**{t('staff.notif.recipient', locale=locale)}** `{record['recipient_type']}`"]
+    if record.get("recipient_id"):
+        recipient.append(f"-# <@{record['recipient_id']}> (`{record['recipient_id']}`)")
+    if record.get("recipient_ref"):
+        recipient.append(f"-# `{record['recipient_ref']}`")
+    if record.get("batch_id"):
+        recipient.append(f"-# {t('staff.notif.batch', locale=locale)} `{record['batch_id']}`")
+    container.add_item(ui.TextDisplay("\n".join(recipient)))
+
+    lines = []
+    for delivery in record.get("deliveries", []):
+        dot = _STATUS_DOT.get(delivery["status"], emojis.YELLOW_STATUS)
+        line = f"{dot} `{delivery['platform']}` — `{delivery['status']}`"
+        if delivery.get("message_id"):
+            line += f" · `{delivery['message_id']}`"
+        if delivery.get("error"):
+            line += f"\n-# {delivery['error'][:150]}"
+        lines.append(line)
+    container.add_item(ui.TextDisplay(
+        f"**{t('staff.notif.delivery', locale=locale)}**\n"
+        + ("\n".join(lines) or f"-# {t('staff.notif.no_delivery', locale=locale)}")))
+
+    # --- content ---------------------------------------------------------- #
+    container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+    content = NotificationContent.from_dict(record.get("content") or {})
+    resolved = content.render(record.get("variables") or {})
+    body = " ".join((resolved.body or "").split())
+    container.add_item(ui.TextDisplay(
+        f"**{t('staff.notif.content', locale=locale)}**\n"
+        f"{resolved.title or '—'}\n"
+        f"-# {body[:600] or '—'}"))
+    container.add_item(ui.TextDisplay(
+        f"-# {t('staff.notif.hash', locale=locale)} `{record['content_hash'][:16]}…` · "
+        f"{t('staff.notif.occurrences', locale=locale)} `{record.get('content_uses', 0)}`"
+        + (f" · {t('staff.notif.template', locale=locale)} `{content.template_id}`"
+           if content.template_id else "")))
+
+    # --- reports ----------------------------------------------------------- #
+    if reports:
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+        rows = []
+        for report in reports:
+            emoji = _REPORT_EMOJI.get(report["status"], emojis.PENDING)
+            rows.append(
+                f"{emoji} `{report['status']}` — <@{report['reporter_id']}>\n"
+                f"-# `{report['id']}`"
+                + (f" · <@{report['decided_by']}>" if report.get("decided_by") else "")
+            )
+        container.add_item(ui.TextDisplay(
+            f"**{t('staff.notif.reports', locale=locale)}** (`{len(reports)}`)\n"
+            + "\n".join(rows[:5])))
+
+    view.add_item(container)
+    return view

--- a/tests/test_altguard.py
+++ b/tests/test_altguard.py
@@ -114,6 +114,8 @@ class FakeBot:
         self._guild = guild
         self.db = db
         self.module_manager = None
+        from notifications import NotificationService
+        self.notifications = NotificationService(self)
 
     def get_guild(self, guild_id):
         return self._guild if self._guild and self._guild.id == guild_id else None

--- a/tests/test_expiration_notifications.py
+++ b/tests/test_expiration_notifications.py
@@ -76,6 +76,12 @@ class FakeBot:
     def __init__(self, guild=None, user=None):
         self._guild = guild
         self._user = user
+        # Every DM goes through the notification system now. With no database
+        # the service records nothing and sends the view as-is, which is
+        # exactly what these tests assert on.
+        from notifications import NotificationService
+        self.notifications = NotificationService(self)
+        self.db = None
 
     def get_guild(self, gid):
         return self._guild if self._guild and self._guild.id == gid else None

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,493 @@
+"""Centralized notification system — model, attribution and report rules.
+
+What these guard, in order of how badly they would hurt in production:
+
+* **Content de-duplication.** The whole storage design rests on identical
+  templates hashing identically *before* placeholder substitution. If that
+  breaks, every welcome DM writes its own body row.
+* **Reproducibility.** A notification must render to the exact wording its
+  recipient saw, months later, from the template plus its variables — that is
+  what the staff "See the message" button shows a reviewer.
+* **Attribution rules.** Which buttons a DM carries, and above all when the
+  report flag is dead: Moddy-authored wording, official notices, and messages
+  from Moddy's own servers are never reportable.
+* **Report authorization.** Only the addressee reports; no staffer reviews
+  their own report.
+
+The pure-Python core is tested directly; the Discord surface is tested through
+stubs (no gateway, no database).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notifications.models import (
+    SERVICES, ContentAuthor, NotificationContent, NotificationSource,
+    RecipientType, SourceKind, get_service, strip_custom_emojis, substitute,
+)
+from notifications.render import resolve_source_context, source_button_emoji
+from notifications.service import NotificationService
+
+_UUID = "0f7d9c62-3b4e-4a1f-9c2d-5e6f70819a2b"
+
+
+# --------------------------------------------------------------------------- #
+# Placeholders
+# --------------------------------------------------------------------------- #
+
+def test_placeholders_are_substituted_from_variables():
+    assert substitute("Welcome {user} on {server}",
+                      {"user": "@bob", "server": "Moddy"}) == "Welcome @bob on Moddy"
+
+
+def test_an_unknown_placeholder_is_left_visible():
+    """Silently blanking it would hide the mistake from whoever wrote it."""
+    assert substitute("Hi {nope}", {"user": "x"}) == "Hi {nope}"
+
+
+def test_a_stray_brace_never_raises():
+    """Server-written text is arbitrary: a lone '{' must not break a delivery."""
+    assert substitute("100% { of the time", {"user": "x"}) == "100% { of the time"
+
+
+def test_a_none_variable_renders_empty():
+    assert substitute("[{maybe}]", {"maybe": None}) == "[]"
+
+
+# --------------------------------------------------------------------------- #
+# Content hashing
+# --------------------------------------------------------------------------- #
+
+def _welcome(body="Welcome {user} on {server}!"):
+    return NotificationContent(title="Server", body=body, icon="<:a:1>",
+                               template_id="welcome_dm.wdm_1")
+
+
+def test_identical_templates_share_one_hash():
+    assert _welcome().template_hash() == _welcome().template_hash()
+
+
+def test_the_hash_ignores_the_resolved_values():
+    """Ten thousand members, one stored body — the point of the design."""
+    template = _welcome()
+    first = template.render({"user": "@bob", "server": "Moddy"})
+    second = template.render({"user": "@alice", "server": "Moddy"})
+    assert first.body != second.body
+    assert template.template_hash() == _welcome().template_hash()
+
+
+def test_a_different_template_hashes_differently():
+    assert _welcome().template_hash() != _welcome("Goodbye {user}").template_hash()
+
+
+def test_a_content_survives_a_round_trip_through_the_database_shape():
+    content = NotificationContent(
+        title="T", body="B {x}", icon="<:i:1>", accent_color=0x3661FF,
+        sections=[{"title": "S", "body": "{x}"}],
+        links=[{"label": "L", "url": "https://moddy.app"}],
+        footer="F", template_id="t.1")
+    assert NotificationContent.from_dict(content.to_dict()).template_hash() \
+        == content.template_hash()
+
+
+def test_the_exact_wording_can_be_rebuilt_later():
+    stored = NotificationContent.from_dict(_welcome().to_dict())
+    rebuilt = stored.render({"user": "@bob", "server": "Moddy"})
+    assert rebuilt.body == "Welcome @bob on Moddy!"
+
+
+# --------------------------------------------------------------------------- #
+# Cross-platform rendering
+# --------------------------------------------------------------------------- #
+
+def test_the_mail_shape_carries_a_subject_a_body_and_the_links():
+    content = NotificationContent(
+        title="Account suspended", body="Your account {user} is suspended.",
+        sections=[{"title": "Reason", "body": "{reason}"}],
+        links=[{"label": "Appeal", "url": "https://moddy.app/support"}],
+        footer="Moddy")
+    mail = content.to_email({"user": "bob", "reason": "spam"})
+    assert mail["subject"] == "Account suspended"
+    assert "Your account bob is suspended." in mail["text"]
+    assert "spam" in mail["text"]
+    assert mail["links"][0]["url"] == "https://moddy.app/support"
+
+
+def test_custom_emojis_are_stripped_outside_discord():
+    """`<:done:123>` is literal noise in an inbox."""
+    content = NotificationContent(title="<:done:1> Done", body="ok")
+    assert content.to_email()["subject"] == "Done"
+    assert strip_custom_emojis("a <a:spin:2> b") == "a b"
+
+
+def test_the_dashboard_shape_keeps_the_markdown_and_the_icon():
+    content = NotificationContent(title="T", body="**bold** {x}", icon="<:i:1>")
+    data = content.to_dashboard({"x": "v"})
+    assert data["body"] == "**bold** v"
+    assert data["icon"] == "<:i:1>"
+
+
+# --------------------------------------------------------------------------- #
+# Sources
+# --------------------------------------------------------------------------- #
+
+def test_an_official_notice_carries_no_attribution_at_all():
+    source = NotificationSource.official("global_sanctions")
+    assert source.has_attribution is False
+    assert source.base_reportable is False
+
+
+def test_guild_written_content_is_reportable():
+    assert NotificationSource.guild(42).base_reportable is True
+
+
+def test_moddy_written_content_is_not_reportable():
+    """A sanction notice is Moddy's wording: there is nothing to judge."""
+    source = NotificationSource.service_guild("automod_ai", 42)
+    assert source.has_attribution is True
+    assert source.base_reportable is False
+
+
+def test_a_source_survives_a_round_trip_through_its_row():
+    source = NotificationSource.service_guild(
+        "welcome_dm", 42, author=ContentAuthor.GUILD, actor_id=7)
+    row = {
+        "kind": source.kind.value, "source_service": source.service_id,
+        "source_guild_id": source.guild_id, "author": source.author.value,
+        "actor_id": source.actor_id,
+    }
+    assert NotificationSource.from_row(row) == source
+
+
+def test_every_registered_service_resolves_to_a_real_emoji():
+    for service_id, service in SERVICES.items():
+        assert get_service(service_id) is service
+        assert service.emoji.startswith("<")
+
+
+def test_an_unknown_service_id_is_tolerated():
+    assert get_service("does_not_exist") is None
+    assert get_service(None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Attribution context (stubbed bot)
+# --------------------------------------------------------------------------- #
+
+class FakeGuild:
+    def __init__(self, gid=42, name="Test Server"):
+        self.id = gid
+        self.name = name
+        self.icon = None
+        self.member_count = 1234
+        self.created_at = None
+
+
+class FakeDB:
+    def __init__(self, attributes=None):
+        self._attributes = attributes or {}
+
+    async def get_guild(self, guild_id):
+        return {"guild_id": guild_id, "attributes": self._attributes}
+
+
+class FakeBot:
+    def __init__(self, guild=None, attributes=None):
+        self._guild = guild
+        self.db = FakeDB(attributes)
+
+    def get_guild(self, guild_id):
+        return self._guild if self._guild and self._guild.id == guild_id else None
+
+
+async def test_a_plain_server_is_reportable_and_unbadged():
+    ctx = await resolve_source_context(
+        FakeBot(FakeGuild()), NotificationSource.guild(42))
+    assert ctx["guild_name"] == "Test Server"
+    assert ctx["reportable"] is True
+    assert ctx["verified"] is False
+    assert ctx["badge"] == ""
+
+
+async def test_a_verified_server_gets_the_check():
+    ctx = await resolve_source_context(
+        FakeBot(FakeGuild(), {"VERIFIED": True}), NotificationSource.guild(42))
+    assert ctx["verified"] is True
+    assert ctx["badge"]  # a hyperlinked badge, per the CLAUDE.md rule
+    assert ctx["reportable"] is True
+    assert source_button_emoji(ctx) != source_button_emoji({"verified": False})
+
+
+async def test_an_official_moddy_server_greys_the_flag_out():
+    """Reporting Moddy to Moddy is a loop with no exit."""
+    ctx = await resolve_source_context(
+        FakeBot(FakeGuild(), {"OFFICIAL": True}), NotificationSource.guild(42))
+    assert ctx["official"] is True
+    assert ctx["verified"] is True
+    assert ctx["reportable"] is False
+    assert ctx["report_block"] == "official_guild"
+
+
+async def test_moddy_authored_content_says_why_the_flag_is_dead():
+    ctx = await resolve_source_context(
+        FakeBot(FakeGuild()), NotificationSource.service_guild("altguard", 42))
+    assert ctx["reportable"] is False
+    assert ctx["report_block"] == "moddy_authored"
+    assert ctx["service_name"]
+
+
+async def test_an_unreachable_guild_degrades_instead_of_raising():
+    ctx = await resolve_source_context(FakeBot(None), NotificationSource.guild(42))
+    assert ctx["guild_name"]  # "Unknown server", not a crash
+    assert ctx["reportable"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Service behaviour without a database
+# --------------------------------------------------------------------------- #
+
+class NoDbBot:
+    db = None
+
+    def get_guild(self, guild_id):
+        return None
+
+
+class Recipient:
+    def __init__(self):
+        self.id = 7
+        self.sent = []
+
+    async def send(self, **kwargs):
+        self.sent.append(kwargs)
+        return None
+
+
+async def test_a_dm_still_goes_out_when_the_database_is_down():
+    """A recording failure must never swallow the message itself."""
+    service = NotificationService(NoDbBot())
+    recipient = Recipient()
+    result = await service.send_dm(
+        recipient,
+        content=NotificationContent(title="T", body="B"),
+        source=NotificationSource.guild(42),
+    )
+    assert result.delivered
+    assert recipient.sent  # sent — just without the attribution row
+    assert result.notification_id is None
+
+
+async def test_may_report_is_the_recipient_only():
+    service = NotificationService(NoDbBot())
+
+    class Interaction:
+        def __init__(self, user_id):
+            self.user = type("U", (), {"id": user_id})()
+            self.guild_id = None
+
+    record = {"recipient_type": RecipientType.DISCORD_USER.value, "recipient_id": 7}
+    assert await service.may_report(record, Interaction(7)) is True
+    assert await service.may_report(record, Interaction(8)) is False
+
+
+async def test_a_server_notice_is_reported_by_a_server_manager():
+    service = NotificationService(NoDbBot())
+
+    class Member:
+        def __init__(self, manage):
+            self.id = 7
+            self.guild_permissions = type(
+                "P", (), {"manage_guild": manage, "administrator": False})()
+
+    class Interaction:
+        def __init__(self, member, guild_id):
+            self.user = member
+            self.guild_id = guild_id
+
+    record = {"recipient_type": RecipientType.DISCORD_GUILD.value, "recipient_id": 42}
+    assert await service.may_report(record, Interaction(Member(True), 42)) is True
+    assert await service.may_report(record, Interaction(Member(False), 42)) is False
+    assert await service.may_report(record, Interaction(Member(True), 99)) is False
+
+
+async def test_a_row_recorded_as_unreportable_can_never_become_reportable():
+    """A server marked official afterwards must not resurrect old flags."""
+    service = NotificationService(FakeBot(FakeGuild()))
+    record = {
+        "kind": SourceKind.GUILD.value, "author": ContentAuthor.GUILD.value,
+        "source_service": None, "source_guild_id": 42, "actor_id": None,
+        "reportable": False,
+    }
+    ctx = await service.source_context(record)
+    assert ctx["reportable"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Attribution row
+# --------------------------------------------------------------------------- #
+
+def _row_labels(row):
+    """Labels of an attribution row.
+
+    Its children are ``DynamicItem`` wrappers (that is what makes them survive a
+    restart), so the label lives on the wrapped button.
+    """
+    return [child.item.label for child in row.children]
+
+
+def test_a_service_and_server_source_shows_three_buttons():
+    from utils.notification_views import build_attribution_row
+
+    row = build_attribution_row(_UUID, {
+        "service_name": "Tickets", "service_emoji": "<:t:1>",
+        "guild_name": "Test Server", "verified": False, "reportable": True,
+    })
+    assert _row_labels(row) == ["Tickets", "Test Server", None]  # flag has no label
+
+
+def test_a_guild_only_source_shows_the_server_and_the_flag():
+    from utils.notification_views import build_attribution_row
+
+    row = build_attribution_row(_UUID, {
+        "guild_name": "Test Server", "reportable": True})
+    assert _row_labels(row) == ["Test Server", None]
+
+
+def test_the_flag_is_disabled_when_the_message_is_not_reportable():
+    from utils.notification_views import build_attribution_row
+
+    row = build_attribution_row(_UUID, {
+        "service_name": "AltGuard", "guild_name": "Test Server",
+        "reportable": False, "report_block": "moddy_authored"})
+    assert list(row.children)[-1].item.disabled is True
+
+
+def test_an_official_notice_gets_no_row_and_the_view_is_untouched():
+    from cogs.error_handler import BaseView
+    from utils.notification_views import attach_attribution, build_attribution_row
+
+    assert build_attribution_row(_UUID, {"service_name": None, "guild_name": None}) is None
+    view = BaseView()
+    before = len(view.children)
+    attach_attribution(view, _UUID, {"service_name": None, "guild_name": None})
+    assert len(view.children) == before
+
+
+def test_every_attribution_custom_id_carries_the_notification_uuid():
+    """After a restart the uuid in the custom_id is all a click has to go on."""
+    from utils.notification_views import build_attribution_row
+
+    row = build_attribution_row(_UUID, {
+        "service_name": "Tickets", "guild_name": "Test Server", "reportable": True})
+    for child in row.children:
+        assert child.custom_id.endswith(_UUID)
+        assert len(child.custom_id) <= 100
+
+
+# --------------------------------------------------------------------------- #
+# i18n completeness
+#
+# A missing key does not crash: it renders as `[notifications.…]` inside a DM
+# that thousands of people receive. These tests are what stops that shipping.
+# --------------------------------------------------------------------------- #
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LOCALES = ("fr", "en-US", "es-ES", "pt-BR", "de")
+
+#: Keys built from a variable at runtime, so a source scan cannot see them.
+_DYNAMIC_KEYS = {
+    "notifications.report.status.pending",
+    "notifications.report.status.claimed",
+    "notifications.report.status.accepted",
+    "notifications.report.status.refused",
+    "notifications.report.sent.title",
+    "notifications.report.sent.description",
+    "notifications.report.already.title",
+    "notifications.report.already.description",
+    "notifications.report.outcome.accepted.title",
+    "notifications.report.outcome.accepted.description",
+    "notifications.report.outcome.refused.title",
+    "notifications.report.outcome.refused.description",
+    "notifications.source.not_reportable.moddy_authored",
+    "notifications.source.not_reportable.official_guild",
+    "notifications.review.buttons.accept",
+    "notifications.review.buttons.refuse",
+    "notifications.review.decision.accept.title",
+    "notifications.review.decision.accept.recap",
+    "notifications.review.decision.accept.done.title",
+    "notifications.review.decision.accept.done.description",
+    "notifications.review.decision.refuse.title",
+    "notifications.review.decision.refuse.recap",
+    "notifications.review.decision.refuse.done.title",
+    "notifications.review.decision.refuse.done.description",
+    "notifications.log.title.created",
+    "notifications.log.title.claimed",
+    "notifications.log.title.accepted",
+    "notifications.log.title.refused",
+    "staff.com.send.audience.user",
+    "staff.com.send.audience.guild",
+    "staff.com.send.audience.users",
+    "staff.com.send.audience.guilds",
+    "staff.com.send.errors.dms_closed.title",
+    "staff.com.send.errors.dms_closed.description",
+    "staff.com.send.errors.failed.title",
+    "staff.com.send.errors.failed.description",
+}
+
+_SOURCES = (
+    "utils/notification_views.py",
+    "notifications/render.py",
+    "notifications/service.py",
+    "staff/commands/mod/notification.py",
+    "staff/commands/com/send.py",
+    "staff/commands/com/_send_modal.py",
+)
+
+_KEY_RE = re.compile(r"[\"']((?:notifications|staff\.(?:notif|com))\.[a-zA-Z0-9_.]+)[\"']")
+
+
+def _used_keys() -> set:
+    keys = set(_DYNAMIC_KEYS)
+    for relative in _SOURCES:
+        source = (ROOT / relative).read_text(encoding="utf-8")
+        for key in _KEY_RE.findall(source):
+            # f-string keys carrying a `{placeholder}` segment are covered by
+            # _DYNAMIC_KEYS above; the scan sees only their literal prefix.
+            if key.endswith("."):
+                continue
+            keys.add(key)
+    # `template_id` values look like keys but name a template, not a string.
+    return {k for k in keys
+            if k not in {"staff.com.send", "notifications.report.outcome"}}
+
+
+def _lookup(data: dict, key: str):
+    current = data
+    for part in key.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_every_notification_string_exists_in_every_locale(locale):
+    data = json.loads((ROOT / "locales" / f"{locale}.json").read_text(encoding="utf-8"))
+    missing = sorted(k for k in _used_keys() if not isinstance(_lookup(data, k), str))
+    assert not missing, f"locales/{locale}.json is missing: {missing}"
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+def test_modal_titles_fit_discords_limit(locale):
+    """Discord rejects a modal whose title is over 45 characters."""
+    data = json.loads((ROOT / "locales" / f"{locale}.json").read_text(encoding="utf-8"))
+    for key in ("notifications.report.modal.title",
+                "notifications.review.decision.accept.title",
+                "notifications.review.decision.refuse.title",
+                "staff.com.send.modal.title"):
+        assert len(_lookup(data, key)) <= 45, f"{key} too long in {locale}"

--- a/tests/test_persistent_views.py
+++ b/tests/test_persistent_views.py
@@ -128,6 +128,10 @@ def _dynamic_item_cases():
         StaffPanelRolesSelect, StaffPanelScopeSelect, StaffPanelPermsSelect, StaffPanelActionButton,
     )
     from utils.ticket_views import TicketOpenButton, TicketOpenSelect
+    from utils.notification_views import (
+        NotificationServiceButton, NotificationSourceButton, NotificationReportButton,
+        NotifReviewClaimButton, NotifReviewPreviewButton, NotifReviewDecisionButton,
+    )
     from modules.configs.tickets_panel_config import (
         TicketPanelButton, TicketPanelSelect, TicketPanelChannelSelect,
     )
@@ -175,6 +179,14 @@ def _dynamic_item_cases():
         (TicketPermRoleSelect, ("p_ab12cd", "c_ab12cd")),
         (TicketPermSelect, ("p_ab12cd", "c_ab12cd", _SNOWFLAKE)),
         (TicketPermButton, ("clear", "p_ab12cd", "c_ab12cd", _SNOWFLAKE)),
+        # Notifications — the attribution row carried by every DM, keyed by the
+        # notification uuid, and the staff review panel, keyed by the report's.
+        (NotificationServiceButton, (_U,)),
+        (NotificationSourceButton, (_U,)),
+        (NotificationReportButton, (_U,)),
+        (NotifReviewClaimButton, (_U,)),
+        (NotifReviewPreviewButton, (_U,)),
+        (NotifReviewDecisionButton, ("accept", _U)),
     ]
 
 

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -1036,9 +1036,16 @@ class TestNoContentWithLayoutView:
                   / "services" / "ticket_service.py").read_text(encoding="utf-8")
         # Every `.send(` call and its argument list, up to the closing paren of
         # the call (good enough: no nested `send(` in this file).
+        #
+        # `content=NotificationContent(...)` is NOT a message content: it is the
+        # uniform payload handed to `bot.notifications.send_dm` (see
+        # docs/NOTIFICATIONS.md), which never reaches Discord as a `content`
+        # field. Only a bare `content=` next to a `view=` is the 400 this
+        # guards against.
         offenders = [
             call for call in re.findall(r"\.send\((.*?)\n\s*\)", source, re.S)
-            if "view=" in call and re.search(r"\bcontent\s*=", call)
+            if "view=" in call
+            and re.search(r"\bcontent\s*=(?!\s*NotificationContent)", call)
         ]
         assert not offenders, (
             "a send() passes both content= and view=; put the text inside the "

--- a/utils/notification_views.py
+++ b/utils/notification_views.py
@@ -1,0 +1,881 @@
+"""
+Notification UI — attribution buttons, abuse reports, and the staff review.
+
+Every DM Moddy sends carries, at the bottom, one small row that answers "where
+does this come from and what do I do about it":
+
+``[ <service> ] [ <server> ] [ 🚩 ]``
+
+The first two open an ephemeral panel identifying the sender (with the server's
+icon, its verification badge, a link into it, and the notification's uuid); the
+red flag opens the report Modal V2. Official Moddy messages (a suspension, a
+leaked-token alert) carry **no** row at all, and messages whose wording is
+Moddy's own show the flag greyed out — the panel then explains why.
+
+Staff side: a report is posted to ``MODDY_NOTIF_REPORT_CHANNEL_ID`` as a review
+panel (Claim / See the message / Accept / Refuse) and every step is mirrored to
+``MODDY_NOTIF_REPORT_LOG_CHANNEL_ID``.
+
+Persistence
+-----------
+Every button is a :class:`discord.ui.DynamicItem` whose ``custom_id`` carries
+the notification (or report) uuid, registered through
+:class:`NotificationsPersistence` — a DM sent today must still be reportable
+after next week's deploy. Modals are one-shot, per the documented exclusion.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+import discord
+from discord import ui
+
+from cogs.error_handler import BaseView, BaseModal
+from notifications.models import NotificationContent, ReportStatus
+from notifications.render import build_content_view, source_button_emoji
+from utils.components_v2 import create_error_message
+from utils.emojis import (
+    DONE, FLAG, GROUPS, HAND, LEGAL, MESSAGE, MODDY, NOTE, PENDING,
+    SNOWFLAKE, TIME, UNDONE, USER, WARNING,
+)
+from utils.i18n import i18n, t
+
+logger = logging.getLogger("moddy.notification_views")
+
+#: UUID fragment shared by every custom_id template below.
+_UUID = r"[0-9a-fA-F-]{36}"
+
+#: Public support entry point, shown under every attribution panel.
+SUPPORT_URL = "https://moddy.app/support"
+
+#: Deep link to a server from a DM — Discord opens it if the user is a member.
+GUILD_URL = "https://discord.com/channels/{guild_id}"
+
+#: Accent colours of the review panel, by report status.
+_REVIEW_ACCENT = {
+    ReportStatus.PENDING.value: 0x3661FF,
+    ReportStatus.CLAIMED.value: 0xFEE75C,
+    ReportStatus.ACCEPTED.value: 0x57F287,
+    ReportStatus.REFUSED.value: 0xED4245,
+}
+
+_STATUS_EMOJI = {
+    ReportStatus.PENDING.value: PENDING,
+    ReportStatus.CLAIMED.value: HAND,
+    ReportStatus.ACCEPTED.value: DONE,
+    ReportStatus.REFUSED.value: UNDONE,
+}
+
+
+def _guarded(callback):
+    """Route unknown errors from a dynamic item to the central error handler.
+
+    Dynamic items dispatched through ``add_dynamic_items`` have no live
+    ``BaseView``, so ``BaseView.on_error`` never fires and an unwrapped
+    exception would vanish. Same pattern as ``utils/appeal_views.py``.
+    """
+    async def wrapper(self, interaction: discord.Interaction):
+        try:
+            await callback(self, interaction)
+        except Exception as exc:  # noqa: BLE001 — funnel everything to the handler
+            from cogs.error_handler import report_component_error
+            await report_component_error(interaction, exc, self.__class__.__name__)
+    return wrapper
+
+
+def _short(text: str, limit: int = 80) -> str:
+    text = (text or "").strip()
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _excerpt(content: NotificationContent, variables: Dict[str, Any], limit: int = 300) -> str:
+    """A few lines of the message, for a recap where the full card won't fit."""
+    resolved = content.render(variables)
+    body = " ".join((resolved.body or "").split())
+    return _short(body, limit) or _short(resolved.title, limit)
+
+
+# =========================================================================== #
+# Attribution row
+# =========================================================================== #
+
+def build_attribution_row(
+    notification_id: str, ctx: Dict[str, Any], *, locale: str = "en-US"
+) -> Optional[ui.ActionRow]:
+    """The row appended under every non-official notification.
+
+    Order is fixed so it reads the same everywhere: the Moddy service that
+    acted, then the server it acted for, then the flag. A source with neither
+    service nor server (which should not happen) gets no row rather than an
+    empty one.
+    """
+    service_name = ctx.get("service_name")
+    guild_name = ctx.get("guild_name")
+    if not service_name and not guild_name:
+        return None
+
+    row = ui.ActionRow()
+
+    if service_name:
+        row.add_item(NotificationServiceButton(
+            notification_id, label=service_name,
+            emoji=ctx.get("service_emoji") or MODDY,
+        ))
+
+    if guild_name:
+        row.add_item(NotificationSourceButton(
+            notification_id, label=guild_name,
+            emoji=source_button_emoji(ctx),
+        ))
+
+    row.add_item(NotificationReportButton(
+        notification_id, disabled=not ctx.get("reportable"),
+    ))
+
+    return row
+
+
+def attach_attribution(
+    view: ui.LayoutView, notification_id: str, ctx: Dict[str, Any], *, locale: str = "en-US"
+) -> ui.LayoutView:
+    """Append the attribution row to an already-built view, in place."""
+    row = build_attribution_row(notification_id, ctx, locale=locale)
+    if row is not None:
+        view.add_item(row)
+    return view
+
+
+# =========================================================================== #
+# Panels
+# =========================================================================== #
+
+def build_source_panel(
+    *, notification_id: str, ctx: Dict[str, Any], created_at=None, locale: str = "en-US"
+) -> BaseView:
+    """The ephemeral card behind the *server* attribution button.
+
+    Answers, in this order: which server, is it trustworthy, how do I get
+    there, which notification is this exactly, and where do I go if something
+    is wrong.
+    """
+    view = BaseView()
+    container = ui.Container(accent_colour=discord.Colour(0x3661FF))
+
+    name = ctx.get("guild_name") or t("notifications.attribution.unknown_guild", locale=locale)
+    badge = ctx.get("badge") or ""
+    container.add_item(ui.TextDisplay(
+        f"### {GROUPS} {t('notifications.source.title', locale=locale)}"
+    ))
+    container.add_item(ui.TextDisplay(
+        f"{t('notifications.source.guild_label', locale=locale)} **{name}**{badge}"
+    ))
+
+    lines = []
+    if ctx.get("guild_id"):
+        lines.append(f"{SNOWFLAKE} {t('notifications.source.id_label', locale=locale)} "
+                     f"`{ctx['guild_id']}`")
+    if ctx.get("guild_member_count") is not None:
+        lines.append(f"{USER} {t('notifications.source.members', locale=locale)} "
+                     f"`{ctx['guild_member_count']}`")
+    if ctx.get("guild_created_at") is not None:
+        lines.append(f"{TIME} {t('notifications.source.created', locale=locale)} "
+                     f"<t:{int(ctx['guild_created_at'].timestamp())}:D>")
+    if lines:
+        container.add_item(ui.TextDisplay("\n".join(lines)))
+
+    if ctx.get("official"):
+        container.add_item(ui.TextDisplay(
+            f"{MODDY} **{t('notifications.source.official', locale=locale)}**"))
+    elif ctx.get("verified"):
+        container.add_item(ui.TextDisplay(
+            f"{DONE} **{t('notifications.source.verified', locale=locale)}**"))
+
+    if ctx.get("service_name"):
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+        container.add_item(ui.TextDisplay(
+            f"{ctx.get('service_emoji') or MODDY} "
+            f"{t('notifications.source.service_label', locale=locale)} "
+            f"**{ctx['service_name']}**"
+        ))
+
+    block = ctx.get("report_block")
+    if block:
+        container.add_item(ui.TextDisplay(
+            f"-# {WARNING} {t(f'notifications.source.not_reportable.{block}', locale=locale)}"
+        ))
+
+    container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+    container.add_item(ui.TextDisplay(_identity_lines(
+        notification_id, created_at=created_at, locale=locale)))
+
+    view.add_item(container)
+
+    if ctx.get("guild_id"):
+        row = ui.ActionRow()
+        row.add_item(ui.Button(
+            label=_short(t("notifications.source.open_server", locale=locale)),
+            url=GUILD_URL.format(guild_id=ctx["guild_id"]),
+            style=discord.ButtonStyle.link,
+        ))
+        view.add_item(row)
+
+    return view
+
+
+def build_service_panel(
+    *, notification_id: str, ctx: Dict[str, Any], created_at=None, locale: str = "en-US"
+) -> BaseView:
+    """The ephemeral card behind the *service* attribution button."""
+    view = BaseView()
+    container = ui.Container(accent_colour=discord.Colour(0x3661FF))
+    emoji = ctx.get("service_emoji") or MODDY
+    name = ctx.get("service_name") or t("notifications.services.moddy", locale=locale)
+
+    container.add_item(ui.TextDisplay(
+        f"### {emoji} {t('notifications.service.title', locale=locale)}"))
+    container.add_item(ui.TextDisplay(
+        f"{t('notifications.source.service_label', locale=locale)} **{name}**"))
+    container.add_item(ui.TextDisplay(
+        t("notifications.service.description", locale=locale)))
+
+    if ctx.get("guild_name"):
+        container.add_item(ui.TextDisplay(
+            f"{GROUPS} {t('notifications.source.guild_label', locale=locale)} "
+            f"**{ctx['guild_name']}**{ctx.get('badge') or ''}"
+        ))
+
+    container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+    container.add_item(ui.TextDisplay(_identity_lines(
+        notification_id, created_at=created_at, locale=locale)))
+    view.add_item(container)
+    return view
+
+
+def _identity_lines(notification_id: str, *, created_at=None, locale: str = "en-US") -> str:
+    """The uuid + support footer shared by both attribution panels."""
+    lines = [f"-# {t('notifications.source.uuid_label', locale=locale)} `{notification_id}`"]
+    if created_at is not None:
+        lines.append(f"-# {t('notifications.source.sent_at', locale=locale)} "
+                     f"<t:{int(created_at.timestamp())}:f>")
+    lines.append(f"-# {t('notifications.source.support_hint', locale=locale, url=SUPPORT_URL)}")
+    return "\n".join(lines)
+
+
+# =========================================================================== #
+# Attribution buttons (persistent)
+# =========================================================================== #
+
+class NotificationServiceButton(
+    ui.DynamicItem[ui.Button],
+    template=rf"moddy:notif:svc:(?P<notification>{_UUID})",
+):
+    """Opens the *service* identity panel. Public: anyone who sees the message."""
+
+    def __init__(self, notification_id: str, *, label: str = "Moddy", emoji: str = MODDY):
+        super().__init__(ui.Button(
+            label=_short(label),
+            style=discord.ButtonStyle.secondary,
+            emoji=discord.PartialEmoji.from_str(emoji) if emoji else None,
+            custom_id=f"moddy:notif:svc:{notification_id}",
+        ))
+        self.notification_id = str(notification_id)
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match["notification"])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        await _open_attribution_panel(interaction, self.notification_id, service=True)
+
+
+class NotificationSourceButton(
+    ui.DynamicItem[ui.Button],
+    template=rf"moddy:notif:src:(?P<notification>{_UUID})",
+):
+    """Opens the *server* identity panel. Public: anyone who sees the message."""
+
+    def __init__(self, notification_id: str, *, label: str = "Server", emoji: str = GROUPS):
+        super().__init__(ui.Button(
+            label=_short(label),
+            style=discord.ButtonStyle.secondary,
+            emoji=discord.PartialEmoji.from_str(emoji) if emoji else None,
+            custom_id=f"moddy:notif:src:{notification_id}",
+        ))
+        self.notification_id = str(notification_id)
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match["notification"])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        await _open_attribution_panel(interaction, self.notification_id, service=False)
+
+
+async def _open_attribution_panel(
+    interaction: discord.Interaction, notification_id: str, *, service: bool
+) -> None:
+    """Shared body of both attribution buttons.
+
+    Everything is re-derived from the interaction and the database: after a
+    restart ``self`` carries nothing but the uuid in the custom_id.
+    """
+    locale = i18n.get_user_locale(interaction)
+    bot = interaction.client
+    notifications = getattr(bot, "notifications", None)
+    record = await notifications.get(notification_id) if notifications else None
+
+    if not record:
+        await interaction.response.send_message(view=create_error_message(
+            t("notifications.errors.unknown.title", locale=locale),
+            t("notifications.errors.unknown.description", locale=locale,
+              uuid=notification_id),
+        ), ephemeral=True)
+        return
+
+    ctx = await notifications.source_context(record, locale=locale)
+    builder = build_service_panel if service else build_source_panel
+    await interaction.response.send_message(
+        view=builder(notification_id=str(record["id"]), ctx=ctx,
+                     created_at=record.get("created_at"), locale=locale),
+        ephemeral=True,
+    )
+
+
+class NotificationReportButton(
+    ui.DynamicItem[ui.Button],
+    template=rf"moddy:notif:flag:(?P<notification>{_UUID})",
+):
+    """The red flag. Auth: the recipient of the notification, and only them."""
+
+    def __init__(self, notification_id: str, *, disabled: bool = False):
+        super().__init__(ui.Button(
+            style=discord.ButtonStyle.danger,
+            emoji=discord.PartialEmoji.from_str(FLAG),
+            custom_id=f"moddy:notif:flag:{notification_id}",
+            disabled=disabled,
+        ))
+        self.notification_id = str(notification_id)
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match["notification"])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        locale = i18n.get_user_locale(interaction)
+        bot = interaction.client
+        notifications = getattr(bot, "notifications", None)
+        record = await notifications.get(self.notification_id) if notifications else None
+
+        if not record:
+            await interaction.response.send_message(view=create_error_message(
+                t("notifications.errors.unknown.title", locale=locale),
+                t("notifications.errors.unknown.description", locale=locale,
+                  uuid=self.notification_id),
+            ), ephemeral=True)
+            return
+
+        # Re-check reportability on every click: a server can be marked
+        # official long after its DM went out.
+        ctx = await notifications.source_context(record, locale=locale)
+        if not ctx.get("reportable"):
+            block = ctx.get("report_block") or "moddy_authored"
+            await interaction.response.send_message(view=create_error_message(
+                t("notifications.report.errors.not_reportable.title", locale=locale),
+                t(f"notifications.source.not_reportable.{block}", locale=locale),
+            ), ephemeral=True)
+            return
+
+        if not await notifications.may_report(record, interaction):
+            await interaction.response.send_message(view=create_error_message(
+                t("notifications.report.errors.not_recipient.title", locale=locale),
+                t("notifications.report.errors.not_recipient.description", locale=locale),
+            ), ephemeral=True)
+            return
+
+        existing = await notifications.existing_report(record["id"], interaction.user.id)
+        if existing:
+            await interaction.response.send_message(
+                view=build_report_status_panel(existing, locale=locale), ephemeral=True)
+            return
+
+        await interaction.response.send_modal(
+            NotificationReportModal(record=record, ctx=ctx, locale=locale))
+
+
+# =========================================================================== #
+# Report modal
+# =========================================================================== #
+
+class NotificationReportModal(BaseModal):
+    """Why is this DM abusive — plus an explicit "this is a real report" tick.
+
+    The recap block matters: a member who has scrolled past ten DMs must see
+    which one they are about to report before typing anything.
+    """
+
+    def __init__(self, *, record: Dict[str, Any], ctx: Dict[str, Any], locale: str = "en-US"):
+        super().__init__(title=_short(t("notifications.report.modal.title", locale=locale), 45))
+        self.record = record
+        self.locale = locale
+
+        content = NotificationContent.from_dict(record.get("content") or {})
+        source_name = ctx.get("guild_name") or ctx.get("service_name") or "Moddy"
+        recap = t(
+            "notifications.report.modal.recap", locale=locale,
+            source=source_name,
+            uuid=str(record["id"]),
+            excerpt=_excerpt(content, record.get("variables") or {}),
+        )
+        self.add_item(ui.TextDisplay(recap[:4000]))
+
+        self.reason = ui.Label(
+            text=_short(t("notifications.report.modal.reason.label", locale=locale), 45),
+            description=_short(
+                t("notifications.report.modal.reason.description", locale=locale), 100),
+            component=ui.TextInput(
+                style=discord.TextStyle.paragraph,
+                placeholder=_short(
+                    t("notifications.report.modal.reason.placeholder", locale=locale), 100),
+                min_length=15,
+                max_length=1000,
+                required=True,
+            ),
+        )
+        self.add_item(self.reason)
+
+        self.confirm = ui.Label(
+            text=_short(t("notifications.report.modal.confirm.label", locale=locale), 45),
+            component=ui.CheckboxGroup(
+                options=[discord.CheckboxGroupOption(
+                    label=_short(
+                        t("notifications.report.modal.confirm.option", locale=locale), 100),
+                    value="confirm",
+                )],
+                min_values=1,
+                max_values=1,
+                required=True,
+            ),
+        )
+        self.add_item(self.confirm)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        notifications = getattr(interaction.client, "notifications", None)
+        report = await notifications.open_report(
+            notification_id=self.record["id"],
+            reporter=interaction.user,
+            reason=self.reason.component.value or "",
+            locale=self.locale,
+        )
+        if report is None:
+            await interaction.followup.send(view=create_error_message(
+                t("notifications.report.errors.failed.title", locale=self.locale),
+                t("notifications.report.errors.failed.description", locale=self.locale),
+            ), ephemeral=True)
+            return
+
+        await interaction.followup.send(
+            view=build_report_status_panel(report, locale=self.locale, just_sent=True),
+            ephemeral=True,
+        )
+
+
+def build_report_status_panel(
+    report: Dict[str, Any], *, locale: str = "en-US", just_sent: bool = False
+) -> BaseView:
+    """What the reporter sees: their report's reference and where it stands."""
+    view = BaseView()
+    status = report.get("status") or ReportStatus.PENDING.value
+    container = ui.Container(accent_colour=discord.Colour(
+        _REVIEW_ACCENT.get(status, 0x3661FF)))
+
+    key = "sent" if just_sent else "already"
+    container.add_item(ui.TextDisplay(
+        f"### {DONE if just_sent else _STATUS_EMOJI.get(status, PENDING)} "
+        f"{t(f'notifications.report.{key}.title', locale=locale)}"))
+    container.add_item(ui.TextDisplay(
+        t(f"notifications.report.{key}.description", locale=locale)))
+    container.add_item(ui.TextDisplay(
+        f"{_STATUS_EMOJI.get(status, PENDING)} "
+        f"{t('notifications.report.status_label', locale=locale)} "
+        f"**{t(f'notifications.report.status.{status}', locale=locale)}**"))
+    if report.get("decision_note"):
+        container.add_item(ui.TextDisplay(
+            f"-# {t('notifications.report.decision_note', locale=locale)} "
+            f"{_short(report['decision_note'], 300)}"))
+    container.add_item(ui.TextDisplay(
+        f"-# {t('notifications.report.reference', locale=locale)} `{report['id']}`"))
+    view.add_item(container)
+    return view
+
+
+# =========================================================================== #
+# Staff review panel
+# =========================================================================== #
+
+def build_review_panel(
+    *, report: Dict[str, Any], record: Dict[str, Any], ctx: Dict[str, Any],
+    locale: str = "en-US",
+) -> BaseView:
+    """The panel staff act on, in the report channel.
+
+    It carries the whole case — who reported, what they said, what was sent, by
+    whom, to whom — so a reviewer never has to leave the message to decide.
+    Buttons disappear once the report is decided; the accent tracks the status.
+    """
+    status = report.get("status") or ReportStatus.PENDING.value
+    content = NotificationContent.from_dict(record.get("content") or {})
+
+    view = BaseView()
+    container = ui.Container(accent_colour=discord.Colour(
+        _REVIEW_ACCENT.get(status, 0x3661FF)))
+
+    container.add_item(ui.TextDisplay(
+        f"### {FLAG} {t('notifications.review.title', locale=locale)}"))
+    container.add_item(ui.TextDisplay(
+        f"{_STATUS_EMOJI.get(status, PENDING)} "
+        f"{t('notifications.report.status_label', locale=locale)} "
+        f"**{t(f'notifications.report.status.{status}', locale=locale)}**"))
+
+    container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+    source_name = ctx.get("guild_name") or ctx.get("service_name") or "Moddy"
+    details = [
+        f"{USER} **{t('notifications.review.reporter', locale=locale)}** "
+        f"<@{report['reporter_id']}> (`{report['reporter_id']}`)",
+        f"{GROUPS} **{t('notifications.review.source', locale=locale)}** "
+        f"{source_name}{ctx.get('badge') or ''}"
+        + (f" (`{ctx['guild_id']}`)" if ctx.get("guild_id") else ""),
+    ]
+    if ctx.get("service_name"):
+        details.append(f"{ctx.get('service_emoji') or MODDY} "
+                       f"**{t('notifications.review.service', locale=locale)}** "
+                       f"{ctx['service_name']}")
+    if record.get("recipient_id"):
+        details.append(f"{MESSAGE} **{t('notifications.review.recipient', locale=locale)}** "
+                       f"<@{record['recipient_id']}> (`{record['recipient_id']}`)")
+    if record.get("created_at") is not None:
+        details.append(f"{TIME} **{t('notifications.review.sent_at', locale=locale)}** "
+                       f"<t:{int(record['created_at'].timestamp())}:f>")
+    details.append(f"{NOTE} **{t('notifications.review.occurrences', locale=locale)}** "
+                   f"`{record.get('content_uses', 1)}`")
+    container.add_item(ui.TextDisplay("\n".join(details)))
+
+    container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+    container.add_item(ui.TextDisplay(
+        f"**{t('notifications.review.reason', locale=locale)}**\n"
+        f"{_short(report.get('reason') or '', 900)}"))
+    container.add_item(ui.TextDisplay(
+        f"**{t('notifications.review.content', locale=locale)}**\n"
+        f"-# {_excerpt(content, record.get('variables') or {}, 600)}"))
+
+    if report.get("claimed_by"):
+        container.add_item(ui.TextDisplay(
+            f"-# {HAND} {t('notifications.review.claimed_by', locale=locale)} "
+            f"<@{report['claimed_by']}>"))
+    if report.get("decided_by"):
+        container.add_item(ui.TextDisplay(
+            f"-# {LEGAL} {t('notifications.review.decided_by', locale=locale)} "
+            f"<@{report['decided_by']}>"))
+    if report.get("decision_note"):
+        container.add_item(ui.TextDisplay(
+            f"-# {NOTE} {_short(report['decision_note'], 300)}"))
+
+    container.add_item(ui.TextDisplay(
+        f"-# {t('notifications.source.uuid_label', locale=locale)} `{record['id']}`\n"
+        f"-# {t('notifications.report.reference', locale=locale)} `{report['id']}`"))
+
+    view.add_item(container)
+
+    report_id = str(report["id"])
+    decided = status in (ReportStatus.ACCEPTED.value, ReportStatus.REFUSED.value)
+    row = ui.ActionRow()
+    row.add_item(NotifReviewClaimButton(
+        report_id, claimed=bool(report.get("claimed_by")) or decided, locale=locale))
+    row.add_item(NotifReviewPreviewButton(report_id, locale=locale))
+    row.add_item(NotifReviewDecisionButton(
+        "accept", report_id, disabled=decided, locale=locale))
+    row.add_item(NotifReviewDecisionButton(
+        "refuse", report_id, disabled=decided, locale=locale))
+    view.add_item(row)
+
+    return view
+
+
+def build_report_log(
+    *, event: str, report: Dict[str, Any], record: Dict[str, Any],
+    actor: Optional[discord.abc.User] = None, jump_url: Optional[str] = None,
+    locale: str = "en-US",
+) -> BaseView:
+    """One immutable line of history, for the report log channel.
+
+    ``event`` is one of ``created`` / ``claimed`` / ``accepted`` / ``refused``.
+    """
+    accent = {
+        "created": 0x3661FF, "claimed": 0xFEE75C,
+        "accepted": 0x57F287, "refused": 0xED4245,
+    }.get(event, 0x99AAB5)
+
+    view = BaseView()
+    container = ui.Container(accent_colour=discord.Colour(accent))
+    container.add_item(ui.TextDisplay(
+        f"### {FLAG} {t(f'notifications.log.title.{event}', locale=locale)}"))
+
+    lines = [
+        f"{NOTE} **{t('notifications.report.reference', locale=locale)}** `{report['id']}`",
+        f"{SNOWFLAKE} **{t('notifications.source.uuid_label', locale=locale)}** `{record['id']}`",
+        f"{USER} **{t('notifications.review.reporter', locale=locale)}** "
+        f"<@{report['reporter_id']}> (`{report['reporter_id']}`)",
+    ]
+    if actor is not None:
+        lines.append(f"{HAND} **{t('notifications.log.actor', locale=locale)}** "
+                     f"{actor.mention} (`{actor.id}`)")
+    if record.get("source_guild_id"):
+        lines.append(f"{GROUPS} **{t('notifications.review.source', locale=locale)}** "
+                     f"`{record['source_guild_id']}`")
+    if record.get("source_service"):
+        lines.append(f"{MODDY} **{t('notifications.review.service', locale=locale)}** "
+                     f"`{record['source_service']}`")
+    if report.get("decision_note"):
+        lines.append(f"{MESSAGE} **{t('notifications.review.note', locale=locale)}** "
+                     f"{_short(report['decision_note'], 300)}")
+    container.add_item(ui.TextDisplay("\n".join(lines)))
+    view.add_item(container)
+
+    if jump_url:
+        row = ui.ActionRow()
+        row.add_item(ui.Button(
+            label=_short(t("notifications.log.jump", locale=locale)),
+            url=jump_url, style=discord.ButtonStyle.link))
+        view.add_item(row)
+
+    return view
+
+
+# =========================================================================== #
+# Review buttons (persistent)
+# =========================================================================== #
+
+async def _load_review(interaction: discord.Interaction, report_id: str, locale: str):
+    """Fetch (report, notification) or answer the click with an error."""
+    notifications = getattr(interaction.client, "notifications", None)
+    report = await notifications.get_report(report_id) if notifications else None
+    if not report:
+        await interaction.response.send_message(view=create_error_message(
+            t("notifications.errors.unknown.title", locale=locale),
+            t("notifications.errors.unknown_report.description", locale=locale,
+              uuid=report_id),
+        ), ephemeral=True)
+        return None, None
+    record = await notifications.get(report["notification_id"])
+    return report, record
+
+
+async def _guard_reviewer(interaction: discord.Interaction, report: Dict[str, Any],
+                          locale: str) -> bool:
+    """Staff node + "not your own report" — re-checked on every single click."""
+    from utils.staff_permissions import has_staff_node
+
+    if not await has_staff_node(interaction.client, interaction.user.id, "notif_review"):
+        await interaction.response.send_message(view=create_error_message(
+            t("notifications.review.no_permission.title", locale=locale),
+            t("notifications.review.no_permission.description", locale=locale),
+        ), ephemeral=True)
+        return False
+
+    if interaction.user.id == report.get("reporter_id"):
+        await interaction.response.send_message(view=create_error_message(
+            t("notifications.review.own_report.title", locale=locale),
+            t("notifications.review.own_report.description", locale=locale),
+        ), ephemeral=True)
+        return False
+
+    return True
+
+
+class NotifReviewClaimButton(
+    ui.DynamicItem[ui.Button],
+    template=rf"moddy:notif:rvclaim:(?P<report>{_UUID})",
+):
+    """Take ownership of a report so two reviewers don't work it at once."""
+
+    def __init__(self, report_id: str, *, claimed: bool = False, locale: str = "en-US"):
+        label_key = ("notifications.review.buttons.claimed" if claimed
+                     else "notifications.review.buttons.claim")
+        super().__init__(ui.Button(
+            label=_short(t(label_key, locale=locale)),
+            style=discord.ButtonStyle.secondary if claimed else discord.ButtonStyle.primary,
+            emoji=discord.PartialEmoji.from_str(HAND),
+            custom_id=f"moddy:notif:rvclaim:{report_id}",
+            disabled=claimed,
+        ))
+        self.report_id = str(report_id)
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match["report"])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        locale = i18n.get_user_locale(interaction)
+        report, _record = await _load_review(interaction, self.report_id, locale)
+        if not report or not await _guard_reviewer(interaction, report, locale):
+            return
+        await interaction.client.notifications.claim_report(
+            report_id=self.report_id, staff=interaction.user, interaction=interaction)
+
+
+class NotifReviewPreviewButton(
+    ui.DynamicItem[ui.Button],
+    template=rf"moddy:notif:rvshow:(?P<report>{_UUID})",
+):
+    """Show the notification exactly as its recipient received it."""
+
+    def __init__(self, report_id: str, *, locale: str = "en-US"):
+        super().__init__(ui.Button(
+            label=_short(t("notifications.review.buttons.preview", locale=locale)),
+            style=discord.ButtonStyle.secondary,
+            emoji=discord.PartialEmoji.from_str(MESSAGE),
+            custom_id=f"moddy:notif:rvshow:{report_id}",
+        ))
+        self.report_id = str(report_id)
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match["report"])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        locale = i18n.get_user_locale(interaction)
+        report, record = await _load_review(interaction, self.report_id, locale)
+        if not report or not record:
+            return
+        if not await _guard_reviewer(interaction, report, locale):
+            return
+
+        # Rendered from the stored template + this notification's variables:
+        # the exact wording that reached the recipient, attribution row left
+        # off (its buttons belong to the recipient, not to the reviewer).
+        content = NotificationContent.from_dict(record.get("content") or {})
+        await interaction.response.send_message(
+            view=build_content_view(content, record.get("variables") or {},
+                                    locale=record.get("locale") or locale),
+            ephemeral=True,
+        )
+
+
+class NotifReviewDecisionButton(
+    ui.DynamicItem[ui.Button],
+    template=rf"moddy:notif:rvdec:(?P<action>accept|refuse):(?P<report>{_UUID})",
+):
+    """Accept (the report is founded) or refuse it, with a note for the record."""
+
+    _STYLE = {"accept": discord.ButtonStyle.success, "refuse": discord.ButtonStyle.danger}
+    _EMOJI = {"accept": DONE, "refuse": UNDONE}
+
+    def __init__(self, action: str, report_id: str, *, disabled: bool = False,
+                 locale: str = "en-US"):
+        super().__init__(ui.Button(
+            label=_short(t(f"notifications.review.buttons.{action}", locale=locale)),
+            style=self._STYLE[action],
+            emoji=discord.PartialEmoji.from_str(self._EMOJI[action]),
+            custom_id=f"moddy:notif:rvdec:{action}:{report_id}",
+            disabled=disabled,
+        ))
+        self.action = action
+        self.report_id = str(report_id)
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match["action"], match["report"])
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        locale = i18n.get_user_locale(interaction)
+        report, _record = await _load_review(interaction, self.report_id, locale)
+        if not report or not await _guard_reviewer(interaction, report, locale):
+            return
+        if report.get("status") in (ReportStatus.ACCEPTED.value, ReportStatus.REFUSED.value):
+            await interaction.response.send_message(view=create_error_message(
+                t("notifications.review.already_decided.title", locale=locale),
+                t("notifications.review.already_decided.description", locale=locale),
+            ), ephemeral=True)
+            return
+        await interaction.response.send_modal(
+            NotifDecisionModal(action=self.action, report_id=self.report_id, locale=locale))
+
+
+class NotifDecisionModal(BaseModal):
+    """The note attached to a decision — optional, but it is what the reporter
+    is shown and what the next reviewer reads six months later."""
+
+    def __init__(self, *, action: str, report_id: str, locale: str = "en-US"):
+        super().__init__(title=_short(
+            t(f"notifications.review.decision.{action}.title", locale=locale), 45))
+        self.action = action
+        self.report_id = report_id
+        self.locale = locale
+
+        self.add_item(ui.TextDisplay(
+            t(f"notifications.review.decision.{action}.recap", locale=locale)))
+        self.note = ui.Label(
+            text=_short(t("notifications.review.decision.note.label", locale=locale), 45),
+            description=_short(
+                t("notifications.review.decision.note.description", locale=locale), 100),
+            component=ui.TextInput(
+                style=discord.TextStyle.paragraph,
+                placeholder=_short(
+                    t("notifications.review.decision.note.placeholder", locale=locale), 100),
+                max_length=500,
+                required=False,
+            ),
+        )
+        self.add_item(self.note)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        status = (ReportStatus.ACCEPTED.value if self.action == "accept"
+                  else ReportStatus.REFUSED.value)
+        ok = await interaction.client.notifications.decide_report(
+            report_id=self.report_id, staff=interaction.user, status=status,
+            note=self.note.component.value or None, locale=self.locale,
+        )
+        if not ok:
+            await interaction.followup.send(view=create_error_message(
+                t("notifications.review.already_decided.title", locale=self.locale),
+                t("notifications.review.already_decided.description", locale=self.locale),
+            ), ephemeral=True)
+            return
+        from utils.components_v2 import create_success_message
+        await interaction.followup.send(view=create_success_message(
+            t(f"notifications.review.decision.{self.action}.done.title", locale=self.locale),
+            t(f"notifications.review.decision.{self.action}.done.description",
+              locale=self.locale),
+        ), ephemeral=True)
+
+
+# =========================================================================== #
+# Persistence
+# =========================================================================== #
+
+class NotificationsPersistence(BaseView):
+    """Marker view: registers every notification dynamic item at startup."""
+
+    __persistent__ = True
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        bot.add_dynamic_items(
+            NotificationServiceButton,
+            NotificationSourceButton,
+            NotificationReportButton,
+            NotifReviewClaimButton,
+            NotifReviewPreviewButton,
+            NotifReviewDecisionButton,
+        )

--- a/utils/persistent_views.py
+++ b/utils/persistent_views.py
@@ -72,6 +72,7 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
         TicketControlView, TicketClosedView, TicketCloseRequestView,
         TicketEscalationView, TicketEscalateConfirmView, TicketsPersistence,
     )
+    from utils.notification_views import NotificationsPersistence
 
     return [
         # Group 1 — /moddy (public informational, no user auth)
@@ -157,6 +158,10 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
         # Group 12h — the public ticket panel's open buttons / dropdown
         # (dynamic items; public: whoever clicks is the member opening).
         TicketsPersistence,
+        # Group 12i — the attribution + report buttons carried by every
+        # notification Moddy sends, and the staff review panel they feed
+        # (dynamic items keyed by the notification / report uuid).
+        NotificationsPersistence,
         # Group 13 — /config automod AI panel (guild permission auth;
         # AutomodAIPrecedentsView is deliberately excluded, see
         # docs/PERSISTENT_VIEWS.md Step 12)

--- a/utils/staff_role_permissions.py
+++ b/utils/staff_role_permissions.py
@@ -27,6 +27,8 @@ MODERATOR_PERMISSIONS = [
     "altguard_manage",        # Manually (un)verify members + read AltGuard refusals
     "interserver_info",       # View inter-server message info
     "interserver_delete",     # Delete inter-server messages
+    "notif_review",           # Review abuse reports filed against a notification
+    "notif_lookup",           # Look a notification up by its uuid
 ]
 
 # Permissions specific to Support role
@@ -42,6 +44,7 @@ SUPPORT_PERMISSIONS = [
 COMMUNICATION_PERMISSIONS = [
     "announce",      # Send announcements
     "broadcast",     # Broadcast messages
+    "notif_lookup",  # Look a notification up by its uuid (what did we send?)
 ]
 
 # Permissions specific to Supervisor_Mod role
@@ -119,6 +122,10 @@ def get_permission_label(permission: str) -> str:
         # Communication
         "announce": "Send Announcements",
         "broadcast": "Broadcast Messages",
+
+        # Notifications
+        "notif_review": "Review Notification Abuse Reports",
+        "notif_lookup": "Look Up a Notification by UUID",
 
         # Supervisor specific
         "manage_mod": "Manage Moderators",


### PR DESCRIPTION
## Summary

Implements a complete centralized notification system that routes all DMs and messages through a single service (`bot.notifications`). Every notification is stored with full provenance, carries attribution buttons identifying the sender, and can be reported by recipients when appropriate. This replaces ad-hoc `user.send()` calls throughout the codebase.

## Key Changes

**Core System**
- `notifications/models.py`: Uniform notification payload model with template-based content (placeholders resolved per-recipient), source identification, and content authorship tracking
- `notifications/service.py`: Central `NotificationService` handling recording, rendering, delivery, and abuse-report lifecycle
- `notifications/render.py`: Pure rendering functions for Discord components and attribution context resolution
- `db/repositories/notifications.py`: Four-table schema for content deduplication (template hash), notifications, deliveries, and reports

**UI & Components**
- `utils/notification_views.py`: Persistent Discord components (881 lines) including:
  - Attribution row buttons (service, server, report flag) with ephemeral identity panels
  - Report Modal V2 with confirmation flow
  - Staff review panels (Claim / See message / Accept / Refuse) with status tracking
  - Dynamic item persistence via `NotificationsPersistence`
- `staff/commands/com/send.py`: `/com send` command for staff to broadcast notifications to users/guilds/segments
- `staff/commands/com/_send_modal.py`: Modal V2 for composing notification content
- `staff/commands/mod/notification.py`: `/mod notif` command to inspect any notification by UUID

**Integration**
- Modified `bot.py`, `config.py`: Added notification service initialization and environment variables
- Updated modules (`welcome_dm.py`, `altguard.py`, `automod_ai.py`, `ticket_service.py`, etc.): Routed DMs through notification system instead of direct `user.send()`
- `cogs/token_detector.py`: Leaked-token alerts now recorded as official notifications
- `cogs/moderation_commands.py`: Sanction notices use notification system

**Database**
- Extended `db/base.py` with `NotificationRepository` mixin
- Four new tables: `notification_contents`, `notifications`, `notification_deliveries`, `notification_reports`
- Updated `docs/DATABASE.md` with full schema documentation

**Localization**
- Added notification UI strings to all 5 locale files (en-US, de, es-ES, fr, pt-BR)
- Strings for attribution panels, report modals, staff review, and `/com send` command

**Testing & Documentation**
- `tests/test_notifications.py`: 493 lines covering content deduplication, placeholder substitution, attribution rules, and report authorization
- `docs/NOTIFICATIONS.md`: Complete system design and usage guide
- `docs/sessions/2026-08-24_centralized-notifications.md`: Implementation session notes
- Updated `docs/PERSISTENT_VIEWS.md`, `docs/STAFF_COMMANDS_FRAMEWORK.md`, `CLAUDE.md`

## Notable Implementation Details

- **Content deduplication**: Templates are hashed *before* placeholder substitution (SHA-256 of canonical JSON), so 10,000 identical welcome DMs share one stored body while remaining reproducible to the character
- **Attribution rules**: Report button liveness is determined by `ContentAuthor` (who wrote the words) and `SourceKind` (who is behind it), re-checked on every click
- **Defensive design**: Database outages degrade gracefully—DMs are sent without attribution rather than lost
- **Persistent components**: All buttons use `DynamicItem` with UUID-based `custom_id` so DMs remain reportable weeks after send
- **Staff review workflow**: Reports post to a dedicated channel with Claim/Review/Accept/Refuse flow, fully logged to an audit channel
- **Multi-platform ready**: `NotificationContent` renders to Discord, email, and dashboard shapes from the same template

## Files Added
- `notifications/` (4 files: `__init__.py`, `models.py`, `service.py`, `render.py`)
- `utils/notification_views.py` (881 lines)
- `db

https://claude.ai/code/session_01KQTM52w62RGewgPDkvS6DR