### PR TITLE
Drop the display-channel annex from the heartbeat doc

### DIFF
--- a/docs/HEALTH_MONITOR.md
+++ b/docs/HEALTH_MONITOR.md
@@ -76,11 +76,3 @@ Every heartbeat response sets `self.heartbeat.incident_active`. Nothing in
 the bot currently branches on it — it is exposed for future use (e.g. cutting
 non-critical notifications during an incident), matching the "optional to
 consume" wording of the monitor's integration contract.
-
-## Out of scope here
-
-The bot's role as the Health Monitor's **display channel** (posting/editing
-incident messages via `moddy:hm:notify` / `moddy:hm:notify:ack`, publishing
-`moddy:hm:command`, the sticky status message and its persistent `Refresh`
-button) is a separate, larger piece of work and is not implemented by this
-heartbeat integration.

--- a/docs/sessions/2026-08-24_health-monitor-heartbeat.md
+++ b/docs/sessions/2026-08-24_health-monitor-heartbeat.md
@@ -62,11 +62,6 @@ What shipped:
 
 ## Known issues and follow-ups
 
-- The bot's separate role as the monitor's **display channel** (Redis
-  `moddy:hm:notify`/`:ack`/`:command`, the sticky status message, its
-  persistent `Refresh` button) is explicitly out of scope per the brief and
-  is not implemented — flagged as a separate follow-up in
-  `docs/HEALTH_MONITOR.md`.
 - `HM_URL` / `HM_INGEST_TOKEN` still need to be set in the Railway
   environment for the heartbeat to actually start; until then it stays
   silently disabled (by design).


### PR DESCRIPTION
## Summary

Follow-up to #357 (already merged). Removes the "Out of scope here" section
from `docs/HEALTH_MONITOR.md` and the matching follow-up note in the session
log — the bot's separate role as the Health Monitor's Redis-driven display
channel (incident rendering, sticky message, `Refresh` button) is a distinct
piece of work and doesn't need a placeholder note inside the heartbeat doc.

## Key Changes

- `docs/HEALTH_MONITOR.md`: removed the "Out of scope here" section
- `docs/sessions/2026-08-24_health-monitor-heartbeat.md`: removed the
  matching follow-up bullet

No code changes.

https://claude.ai/code/session_01FG3kCinrkHeEAiqrX6YRBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG3kCinrkHeEAiqrX6YRBW)_