### PR TITLE
Notifications: `sent by` attribution line + backend integration contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ moddy/
 │
 ├── notifications/             # Centralized notifications (EVERY DM goes through it)
 │   ├── models.py              #   Uniform payload + source + service registry + hashing
-│   ├── render.py              #   Payload → Components V2 + attribution context
+│   ├── render.py              #   Payload → Components V2 + `sent by` attribution line
 │   └── service.py             #   NotificationService (bot.notifications)
 │
 ├── automod/                   # Automod AI DETECTION pipeline (decides only; no side effects)
@@ -183,7 +183,7 @@ moddy/
 │   ├── altguard_views.py      #   AltGuard panel (persistent), consent Modal V2, link + log cards
 │   ├── automod_shadow_views.py #  Automod shadow-mode (dry_run) SIMULATION card + annotation buttons (persistent)
 │   ├── automod_render.py      #   Shared automod card helpers (barème breakdown, sanction name/accent)
-│   ├── notification_views.py  #   Notification attribution row, report Modal V2, staff review panels
+│   ├── notification_views.py  #   Notification abuse-report review panels (staff side)
 │   ├── ticket_views.py        #   Ticket panel, ticket message, cards, claim, participants modal
 │   ├── transcription_views.py #   Voice transcription cards + persistent Transcribe button
 │   ├── appeal_views.py        #   Automod appeal UI (DM buttons + reviewer panels, persistent)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,6 +452,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/PREMIUM.md](docs/PREMIUM.md) | **Premium gating** — how to check whether a server (or a user) is premium |
 | [docs/STAFF_SYSTEM.md](docs/STAFF_SYSTEM.md) | Staff/dev commands, permissions, roles |
 | [docs/NOTIFICATIONS.md](docs/NOTIFICATIONS.md) | **Centralized notifications** — every DM/mail/dashboard message, attribution buttons, abuse reports, `/com send`, `/mod notif` |
+| [docs/NOTIFICATIONS_INTEGRATION.md](docs/NOTIFICATIONS_INTEGRATION.md) | Notifications ↔ backend contract — tables the backend reads/owns, exact payload rendering + placeholder algorithm, mail/dashboard delivery loop |
 | [docs/LOGS.md](docs/LOGS.md) | **Advanced server logs** — 163 events, registry, rendering, webhook delivery, stored config & dashboard contract |
 | [docs/MODERATION_CASES.md](docs/MODERATION_CASES.md) | Moderation cases/sanctions, the case service & sources, auto-sync |
 | [docs/GLOBAL_SANCTIONS.md](docs/GLOBAL_SANCTIONS.md) | **Global sanctions** — Moddy-team warn / limited / suspended, on users *and* servers |

--- a/cogs/moderation_commands.py
+++ b/cogs/moderation_commands.py
@@ -193,6 +193,8 @@ async def _send_sanction_dm(
             source=NotificationSource.guild(guild_id, actor_id=mod_id),
             view=dm_view,
             locale=dm_locale,
+            # The card already ends with its own `sent_by` line.
+            attribution=False,
         )
     except discord.Forbidden:
         pass  # DMs disabled

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -586,9 +586,10 @@ See → [NOTIFICATIONS.md](NOTIFICATIONS.md).
 
 ### 14. Table `notifications`
 
-One row per **(message, recipient)**. The `id` is the uuid a recipient reads at
-the bottom of a Moddy DM and quotes to support, and the uuid the attribution and
-report buttons carry in their `custom_id`.
+One row per **(message, recipient)**. The `id` is the notification's public
+reference: what a staff member looks up with `/mod notif`, and what an abuse
+report points at. It is not surfaced to the recipient in Discord (the DM only
+carries a `sent by` line), but it is safe to display — see NOTIFICATIONS.md.
 
 A broadcast is exploded into one row per recipient, all sharing the same
 `batch_id`, so "who did this campaign reach, and how did it go" is a single

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -301,6 +301,17 @@ tests/test_notifications.py
 
 ---
 
+## Backend & dashboard
+
+The mail and dashboard halves are delivered by the backend, from the same rows:
+the bot creates their `notification_deliveries` entries as `pending` and never
+touches them again. The exact contract — what the backend reads, what it owns,
+how to render the stored template so a mail says what the DM said, and the
+placeholder algorithm it must match character for character — is in
+[NOTIFICATIONS_INTEGRATION.md](NOTIFICATIONS_INTEGRATION.md).
+
+---
+
 ## Adding a sender
 
 1. Register the service in `notifications/models.py::SERVICES` (one line) and

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -17,48 +17,51 @@ not answer "what did we send this person, and when".
 
 Three answers, one system:
 
-1. **Provenance.** Under every DM, a button carries the name and icon of the
-   server or the Moddy service that sent it. Clicking it identifies the sender,
-   links into the server, and shows the notification's uuid.
-2. **Reporting.** Next to it, a red flag opens a Modal V2 that recaps the
-   message, asks why, and requires an explicit "this report is legitimate"
-   confirmation. The report lands in a staff review channel with Claim / See the
-   message / Accept / Decline, and every step is logged.
-3. **Memory.** Every notification is a row: uuid, sender, recipient, target
+1. **Provenance.** Every DM closes with one greyed line naming its origin:
+
+   ```
+   -# Sent by [**Server name**](https://discord.com/channels/1421493239579676682) (`1421493239579676682`)
+   ```
+
+   The same shape the sanction DMs have always used, now on everything Moddy
+   sends. No buttons, no panel to open.
+2. **Memory.** Every notification is a row: uuid, sender, recipient, target
    platforms, per-platform delivery status, and enough to rebuild the exact
    wording months later.
+3. **Accountability.** An abuse report can be filed against a stored
+   notification and reviewed by staff in Discord (Claim / See the message /
+   Accept / Decline), with every step logged.
 
 ---
 
-## The three shapes of a notification
+## The attribution line
 
-| Source | Buttons under the message | Report flag |
-|---|---|---|
-| **Official** — account suspension, leaked-token alert | *none at all* | — |
-| **Service** — a Moddy feature acting alone (reminder) | `[ Service ]` `[ 🚩 ]` | greyed out (Moddy wrote it) |
-| **Server** — a server's own words (welcome DM, sanction reason) | `[ Server ]` `[ 🚩 ]` | **live** |
-| **Service + server** — a feature acting for a server (AltGuard, tickets, automod) | `[ Service ]` `[ Server ]` `[ 🚩 ]` | greyed out unless the server wrote the words |
+| Source | Line at the bottom of the DM |
+|---|---|
+| **Official** — account suspension, leaked-token alert | *none* |
+| **Service** — a Moddy feature acting alone (reminder, appeal outcome) | `-# Sent by **Reminders**` |
+| **Server** — a server's own words (welcome DM, sanction reason) | `-# Sent by [**Server**](link) (`id`)` |
+| **Service + server** — a feature acting for a server (AltGuard, tickets, automod) | same as above: the **server** is the origin |
 
-Two rules decide the flag, and they are re-checked on **every click**, not only
-at send time:
+The server is always the origin when there is one; which internal service acted
+for it is not something a member needs. A notification with no server at all
+names the Moddy service instead, so there is always exactly one origin.
 
-- **Who wrote the words** (`ContentAuthor`). Only `GUILD`-authored content can
-  be abusive. A sanction notice worded by Moddy on a server's behalf is not
-  reportable — its exit is the appeal, not the flag.
-- **Whose server it is.** A message from a server carrying the `OFFICIAL`
-  attribute (one of Moddy's own) is never reportable: reporting Moddy to Moddy
-  is a loop with no exit. The flag is rendered disabled, and the identity panel
-  says *why* — a dead button with no explanation is a bug.
+An official notice carries no line: a suspension **is** Moddy speaking, there is
+no third party to name.
 
-A verified server (`VERIFIED`, `VERIFIED_ORG` or `PARTNER`) shows the
-verification check next to its name, hyperlinked like everywhere else in Moddy
-(CLAUDE.md rule #7). An official Moddy server shows it too, plus an explicit
-"Official Moddy server" line.
+A verified server (`VERIFIED`, `VERIFIED_ORG` or `PARTNER`) gets the
+verification check right after its name, hyperlinked like everywhere else in
+Moddy (CLAUDE.md rule #7).
 
-> **Button icons.** A Discord button emoji must be a real emoji — a server icon
-> URL cannot go on one. The button therefore carries a generic server icon (or
-> the verification check), and the **real** server icon is shown in the panel
-> the button opens.
+The line goes **inside the last container** of the card, not under it: a `-#`
+floating as its own component reads as a separate message.
+
+### Cards that already say it
+
+Three senders have printed their own `sent_by` line since long before this
+system (the manual sanction DM, the automod sanction DM, the sanction-expiry
+DM). They pass `attribution=False` so the line is not printed twice.
 
 ---
 
@@ -84,6 +87,9 @@ result = await bot.notifications.send_dm(
 if result.forbidden:      # DMs closed — every other send would fail the same
     return
 ```
+
+Pass `attribution=False` when the card you hand over already ends with its own
+`sent_by` line.
 
 `send_dm` returns a `DeliveryResult` (`notification_id`, `message`, `status`,
 `error`, plus `delivered` / `forbidden`). It never raises on a delivery
@@ -210,22 +216,29 @@ later must not resurrect old flags.
 
 ## Reporting flow
 
-1. The recipient clicks 🚩 on their DM. Authorization: the addressee, and only
-   them (`may_report`) — for a server-wide notice, that means a member with
-   Manage Server.
-2. A Modal V2 recaps the source, the uuid and an excerpt, asks for a reason
-   (15–1000 chars) and requires a `CheckboxGroup` confirmation.
-3. The report is written and posted to `MODDY_NOTIF_REPORT_CHANNEL_ID` as a
-   review panel: **Claim**, **See the message**, **Accept**, **Decline**.
-4. Every step (created / claimed / accepted / declined) is mirrored to
+> **No entry point in Discord today.** The flag button that used to open a
+> report was removed along with the rest of the DM-side buttons. The pipeline
+> below is intact and reachable through `NotificationService.open_report(...)`;
+> what is missing is something that calls it — a report control on the
+> dashboard being the obvious candidate. Everything downstream already works.
+
+1. `open_report(notification_id, reporter, reason)` writes the report. Who may
+   file one is `may_report()`: the addressee, and only them — for a server-wide
+   notice, a member with Manage Server.
+2. The report is posted to `MODDY_NOTIF_REPORT_CHANNEL_ID` as a review panel:
+   **Claim**, **See the message**, **Accept**, **Decline**.
+3. Every step (created / claimed / accepted / declined) is mirrored to
    `MODDY_NOTIF_REPORT_LOG_CHANNEL_ID`.
-5. On a decision, the reporter receives the outcome — as an official
+4. On a decision, the reporter receives the outcome — as an official
    notification, through this same system.
 
 Reviewer rules, re-checked on every click: the `notif_review` permission node,
-and never your own report. A second click on the flag by the same person shows
-the status of their existing report instead of opening a new one
-(`UNIQUE (notification_id, reporter_id)`).
+and never your own report. `UNIQUE (notification_id, reporter_id)` keeps it to
+one report per person per notification.
+
+`reportable` is still computed and frozen on every row (`ContentAuthor.GUILD`
+wording, minus messages from `OFFICIAL` Moddy servers), so whatever surface
+grows the entry point already has its answer.
 
 Configuration:
 
@@ -265,21 +278,22 @@ live progress panel, paced by `BROADCAST_DELAY`. Node: `broadcast`.
 
 ## Persistence
 
-Every button is a `discord.ui.DynamicItem` whose `custom_id` carries the
-notification (or report) uuid, registered through `NotificationsPersistence`:
+A member's DM carries no component at all — its origin is plain text, which
+cannot break, expire or lose its handler.
+
+The staff review panel does, and every one of its buttons is a
+`discord.ui.DynamicItem` whose `custom_id` carries the report uuid, registered
+through `NotificationsPersistence`:
 
 | custom_id | Item | Auth |
 |---|---|---|
-| `moddy:notif:svc:<uuid>` | service identity panel | public |
-| `moddy:notif:src:<uuid>` | server identity panel | public |
-| `moddy:notif:flag:<uuid>` | report | the addressee |
 | `moddy:notif:rvclaim:<uuid>` | claim | `notif_review`, not the reporter |
 | `moddy:notif:rvshow:<uuid>` | see the message | `notif_review`, not the reporter |
 | `moddy:notif:rvdec:<accept\|refuse>:<uuid>` | decide | `notif_review`, not the reporter |
 
-A DM sent today must still be reportable after next week's deploy, so nothing
-may rely on in-memory state: every callback re-derives the notification from its
-uuid and the database. See [PERSISTENT_VIEWS.md](PERSISTENT_VIEWS.md).
+A report opened today must still be decidable after next week's deploy, so
+nothing may rely on in-memory state: every callback re-derives the report from
+its uuid and the database. See [PERSISTENT_VIEWS.md](PERSISTENT_VIEWS.md).
 
 ---
 
@@ -292,7 +306,7 @@ notifications/
 ├── render.py         # content → Components V2, attribution context
 └── service.py        # NotificationService (bot.notifications)
 
-utils/notification_views.py     # attribution row, report modal, review panels
+utils/notification_views.py     # staff review panel, decision modal, report log
 db/repositories/notifications.py
 staff/commands/mod/notification.py   # /mod notif
 staff/commands/com/send.py           # /com send

--- a/docs/NOTIFICATIONS_INTEGRATION.md
+++ b/docs/NOTIFICATIONS_INTEGRATION.md
@@ -1,0 +1,453 @@
+# Notifications ↔ backend — integration contract
+
+> What the **backend** and the **dashboard** have to do with the centralized
+> notification system: which rows they read, which rows they own, how to render
+> the stored payload so a mail and a dashboard card say exactly what the Discord
+> DM said, and what they must never touch.
+>
+> Functional overview: [NOTIFICATIONS.md](NOTIFICATIONS.md).
+> Bot implementation: [`notifications/`](../notifications/),
+> [`db/repositories/notifications.py`](../db/repositories/notifications.py).
+> General bot ↔ backend rules: [BACKEND-INTEGRATION.md](BACKEND-INTEGRATION.md).
+
+The bot and the backend **share the same PostgreSQL database**, so this
+integration is a table contract, not an HTTP API. Nothing here needs a call to
+the bot.
+
+---
+
+## 0. Who owns what
+
+| Thing | Owner | The other side may |
+|---|---|---|
+| Creating a notification row | **bot** | read |
+| `notification_contents` | **bot** (insert-on-conflict) | read |
+| `notifications` | **bot** | read |
+| `notification_deliveries` where `platform = 'discord'` | **bot** | read |
+| `notification_deliveries` where `platform IN ('email','dashboard')` | **backend** | bot only creates the row, `pending` |
+| `notification_reports` | **bot** | read only — see §7 |
+
+One sentence to keep: **the bot writes the message, the backend delivers the
+non-Discord half of it.** A row the bot created for `email` or `dashboard` stays
+`pending` forever until the backend moves it.
+
+---
+
+## 1. The three tables you read
+
+Full column reference: [DATABASE.md](DATABASE.md) §13–16. What matters here:
+
+### `notifications` — one row per (message, recipient)
+
+```
+id              UUID   -- the public reference; the recipient sees it in Discord
+batch_id        UUID   -- groups one broadcast; NULL for a one-off
+kind            TEXT   -- official | service | guild | service_guild
+author          TEXT   -- moddy | guild | staff  (who wrote the words)
+source_service  TEXT   -- 'welcome_dm', 'tickets', 'global_sanctions'… or NULL
+source_guild_id BIGINT -- the server it was sent on behalf of, or NULL
+actor_id        BIGINT -- the human who triggered it, or NULL
+recipient_type  TEXT   -- discord_user | discord_guild | all_users | all_guilds | segment | email
+recipient_id    BIGINT -- Discord id when the recipient is one
+recipient_ref   TEXT   -- non-Discord recipient (segment name, email address)
+content_hash    TEXT   -- FK -> notification_contents(hash)
+variables       JSONB  -- the values substituted for THIS row
+platforms       TEXT[] -- what it targets, default {discord}
+reportable      BOOLEAN
+locale          TEXT   -- the locale the bot rendered it in
+created_at      TIMESTAMPTZ
+```
+
+### `notification_contents` — the wording, once
+
+```
+hash          TEXT PRIMARY KEY   -- SHA-256 of the canonical template (§4)
+payload       JSONB              -- the template, placeholders UNRESOLVED
+uses          BIGINT             -- how many notifications used this wording
+first_seen_at TIMESTAMPTZ
+last_seen_at  TIMESTAMPTZ
+```
+
+**This is the part that surprises people:** `payload` is a *template*. Its
+strings still contain `{user}`, `{server}`, `{reason}`. Ten thousand members
+receiving the same welcome DM share this single row; each `notifications.variables`
+holds what was substituted for that one recipient. Render with §3 — never show
+`payload` raw to a human.
+
+### `notification_deliveries` — one row per (notification, platform)
+
+```
+notification_id UUID     -- FK, ON DELETE CASCADE
+platform        TEXT     -- discord | email | dashboard
+status          TEXT     -- pending | sent | failed | skipped
+channel_id      BIGINT   -- Discord only
+message_id      BIGINT   -- Discord only
+error           TEXT     -- max 500 chars, free text
+updated_at      TIMESTAMPTZ
+PRIMARY KEY (notification_id, platform)
+```
+
+`status` and `platform` are `CHECK`-constrained: an unknown value is a rejected
+insert, not a silently stored typo.
+
+---
+
+## 2. The uniform payload
+
+`notification_contents.payload` always has these keys (nullable, never absent):
+
+| Key | Type | Discord | Mail | Dashboard |
+|---|---|---|---|---|
+| `title` | string | `### <icon> title` | **subject** | card title |
+| `body` | string, markdown | container text | text body | markdown |
+| `sections` | `[{title, body}]` | `**title**` + body | labelled blocks | blocks |
+| `links` | `[{label, url}]` | link buttons | link list | buttons |
+| `footer` | string \| null | `-# footer` | last line | footer |
+| `icon` | string | custom emoji | **strip it** | emoji or your own asset |
+| `accent_color` | int \| null | container accent | header colour | accent |
+| `template_id` | string \| null | — | — | grouping / analytics key |
+
+Example row (`payload`, verbatim — note the unresolved placeholders):
+
+```json
+{
+  "title": "{server}",
+  "body": "Welcome {user} on **{server}**!",
+  "icon": "<:waving_hand:1519789691711393982>",
+  "accent_color": 5793266,
+  "sections": [{"title": "Rules", "body": "Read {channel}"}],
+  "links": [{"label": "Open the server", "url": "https://discord.com/channels/{guild_id}"}],
+  "footer": "Sent by {server}",
+  "template_id": "welcome_dm.wdm_a1b2"
+}
+```
+
+With `variables = {"server":"Moddy","user":"<@7>","channel":"#rules","guild_id":"42"}`:
+
+```json
+// mail shape
+{
+  "subject": "Moddy",
+  "text": "Welcome <@7> on **Moddy**!\n\nRules\nRead #rules\n\nSent by Moddy",
+  "links": [{"label": "Open the server", "url": "https://discord.com/channels/42"}]
+}
+
+// dashboard shape
+{
+  "title": "Moddy",
+  "body": "Welcome <@7> on **Moddy**!",
+  "icon": "<:waving_hand:1519789691711393982>",
+  "accent_color": 5793266,
+  "sections": [{"title": "Rules", "body": "Read #rules"}],
+  "links": [{"label": "Open the server", "url": "https://discord.com/channels/42"}],
+  "footer": "Sent by Moddy",
+  "template_id": "welcome_dm.wdm_a1b2"
+}
+```
+
+### Rendering rules that are not negotiable
+
+- **Strip Discord custom emojis outside Discord.** `<:done:123>` and
+  `<a:spin:456>` are literal noise in an inbox. Regex:
+  `/<a?:[a-zA-Z0-9_]+:\d+>/g`, then collapse runs of 2+ spaces.
+- **`body` and `sections[].body` are markdown**, and they can carry
+  Discord-specific syntax the bot's own callers wrote: `<@123>` (user mention),
+  `<#123>` (channel), `<t:1700000000:R>` (relative timestamp), `-#` (small
+  text). Decide per surface: the dashboard can resolve mentions and timestamps;
+  a mail should degrade them to plain text rather than print raw syntax.
+- **`accent_color` is an int**, not a CSS string: `5793266` → `#5865F2`
+  (`"#%06X" % value`).
+- **`links[].url` is already substituted** — it may contain placeholders before
+  rendering, never after.
+- **Never trust the text.** `body` frequently contains words a *server admin*
+  typed (a welcome DM, a sanction reason). Escape it for your surface; a mail
+  template that interpolates it into HTML unescaped is an injection.
+
+---
+
+## 3. Placeholder substitution — the exact algorithm
+
+Must match the bot character for character, or a staff member comparing the
+dashboard with the Discord DM will find two different messages.
+
+`notifications/models.py::substitute()`:
+
+1. Pattern: `\{([a-zA-Z0-9_]+)\}` — letters, digits, underscore only.
+2. Key **present** in `variables` → replaced by `str(value)`; `None` → `""`.
+3. Key **absent** → the placeholder is **left as-is**, braces included. Do not
+   blank it: a visible `{oops}` is how a broken template gets noticed.
+4. Everything else is copied verbatim. Never use a format/template engine that
+   throws on an unknown or malformed brace — this text is arbitrary and a lone
+   `{` must not break a render.
+
+```python
+import re
+
+_PLACEHOLDER = re.compile(r"\{([a-zA-Z0-9_]+)\}")
+
+def substitute(text: str | None, variables: dict) -> str:
+    if not text:
+        return ""
+    if not variables:
+        return text
+    def _replace(m):
+        key = m.group(1)
+        if key in variables:
+            value = variables[key]
+            return "" if value is None else str(value)
+        return m.group(0)
+    return _PLACEHOLDER.sub(_replace, text)
+```
+
+Apply it to `title`, `body`, every `sections[].title` / `sections[].body`,
+every `links[].label` / `links[].url`, and `footer`. **Not** to `icon`,
+`accent_color` or `template_id`.
+
+---
+
+## 4. The content hash
+
+Only needed if the backend ever **writes** a notification itself (it should not
+— see §6). Reading never requires recomputing it.
+
+`hash = sha256(canonical_json(payload))` where `canonical_json` is:
+
+- JSON of the eight payload keys,
+- `sort_keys=True` — recursively, so `{"title","body"}` inside `sections[]` is
+  sorted too,
+- `ensure_ascii=False` (real UTF-8, not `\uXXXX`),
+- separators `,` and `:` — **no spaces**,
+- encoded UTF-8.
+
+```
+{"accent_color":5793266,"body":"Welcome {user} on **{server}**!","footer":"Sent by {server}","icon":"<:waving_hand:1519789691711393982>","links":[{"label":"Open the server","url":"https://discord.com/channels/{guild_id}"}],"sections":[{"body":"Read {channel}","title":"Rules"}],"template_id":"welcome_dm.wdm_a1b2","title":"{server}"}
+```
+
+→ `398513a4c1c0e3ec2bf56a22fad587f30dccbb544a80d74fc510b5a043f1352b`
+
+The hash is over the **template**, never over the rendered text. That is the
+whole point: it is what makes ten thousand identical DMs one row.
+
+---
+
+## 5. What the backend must implement
+
+### 5.1 The delivery loop (mail, dashboard)
+
+A notification targeting your platform is a `notification_deliveries` row with
+`status = 'pending'`. Claim it, deliver it, mark it. One query:
+
+```sql
+-- Claim a batch, skipping rows another worker holds.
+WITH claimed AS (
+    SELECT d.notification_id
+    FROM notification_deliveries d
+    WHERE d.platform = $1          -- 'email' | 'dashboard'
+      AND d.status = 'pending'
+    ORDER BY d.updated_at
+    FOR UPDATE SKIP LOCKED
+    LIMIT $2
+)
+SELECT n.id, n.recipient_type, n.recipient_id, n.recipient_ref, n.locale,
+       n.variables, n.kind, n.author, n.source_service, n.source_guild_id,
+       n.created_at, c.payload
+FROM claimed
+JOIN notifications n ON n.id = claimed.notification_id
+JOIN notification_contents c ON c.hash = n.content_hash;
+```
+
+Then, per row:
+
+```sql
+INSERT INTO notification_deliveries
+    (notification_id, platform, status, error, updated_at)
+VALUES ($1, $2, $3, $4, now())
+ON CONFLICT (notification_id, platform) DO UPDATE
+   SET status = EXCLUDED.status,
+       error = EXCLUDED.error,
+       updated_at = now();
+```
+
+| Use | When |
+|---|---|
+| `sent` | the platform accepted it |
+| `failed` | it was attempted and refused — put the reason in `error` (≤ 500 chars) |
+| `skipped` | deliberately not attempted: no email on file, user opted out, unsupported recipient type. **Not** an error |
+
+Leave `channel_id` / `message_id` `NULL` — they are Discord's.
+
+Retries are yours to decide; the schema does not count attempts. If you need
+one, add a backend-side table rather than a column here — the bot rewrites this
+row on its own schedule for Discord.
+
+> **Today, in practice.** Every bot caller currently sends with the default
+> `platforms = {discord}`, so there are **no** pending `email` / `dashboard`
+> rows yet. Build the loop anyway: the moment a caller opts a notification into
+> another platform, its row appears with no further code change on the bot side.
+> The dashboard *inbox* below does not wait for this.
+
+### 5.2 The dashboard inbox
+
+Independent of `platforms`: a user's notification history is simply their rows.
+
+```sql
+SELECT n.id, n.kind, n.author, n.source_service, n.source_guild_id,
+       n.locale, n.variables, n.created_at, c.payload,
+       d.status AS discord_status, d.message_id
+FROM notifications n
+JOIN notification_contents c ON c.hash = n.content_hash
+LEFT JOIN notification_deliveries d
+       ON d.notification_id = n.id AND d.platform = 'discord'
+WHERE n.recipient_type = 'discord_user'
+  AND n.recipient_id = $1
+ORDER BY n.created_at DESC
+LIMIT $2 OFFSET $3;
+```
+
+`idx_notifications_recipient` on `(recipient_id, created_at DESC)` covers it.
+
+Render each row with §2 + §3. Show the source the same way Discord does —
+service name, server name, verification badge — so the two surfaces agree:
+
+- `source_service` → a service label (the bot's own names live in
+  `locales/<locale>.json` → `notifications.services.<id>`),
+- `source_guild_id` → the server (name/icon from your own guild cache),
+- `kind = 'official'` → Moddy itself; show no "report" affordance at all,
+- `reportable = false` → no report affordance either, and if you explain why,
+  match the bot's two reasons: the wording is Moddy's, or the server is an
+  official Moddy server.
+
+### 5.3 Campaign status
+
+A broadcast is one `batch_id` across many rows:
+
+```sql
+SELECT d.platform, d.status, COUNT(*) AS total
+FROM notifications n
+JOIN notification_deliveries d ON d.notification_id = n.id
+WHERE n.batch_id = $1
+GROUP BY d.platform, d.status;
+```
+
+`idx_notifications_batch` covers the lookup. `recipient_ref` on those rows
+carries the segment the campaign targeted (`all`, `PREMIUM`, …).
+
+---
+
+## 6. Backend → bot: asking for a Discord send
+
+**Not implemented.** There is no task type today that makes the bot send a
+notification, and the backend must not insert `notifications` rows itself: the
+uuid has to exist *before* the DM is sent, because the attribution and report
+buttons carry it in their `custom_id`. A row written by the backend would
+describe a message nobody received.
+
+Two consequences worth knowing:
+
+- The existing `send_announcement` task
+  ([`bot.py::_process_task`](../bot.py)) predates this system. It posts raw text
+  to `guild.system_channel` and is **not** recorded, **not** attributed and
+  **not** reportable. Treat it as legacy; do not build on it.
+- Anything the team wants to send today goes out through `/com send` (Discord,
+  staff-side).
+
+When this is wired up it will be a `moddy:tasks` entry like every other critical
+task — signed, deduplicated, replayable
+([TASK_SIGNATURE.md](TASK_SIGNATURE.md)) — with roughly this payload:
+
+```jsonc
+// type: "notification_send"   — PROPOSED, NOT IMPLEMENTED
+{
+  "target": {"type": "user", "id": "123456789012345678"},   // or guild / segment
+  "content": {"title": "…", "body": "…", "links": [], "footer": null},
+  "variables": {},
+  "platforms": ["discord", "dashboard"],
+  "source": {"kind": "service", "service_id": "moddy", "author": "staff",
+             "actor_id": "987654321098765432"},
+  "locale": "fr"
+}
+```
+
+Do not implement against that shape until it lands in the bot — it is written
+here so the two sides design it once, not so it can be shipped early.
+
+---
+
+## 7. Abuse reports
+
+`notification_reports` is **read-only for the backend**. A decision is not a
+column update: accepting or declining a report also edits the review panel in
+Discord, writes the report log channel, and DMs the reporter — all bot-side.
+Writing `status` directly desynchronises the three.
+
+Read it freely (a staff dashboard listing open reports is a good idea):
+
+```sql
+SELECT r.id, r.notification_id, r.reporter_id, r.reason, r.status,
+       r.claimed_by, r.decided_by, r.decision_note, r.created_at,
+       n.source_guild_id, n.source_service, n.recipient_id, c.payload, n.variables
+FROM notification_reports r
+JOIN notifications n ON n.id = r.notification_id
+JOIN notification_contents c ON c.hash = n.content_hash
+WHERE r.status IN ('pending', 'claimed')
+ORDER BY r.created_at;
+```
+
+`status` is `pending` → `claimed` → `accepted` | `refused`.
+`UNIQUE (notification_id, reporter_id)`: one report per person per notification,
+so a count of rows is a count of distinct reporters.
+
+---
+
+## 8. Invariants
+
+Breaking one of these does not raise; it produces a wrong message or a dead
+button in someone's DMs.
+
+1. **Never make a notification more reportable than it was recorded.**
+   `reportable` is frozen at send time. The bot only ever tightens it at click
+   time (a server marked `OFFICIAL` later). Anything you display must follow
+   the same direction.
+2. **Never mutate `notification_contents.payload`.** Its hash is its primary
+   key and thousands of rows point at it; editing it rewrites history for every
+   one of them. A new wording is a new hash — that is automatic on the bot side.
+3. **Never mutate `notifications.variables`** after the fact: it is the record
+   of what a specific person was actually shown.
+4. **Never delete rows.** `notification_deliveries` and `notification_reports`
+   cascade from `notifications`; a delete erases the evidence behind an open
+   abuse report. Add a retention job only with a deliberate policy, and never
+   delete a notification that has a report.
+5. **The uuid is public.** The recipient reads it in Discord and quotes it to
+   support. It is safe to display; it is not a secret and must not be treated
+   as one.
+6. **`recipient_id` is a Discord snowflake in a BIGINT.** JavaScript loses
+   precision above 2^53 — serialise it as a string in every API response, like
+   everywhere else in Moddy.
+7. **Localise from `locale`, not from the reader.** The row carries the locale
+   the message was rendered in; re-rendering a French DM's chrome in English
+   next to French body text is the mistake this column exists to prevent.
+
+---
+
+## 9. Checklist
+
+- [ ] Read path: `notifications` ⋈ `notification_contents` ⋈ `notification_deliveries`
+- [ ] Substitution implemented exactly as §3 (unknown key left visible, `None` → empty)
+- [ ] Custom emojis stripped for mail; markdown escaped per surface
+- [ ] `accent_color` int → hex
+- [ ] Snowflakes serialised as strings
+- [ ] Delivery loop claims with `FOR UPDATE SKIP LOCKED` and marks
+      `sent` / `failed` / `skipped` (never leaves a row `pending` after handling it)
+- [ ] Dashboard inbox shows source + verification exactly like Discord, and no
+      report affordance when `kind = 'official'` or `reportable = false`
+- [ ] `notification_reports` treated as read-only
+- [ ] No writes to `notifications`, `notification_contents`, or Discord delivery rows
+
+---
+
+## 10. Related
+
+- [NOTIFICATIONS.md](NOTIFICATIONS.md) — the system itself, and the Discord side
+- [DATABASE.md](DATABASE.md) §13–16 — full column reference
+- [BACKEND-INTEGRATION.md](BACKEND-INTEGRATION.md) — Redis, streams, shared DB rules
+- [TASK_SIGNATURE.md](TASK_SIGNATURE.md) — signing `moddy:tasks` entries, for §6

--- a/docs/NOTIFICATIONS_INTEGRATION.md
+++ b/docs/NOTIFICATIONS_INTEGRATION.md
@@ -306,8 +306,10 @@ LIMIT $2 OFFSET $3;
 
 `idx_notifications_recipient` on `(recipient_id, created_at DESC)` covers it.
 
-Render each row with §2 + §3. Show the source the same way Discord does —
-service name, server name, verification badge — so the two surfaces agree:
+Render each row with §2 + §3. In Discord the origin is one greyed line at the
+bottom of the card (`-# Sent by [**Server**](link) (`id`)`, plus the
+verification check when the server has one). Show the same thing, so the two
+surfaces agree:
 
 - `source_service` → a service label (the bot's own names live in
   `locales/<locale>.json` → `notifications.services.<id>`),
@@ -316,6 +318,15 @@ service name, server name, verification badge — so the two surfaces agree:
 - `reportable = false` → no report affordance either, and if you explain why,
   match the bot's two reasons: the wording is Moddy's, or the server is an
   official Moddy server.
+
+> **The dashboard is now the only place a report can be filed.** The flag
+> button that used to sit under a DM was removed; the pipeline behind it is
+> intact (`notification_reports`, the staff review panel in Discord, the
+> outcome DM) and only lacks a trigger. That trigger cannot be an `INSERT`
+> from the backend — filing a report also posts the review panel and logs it,
+> both bot-side. It needs the `notification_send`-style task of §6, extended
+> with a `notification_report` type. Until that exists, `reportable` is
+> information you display, not an action you can offer.
 
 ### 5.3 Campaign status
 
@@ -417,9 +428,11 @@ button in someone's DMs.
    cascade from `notifications`; a delete erases the evidence behind an open
    abuse report. Add a retention job only with a deliberate policy, and never
    delete a notification that has a report.
-5. **The uuid is public.** The recipient reads it in Discord and quotes it to
-   support. It is safe to display; it is not a secret and must not be treated
-   as one.
+5. **The uuid is safe to display.** It is the reference staff look a
+   notification up by (`/mod notif`), and the natural id for a dashboard
+   report control. It is not a secret and must not be treated as one — but the
+   Discord DM does not show it, so a user who has only seen the DM cannot
+   quote it: identify their notification by recipient and date.
 6. **`recipient_id` is a Discord snowflake in a BIGINT.** JavaScript loses
    precision above 2^53 — serialise it as a string in every API response, like
    everywhere else in Moddy.

--- a/docs/PERSISTENT_VIEWS.md
+++ b/docs/PERSISTENT_VIEWS.md
@@ -511,12 +511,13 @@ Registered persistent views live in
 the `/moddy` views, `/config` and every `modules/configs/*` panel, social
 notifications, `/cases` & `/mycases`, automod appeals and shadow-mode
 annotations, reminders, preferences, saved messages, and the staff
-help/server-list/manager panels, and the notification attribution + abuse
-report buttons (`NotificationsPersistence`, see
-[NOTIFICATIONS.md](NOTIFICATIONS.md)) — a DM sent today must still be
-reportable after next week's deploy, so every one of its buttons carries the
-notification (or report) uuid in its custom_id and rebuilds from the database
-on each click.
+help/server-list/manager panels, and the notification abuse-report review
+buttons (`NotificationsPersistence`, see [NOTIFICATIONS.md](NOTIFICATIONS.md))
+— a report opened today must still be decidable after next week's deploy, so
+each of its buttons carries the report uuid in its custom_id and rebuilds from
+the database on each click. The notification DMs themselves carry no component
+at all: their origin is one greyed `sent by` line, which cannot lose its
+handler in the first place.
 
 **`staff/commands/manage/staff.py::StaffManagerPanel`** grants and revokes
 staff roles/permissions. Making it persistent required changing its

--- a/docs/WELCOME_DM.md
+++ b/docs/WELCOME_DM.md
@@ -205,20 +205,21 @@ Welcome DMs are not sent with `member.send(...)`. They go through
 `bot.notifications.send_dm()` — see [NOTIFICATIONS.md](NOTIFICATIONS.md) — which
 changes three things:
 
-- **Every DM is recorded.** One `notifications` row per member, carrying the
-  uuid the recipient can quote to support, the delivery result, and the
+- **Every DM is recorded.** One `notifications` row per member, carrying its
+  uuid (what staff look up with `/mod notif`), the delivery result, and the
   `variables` that were substituted (`message_variables()`), so the exact
   wording sent to a given member can be rebuilt later. The body itself is
   stored **as a template**, placeholders unresolved (`welcome_content()` keeps
   `{server}` / `{user}` in the text), so all the members of one server share a
   single stored content row.
-- **It is attributed to the server.** A button under the message carries the
-  server's name and opens a panel identifying it — the recipient can always
-  tell which server DMed them.
-- **It is reportable.** The source is `NotificationSource.guild(guild.id)`,
+- **It is attributed to the server.** The DM ends with one greyed line —
+  `-# Sent by [**Server**](https://discord.com/channels/<id>) (`<id>`)`, plus
+  the verification check when the server carries one — so the recipient can
+  always tell which server DMed them.
+- **It is marked reportable.** The source is `NotificationSource.guild(guild.id)`,
   whose default author is `ContentAuthor.GUILD`: the text is the server's own
-  words, which is exactly what can be abused, so the red flag next to the
-  attribution button is live and files an abuse report to the Moddy team.
+  words, which is exactly what can be abused. That flag is what an abuse report
+  against a welcome DM will be checked against.
 
 `send_dm()` returns a `DeliveryResult` instead of raising: `result.forbidden`
 means the member's DMs are closed (the module stops there), `result.delivered`
@@ -226,6 +227,6 @@ that the message went out, and `result.notification_id` is what the module logs.
 
 The rendered container is unchanged — the module still builds its own
 Components V2 view holding only the guild's text — and is passed as `view=`;
-the attribution row is appended to it. The uniform `content` is still required:
-it is what the dashboard and the mail pipeline render, and what a staff reviewer
-sees when handling a report.
+the attribution line is appended inside its container. The uniform `content` is
+still required: it is what the dashboard and the mail pipeline render, and what
+a staff reviewer sees when handling a report.

--- a/docs/sessions/2026-08-24_centralized-notifications.md
+++ b/docs/sessions/2026-08-24_centralized-notifications.md
@@ -15,11 +15,12 @@ What shipped:
 - **Uniform payload.** `NotificationContent` renders to Discord, to a mail
   shape and to a dashboard shape, so a suspension notice reads the same
   everywhere. Titles, body, sections, links, footer, icon, accent.
-- **Attribution row** under every non-official DM: `[ Service ] [ Server ] [ 🚩 ]`.
-  The first two open an ephemeral identity panel (server icon, verification
-  badge, member count, link into the server, the notification's uuid, a support
-  link). The flag opens a report Modal V2 (recap + reason + explicit legitimacy
-  confirmation).
+- **Attribution line** at the bottom of every non-official DM —
+  `-# Sent by [**Server**](link) (`id`)`, plus the verification check when the
+  server has one. Same shape the sanction DMs have always used, now on
+  everything. (An earlier iteration in this session put buttons and an identity
+  panel there instead; that was replaced by the line on request — see the
+  decisions below.)
 - **Abuse reports** posted to the staff review channel with Claim / See the
   message / Accept / Decline, every step mirrored to the report log channel, and
   the reporter told the outcome — through this same system.
@@ -29,7 +30,8 @@ What shipped:
   one of them stays reproducible to the character.
 - **Staff commands**: `/mod notif <uuid>` (everything about one notification or
   report) and `/com send` (one user, one server, or thousands of either).
-- **Eleven senders migrated** off `user.send(...)`.
+- **Eleven senders migrated** off `user.send(...)`. The three whose card
+  already printed its own `sent_by` line pass `attribution=False`.
 
 ## Changes Made
 
@@ -96,12 +98,18 @@ What shipped:
 - **Official notices carry no attribution at all** — a suspension is Moddy
   speaking as an institution; offering to "report" it is nonsense. They are
   still stored and counted.
-- **Every button is a `DynamicItem` keyed by uuid.** A DM sent today must still
-  be reportable after next week's deploy, so no callback may rely on in-memory
-  state.
-- **Attribution button icons are Moddy emojis, not server icons.** Discord
-  button emojis must be real emojis; the *actual* server icon is shown in the
-  panel the button opens.
+- **A member's DM carries no component at all.** Attribution is plain text, so
+  it cannot expire, lose its handler or need registering. This replaced an
+  earlier button+panel design in the same session: a button can only carry an
+  emoji (never a server icon), and one greyed line says everything the panel
+  said that a member actually needs. The staff review panel keeps its
+  `DynamicItem` buttons, keyed by the report uuid.
+- **The Discord entry point for filing a report is gone with the buttons.**
+  The pipeline behind it — `notification_reports`, the review panel, the
+  outcome DM, `reportable` computed and frozen per row — is intact and
+  reachable through `NotificationService.open_report()`. It is kept rather than
+  deleted because the natural new trigger is a dashboard control, and
+  everything downstream of it already works.
 - **Broadcasts explode into one row per recipient** sharing a `batch_id`. Per-
   recipient delivery status is the whole point of the table, and "how did this
   campaign go" is still one query.
@@ -122,9 +130,16 @@ What shipped:
       `notification_send` payload is sketched in the integration doc §6. The
       legacy `send_announcement` task still posts unrecorded raw text to
       `guild.system_channel`.
+- [ ] **Nothing can file a report today** — the flag button was removed and no
+      other surface calls `open_report()` yet. A dashboard control is the
+      obvious next step; it needs a bot-side task type, since filing also posts
+      the review panel and logs it (see NOTIFICATIONS_INTEGRATION.md §5.2).
 - [ ] Accepting a report records the decision and tells the reporter; it takes
       **no automatic action** against the server. Wiring it to the global
       sanction / case system is a deliberate next step, not an oversight.
+- [ ] The recipient no longer sees the notification uuid anywhere in Discord.
+      Support has to identify a message by user + date instead. Putting it back
+      as a second `-#` line is one line of code if that turns out to hurt.
 - [ ] `/com send` progress edits stop if the interaction token expires (15 min);
       the batch keeps running and stays queryable by `batch_id`. A long campaign
       would be better served by a status message in a staff channel.

--- a/docs/sessions/2026-08-24_centralized-notifications.md
+++ b/docs/sessions/2026-08-24_centralized-notifications.md
@@ -50,6 +50,9 @@ What shipped:
 - `tests/test_notifications.py` — 39 tests (hashing, reproducibility,
   attribution rules, report authorization, i18n completeness on 5 locales)
 - `docs/NOTIFICATIONS.md`
+- `docs/NOTIFICATIONS_INTEGRATION.md` — backend/dashboard contract: tables read
+  vs owned, exact payload rendering, the placeholder algorithm the backend must
+  match character for character, the mail/dashboard delivery loop
 
 ### Modified
 
@@ -109,8 +112,16 @@ What shipped:
 
 - [ ] The **mail** and **dashboard** platforms are declared, stored and rendered
       (`to_email()` / `to_dashboard()`) but nothing sends them: their delivery
-      rows stay `pending` for the backend to pick up and mark. Needs the
-      backend-side contract.
+      rows stay `pending` for the backend to pick up and mark. The contract is
+      now written (`docs/NOTIFICATIONS_INTEGRATION.md`); the backend side is
+      not built. Note that no bot caller opts into a non-Discord platform yet,
+      so there are no pending rows to consume until one does.
+- [ ] **The backend cannot trigger a send.** There is no `moddy:tasks` type for
+      it, and it must not write `notifications` rows itself (the uuid has to
+      exist before the DM goes out — the buttons carry it). A proposed
+      `notification_send` payload is sketched in the integration doc §6. The
+      legacy `send_announcement` task still posts unrecorded raw text to
+      `guild.system_channel`.
 - [ ] Accepting a report records the decision and tells the reporter; it takes
       **no automatic action** against the server. Wiring it to the global
       sanction / case system is a deliberate next step, not an oversight.

--- a/locales/de.json
+++ b/locales/de.json
@@ -4000,61 +4000,22 @@
       "expirations": "Sanktionsende"
     },
     "attribution": {
-      "unknown_guild": "Unbekannter Server"
+      "unknown_guild": "Unbekannter Server",
+      "sent_by": "Gesendet von [**{guild}**]({guild_url}){badge} (`{guild_id}`)",
+      "sent_by_service": "Gesendet von **{service}**"
     },
     "source": {
-      "title": "Herkunft dieser Benachrichtigung",
-      "guild_label": "Server:",
-      "service_label": "Dienst:",
-      "id_label": "ID:",
-      "members": "Mitglieder:",
-      "created": "Erstellt am:",
-      "verified": "Verifizierter Server",
-      "official": "Offizieller Moddy-Server",
-      "open_server": "Server öffnen",
-      "uuid_label": "Benachrichtigung:",
-      "sent_at": "Gesendet am:",
-      "support_hint": "Ein Problem mit dieser Benachrichtigung? [Support kontaktieren]({url})",
-      "not_reportable": {
-        "moddy_authored": "Diese Nachricht stammt von Moddy: Es gibt nichts zu melden.",
-        "official_guild": "Diese Nachricht kommt von einem offiziellen Moddy-Server: Sie kann nicht gemeldet werden."
-      }
-    },
-    "service": {
-      "title": "Herkunft dieser Benachrichtigung",
-      "description": "Diese Nachricht wurde dir von einem Moddy-Dienst gesendet."
+      "uuid_label": "Benachrichtigung:"
     },
     "errors": {
       "unknown": {
-        "title": "Benachrichtigung nicht gefunden",
-        "description": "Die Benachrichtigung `{uuid}` existiert nicht mehr in unseren Aufzeichnungen."
+        "title": "Benachrichtigung nicht gefunden"
       },
       "unknown_report": {
         "description": "Die Meldung `{uuid}` existiert nicht mehr."
       }
     },
     "report": {
-      "modal": {
-        "title": "Diese Benachrichtigung melden",
-        "recap": "**Herkunft:** {source}\n**Benachrichtigung:** `{uuid}`\n\n> {excerpt}",
-        "reason": {
-          "label": "Warum meldest du diese Nachricht?",
-          "description": "Beschreibe das Problem so genau wie möglich.",
-          "placeholder": "Diese Nachricht enthält…"
-        },
-        "confirm": {
-          "label": "Bestätigung",
-          "option": "Ich bestätige, dass diese Meldung berechtigt ist"
-        }
-      },
-      "sent": {
-        "title": "Meldung gesendet",
-        "description": "Das Moddy-Team wird diese Nachricht prüfen. Danke für deine Hilfe."
-      },
-      "already": {
-        "title": "Meldung bereits gesendet",
-        "description": "Du hast diese Benachrichtigung bereits gemeldet."
-      },
       "status_label": "Status:",
       "status": {
         "pending": "Ausstehend",
@@ -4063,20 +4024,6 @@
         "refused": "Abgelehnt"
       },
       "reference": "Meldung:",
-      "decision_note": "Hinweis des Teams:",
-      "errors": {
-        "not_recipient": {
-          "title": "Melden nicht möglich",
-          "description": "Nur der Empfänger dieser Benachrichtigung kann sie melden."
-        },
-        "not_reportable": {
-          "title": "Melden nicht möglich"
-        },
-        "failed": {
-          "title": "Melden nicht möglich",
-          "description": "Die Meldung konnte nicht gespeichert werden. Versuche es gleich noch einmal."
-        }
-      },
       "outcome": {
         "accepted": {
           "title": "Meldung angenommen",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -4000,61 +4000,22 @@
       "expirations": "Sanction expiry"
     },
     "attribution": {
-      "unknown_guild": "Unknown server"
+      "unknown_guild": "Unknown server",
+      "sent_by": "Sent by [**{guild}**]({guild_url}){badge} (`{guild_id}`)",
+      "sent_by_service": "Sent by **{service}**"
     },
     "source": {
-      "title": "Where this notification comes from",
-      "guild_label": "Server:",
-      "service_label": "Service:",
-      "id_label": "ID:",
-      "members": "Members:",
-      "created": "Created:",
-      "verified": "Verified server",
-      "official": "Official Moddy server",
-      "open_server": "Open the server",
-      "uuid_label": "Notification:",
-      "sent_at": "Sent:",
-      "support_hint": "Something wrong with this notification? [Contact support]({url})",
-      "not_reportable": {
-        "moddy_authored": "This message is written by Moddy: there is nothing to report.",
-        "official_guild": "This message comes from an official Moddy server: it cannot be reported."
-      }
-    },
-    "service": {
-      "title": "Where this notification comes from",
-      "description": "This message was sent to you by a Moddy service."
+      "uuid_label": "Notification:"
     },
     "errors": {
       "unknown": {
-        "title": "Notification not found",
-        "description": "Notification `{uuid}` no longer exists in our records."
+        "title": "Notification not found"
       },
       "unknown_report": {
         "description": "Report `{uuid}` no longer exists."
       }
     },
     "report": {
-      "modal": {
-        "title": "Report this notification",
-        "recap": "**From:** {source}\n**Notification:** `{uuid}`\n\n> {excerpt}",
-        "reason": {
-          "label": "Why are you reporting this message?",
-          "description": "Describe the problem as precisely as you can.",
-          "placeholder": "This message contains…"
-        },
-        "confirm": {
-          "label": "Confirmation",
-          "option": "I confirm this report is legitimate"
-        }
-      },
-      "sent": {
-        "title": "Report sent",
-        "description": "The Moddy team will review this message. Thank you for your help."
-      },
-      "already": {
-        "title": "Report already sent",
-        "description": "You have already reported this notification."
-      },
       "status_label": "Status:",
       "status": {
         "pending": "Pending",
@@ -4063,20 +4024,6 @@
         "refused": "Declined"
       },
       "reference": "Report:",
-      "decision_note": "Team note:",
-      "errors": {
-        "not_recipient": {
-          "title": "Cannot report",
-          "description": "Only the recipient of this notification can report it."
-        },
-        "not_reportable": {
-          "title": "Cannot report"
-        },
-        "failed": {
-          "title": "Cannot report",
-          "description": "The report could not be saved. Please try again in a moment."
-        }
-      },
       "outcome": {
         "accepted": {
           "title": "Report accepted",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -4000,61 +4000,22 @@
       "expirations": "Fin de sanción"
     },
     "attribution": {
-      "unknown_guild": "Servidor desconocido"
+      "unknown_guild": "Servidor desconocido",
+      "sent_by": "Enviado por [**{guild}**]({guild_url}){badge} (`{guild_id}`)",
+      "sent_by_service": "Enviado por **{service}**"
     },
     "source": {
-      "title": "Origen de esta notificación",
-      "guild_label": "Servidor:",
-      "service_label": "Servicio:",
-      "id_label": "Identificador:",
-      "members": "Miembros:",
-      "created": "Creado el:",
-      "verified": "Servidor verificado",
-      "official": "Servidor oficial de Moddy",
-      "open_server": "Abrir el servidor",
-      "uuid_label": "Notificación:",
-      "sent_at": "Enviada el:",
-      "support_hint": "¿Algún problema con esta notificación? [Contactar con el soporte]({url})",
-      "not_reportable": {
-        "moddy_authored": "Este mensaje está redactado por Moddy: no hay nada que reportar.",
-        "official_guild": "Este mensaje proviene de un servidor oficial de Moddy: no se puede reportar."
-      }
-    },
-    "service": {
-      "title": "Origen de esta notificación",
-      "description": "Este mensaje te lo ha enviado un servicio de Moddy."
+      "uuid_label": "Notificación:"
     },
     "errors": {
       "unknown": {
-        "title": "Notificación no encontrada",
-        "description": "La notificación `{uuid}` ya no existe en nuestros registros."
+        "title": "Notificación no encontrada"
       },
       "unknown_report": {
         "description": "El reporte `{uuid}` ya no existe."
       }
     },
     "report": {
-      "modal": {
-        "title": "Reportar esta notificación",
-        "recap": "**Origen:** {source}\n**Notificación:** `{uuid}`\n\n> {excerpt}",
-        "reason": {
-          "label": "¿Por qué reportas este mensaje?",
-          "description": "Describe el problema con la mayor precisión posible.",
-          "placeholder": "Este mensaje contiene…"
-        },
-        "confirm": {
-          "label": "Confirmación",
-          "option": "Confirmo que este reporte es legítimo"
-        }
-      },
-      "sent": {
-        "title": "Reporte enviado",
-        "description": "El equipo de Moddy va a revisar este mensaje. Gracias por tu ayuda."
-      },
-      "already": {
-        "title": "Reporte ya enviado",
-        "description": "Ya has reportado esta notificación."
-      },
       "status_label": "Estado:",
       "status": {
         "pending": "Pendiente",
@@ -4063,20 +4024,6 @@
         "refused": "Rechazado"
       },
       "reference": "Reporte:",
-      "decision_note": "Nota del equipo:",
-      "errors": {
-        "not_recipient": {
-          "title": "No se puede reportar",
-          "description": "Solo el destinatario de esta notificación puede reportarla."
-        },
-        "not_reportable": {
-          "title": "No se puede reportar"
-        },
-        "failed": {
-          "title": "No se puede reportar",
-          "description": "No se ha podido guardar el reporte. Inténtalo de nuevo en un momento."
-        }
-      },
       "outcome": {
         "accepted": {
           "title": "Reporte aceptado",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3999,61 +3999,22 @@
       "expirations": "Fin de sanction"
     },
     "attribution": {
-      "unknown_guild": "Serveur inconnu"
+      "unknown_guild": "Serveur inconnu",
+      "sent_by": "Envoyé par [**{guild}**]({guild_url}){badge} (`{guild_id}`)",
+      "sent_by_service": "Envoyé par **{service}**"
     },
     "source": {
-      "title": "Origine de cette notification",
-      "guild_label": "Serveur :",
-      "service_label": "Service :",
-      "id_label": "Identifiant :",
-      "members": "Membres :",
-      "created": "Créé le :",
-      "verified": "Serveur vérifié",
-      "official": "Serveur officiel Moddy",
-      "open_server": "Ouvrir le serveur",
-      "uuid_label": "Notification :",
-      "sent_at": "Envoyée le :",
-      "support_hint": "Un problème avec cette notification ? [Contacter le support]({url})",
-      "not_reportable": {
-        "moddy_authored": "Ce message est rédigé par Moddy : il n'y a rien à signaler.",
-        "official_guild": "Ce message provient d'un serveur officiel Moddy : il ne peut pas être signalé."
-      }
-    },
-    "service": {
-      "title": "Origine de cette notification",
-      "description": "Ce message t'a été envoyé par un service de Moddy."
+      "uuid_label": "Notification :"
     },
     "errors": {
       "unknown": {
-        "title": "Notification introuvable",
-        "description": "La notification `{uuid}` n'existe plus dans nos registres."
+        "title": "Notification introuvable"
       },
       "unknown_report": {
         "description": "Le signalement `{uuid}` n'existe plus."
       }
     },
     "report": {
-      "modal": {
-        "title": "Signaler cette notification",
-        "recap": "**Origine :** {source}\n**Notification :** `{uuid}`\n\n> {excerpt}",
-        "reason": {
-          "label": "Pourquoi signales-tu ce message ?",
-          "description": "Décris le problème le plus précisément possible.",
-          "placeholder": "Ce message contient…"
-        },
-        "confirm": {
-          "label": "Confirmation",
-          "option": "Je confirme que ce signalement est légitime"
-        }
-      },
-      "sent": {
-        "title": "Signalement envoyé",
-        "description": "L'équipe Moddy va examiner ce message. Merci de ton aide."
-      },
-      "already": {
-        "title": "Signalement déjà envoyé",
-        "description": "Tu as déjà signalé cette notification."
-      },
       "status_label": "Statut :",
       "status": {
         "pending": "En attente",
@@ -4062,20 +4023,6 @@
         "refused": "Refusé"
       },
       "reference": "Signalement :",
-      "decision_note": "Note de l'équipe :",
-      "errors": {
-        "not_recipient": {
-          "title": "Signalement impossible",
-          "description": "Seul le destinataire de cette notification peut la signaler."
-        },
-        "not_reportable": {
-          "title": "Signalement impossible"
-        },
-        "failed": {
-          "title": "Signalement impossible",
-          "description": "Le signalement n'a pas pu être enregistré. Réessaie dans un instant."
-        }
-      },
       "outcome": {
         "accepted": {
           "title": "Signalement accepté",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -4000,61 +4000,22 @@
       "expirations": "Fim de sanção"
     },
     "attribution": {
-      "unknown_guild": "Servidor desconhecido"
+      "unknown_guild": "Servidor desconhecido",
+      "sent_by": "Enviado por [**{guild}**]({guild_url}){badge} (`{guild_id}`)",
+      "sent_by_service": "Enviado por **{service}**"
     },
     "source": {
-      "title": "Origem desta notificação",
-      "guild_label": "Servidor:",
-      "service_label": "Serviço:",
-      "id_label": "Identificador:",
-      "members": "Membros:",
-      "created": "Criado em:",
-      "verified": "Servidor verificado",
-      "official": "Servidor oficial da Moddy",
-      "open_server": "Abrir o servidor",
-      "uuid_label": "Notificação:",
-      "sent_at": "Enviada em:",
-      "support_hint": "Algum problema com esta notificação? [Falar com o suporte]({url})",
-      "not_reportable": {
-        "moddy_authored": "Esta mensagem foi escrita pelo Moddy: não há nada a denunciar.",
-        "official_guild": "Esta mensagem vem de um servidor oficial da Moddy: ela não pode ser denunciada."
-      }
-    },
-    "service": {
-      "title": "Origem desta notificação",
-      "description": "Esta mensagem foi enviada a você por um serviço do Moddy."
+      "uuid_label": "Notificação:"
     },
     "errors": {
       "unknown": {
-        "title": "Notificação não encontrada",
-        "description": "A notificação `{uuid}` não existe mais em nossos registros."
+        "title": "Notificação não encontrada"
       },
       "unknown_report": {
         "description": "A denúncia `{uuid}` não existe mais."
       }
     },
     "report": {
-      "modal": {
-        "title": "Denunciar esta notificação",
-        "recap": "**Origem:** {source}\n**Notificação:** `{uuid}`\n\n> {excerpt}",
-        "reason": {
-          "label": "Por que você está denunciando isto?",
-          "description": "Descreva o problema da forma mais precisa possível.",
-          "placeholder": "Esta mensagem contém…"
-        },
-        "confirm": {
-          "label": "Confirmação",
-          "option": "Confirmo que esta denúncia é legítima"
-        }
-      },
-      "sent": {
-        "title": "Denúncia enviada",
-        "description": "A equipe do Moddy vai analisar esta mensagem. Obrigado pela sua ajuda."
-      },
-      "already": {
-        "title": "Denúncia já enviada",
-        "description": "Você já denunciou esta notificação."
-      },
       "status_label": "Status:",
       "status": {
         "pending": "Pendente",
@@ -4063,20 +4024,6 @@
         "refused": "Recusada"
       },
       "reference": "Denúncia:",
-      "decision_note": "Nota da equipe:",
-      "errors": {
-        "not_recipient": {
-          "title": "Não é possível denunciar",
-          "description": "Somente o destinatário desta notificação pode denunciá-la."
-        },
-        "not_reportable": {
-          "title": "Não é possível denunciar"
-        },
-        "failed": {
-          "title": "Não é possível denunciar",
-          "description": "A denúncia não pôde ser salva. Tente novamente em instantes."
-        }
-      },
       "outcome": {
         "accepted": {
           "title": "Denúncia aceita",

--- a/modules/automod_ai.py
+++ b/modules/automod_ai.py
@@ -1127,6 +1127,8 @@ class AutomodModule(ModuleBase):
                 view=view,
                 files=files,
                 locale=locale,
+                # build_sanction_dm_view already ends with its own `sent_by`.
+                attribution=False,
             )
         except (discord.Forbidden, discord.HTTPException):
             pass  # closed DMs — the case + channel notification still stand

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -137,7 +137,7 @@ class ServiceInfo:
     @property
     def emoji(self) -> str:
         from utils import emojis as _emojis
-        return getattr(_emojis, self.emoji_name, _emojis.MODDY)
+        return getattr(_emojis, self.emoji_name, _emojis.MODDY_SQUARE_MIN)
 
 
 def _svc(sid: str, emoji_name: str) -> ServiceInfo:
@@ -147,7 +147,7 @@ def _svc(sid: str, emoji_name: str) -> ServiceInfo:
 #: service id -> ServiceInfo. Adding a sender means adding one line here.
 SERVICES: Dict[str, ServiceInfo] = {
     s.id: s for s in (
-        _svc("moddy", "MODDY"),                      # Moddy itself / staff broadcasts
+        _svc("moddy", "MODDY_SQUARE_MIN"),           # Moddy itself / staff broadcasts
         _svc("welcome_dm", "WAVING_HAND"),           # modules/welcome_dm.py
         _svc("moderation", "LEGAL"),                 # manual sanctions
         _svc("automod_ai", "SHIELD"),                # modules/automod_ai.py

--- a/notifications/render.py
+++ b/notifications/render.py
@@ -30,7 +30,7 @@ from cogs.error_handler import BaseView
 from notifications.models import (
     ContentAuthor, NotificationContent, NotificationSource, get_service,
 )
-from utils.emojis import GROUPS, MODDY, VERIFIED, format_verification_badge
+from utils.emojis import MODDY_SQUARE_MIN, VERIFIED, format_verification_badge
 from utils.i18n import t
 
 logger = logging.getLogger("moddy.notifications.render")
@@ -107,7 +107,7 @@ async def resolve_source_context(
 
     ``service`` / ``service_name`` / ``service_emoji``
         The Moddy feature behind the message, when there is one.
-    ``guild_name`` / ``guild_icon_url`` / ``guild_id``
+    ``guild_name`` / ``guild_id``
         The server, when the message was sent on one's behalf.
     ``verified`` / ``official`` / ``badge``
         Whether that server carries the check, and whether it is Moddy's own.
@@ -123,12 +123,9 @@ async def resolve_source_context(
         "author": source.author.value,
         "service_id": source.service_id,
         "service_name": t(service.i18n_key, locale=locale) if service else None,
-        "service_emoji": service.emoji if service else MODDY,
+        "service_emoji": service.emoji if service else MODDY_SQUARE_MIN,
         "guild_id": source.guild_id,
         "guild_name": None,
-        "guild_icon_url": None,
-        "guild_member_count": None,
-        "guild_created_at": None,
         "verified": False,
         "official": False,
         "badge": "",
@@ -137,13 +134,15 @@ async def resolve_source_context(
     }
 
     if source.guild_id:
-        guild = bot.get_guild(source.guild_id) if bot else None
-        if guild is not None:
-            ctx["guild_name"] = guild.name
-            ctx["guild_icon_url"] = guild.icon.url if guild.icon else None
-            ctx["guild_member_count"] = guild.member_count
-            ctx["guild_created_at"] = guild.created_at
-        else:
+        # Everything below is best-effort: this runs on the delivery path, and
+        # a missing guild or an unreachable database must cost the badge, never
+        # the message.
+        try:
+            guild = bot.get_guild(source.guild_id) if bot else None
+            ctx["guild_name"] = guild.name if guild is not None else None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not resolve guild %s: %s", source.guild_id, exc)
+        if not ctx["guild_name"]:
             ctx["guild_name"] = t("notifications.attribution.unknown_guild", locale=locale)
 
         attributes = {}
@@ -169,13 +168,35 @@ async def resolve_source_context(
     return ctx
 
 
-def source_button_emoji(ctx: Dict[str, Any]) -> str:
-    """The emoji shown on the *server* attribution button.
+#: Deep link to a server. Discord opens it when the reader is a member.
+GUILD_URL = "https://discord.com/channels/{guild_id}"
 
-    Buttons can only carry a real Discord emoji, never a server icon URL — the
-    icon itself is shown as the thumbnail of the panel the button opens.
+
+def build_attribution_line(ctx: Dict[str, Any], *, locale: str = "en-US") -> Optional[str]:
+    """The one greyed line closing every attributable notification.
+
+    ``-# Sent by [**Server**](link) (`id`)`` — the same shape the sanction DMs
+    have always used (``commands.moderation.dm.sent_by``), so a member sees one
+    consistent sentence at the bottom of anything Moddy sends them, whatever
+    feature produced it. The verification badge is appended right after the
+    name when the server carries one, per the badge rule in CLAUDE.md.
+
+    A notification with no server (a reminder, an appeal outcome) names the
+    Moddy service instead. An official notice gets no line at all — the caller
+    does not even reach here.
     """
-    return VERIFIED if ctx.get("verified") else GROUPS
+    if ctx.get("guild_id") and ctx.get("guild_name"):
+        return "-# " + t(
+            "notifications.attribution.sent_by", locale=locale,
+            guild=ctx["guild_name"],
+            guild_url=GUILD_URL.format(guild_id=ctx["guild_id"]),
+            guild_id=ctx["guild_id"],
+            badge=ctx.get("badge") or "",
+        )
+    if ctx.get("service_name"):
+        return "-# " + t("notifications.attribution.sent_by_service",
+                         locale=locale, service=ctx["service_name"])
+    return None
 
 
 def author_is_guild(source: NotificationSource) -> bool:

--- a/notifications/service.py
+++ b/notifications/service.py
@@ -36,7 +36,9 @@ from notifications.models import (
     DeliveryStatus, NotificationContent, NotificationSource,
     Platform, RecipientType, ReportStatus,
 )
-from notifications.render import build_content_view, resolve_source_context
+from notifications.render import (
+    build_attribution_line, build_content_view, resolve_source_context,
+)
 
 logger = logging.getLogger("moddy.notifications")
 
@@ -243,6 +245,7 @@ class NotificationService:
         platforms: Sequence[Platform] = (Platform.DISCORD,),
         locale: Optional[str] = None,
         batch_id: Optional[Any] = None,
+        attribution: bool = True,
     ) -> DeliveryResult:
         """Send one notification as a DM.
 
@@ -257,7 +260,8 @@ class NotificationService:
             recipient_id=getattr(user, "id", None),
             variables=variables, platforms=platforms, locale=locale, batch_id=batch_id,
         )
-        payload = await self._build_view(record, content, source, variables, view, locale)
+        payload = await self._build_view(record, content, source, variables, view,
+                                         locale, attribution)
         return await self._deliver(
             destination=user, record=record, view=payload,
             files=files, allowed_mentions=allowed_mentions,
@@ -276,6 +280,7 @@ class NotificationService:
         platforms: Sequence[Platform] = (Platform.DISCORD,),
         locale: Optional[str] = None,
         batch_id: Optional[Any] = None,
+        attribution: bool = True,
     ) -> DeliveryResult:
         """Send one notification into a server channel (a server-wide notice)."""
         record = await self.record(
@@ -284,29 +289,44 @@ class NotificationService:
             recipient_id=guild_id or getattr(getattr(channel, "guild", None), "id", None),
             variables=variables, platforms=platforms, locale=locale, batch_id=batch_id,
         )
-        payload = await self._build_view(record, content, source, variables, view, locale)
+        payload = await self._build_view(record, content, source, variables, view,
+                                         locale, attribution)
         return await self._deliver(
             destination=channel, record=record, view=payload,
             allowed_mentions=allowed_mentions,
         )
 
-    async def _build_view(self, record, content, source, variables, view, locale):
-        """Render (or take) the view and bolt the attribution row onto it."""
+    async def _build_view(self, record, content, source, variables, view, locale,
+                          attribution: bool = True):
+        """Render (or take) the view and close it with the attribution line.
+
+        The line is appended **inside the last container** of the view — at the
+        bottom of the card the recipient reads, not as a separate component —
+        so a welcome DM and a sanction DM end the same way.
+        """
         payload = view if view is not None else build_content_view(
             content, variables, locale=locale or "en-US")
 
-        if not source.has_attribution:
-            return payload  # official notices carry no attribution at all
-        if not record:
-            # No uuid means no working custom_id: better an unattributed DM
-            # than dead buttons.
-            logger.warning("Notification not recorded — sending without attribution row")
+        if not attribution or not source.has_attribution:
+            # Official notices say nothing about their origin: they ARE Moddy.
+            # `attribution=False` is for the callers whose card already prints
+            # its own "sent by" line (sanction DMs, expiry DMs).
             return payload
 
-        from utils.notification_views import attach_attribution
-        ctx = await self.source_context(record, locale=locale or record.get("locale") or "en-US")
-        return attach_attribution(payload, str(record["id"]), ctx,
-                                  locale=locale or "en-US")
+        # The line is plain text built from the source itself, so a failed
+        # database write costs the record, never the attribution: the recipient
+        # is still told which server wrote to them.
+        if record:
+            ctx = await self.source_context(
+                record, locale=locale or record.get("locale") or "en-US")
+        else:
+            logger.warning("Notification not recorded — attributing from the source")
+            ctx = await resolve_source_context(self.bot, source, locale=locale or "en-US")
+
+        line = build_attribution_line(ctx, locale=locale or "en-US")
+        if line:
+            _append_footer_line(payload, line)
+        return payload
 
     async def _deliver(self, *, destination, record, view, files=None,
                        allowed_mentions=None) -> DeliveryResult:
@@ -672,6 +692,29 @@ class NotificationService:
         """Staff-facing panels are rendered in one language, like the appeal
         review panels (``services/appeal_service._PANEL_LOCALE``)."""
         return STAFF_PANEL_LOCALE
+
+
+def _append_footer_line(view: discord.ui.LayoutView, line: str) -> None:
+    """Add ``line`` at the bottom of the view's last container.
+
+    Inside the container rather than under it: a `-#` line floating as its own
+    top-level component reads as a separate message. Falls back to a top-level
+    text block when the view has no container, or when the container is already
+    at Discord's child limit.
+    """
+    for child in reversed(list(view.children)):
+        if isinstance(child, discord.ui.Container):
+            try:
+                child.add_item(discord.ui.TextDisplay(line))
+                return
+            except Exception as exc:  # noqa: BLE001 — full container, keep the line
+                logger.debug("Could not append the attribution line inside the "
+                             "container (%s), falling back to top level", exc)
+                break
+    try:
+        view.add_item(discord.ui.TextDisplay(line))
+    except Exception as exc:  # noqa: BLE001 — never lose the message over its footer
+        logger.warning("Could not append the attribution line: %s", exc)
 
 
 async def _maybe_await(value):

--- a/services/expiration_notifier.py
+++ b/services/expiration_notifier.py
@@ -163,6 +163,8 @@ class ExpirationNotifier:
                            "reference": str(row.get("reference") or "—")},
                 view=view,
                 locale=locale,
+                # build_expiration_dm_view already ends with `sent_by`.
+                attribution=False,
             )
             return result.delivered
         except discord.HTTPException as exc:

--- a/staff/commands/com/send.py
+++ b/staff/commands/com/send.py
@@ -168,7 +168,7 @@ def _build_content(payload: Dict[str, Any]) -> NotificationContent:
     return NotificationContent(
         title=payload["title"],
         body=payload["body"],
-        icon=emojis.MODDY,
+        icon=emojis.MODDY_SQUARE_MIN,
         accent_color=0x3661FF,
         links=payload.get("links") or [],
         template_id="staff.com.send",

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -26,7 +26,7 @@ from notifications.models import (
     SERVICES, ContentAuthor, NotificationContent, NotificationSource,
     RecipientType, SourceKind, get_service, strip_custom_emojis, substitute,
 )
-from notifications.render import resolve_source_context, source_button_emoji
+from notifications.render import build_attribution_line, resolve_source_context
 from notifications.service import NotificationService
 
 _UUID = "0f7d9c62-3b4e-4a1f-9c2d-5e6f70819a2b"
@@ -179,9 +179,6 @@ class FakeGuild:
     def __init__(self, gid=42, name="Test Server"):
         self.id = gid
         self.name = name
-        self.icon = None
-        self.member_count = 1234
-        self.created_at = None
 
 
 class FakeDB:
@@ -216,7 +213,8 @@ async def test_a_verified_server_gets_the_check():
     assert ctx["verified"] is True
     assert ctx["badge"]  # a hyperlinked badge, per the CLAUDE.md rule
     assert ctx["reportable"] is True
-    assert source_button_emoji(ctx) != source_button_emoji({"verified": False})
+    # …and it is the badge that reaches the attribution line.
+    assert ctx["badge"] in build_attribution_line(ctx, locale="en-US")
 
 
 async def test_an_official_moddy_server_greys_the_flag_out():
@@ -243,6 +241,18 @@ async def test_an_unreachable_guild_degrades_instead_of_raising():
     assert ctx["reportable"] is True
 
 
+async def test_a_broken_guild_object_costs_the_badge_not_the_message():
+    """This runs on the delivery path: nothing in it may raise."""
+    class Exploding:
+        def get_guild(self, guild_id):
+            raise RuntimeError("cache is on fire")
+        db = None
+
+    ctx = await resolve_source_context(Exploding(), NotificationSource.guild(42))
+    assert ctx["guild_name"]      # falls back to "Unknown server"
+    assert ctx["badge"] == ""
+
+
 # --------------------------------------------------------------------------- #
 # Service behaviour without a database
 # --------------------------------------------------------------------------- #
@@ -265,8 +275,14 @@ class Recipient:
 
 
 async def test_a_dm_still_goes_out_when_the_database_is_down():
-    """A recording failure must never swallow the message itself."""
-    service = NotificationService(NoDbBot())
+    """A recording failure must never swallow the message itself.
+
+    And, since the attribution is plain text built from the source rather than
+    a button needing the stored uuid, the recipient is still told who wrote to
+    them — a failed INSERT costs the record, not the accountability.
+    """
+    service = NotificationService(FakeBot(FakeGuild()))
+    service.db  # the guild lookup works; create_notification does not exist
     recipient = Recipient()
     result = await service.send_dm(
         recipient,
@@ -274,8 +290,15 @@ async def test_a_dm_still_goes_out_when_the_database_is_down():
         source=NotificationSource.guild(42),
     )
     assert result.delivered
-    assert recipient.sent  # sent — just without the attribution row
-    assert result.notification_id is None
+    assert result.notification_id is None          # nothing was recorded…
+    rendered = str(recipient.sent[0]["view"].to_components())
+    assert "Sent by" in rendered and "Test Server" in rendered   # …but it is attributed
+
+
+async def test_the_moddy_logo_is_the_small_square_mark():
+    """One logo everywhere: the inline-sized rounded square."""
+    from utils.emojis import MODDY_SQUARE_MIN
+    assert SERVICES["moddy"].emoji == MODDY_SQUARE_MIN
 
 
 async def test_may_report_is_the_recipient_only():
@@ -324,65 +347,95 @@ async def test_a_row_recorded_as_unreportable_can_never_become_reportable():
 
 
 # --------------------------------------------------------------------------- #
-# Attribution row
+# Attribution line
+#
+# One greyed line at the bottom of every attributable DM, in place of the
+# buttons an earlier iteration carried. It is the only thing a recipient sees
+# about where their message came from, so its shape is load-bearing.
 # --------------------------------------------------------------------------- #
 
-def _row_labels(row):
-    """Labels of an attribution row.
+def test_a_server_source_names_the_server_with_a_link_and_its_id():
+    from notifications.render import build_attribution_line
 
-    Its children are ``DynamicItem`` wrappers (that is what makes them survive a
-    restart), so the label lives on the wrapped button.
-    """
-    return [child.item.label for child in row.children]
-
-
-def test_a_service_and_server_source_shows_three_buttons():
-    from utils.notification_views import build_attribution_row
-
-    row = build_attribution_row(_UUID, {
-        "service_name": "Tickets", "service_emoji": "<:t:1>",
-        "guild_name": "Test Server", "verified": False, "reportable": True,
-    })
-    assert _row_labels(row) == ["Tickets", "Test Server", None]  # flag has no label
+    line = build_attribution_line({
+        "guild_id": 42, "guild_name": "Test Server", "badge": "",
+        "service_name": "Welcome message",
+    }, locale="en-US")
+    assert line == ("-# Sent by [**Test Server**](https://discord.com/channels/42) (`42`)")
 
 
-def test_a_guild_only_source_shows_the_server_and_the_flag():
-    from utils.notification_views import build_attribution_row
+def test_the_verification_badge_follows_the_name():
+    """CLAUDE.md rule #7: the badge sits right after the bold name."""
+    from notifications.render import build_attribution_line
 
-    row = build_attribution_row(_UUID, {
-        "guild_name": "Test Server", "reportable": True})
-    assert _row_labels(row) == ["Test Server", None]
-
-
-def test_the_flag_is_disabled_when_the_message_is_not_reportable():
-    from utils.notification_views import build_attribution_row
-
-    row = build_attribution_row(_UUID, {
-        "service_name": "AltGuard", "guild_name": "Test Server",
-        "reportable": False, "report_block": "moddy_authored"})
-    assert list(row.children)[-1].item.disabled is True
+    line = build_attribution_line({
+        "guild_id": 42, "guild_name": "Test Server", "badge": "[<:v:1>](https://d)",
+    }, locale="en-US")
+    assert "[**Test Server**](https://discord.com/channels/42)[<:v:1>](https://d)" in line
 
 
-def test_an_official_notice_gets_no_row_and_the_view_is_untouched():
-    from cogs.error_handler import BaseView
-    from utils.notification_views import attach_attribution, build_attribution_row
+def test_a_service_only_source_names_the_service():
+    """A reminder has no server to point at — the service is the origin."""
+    from notifications.render import build_attribution_line
 
-    assert build_attribution_row(_UUID, {"service_name": None, "guild_name": None}) is None
-    view = BaseView()
-    before = len(view.children)
-    attach_attribution(view, _UUID, {"service_name": None, "guild_name": None})
-    assert len(view.children) == before
+    line = build_attribution_line({"service_name": "Reminders"}, locale="en-US")
+    assert line == "-# Sent by **Reminders**"
 
 
-def test_every_attribution_custom_id_carries_the_notification_uuid():
-    """After a restart the uuid in the custom_id is all a click has to go on."""
-    from utils.notification_views import build_attribution_row
+def test_a_source_with_nothing_to_name_gets_no_line():
+    from notifications.render import build_attribution_line
 
-    row = build_attribution_row(_UUID, {
-        "service_name": "Tickets", "guild_name": "Test Server", "reportable": True})
-    for child in row.children:
-        assert child.custom_id.endswith(_UUID)
-        assert len(child.custom_id) <= 100
+    assert build_attribution_line({}, locale="en-US") is None
+
+
+def test_the_line_is_greyed_out_in_every_locale():
+    """`-#` is what makes it a footnote rather than part of the message."""
+    from notifications.render import build_attribution_line
+
+    for locale in ("fr", "en-US", "es-ES", "pt-BR", "de"):
+        line = build_attribution_line(
+            {"guild_id": 42, "guild_name": "S", "badge": ""}, locale=locale)
+        assert line.startswith("-# ")
+        assert "https://discord.com/channels/42" in line
+        assert "`42`" in line
+
+
+async def test_the_line_lands_inside_the_last_container():
+    """Under the card's text, not floating as its own component."""
+    from discord import ui
+    from notifications.service import _append_footer_line
+
+    view = ui.LayoutView(timeout=None)
+    container = ui.Container(ui.TextDisplay("body"))
+    view.add_item(container)
+    _append_footer_line(view, "-# Sent by **Moddy**")
+
+    assert len(list(view.children)) == 1  # no new top-level component
+    assert list(container.children)[-1].content == "-# Sent by **Moddy**"
+
+
+async def test_a_view_without_a_container_still_gets_the_line():
+    from discord import ui
+    from notifications.service import _append_footer_line
+
+    view = ui.LayoutView(timeout=None)
+    view.add_item(ui.TextDisplay("body"))
+    _append_footer_line(view, "-# Sent by **Moddy**")
+    assert list(view.children)[-1].content == "-# Sent by **Moddy**"
+
+
+async def test_an_official_notice_says_nothing_about_its_origin():
+    """A suspension IS Moddy speaking; there is no third party to name."""
+    service = NotificationService(NoDbBot())
+    recipient = Recipient()
+    await service.send_dm(
+        recipient,
+        content=NotificationContent(title="T", body="B"),
+        source=NotificationSource.official("global_sanctions"),
+    )
+    view = recipient.sent[0]["view"]
+    rendered = str(view.to_components())
+    assert "Sent by" not in rendered
 
 
 # --------------------------------------------------------------------------- #
@@ -405,16 +458,10 @@ _DYNAMIC_KEYS = {
     "notifications.report.status.claimed",
     "notifications.report.status.accepted",
     "notifications.report.status.refused",
-    "notifications.report.sent.title",
-    "notifications.report.sent.description",
-    "notifications.report.already.title",
-    "notifications.report.already.description",
     "notifications.report.outcome.accepted.title",
     "notifications.report.outcome.accepted.description",
     "notifications.report.outcome.refused.title",
     "notifications.report.outcome.refused.description",
-    "notifications.source.not_reportable.moddy_authored",
-    "notifications.source.not_reportable.official_guild",
     "notifications.review.buttons.accept",
     "notifications.review.buttons.refuse",
     "notifications.review.decision.accept.title",
@@ -486,8 +533,7 @@ def test_every_notification_string_exists_in_every_locale(locale):
 def test_modal_titles_fit_discords_limit(locale):
     """Discord rejects a modal whose title is over 45 characters."""
     data = json.loads((ROOT / "locales" / f"{locale}.json").read_text(encoding="utf-8"))
-    for key in ("notifications.report.modal.title",
-                "notifications.review.decision.accept.title",
+    for key in ("notifications.review.decision.accept.title",
                 "notifications.review.decision.refuse.title",
                 "staff.com.send.modal.title"):
         assert len(_lookup(data, key)) <= 45, f"{key} too long in {locale}"

--- a/tests/test_persistent_views.py
+++ b/tests/test_persistent_views.py
@@ -129,7 +129,6 @@ def _dynamic_item_cases():
     )
     from utils.ticket_views import TicketOpenButton, TicketOpenSelect
     from utils.notification_views import (
-        NotificationServiceButton, NotificationSourceButton, NotificationReportButton,
         NotifReviewClaimButton, NotifReviewPreviewButton, NotifReviewDecisionButton,
     )
     from modules.configs.tickets_panel_config import (
@@ -178,11 +177,9 @@ def _dynamic_item_cases():
         (TicketPermRoleSelect, ("p_ab12cd", "c_ab12cd")),
         (TicketPermSelect, ("p_ab12cd", "c_ab12cd", _SNOWFLAKE)),
         (TicketPermButton, ("clear", "p_ab12cd", "c_ab12cd", _SNOWFLAKE)),
-        # Notifications — the attribution row carried by every DM, keyed by the
-        # notification uuid, and the staff review panel, keyed by the report's.
-        (NotificationServiceButton, (_U,)),
-        (NotificationSourceButton, (_U,)),
-        (NotificationReportButton, (_U,)),
+        # Notifications — the staff review panel, keyed by the report uuid.
+        # A member's DM carries no button at all: its origin is one greyed
+        # `sent by` line (see notifications/render.py).
         (NotifReviewClaimButton, (_U,)),
         (NotifReviewPreviewButton, (_U,)),
         (NotifReviewDecisionButton, ("accept", _U)),

--- a/utils/emojis.py
+++ b/utils/emojis.py
@@ -52,6 +52,9 @@ USER = "<:user:1519798911517196511>"
 DEV = "<:dev:1398729645557285066>"
 MODDY = "<:ModdyIcon:1517239367184285909>"
 MODDY_SQUARE = "<:ModdyIconCarre:1517239121322578090>"  # rounded-square variant
+# Smaller rounded-square variant — the one to use when the logo sits inline in
+# a line of text or as a title icon, where the full-size mark reads as oversized.
+MODDY_SQUARE_MIN = "<:ModdyIconCarreMin:1517240474916880556>"
 MODDY_ALT = "<:moddy:1451280939412881508>"
 BLACKLIST = "<:blacklist:1519797375470669944>"
 TIME = "<:time:1519798202990330087>"
@@ -219,6 +222,7 @@ EMOJIS = {
     # Bot
     "moddy": MODDY,
     "moddy_square": MODDY_SQUARE,
+    "moddy_square_min": MODDY_SQUARE_MIN,
     "developer": DEV,
     "staff": STAFF,
     "ping": SUPPORT,

--- a/utils/notification_views.py
+++ b/utils/notification_views.py
@@ -1,27 +1,22 @@
 """
-Notification UI — attribution buttons, abuse reports, and the staff review.
+Notification UI — the staff side of abuse reports.
 
-Every DM Moddy sends carries, at the bottom, one small row that answers "where
-does this come from and what do I do about it":
+Every DM Moddy sends closes with one greyed line naming its origin
+(``-# Sent by [**Server**](link) (`id`)``) — that line is built in
+``notifications/render.py`` and appended by the service; there are no
+attribution buttons on a member's DM.
 
-``[ <service> ] [ <server> ] [ 🚩 ]``
-
-The first two open an ephemeral panel identifying the sender (with the server's
-icon, its verification badge, a link into it, and the notification's uuid); the
-red flag opens the report Modal V2. Official Moddy messages (a suspension, a
-leaked-token alert) carry **no** row at all, and messages whose wording is
-Moddy's own show the flag greyed out — the panel then explains why.
-
-Staff side: a report is posted to ``MODDY_NOTIF_REPORT_CHANNEL_ID`` as a review
-panel (Claim / See the message / Accept / Refuse) and every step is mirrored to
+What lives here is what staff act on: the review panel posted to
+``MODDY_NOTIF_REPORT_CHANNEL_ID`` when a report is filed (Claim / See the
+message / Accept / Decline), the decision modal, and the log card mirrored to
 ``MODDY_NOTIF_REPORT_LOG_CHANNEL_ID``.
 
 Persistence
 -----------
 Every button is a :class:`discord.ui.DynamicItem` whose ``custom_id`` carries
-the notification (or report) uuid, registered through
-:class:`NotificationsPersistence` — a DM sent today must still be reportable
-after next week's deploy. Modals are one-shot, per the documented exclusion.
+the report uuid, registered through :class:`NotificationsPersistence` — a
+report opened today must still be decidable after next week's deploy. Modals
+are one-shot, per the documented exclusion.
 """
 
 from __future__ import annotations
@@ -35,11 +30,11 @@ from discord import ui
 
 from cogs.error_handler import BaseView, BaseModal
 from notifications.models import NotificationContent, ReportStatus
-from notifications.render import build_content_view, source_button_emoji
+from notifications.render import build_content_view
 from utils.components_v2 import create_error_message
 from utils.emojis import (
-    DONE, FLAG, GROUPS, HAND, LEGAL, MESSAGE, MODDY, NOTE, PENDING,
-    SNOWFLAKE, TIME, UNDONE, USER, WARNING,
+    DONE, FLAG, GROUPS, HAND, LEGAL, MESSAGE, MODDY_SQUARE_MIN, NOTE, PENDING,
+    SNOWFLAKE, TIME, UNDONE, USER,
 )
 from utils.i18n import i18n, t
 
@@ -99,423 +94,6 @@ def _excerpt(content: NotificationContent, variables: Dict[str, Any], limit: int
 
 
 # =========================================================================== #
-# Attribution row
-# =========================================================================== #
-
-def build_attribution_row(
-    notification_id: str, ctx: Dict[str, Any], *, locale: str = "en-US"
-) -> Optional[ui.ActionRow]:
-    """The row appended under every non-official notification.
-
-    Order is fixed so it reads the same everywhere: the Moddy service that
-    acted, then the server it acted for, then the flag. A source with neither
-    service nor server (which should not happen) gets no row rather than an
-    empty one.
-    """
-    service_name = ctx.get("service_name")
-    guild_name = ctx.get("guild_name")
-    if not service_name and not guild_name:
-        return None
-
-    row = ui.ActionRow()
-
-    if service_name:
-        row.add_item(NotificationServiceButton(
-            notification_id, label=service_name,
-            emoji=ctx.get("service_emoji") or MODDY,
-        ))
-
-    if guild_name:
-        row.add_item(NotificationSourceButton(
-            notification_id, label=guild_name,
-            emoji=source_button_emoji(ctx),
-        ))
-
-    row.add_item(NotificationReportButton(
-        notification_id, disabled=not ctx.get("reportable"),
-    ))
-
-    return row
-
-
-def attach_attribution(
-    view: ui.LayoutView, notification_id: str, ctx: Dict[str, Any], *, locale: str = "en-US"
-) -> ui.LayoutView:
-    """Append the attribution row to an already-built view, in place."""
-    row = build_attribution_row(notification_id, ctx, locale=locale)
-    if row is not None:
-        view.add_item(row)
-    return view
-
-
-# =========================================================================== #
-# Panels
-# =========================================================================== #
-
-def build_source_panel(
-    *, notification_id: str, ctx: Dict[str, Any], created_at=None, locale: str = "en-US"
-) -> BaseView:
-    """The ephemeral card behind the *server* attribution button.
-
-    Answers, in this order: which server, is it trustworthy, how do I get
-    there, which notification is this exactly, and where do I go if something
-    is wrong.
-    """
-    view = BaseView()
-    container = ui.Container(accent_colour=discord.Colour(0x3661FF))
-
-    name = ctx.get("guild_name") or t("notifications.attribution.unknown_guild", locale=locale)
-    badge = ctx.get("badge") or ""
-    container.add_item(ui.TextDisplay(
-        f"### {GROUPS} {t('notifications.source.title', locale=locale)}"
-    ))
-    container.add_item(ui.TextDisplay(
-        f"{t('notifications.source.guild_label', locale=locale)} **{name}**{badge}"
-    ))
-
-    lines = []
-    if ctx.get("guild_id"):
-        lines.append(f"{SNOWFLAKE} {t('notifications.source.id_label', locale=locale)} "
-                     f"`{ctx['guild_id']}`")
-    if ctx.get("guild_member_count") is not None:
-        lines.append(f"{USER} {t('notifications.source.members', locale=locale)} "
-                     f"`{ctx['guild_member_count']}`")
-    if ctx.get("guild_created_at") is not None:
-        lines.append(f"{TIME} {t('notifications.source.created', locale=locale)} "
-                     f"<t:{int(ctx['guild_created_at'].timestamp())}:D>")
-    if lines:
-        container.add_item(ui.TextDisplay("\n".join(lines)))
-
-    if ctx.get("official"):
-        container.add_item(ui.TextDisplay(
-            f"{MODDY} **{t('notifications.source.official', locale=locale)}**"))
-    elif ctx.get("verified"):
-        container.add_item(ui.TextDisplay(
-            f"{DONE} **{t('notifications.source.verified', locale=locale)}**"))
-
-    if ctx.get("service_name"):
-        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
-        container.add_item(ui.TextDisplay(
-            f"{ctx.get('service_emoji') or MODDY} "
-            f"{t('notifications.source.service_label', locale=locale)} "
-            f"**{ctx['service_name']}**"
-        ))
-
-    block = ctx.get("report_block")
-    if block:
-        container.add_item(ui.TextDisplay(
-            f"-# {WARNING} {t(f'notifications.source.not_reportable.{block}', locale=locale)}"
-        ))
-
-    container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
-    container.add_item(ui.TextDisplay(_identity_lines(
-        notification_id, created_at=created_at, locale=locale)))
-
-    view.add_item(container)
-
-    if ctx.get("guild_id"):
-        row = ui.ActionRow()
-        row.add_item(ui.Button(
-            label=_short(t("notifications.source.open_server", locale=locale)),
-            url=GUILD_URL.format(guild_id=ctx["guild_id"]),
-            style=discord.ButtonStyle.link,
-        ))
-        view.add_item(row)
-
-    return view
-
-
-def build_service_panel(
-    *, notification_id: str, ctx: Dict[str, Any], created_at=None, locale: str = "en-US"
-) -> BaseView:
-    """The ephemeral card behind the *service* attribution button."""
-    view = BaseView()
-    container = ui.Container(accent_colour=discord.Colour(0x3661FF))
-    emoji = ctx.get("service_emoji") or MODDY
-    name = ctx.get("service_name") or t("notifications.services.moddy", locale=locale)
-
-    container.add_item(ui.TextDisplay(
-        f"### {emoji} {t('notifications.service.title', locale=locale)}"))
-    container.add_item(ui.TextDisplay(
-        f"{t('notifications.source.service_label', locale=locale)} **{name}**"))
-    container.add_item(ui.TextDisplay(
-        t("notifications.service.description", locale=locale)))
-
-    if ctx.get("guild_name"):
-        container.add_item(ui.TextDisplay(
-            f"{GROUPS} {t('notifications.source.guild_label', locale=locale)} "
-            f"**{ctx['guild_name']}**{ctx.get('badge') or ''}"
-        ))
-
-    container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
-    container.add_item(ui.TextDisplay(_identity_lines(
-        notification_id, created_at=created_at, locale=locale)))
-    view.add_item(container)
-    return view
-
-
-def _identity_lines(notification_id: str, *, created_at=None, locale: str = "en-US") -> str:
-    """The uuid + support footer shared by both attribution panels."""
-    lines = [f"-# {t('notifications.source.uuid_label', locale=locale)} `{notification_id}`"]
-    if created_at is not None:
-        lines.append(f"-# {t('notifications.source.sent_at', locale=locale)} "
-                     f"<t:{int(created_at.timestamp())}:f>")
-    lines.append(f"-# {t('notifications.source.support_hint', locale=locale, url=SUPPORT_URL)}")
-    return "\n".join(lines)
-
-
-# =========================================================================== #
-# Attribution buttons (persistent)
-# =========================================================================== #
-
-class NotificationServiceButton(
-    ui.DynamicItem[ui.Button],
-    template=rf"moddy:notif:svc:(?P<notification>{_UUID})",
-):
-    """Opens the *service* identity panel. Public: anyone who sees the message."""
-
-    def __init__(self, notification_id: str, *, label: str = "Moddy", emoji: str = MODDY):
-        super().__init__(ui.Button(
-            label=_short(label),
-            style=discord.ButtonStyle.secondary,
-            emoji=discord.PartialEmoji.from_str(emoji) if emoji else None,
-            custom_id=f"moddy:notif:svc:{notification_id}",
-        ))
-        self.notification_id = str(notification_id)
-
-    @classmethod
-    async def from_custom_id(cls, interaction, item, match: re.Match):
-        return cls(match["notification"])
-
-    @_guarded
-    async def callback(self, interaction: discord.Interaction):
-        await _open_attribution_panel(interaction, self.notification_id, service=True)
-
-
-class NotificationSourceButton(
-    ui.DynamicItem[ui.Button],
-    template=rf"moddy:notif:src:(?P<notification>{_UUID})",
-):
-    """Opens the *server* identity panel. Public: anyone who sees the message."""
-
-    def __init__(self, notification_id: str, *, label: str = "Server", emoji: str = GROUPS):
-        super().__init__(ui.Button(
-            label=_short(label),
-            style=discord.ButtonStyle.secondary,
-            emoji=discord.PartialEmoji.from_str(emoji) if emoji else None,
-            custom_id=f"moddy:notif:src:{notification_id}",
-        ))
-        self.notification_id = str(notification_id)
-
-    @classmethod
-    async def from_custom_id(cls, interaction, item, match: re.Match):
-        return cls(match["notification"])
-
-    @_guarded
-    async def callback(self, interaction: discord.Interaction):
-        await _open_attribution_panel(interaction, self.notification_id, service=False)
-
-
-async def _open_attribution_panel(
-    interaction: discord.Interaction, notification_id: str, *, service: bool
-) -> None:
-    """Shared body of both attribution buttons.
-
-    Everything is re-derived from the interaction and the database: after a
-    restart ``self`` carries nothing but the uuid in the custom_id.
-    """
-    locale = i18n.get_user_locale(interaction)
-    bot = interaction.client
-    notifications = getattr(bot, "notifications", None)
-    record = await notifications.get(notification_id) if notifications else None
-
-    if not record:
-        await interaction.response.send_message(view=create_error_message(
-            t("notifications.errors.unknown.title", locale=locale),
-            t("notifications.errors.unknown.description", locale=locale,
-              uuid=notification_id),
-        ), ephemeral=True)
-        return
-
-    ctx = await notifications.source_context(record, locale=locale)
-    builder = build_service_panel if service else build_source_panel
-    await interaction.response.send_message(
-        view=builder(notification_id=str(record["id"]), ctx=ctx,
-                     created_at=record.get("created_at"), locale=locale),
-        ephemeral=True,
-    )
-
-
-class NotificationReportButton(
-    ui.DynamicItem[ui.Button],
-    template=rf"moddy:notif:flag:(?P<notification>{_UUID})",
-):
-    """The red flag. Auth: the recipient of the notification, and only them."""
-
-    def __init__(self, notification_id: str, *, disabled: bool = False):
-        super().__init__(ui.Button(
-            style=discord.ButtonStyle.danger,
-            emoji=discord.PartialEmoji.from_str(FLAG),
-            custom_id=f"moddy:notif:flag:{notification_id}",
-            disabled=disabled,
-        ))
-        self.notification_id = str(notification_id)
-
-    @classmethod
-    async def from_custom_id(cls, interaction, item, match: re.Match):
-        return cls(match["notification"])
-
-    @_guarded
-    async def callback(self, interaction: discord.Interaction):
-        locale = i18n.get_user_locale(interaction)
-        bot = interaction.client
-        notifications = getattr(bot, "notifications", None)
-        record = await notifications.get(self.notification_id) if notifications else None
-
-        if not record:
-            await interaction.response.send_message(view=create_error_message(
-                t("notifications.errors.unknown.title", locale=locale),
-                t("notifications.errors.unknown.description", locale=locale,
-                  uuid=self.notification_id),
-            ), ephemeral=True)
-            return
-
-        # Re-check reportability on every click: a server can be marked
-        # official long after its DM went out.
-        ctx = await notifications.source_context(record, locale=locale)
-        if not ctx.get("reportable"):
-            block = ctx.get("report_block") or "moddy_authored"
-            await interaction.response.send_message(view=create_error_message(
-                t("notifications.report.errors.not_reportable.title", locale=locale),
-                t(f"notifications.source.not_reportable.{block}", locale=locale),
-            ), ephemeral=True)
-            return
-
-        if not await notifications.may_report(record, interaction):
-            await interaction.response.send_message(view=create_error_message(
-                t("notifications.report.errors.not_recipient.title", locale=locale),
-                t("notifications.report.errors.not_recipient.description", locale=locale),
-            ), ephemeral=True)
-            return
-
-        existing = await notifications.existing_report(record["id"], interaction.user.id)
-        if existing:
-            await interaction.response.send_message(
-                view=build_report_status_panel(existing, locale=locale), ephemeral=True)
-            return
-
-        await interaction.response.send_modal(
-            NotificationReportModal(record=record, ctx=ctx, locale=locale))
-
-
-# =========================================================================== #
-# Report modal
-# =========================================================================== #
-
-class NotificationReportModal(BaseModal):
-    """Why is this DM abusive — plus an explicit "this is a real report" tick.
-
-    The recap block matters: a member who has scrolled past ten DMs must see
-    which one they are about to report before typing anything.
-    """
-
-    def __init__(self, *, record: Dict[str, Any], ctx: Dict[str, Any], locale: str = "en-US"):
-        super().__init__(title=_short(t("notifications.report.modal.title", locale=locale), 45))
-        self.record = record
-        self.locale = locale
-
-        content = NotificationContent.from_dict(record.get("content") or {})
-        source_name = ctx.get("guild_name") or ctx.get("service_name") or "Moddy"
-        recap = t(
-            "notifications.report.modal.recap", locale=locale,
-            source=source_name,
-            uuid=str(record["id"]),
-            excerpt=_excerpt(content, record.get("variables") or {}),
-        )
-        self.add_item(ui.TextDisplay(recap[:4000]))
-
-        self.reason = ui.Label(
-            text=_short(t("notifications.report.modal.reason.label", locale=locale), 45),
-            description=_short(
-                t("notifications.report.modal.reason.description", locale=locale), 100),
-            component=ui.TextInput(
-                style=discord.TextStyle.paragraph,
-                placeholder=_short(
-                    t("notifications.report.modal.reason.placeholder", locale=locale), 100),
-                min_length=15,
-                max_length=1000,
-                required=True,
-            ),
-        )
-        self.add_item(self.reason)
-
-        self.confirm = ui.Label(
-            text=_short(t("notifications.report.modal.confirm.label", locale=locale), 45),
-            component=ui.CheckboxGroup(
-                options=[discord.CheckboxGroupOption(
-                    label=_short(
-                        t("notifications.report.modal.confirm.option", locale=locale), 100),
-                    value="confirm",
-                )],
-                min_values=1,
-                max_values=1,
-                required=True,
-            ),
-        )
-        self.add_item(self.confirm)
-
-    async def on_submit(self, interaction: discord.Interaction):
-        await interaction.response.defer(ephemeral=True, thinking=True)
-        notifications = getattr(interaction.client, "notifications", None)
-        report = await notifications.open_report(
-            notification_id=self.record["id"],
-            reporter=interaction.user,
-            reason=self.reason.component.value or "",
-            locale=self.locale,
-        )
-        if report is None:
-            await interaction.followup.send(view=create_error_message(
-                t("notifications.report.errors.failed.title", locale=self.locale),
-                t("notifications.report.errors.failed.description", locale=self.locale),
-            ), ephemeral=True)
-            return
-
-        await interaction.followup.send(
-            view=build_report_status_panel(report, locale=self.locale, just_sent=True),
-            ephemeral=True,
-        )
-
-
-def build_report_status_panel(
-    report: Dict[str, Any], *, locale: str = "en-US", just_sent: bool = False
-) -> BaseView:
-    """What the reporter sees: their report's reference and where it stands."""
-    view = BaseView()
-    status = report.get("status") or ReportStatus.PENDING.value
-    container = ui.Container(accent_colour=discord.Colour(
-        _REVIEW_ACCENT.get(status, 0x3661FF)))
-
-    key = "sent" if just_sent else "already"
-    container.add_item(ui.TextDisplay(
-        f"### {DONE if just_sent else _STATUS_EMOJI.get(status, PENDING)} "
-        f"{t(f'notifications.report.{key}.title', locale=locale)}"))
-    container.add_item(ui.TextDisplay(
-        t(f"notifications.report.{key}.description", locale=locale)))
-    container.add_item(ui.TextDisplay(
-        f"{_STATUS_EMOJI.get(status, PENDING)} "
-        f"{t('notifications.report.status_label', locale=locale)} "
-        f"**{t(f'notifications.report.status.{status}', locale=locale)}**"))
-    if report.get("decision_note"):
-        container.add_item(ui.TextDisplay(
-            f"-# {t('notifications.report.decision_note', locale=locale)} "
-            f"{_short(report['decision_note'], 300)}"))
-    container.add_item(ui.TextDisplay(
-        f"-# {t('notifications.report.reference', locale=locale)} `{report['id']}`"))
-    view.add_item(container)
-    return view
-
-
-# =========================================================================== #
 # Staff review panel
 # =========================================================================== #
 
@@ -554,7 +132,7 @@ def build_review_panel(
         + (f" (`{ctx['guild_id']}`)" if ctx.get("guild_id") else ""),
     ]
     if ctx.get("service_name"):
-        details.append(f"{ctx.get('service_emoji') or MODDY} "
+        details.append(f"{ctx.get('service_emoji') or MODDY_SQUARE_MIN} "
                        f"**{t('notifications.review.service', locale=locale)}** "
                        f"{ctx['service_name']}")
     if record.get("recipient_id"):
@@ -640,7 +218,7 @@ def build_report_log(
         lines.append(f"{GROUPS} **{t('notifications.review.source', locale=locale)}** "
                      f"`{record['source_guild_id']}`")
     if record.get("source_service"):
-        lines.append(f"{MODDY} **{t('notifications.review.service', locale=locale)}** "
+        lines.append(f"{MODDY_SQUARE_MIN} **{t('notifications.review.service', locale=locale)}** "
                      f"`{record['source_service']}`")
     if report.get("decision_note"):
         lines.append(f"{MESSAGE} **{t('notifications.review.note', locale=locale)}** "
@@ -865,16 +443,13 @@ class NotifDecisionModal(BaseModal):
 # =========================================================================== #
 
 class NotificationsPersistence(BaseView):
-    """Marker view: registers every notification dynamic item at startup."""
+    """Marker view: registers the report review buttons at startup."""
 
     __persistent__ = True
 
     @classmethod
     def register_persistent(cls, bot) -> None:
         bot.add_dynamic_items(
-            NotificationServiceButton,
-            NotificationSourceButton,
-            NotificationReportButton,
             NotifReviewClaimButton,
             NotifReviewPreviewButton,
             NotifReviewDecisionButton,


### PR DESCRIPTION
## Summary

Follow-up to the centralized notification system merged in #354. Two changes on top of it, requested after review:

- **Replace the attribution buttons with a `sent by` line.** Every DM now closes with one greyed line naming its origin — `-# Sent by [**Server**](link) (`id`)`, the same shape the sanction DMs have used all along, now on everything Moddy sends. The identity buttons and the ephemeral panel behind them are gone: a Discord button can only carry an emoji, never a server icon, and one line says what a member actually needs. The verification check follows the name when the server carries one. Plain text also means a failed database write now costs the stored record, never the attribution — the line is built from the source itself.
- **Document the notifications ↔ backend contract** (`docs/NOTIFICATIONS_INTEGRATION.md`): which tables the backend reads vs. owns, exact payload rendering so a mail/dashboard card says what the Discord DM said, and the placeholder-substitution algorithm the backend must match character for character.

## Notable details

- Cards that already printed their own `sent_by` line (manual sanction DM, automod sanction DM, expiry DM) pass `attribution=False` instead of printing it twice.
- Hardened `resolve_source_context`: it runs on the delivery path, so a guild/attribute lookup that raises now degrades the badge instead of killing the DM (caught by a rebased AltGuard test).
- Reporting loses its Discord entry point along with the flag button. The pipeline behind it (`notification_reports`, staff review panel, outcome DM, `reportable` computed and frozen per row) is intentionally kept — reachable via `NotificationService.open_report()` — since the natural new trigger is a dashboard control and everything downstream already works. Flagged as a known gap in the session log and the integration doc.
- Switched the Moddy mark used by the system to the inline-sized `<:ModdyIconCarreMin:1517240474916880556>`.
- Pruned ~19×5 locale keys that belonged to the removed buttons/panels/modal.
- Rebased onto latest `main` (this branch's first commit was already merged as #354); one conflict in `services/expiration_notifier.py` against #352's async `guild_locale` change, resolved by reusing the already-awaited `locale` local instead of the stale sync call.

## Test plan

- [x] `pytest tests/` — 1261 passed, 1 skipped (no fastapi)
- [x] Manually rendered the four DM shapes (plain server / verified server / service-only / official notice) to confirm the line text and placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQTM52w62RGewgPDkvS6DR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQTM52w62RGewgPDkvS6DR)_