### PR TITLE
Add Health Monitor heartbeat integration (dead man's switch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,7 @@ moddy/
 │   ├── precedent_service.py   #   Automod server precedents (record + serve, RAG)
 │   ├── ticket_service.py      #   Ticket lifecycle (open/close/escalate/move/participants)
 │   ├── transcription_service.py #  Voice/audio speech-to-text (shared by cog + module)
+│   ├── heartbeat.py           #   Moddy Health Monitor heartbeat (dead man's switch)
 │   └── railway_diagnostic.py  #   Railway diagnostics
 │
 ├── internal_api/              # FastAPI internal API
@@ -260,7 +261,8 @@ moddy/
     ├── test_transcription.py  #   Voice transcription helpers, guard rails, cards
     ├── test_notifications.py  #   Notifications: hashing, attribution, report rules, i18n
     ├── test_logs.py           #   Server logs: registry, routing, rendering, delivery
-    └── test_logs_i18n.py      #   Server logs: i18n completeness on the 5 locales
+    ├── test_logs_i18n.py      #   Server logs: i18n completeness on the 5 locales
+    └── test_heartbeat.py      #   Health Monitor heartbeat: payload, lifecycle, status decisions
 ```
 
 ---
@@ -456,6 +458,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/MODERATION_CASES.md](docs/MODERATION_CASES.md) | Moderation cases/sanctions, the case service & sources, auto-sync |
 | [docs/GLOBAL_SANCTIONS.md](docs/GLOBAL_SANCTIONS.md) | **Global sanctions** — Moddy-team warn / limited / suspended, on users *and* servers |
 | [docs/TECHNICAL_LOGS.md](docs/TECHNICAL_LOGS.md) | Internal technical staff logs (webhook-based, per-event channels) |
+| [docs/HEALTH_MONITOR.md](docs/HEALTH_MONITOR.md) | **Health Monitor heartbeat** — dead man's switch push to `moddy-health-monitor`, `HM_URL`/`HM_INGEST_TOKEN` |
 | [docs/DATABASE.md](docs/DATABASE.md) | Database schema, queries, repository pattern |
 
 ### Infrastructure

--- a/bot.py
+++ b/bot.py
@@ -15,6 +15,8 @@ from pathlib import Path
 import traceback
 import aiohttp
 
+import math
+
 from config import (
     DEBUG,
     DEFAULT_PREFIX,
@@ -28,6 +30,8 @@ from config import (
     IS_MAINTENANCE,
     DEV_ALLOWED_IDS,
     ENV_MODE,
+    HM_URL,
+    HM_INGEST_TOKEN,
 )
 from utils.emojis import EMOJIS, ERROR as ERROR_EMOJI
 
@@ -137,6 +141,15 @@ class ModdyBot(ModdyFrameworkBot):
         self.notifications = NotificationService(self)
         from gateway import Gateway
         self.gateway = Gateway()
+        from services.heartbeat import HeartbeatClient
+        # Dead man's switch push to the Moddy Health Monitor (docs/HEALTH_MONITOR.md).
+        # Started in on_ready (a bot that was never ready has nothing to report).
+        self.heartbeat = HeartbeatClient(
+            "moddy-bot",
+            url=HM_URL,
+            token=HM_INGEST_TOKEN,
+            build=self._build_heartbeat_checks,
+        )
         self.redis = None  # Redis client (shared with backend)
         self._dev_team_ids: Set[int] = set()
         self.maintenance_mode = False
@@ -946,6 +959,7 @@ class ModdyBot(ModdyFrameworkBot):
 
         # Fetch bot version from GitHub
         await self.fetch_version()
+        self.heartbeat.version = self.version or "0.0.0"
 
         # Configure error handler for slash commands
         self.tree.on_error = self.on_app_command_error
@@ -1607,6 +1621,50 @@ class ModdyBot(ModdyFrameworkBot):
         # Run startup health checks
         await self.run_startup_checks()
 
+        # Start the Health Monitor heartbeat. Only from here on: an event
+        # loop with a dead gateway connection has nothing worth reporting.
+        self.heartbeat.start()
+
+    async def _build_heartbeat_checks(self) -> dict:
+        """Build the ``checks``/``status`` the heartbeat reports for this bot.
+
+        An event loop that is alive but whose gateway connection is dead must
+        never report ``ok`` — that is the exact failure mode a dead man's
+        switch exists to catch. ``bot.latency`` is ``nan`` until the gateway
+        has answered at least once.
+        """
+        ready = bool(self.is_ready())
+        latency_ms = round(self.latency * 1000) if math.isfinite(self.latency) else None
+
+        shards = getattr(self, "shards", None) or {}
+        if shards:
+            total = len(shards)
+            connected = len([s for s in shards.values() if not s.is_closed()])
+        else:
+            # Not sharded: one virtual shard, up iff the gateway is ready.
+            total = 1
+            connected = int(ready)
+
+        if not ready:
+            status = "down"
+        elif connected < total:
+            status = "degraded"
+        else:
+            status = "ok"
+
+        return {
+            "status": status,
+            "checks": {
+                "is_ready": {"ok": ready},
+                "discord_gateway": {"ok": ready, "latency_ms": latency_ms},
+                "shards": {"ok": connected == total, "connected": connected, "total": total},
+            },
+            "meta": {
+                "shards": f"{connected}/{total}",
+                "guilds": len(self.guilds),
+            },
+        }
+
     async def run_startup_checks(self):
         """Run comprehensive startup health checks on all systems."""
         logger.info("Running startup health checks...")
@@ -2254,6 +2312,9 @@ class ModdyBot(ModdyFrameworkBot):
 
         # Stop API gateway (flushes log buffer)
         await self.gateway.stop()
+
+        # Stop the Health Monitor heartbeat
+        await self.heartbeat.stop()
 
         # Close the AltGuard HTTP session
         try:

--- a/config.py
+++ b/config.py
@@ -105,6 +105,18 @@ ALTGUARD_API_URL: str = os.environ.get(
 ALTGUARD_BOT_TOKEN: str = os.environ.get("ALTGUARD_BOT_TOKEN", "")
 
 # =============================================================================
+# MODDY HEALTH MONITOR (dead man's switch — see docs/HEALTH_MONITOR.md)
+# =============================================================================
+# The bot pushes a heartbeat every 20s; the monitor never polls it. Either
+# variable missing disables the heartbeat with a warning, never a crash.
+
+# Base URL of the health monitor, no trailing slash - Variable Railway: HM_URL
+HM_URL: str = os.environ.get("HM_URL", "").rstrip("/")
+
+# Shared secret sent as `X-Health-Token` - Variable Railway: HM_INGEST_TOKEN
+HM_INGEST_TOKEN: str = os.environ.get("HM_INGEST_TOKEN", "")
+
+# =============================================================================
 # TECHNICAL LOGS (internal staff webhooks)
 # =============================================================================
 # Internal technical logs are NOT sent by the bot itself but through Discord

--- a/docs/HEALTH_MONITOR.md
+++ b/docs/HEALTH_MONITOR.md
@@ -1,0 +1,86 @@
+# Health Monitor Heartbeat
+
+The `moddy-health-monitor` service watches the whole Moddy ecosystem as a
+**dead man's switch**: it never polls a service for its state — each service
+pushes its own state every 20 seconds, and silence *is* the signal. Three
+missed heartbeats (60s TTL) and the service is considered down.
+
+This document covers the bot's side of that contract only. It is an isolated
+addition and changes nothing about existing bot behavior.
+
+## Contract
+
+```
+POST https://<monitor>/ingest/heartbeat
+X-Health-Token: <HM_INGEST_TOKEN>
+Content-Type: application/json
+```
+
+```json
+{
+  "service": "moddy-bot",
+  "status": "ok",
+  "version": "v1.4.2",
+  "uptime_s": 84213,
+  "checks": {
+    "is_ready": { "ok": true },
+    "discord_gateway": { "ok": true, "latency_ms": 42 },
+    "shards": { "ok": true, "connected": 1, "total": 1 }
+  },
+  "meta": { "shards": "1/1", "guilds": 512 }
+}
+```
+
+Response: `{"ok": true, "received_at": "...", "incident_active": false}`.
+Error codes: `401` missing/invalid token, `503` monitor misconfigured, `422`
+invalid body.
+
+The monitor has no per-service logic: it never interprets `checks` keys, it
+only renders them. The service alone decides what its own dependencies mean —
+for the bot, an event loop that is alive but whose gateway connection is dead
+must **never** report `ok`.
+
+## Implementation
+
+- `services/heartbeat.py` — `HeartbeatClient`: a fire-and-forget background
+  task (`asyncio.create_task`), 5s timeout per request, 20s interval. A
+  failure only logs; the loop never stops itself, never retries aggressively,
+  and never blocks anything else. `start()` is a no-op (with a warning) when
+  `HM_URL` or `HM_INGEST_TOKEN` is not configured.
+- `bot.py`:
+  - `ModdyBot.__init__` constructs `self.heartbeat = HeartbeatClient("moddy-bot", ...)`
+    with `build=self._build_heartbeat_checks`.
+  - `setup_hook()` sets `self.heartbeat.version` once `fetch_version()` resolves.
+  - `on_ready()` calls `self.heartbeat.start()` **after** `run_startup_checks()`
+    — a bot that has never been ready has nothing to report.
+  - `close()` calls `await self.heartbeat.stop()` alongside the other shutdown
+    steps.
+  - `ModdyBot._build_heartbeat_checks()` builds the payload: `is_ready`,
+    `discord_gateway` (latency, `None` while `bot.latency` is `nan`), and
+    `shards` (the bot is not sharded, so this is always `1/1` when ready).
+    Not ready → `down`; a shard down → `degraded`; otherwise `ok`.
+
+## Environment variables
+
+```env
+HM_URL=https://<monitor>            # no trailing slash
+HM_INGEST_TOKEN=<shared secret>     # identical across every monitored service
+```
+
+Either missing disables the heartbeat cleanly with a `logger.warning` — never
+a crash, never a delayed startup. See [RAILWAY.md](RAILWAY.md).
+
+## `incident_active`
+
+Every heartbeat response sets `self.heartbeat.incident_active`. Nothing in
+the bot currently branches on it — it is exposed for future use (e.g. cutting
+non-critical notifications during an incident), matching the "optional to
+consume" wording of the monitor's integration contract.
+
+## Out of scope here
+
+The bot's role as the Health Monitor's **display channel** (posting/editing
+incident messages via `moddy:hm:notify` / `moddy:hm:notify:ack`, publishing
+`moddy:hm:command`, the sticky status message and its persistent `Refresh`
+button) is a separate, larger piece of work and is not implemented by this
+heartbeat integration.

--- a/docs/RAILWAY.md
+++ b/docs/RAILWAY.md
@@ -100,6 +100,16 @@ AltGuard — sans lui, le bouton de vérification répond « service indisponibl
 Les canaux Redis `altguard:verdict` / `altguard:membership` passent par le Redis
 déjà configuré (`REDIS_URL`), rien à ajouter — voir [ALTGUARD.md](ALTGUARD.md)
 
+### HM_URL
+**Valeur :** URL de base du Moddy Health Monitor, sans slash final (optionnel —
+sans elle, le heartbeat se désactive proprement avec un warning)
+
+### HM_INGEST_TOKEN
+**Valeur :** Secret partagé envoyé en `X-Health-Token` sur
+`POST /ingest/heartbeat` — identique sur tous les services surveillés
+(optionnel, même comportement que `HM_URL` si absent) — voir
+[HEALTH_MONITOR.md](HEALTH_MONITOR.md)
+
 ## Notifications centralisées
 
 Les deux salons vivent dans le serveur de l'équipe Moddy. Défauts dans
@@ -132,6 +142,8 @@ pris en charge, accepté, refusé) est journalisée
 - [ ] `ALTGUARD_API_URL` (optionnel, défaut `https://verify.moddy.app`)
 - [ ] `MODDY_NOTIF_REPORT_CHANNEL_ID` (optionnel, défaut en dur dans `config.py`)
 - [ ] `MODDY_NOTIF_REPORT_LOG_CHANNEL_ID` (optionnel, défaut en dur dans `config.py`)
+- [ ] `HM_URL` (optionnel, désactive le heartbeat si absent)
+- [ ] `HM_INGEST_TOKEN` (optionnel, désactive le heartbeat si absent, identique sur tous les services)
 
 ## Dépannage
 

--- a/docs/sessions/2026-08-24_health-monitor-heartbeat.md
+++ b/docs/sessions/2026-08-24_health-monitor-heartbeat.md
@@ -1,0 +1,72 @@
+# Session: Moddy Health Monitor heartbeat integration
+
+**Date:** 2026-08-24
+**Agent:** Claude Code
+
+## Summary
+
+Wired `moddy-bot` onto the `moddy-health-monitor` dead man's switch: the bot
+now pushes its own state every 20s instead of the monitor ever polling it.
+Isolated addition — nothing about existing bot behavior changes.
+
+What shipped:
+
+- `services/heartbeat.py` — `HeartbeatClient`: fire-and-forget background
+  task (`asyncio.create_task`), 5s per-request timeout, 20s interval. A
+  failed push only logs; it never blocks, never retries aggressively, never
+  keeps the bot from starting or shutting down. Uses `aiohttp` (already a
+  dependency) rather than `httpx`, to match the rest of the codebase
+  (`services/altguard_client.py` and friends).
+- `bot.py`: `self.heartbeat` constructed in `__init__`, version set once
+  `fetch_version()` resolves in `setup_hook()`, started in `on_ready()`
+  (after `run_startup_checks()` — a bot never ready has nothing to report),
+  stopped in `close()`.
+- `ModdyBot._build_heartbeat_checks()` — the bot decides its own status:
+  `is_ready`, `discord_gateway` (latency, `None` while `bot.latency` is
+  `nan`), `shards` (bot is not sharded here, so always `1/1` once ready).
+  Not ready -> `down`; a shard down -> `degraded`; else `ok`.
+- `config.py`: `HM_URL` / `HM_INGEST_TOKEN`, both optional — either missing
+  disables the heartbeat with a `logger.warning`, never a crash.
+- `docs/HEALTH_MONITOR.md` (new) documents the contract and the bot-side
+  wiring; `docs/RAILWAY.md` gets the two new env vars; `CLAUDE.md` project
+  structure + doc index updated.
+- `tests/test_heartbeat.py`: payload defaults/overrides, start()/stop()
+  lifecycle (no-op without config), and the down/degraded/ok decision table
+  for `_build_heartbeat_checks` against a bare stand-in object (no live
+  Discord gateway needed).
+
+## Files modified
+
+- `services/heartbeat.py` (new)
+- `bot.py`
+- `config.py`
+- `docs/HEALTH_MONITOR.md` (new)
+- `docs/RAILWAY.md`
+- `CLAUDE.md`
+- `tests/test_heartbeat.py` (new)
+
+## Decisions made and why
+
+- **aiohttp over httpx**: the brief's sample code used `httpx`, but this repo
+  standardizes on `aiohttp` for every other outbound HTTP client
+  (`services/altguard_client.py`, the gateway adapters). Matching that avoids
+  adding a second HTTP dependency for the same job.
+- **Start in `on_ready`, not `setup_hook`**: the brief calls this out
+  explicitly for the bot ("a bot that has never been ready has nothing to
+  report"), and it lines up with how `status_update`/other tasks already wait
+  on `wait_until_ready()`.
+- **No sharding branch beyond the "not sharded" default**: `ModdyBot` extends
+  `commands.Bot`, not `AutoShardedClient` (confirmed in `moddy/commands.py`),
+  so `shards` is always empty and the checks fall back to the single virtual
+  shard the brief describes for an unsharded process.
+
+## Known issues and follow-ups
+
+- The bot's separate role as the monitor's **display channel** (Redis
+  `moddy:hm:notify`/`:ack`/`:command`, the sticky status message, its
+  persistent `Refresh` button) is explicitly out of scope per the brief and
+  is not implemented — flagged as a separate follow-up in
+  `docs/HEALTH_MONITOR.md`.
+- `HM_URL` / `HM_INGEST_TOKEN` still need to be set in the Railway
+  environment for the heartbeat to actually start; until then it stays
+  silently disabled (by design).

--- a/services/heartbeat.py
+++ b/services/heartbeat.py
@@ -1,0 +1,119 @@
+"""
+Heartbeat to the Moddy Health Monitor (see docs/HEALTH_MONITOR.md).
+
+The monitor never polls a service for its state: each service pushes its own
+state every 20 seconds, and silence *is* the signal (dead man's switch — the
+monitor's TTL is 60s, three missed heartbeats). This client is fire-and-forget
+and must never become part of a critical path: a failed push only logs, the
+loop just tries again on the next interval.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, Dict, Optional
+
+import aiohttp
+
+logger = logging.getLogger("moddy.services.heartbeat")
+
+BuildChecks = Callable[[], Awaitable[Dict[str, Any]]]
+
+
+class HeartbeatClient:
+    """Pushes a periodic heartbeat to the Moddy Health Monitor.
+
+    ``build`` is an optional coroutine returning
+    ``{"status": ..., "checks": {...}, "meta": {...}}`` — the caller decides
+    what its own dependencies mean (a dead vital dependency is ``down``, a
+    dead secondary one is ``degraded``). The monitor itself never interprets
+    ``checks`` keys; it only renders them.
+    """
+
+    def __init__(
+        self,
+        service: str,
+        *,
+        url: str,
+        token: str,
+        version: str = "0.0.0",
+        build: Optional[BuildChecks] = None,
+        interval: int = 20,
+    ) -> None:
+        self.service = service
+        self.url = (url or "").rstrip("/")
+        self.token = token or ""
+        self.version = version
+        self._build = build
+        self._interval = interval
+        self._started = time.monotonic()
+        self._task: Optional[asyncio.Task] = None
+        self._session: Optional[aiohttp.ClientSession] = None
+        # Set from the monitor's response on every heartbeat: lets a service
+        # cut non-critical notifications / heavy background work / aggressive
+        # retries while an incident is active. Purely optional to consume.
+        self.incident_active = False
+
+    def start(self) -> None:
+        """Start the background heartbeat loop. Safe to call once; a no-op
+        (with a warning) when HM_URL or HM_INGEST_TOKEN is not configured."""
+        if self._task is not None:
+            return
+        if not self.url or not self.token:
+            logger.warning(
+                "HM_URL or HM_INGEST_TOKEN missing: heartbeat disabled for %s",
+                self.service,
+            )
+            return
+        self._task = asyncio.create_task(self._loop(), name=f"heartbeat:{self.service}")
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._task = None
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def _payload(self) -> Dict[str, Any]:
+        extra = await self._build() if self._build else {}
+        return {
+            "service": self.service,
+            "status": extra.get("status", "ok"),
+            "version": self.version,
+            "uptime_s": int(time.monotonic() - self._started),
+            "checks": extra.get("checks", {}),
+            "meta": extra.get("meta", {}),
+        }
+
+    async def _loop(self) -> None:
+        timeout = aiohttp.ClientTimeout(total=5)
+        self._session = aiohttp.ClientSession(timeout=timeout)
+        while True:
+            try:
+                payload = await self._payload()
+                async with self._session.post(
+                    f"{self.url}/ingest/heartbeat",
+                    json=payload,
+                    headers={"X-Health-Token": self.token},
+                ) as response:
+                    if response.status < 400:
+                        data = await response.json()
+                        self.incident_active = bool(data.get("incident_active"))
+                    else:
+                        logger.warning(
+                            "Heartbeat rejected for %s (HTTP %s)",
+                            self.service, response.status,
+                        )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Heartbeat failed for %s: %s", self.service, exc)
+            await asyncio.sleep(self._interval)

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,122 @@
+"""Tests for the Moddy Health Monitor heartbeat (see docs/HEALTH_MONITOR.md).
+
+Nothing here talks to the network: ``HeartbeatClient`` is tested on its pure
+payload-building logic and its start()/stop() lifecycle, and the bot's own
+``_build_heartbeat_checks`` is tested against a bare stand-in object so no
+live Discord gateway is required.
+
+    pytest tests/test_heartbeat.py -q
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from services.heartbeat import HeartbeatClient
+
+
+# --------------------------------------------------------------- HeartbeatClient
+
+def test_payload_defaults_without_build():
+    client = HeartbeatClient("moddy-api", url="https://hm.example", token="secret")
+    payload = asyncio.run(client._payload())
+
+    assert payload["service"] == "moddy-api"
+    assert payload["status"] == "ok"
+    assert payload["checks"] == {}
+    assert payload["meta"] == {}
+    assert isinstance(payload["uptime_s"], int)
+
+
+def test_payload_uses_build_output():
+    async def build():
+        return {
+            "status": "degraded",
+            "checks": {"redis": {"ok": False}},
+            "meta": {"workers": 4},
+        }
+
+    client = HeartbeatClient(
+        "moddy-api", url="https://hm.example", token="secret",
+        version="1.4.2", build=build,
+    )
+    payload = asyncio.run(client._payload())
+
+    assert payload["status"] == "degraded"
+    assert payload["version"] == "1.4.2"
+    assert payload["checks"] == {"redis": {"ok": False}}
+    assert payload["meta"] == {"workers": 4}
+
+
+def test_start_is_noop_without_url_or_token():
+    client = HeartbeatClient("moddy-api", url="", token="")
+
+    async def run():
+        client.start()
+        assert client._task is None
+        await client.stop()  # must not raise even though it never started
+
+    asyncio.run(run())
+
+
+def test_start_creates_task_when_configured():
+    async def run():
+        client = HeartbeatClient("moddy-api", url="https://hm.example", token="secret")
+        client.start()
+        assert client._task is not None
+        await client.stop()
+        assert client._task is None
+
+    asyncio.run(run())
+
+
+def test_incident_active_defaults_to_false():
+    client = HeartbeatClient("moddy-api", url="https://hm.example", token="secret")
+    assert client.incident_active is False
+
+
+# --------------------------------------------------------------- bot checks
+
+def _fake_bot(*, ready: bool, latency: float, guild_count: int = 3, shards=None):
+    return SimpleNamespace(
+        is_ready=lambda: ready,
+        latency=latency,
+        shards=shards or {},
+        guilds=[object()] * guild_count,
+    )
+
+
+def test_build_bot_checks_down_when_not_ready():
+    from bot import ModdyBot
+
+    fake = _fake_bot(ready=False, latency=float("nan"))
+    result = asyncio.run(ModdyBot._build_heartbeat_checks(fake))
+
+    assert result["status"] == "down"
+    assert result["checks"]["is_ready"]["ok"] is False
+    assert result["checks"]["discord_gateway"]["latency_ms"] is None
+
+
+def test_build_bot_checks_ok_when_ready():
+    from bot import ModdyBot
+
+    fake = _fake_bot(ready=True, latency=0.042)
+    result = asyncio.run(ModdyBot._build_heartbeat_checks(fake))
+
+    assert result["status"] == "ok"
+    assert result["checks"]["discord_gateway"]["latency_ms"] == 42
+    assert result["checks"]["shards"] == {"ok": True, "connected": 1, "total": 1}
+    assert result["meta"]["guilds"] == 3
+
+
+def test_build_bot_checks_degraded_when_a_shard_is_down():
+    from bot import ModdyBot
+
+    open_shard = SimpleNamespace(is_closed=lambda: False)
+    closed_shard = SimpleNamespace(is_closed=lambda: True)
+    fake = _fake_bot(ready=True, latency=0.01, shards={0: open_shard, 1: closed_shard})
+    result = asyncio.run(ModdyBot._build_heartbeat_checks(fake))
+
+    assert result["status"] == "degraded"
+    assert result["checks"]["shards"] == {"ok": False, "connected": 1, "total": 2}


### PR DESCRIPTION
## Summary

Integrates `moddy-bot` with the `moddy-health-monitor` service as a dead man's switch: the bot now pushes its own health state every 20 seconds instead of the monitor polling it. Silence (three missed heartbeats = 60s TTL) signals a service down. This is an isolated addition with no impact on existing bot behavior.

## Key Changes

- **`services/heartbeat.py` (new)**: `HeartbeatClient` class implementing fire-and-forget background heartbeat pushes
  - 20s interval, 5s per-request timeout via `aiohttp`
  - Optional `build` coroutine for custom health checks
  - `start()` is a no-op (with warning) when `HM_URL` or `HM_INGEST_TOKEN` missing
  - Failed pushes only log; loop never stops or blocks other operations
  - Exposes `incident_active` flag from monitor responses for future use

- **`bot.py`**: Wired heartbeat into bot lifecycle
  - `__init__`: Constructs `self.heartbeat` with `_build_heartbeat_checks` as the build callback
  - `setup_hook()`: Sets heartbeat version once `fetch_version()` resolves
  - `on_ready()`: Starts heartbeat **after** `run_startup_checks()` (a bot never ready has nothing to report)
  - `close()`: Stops heartbeat alongside other shutdown steps
  - `_build_heartbeat_checks()` (new): Builds health payload with three checks:
    - `is_ready`: Bot readiness status
    - `discord_gateway`: Gateway latency (ms) or `None` while `bot.latency` is `nan`
    - `shards`: Connected/total shard count (always 1/1 for unsharded bot when ready)
    - Status logic: `down` if not ready, `degraded` if any shard down, else `ok`

- **`config.py`**: Added two optional environment variables
  - `HM_URL`: Base URL of health monitor (no trailing slash)
  - `HM_INGEST_TOKEN`: Shared secret sent as `X-Health-Token` header

- **`docs/HEALTH_MONITOR.md` (new)**: Complete contract documentation
  - HTTP request/response format
  - Bot-side implementation details
  - Environment variable setup
  - Out-of-scope follow-ups (monitor's display channel role)

- **`docs/RAILWAY.md`**: Added `HM_URL` and `HM_INGEST_TOKEN` to deployment checklist

- **`tests/test_heartbeat.py` (new)**: Comprehensive test coverage
  - Payload defaults and build callback integration
  - `start()`/`stop()` lifecycle (no-op without config)
  - Down/degraded/ok decision table for `_build_heartbeat_checks` against mock bot

- **`CLAUDE.md`**: Updated project structure index to include `heartbeat.py`

## Implementation Notes

- Uses `aiohttp` (already a project dependency) rather than `httpx` to match existing HTTP clients (`services/altguard_client.py`, gateway adapters)
- Heartbeat starts in `on_ready()` rather than `setup_hook()` per brief requirement: a bot that has never been ready has nothing worth reporting
- No sharding logic beyond the "not sharded" default since `ModdyBot` extends `commands.Bot` (not `AutoShardedClient`)
- All environment variables are optional; missing either disables the heartbeat cleanly with a warning, never a crash or startup delay

https://claude.ai/code/session_01FG3kCinrkHeEAiqrX6YRBW