### PR TITLE
Rename badge localization parameter from `key` to `badge_key`

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -3657,9 +3657,9 @@
       },
       "badge": {
         "removed_title": "Abzeichen entfernt",
-        "removed": "Das Abzeichen {key} wurde von {user} entfernt.",
+        "removed": "Das Abzeichen {badge_key} wurde von {user} entfernt.",
         "assigned_title": "Abzeichen zugewiesen",
-        "assigned": "Das Abzeichen {key} wurde {user} zugewiesen.",
+        "assigned": "Das Abzeichen {badge_key} wurde {user} zugewiesen.",
         "orgs": "Organisation(en): {orgs}",
         "import_fail_title": "Importfehler",
         "import_bad_json": "Ungültiges JSON — ein Array von Einträgen wird erwartet.",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -3657,9 +3657,9 @@
       },
       "badge": {
         "removed_title": "Badge Removed",
-        "removed": "Removed the {key} badge from {user}.",
+        "removed": "Removed the {badge_key} badge from {user}.",
         "assigned_title": "Badge Assigned",
-        "assigned": "Assigned the {key} badge to {user}.",
+        "assigned": "Assigned the {badge_key} badge to {user}.",
         "orgs": "Organisation(s): {orgs}",
         "import_fail_title": "Import Error",
         "import_bad_json": "Invalid JSON — expected an array of entries.",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -3657,9 +3657,9 @@
       },
       "badge": {
         "removed_title": "Insignia eliminada",
-        "removed": "Se eliminó la insignia {key} de {user}.",
+        "removed": "Se eliminó la insignia {badge_key} de {user}.",
         "assigned_title": "Insignia asignada",
-        "assigned": "Se asignó la insignia {key} a {user}.",
+        "assigned": "Se asignó la insignia {badge_key} a {user}.",
         "orgs": "Organización(es): {orgs}",
         "import_fail_title": "Error de importación",
         "import_bad_json": "JSON no válido — se esperaba un array de entradas.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3656,9 +3656,9 @@
       },
       "badge": {
         "removed_title": "Badge retiré",
-        "removed": "Badge {key} retiré de {user}.",
+        "removed": "Badge {badge_key} retiré de {user}.",
         "assigned_title": "Badge attribué",
-        "assigned": "Badge {key} attribué à {user}.",
+        "assigned": "Badge {badge_key} attribué à {user}.",
         "orgs": "Organisation(s) : {orgs}",
         "import_fail_title": "Erreur d'import",
         "import_bad_json": "JSON invalide — un tableau d'entrées est attendu.",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -3657,9 +3657,9 @@
       },
       "badge": {
         "removed_title": "Emblema Removido",
-        "removed": "Emblema {key} removido de {user}.",
+        "removed": "Emblema {badge_key} removido de {user}.",
         "assigned_title": "Emblema Atribuído",
-        "assigned": "Emblema {key} atribuído a {user}.",
+        "assigned": "Emblema {badge_key} atribuído a {user}.",
         "orgs": "Organização(ões): {orgs}",
         "import_fail_title": "Erro de Importação",
         "import_bad_json": "JSON inválido — esperava-se um array de entradas.",

--- a/staff/commands/manage/badge.py
+++ b/staff/commands/manage/badge.py
@@ -90,12 +90,12 @@ class BadgeCommand(StaffCommand):
             await _apply_remove(db, user.id, attr_key, ctx.author.id)
             await ctx.send(view=design.success(
                 t("staff.manage.badge.removed_title", locale=locale),
-                t("staff.manage.badge.removed", locale=locale, key=f"`{attr_key}`", user=user.mention),
+                t("staff.manage.badge.removed", locale=locale, badge_key=f"`{attr_key}`", user=user.mention),
             ))
             return
 
         merged = await _apply_set(db, user.id, attr_key, ctx.author.id, orgs)
-        desc = t("staff.manage.badge.assigned", locale=locale, key=f"`{attr_key}`", user=user.mention)
+        desc = t("staff.manage.badge.assigned", locale=locale, badge_key=f"`{attr_key}`", user=user.mention)
         if merged:
             desc += "\n" + t("staff.manage.badge.orgs", locale=locale, orgs=", ".join(f"**{o}**" for o in merged))
         await ctx.send(view=design.success(t("staff.manage.badge.assigned_title", locale=locale), desc))
@@ -135,7 +135,7 @@ class BadgeCommand(StaffCommand):
             await _apply_remove(db, target_id, attr_key, ctx.author.id)
             await ctx.send(view=design.success(
                 t("staff.manage.badge.removed_title", locale=locale),
-                t("staff.manage.badge.removed", locale=locale, key=f"`{attr_key}`", user=mention),
+                t("staff.manage.badge.removed", locale=locale, badge_key=f"`{attr_key}`", user=mention),
             ))
             return
 
@@ -146,7 +146,7 @@ class BadgeCommand(StaffCommand):
         attr_key = BADGE_ALIASES[action]
         orgs = [o.strip() for o in " ".join(tokens[1:]).split(",") if o.strip()]
         merged = await _apply_set(db, target_id, attr_key, ctx.author.id, orgs)
-        desc = t("staff.manage.badge.assigned", locale=locale, key=f"`{attr_key}`", user=mention)
+        desc = t("staff.manage.badge.assigned", locale=locale, badge_key=f"`{attr_key}`", user=mention)
         if merged:
             desc += "\n" + t("staff.manage.badge.orgs", locale=locale, orgs=", ".join(f"**{o}**" for o in merged))
         await ctx.send(view=design.success(t("staff.manage.badge.assigned_title", locale=locale), desc))


### PR DESCRIPTION
## Summary
Standardizes the localization parameter name for badge management messages across all supported languages and command handlers.

## Changes
- **Command handlers** (`staff/commands/manage/badge.py`):
  - Updated 4 translation calls to use `badge_key` instead of `key` parameter
  - Affects both slash command (`_slash_single`) and message command (`_message_single`) handlers
  - Changes apply to both "removed" and "assigned" badge action messages

- **Localization files** (all 5 supported languages):
  - `locales/en-US.json`: Updated "removed" and "assigned" messages
  - `locales/de.json`: Updated "removed" and "assigned" messages
  - `locales/es-ES.json`: Updated "removed" and "assigned" messages
  - `locales/fr.json`: Updated "removed" and "assigned" messages
  - `locales/pt-BR.json`: Updated "removed" and "assigned" messages

## Details
This change improves clarity by using a more descriptive parameter name (`badge_key`) that explicitly indicates the parameter contains a badge identifier, reducing ambiguity in the localization strings and making the codebase more maintainable.

https://claude.ai/code/session_01TjXhmmJkeJdVrQS7UNNWEW