### PR TITLE
Add Better Stack cron/heartbeat monitor ping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,7 @@ moddy/
 │   ├── ticket_service.py      #   Ticket lifecycle (open/close/escalate/move/participants)
 │   ├── transcription_service.py #  Voice/audio speech-to-text (shared by cog + module)
 │   ├── heartbeat.py           #   Moddy Health Monitor heartbeat (dead man's switch)
+│   ├── betterstack_heartbeat.py #  Better Stack cron/heartbeat monitor ping (3 min)
 │   └── railway_diagnostic.py  #   Railway diagnostics
 │
 ├── internal_api/              # FastAPI internal API
@@ -459,7 +460,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/MODERATION_CASES.md](docs/MODERATION_CASES.md) | Moderation cases/sanctions, the case service & sources, auto-sync |
 | [docs/GLOBAL_SANCTIONS.md](docs/GLOBAL_SANCTIONS.md) | **Global sanctions** — Moddy-team warn / limited / suspended, on users *and* servers |
 | [docs/TECHNICAL_LOGS.md](docs/TECHNICAL_LOGS.md) | Internal technical staff logs (webhook-based, per-event channels) |
-| [docs/HEALTH_MONITOR.md](docs/HEALTH_MONITOR.md) | **Health Monitor heartbeat** — dead man's switch push to `moddy-health-monitor`, `HM_URL`/`HM_INGEST_TOKEN` |
+| [docs/HEALTH_MONITOR.md](docs/HEALTH_MONITOR.md) | **Health Monitor heartbeats** — dead man's switch push to `moddy-health-monitor` (`HM_URL`/`HM_INGEST_TOKEN`) and the Better Stack cron ping (`BETTERSTACK_HEARTBEAT_URL`) |
 | [docs/DATABASE.md](docs/DATABASE.md) | Database schema, queries, repository pattern |
 
 ### Infrastructure

--- a/bot.py
+++ b/bot.py
@@ -32,6 +32,7 @@ from config import (
     ENV_MODE,
     HM_URL,
     HM_INGEST_TOKEN,
+    BETTERSTACK_HEARTBEAT_URL,
 )
 from utils.emojis import EMOJIS, ERROR as ERROR_EMOJI
 
@@ -149,6 +150,13 @@ class ModdyBot(ModdyFrameworkBot):
             url=HM_URL,
             token=HM_INGEST_TOKEN,
             build=self._build_heartbeat_checks,
+        )
+        from services.betterstack_heartbeat import BetterStackHeartbeat
+        # Better Stack cron/heartbeat monitor: a plain ping every 3 minutes,
+        # `/fail` when the bot itself thinks it is unhealthy (docs/HEALTH_MONITOR.md).
+        self.betterstack_heartbeat = BetterStackHeartbeat(
+            url=BETTERSTACK_HEARTBEAT_URL,
+            healthy=self._is_bot_healthy,
         )
         self.redis = None  # Redis client (shared with backend)
         self._dev_team_ids: Set[int] = set()
@@ -1624,6 +1632,14 @@ class ModdyBot(ModdyFrameworkBot):
         # Start the Health Monitor heartbeat. Only from here on: an event
         # loop with a dead gateway connection has nothing worth reporting.
         self.heartbeat.start()
+        self.betterstack_heartbeat.start()
+
+    async def _is_bot_healthy(self) -> bool:
+        """Whether the bot is healthy enough to ping the Better Stack
+        heartbeat as a success — reuses the same down/degraded/ok verdict as
+        the Moddy Health Monitor checks so the two never disagree."""
+        checks = await self._build_heartbeat_checks()
+        return checks["status"] == "ok"
 
     async def _build_heartbeat_checks(self) -> dict:
         """Build the ``checks``/``status`` the heartbeat reports for this bot.
@@ -2315,6 +2331,7 @@ class ModdyBot(ModdyFrameworkBot):
 
         # Stop the Health Monitor heartbeat
         await self.heartbeat.stop()
+        await self.betterstack_heartbeat.stop()
 
         # Close the AltGuard HTTP session
         try:

--- a/config.py
+++ b/config.py
@@ -117,6 +117,18 @@ HM_URL: str = os.environ.get("HM_URL", "").rstrip("/")
 HM_INGEST_TOKEN: str = os.environ.get("HM_INGEST_TOKEN", "")
 
 # =============================================================================
+# BETTER STACK HEARTBEAT MONITOR (cron/heartbeat monitor, see docs/HEALTH_MONITOR.md)
+# =============================================================================
+# Separate from the Moddy Health Monitor above: a plain GET every 3 minutes to
+# a secret Better Stack URL means "alive"; GET .../fail reports a failure
+# explicitly. Missing this variable disables the ping with a warning.
+
+# Full secret heartbeat URL from the Better Stack heartbeat detail page,
+# e.g. https://uptime.betterstack.com/api/v1/heartbeat/<TOKEN>
+# Variable Railway: BETTERSTACK_HEARTBEAT_URL
+BETTERSTACK_HEARTBEAT_URL: str = os.environ.get("BETTERSTACK_HEARTBEAT_URL", "").rstrip("/")
+
+# =============================================================================
 # TECHNICAL LOGS (internal staff webhooks)
 # =============================================================================
 # Internal technical logs are NOT sent by the bot itself but through Discord

--- a/docs/HEALTH_MONITOR.md
+++ b/docs/HEALTH_MONITOR.md
@@ -1,14 +1,29 @@
-# Health Monitor Heartbeat
+# Health Monitor Heartbeats
 
-The `moddy-health-monitor` service watches the whole Moddy ecosystem as a
-**dead man's switch**: it never polls a service for its state — each service
-pushes its own state every 20 seconds, and silence *is* the signal. Three
-missed heartbeats (60s TTL) and the service is considered down.
+The bot pushes two independent heartbeats. Neither one polls anything —
+each is the bot proactively saying "I'm alive" on its own schedule, and
+silence is what triggers an alert on the receiving end.
 
-This document covers the bot's side of that contract only. It is an isolated
-addition and changes nothing about existing bot behavior.
+| | Moddy Health Monitor | Better Stack |
+|---|---|---|
+| Purpose | Internal ecosystem dashboard (`moddy-health-monitor`) | External uptime/incident alerting |
+| Interval | 20s | 3 minutes |
+| Transport | `POST .../ingest/heartbeat`, JSON body, `X-Health-Token` | plain `GET` on a secret URL |
+| Client | `services/heartbeat.py` (`HeartbeatClient`) | `services/betterstack_heartbeat.py` (`BetterStackHeartbeat`) |
+| Env vars | `HM_URL`, `HM_INGEST_TOKEN` | `BETTERSTACK_HEARTBEAT_URL` |
 
-## Contract
+Both are isolated additions: fire-and-forget background tasks that never
+block the bot's own startup, shutdown, or request handling, and that disable
+themselves cleanly (with a `logger.warning`) when their env var is missing.
+
+## Moddy Health Monitor
+
+Watches the whole Moddy ecosystem as a **dead man's switch**: it never polls
+a service for its state — each service pushes its own state every 20
+seconds. Three missed heartbeats (60s TTL) and the service is considered
+down.
+
+### Contract
 
 ```
 POST https://<monitor>/ingest/heartbeat
@@ -40,7 +55,7 @@ only renders them. The service alone decides what its own dependencies mean —
 for the bot, an event loop that is alive but whose gateway connection is dead
 must **never** report `ok`.
 
-## Implementation
+### Implementation
 
 - `services/heartbeat.py` — `HeartbeatClient`: a fire-and-forget background
   task (`asyncio.create_task`), 5s timeout per request, 20s interval. A
@@ -60,19 +75,52 @@ must **never** report `ok`.
     `shards` (the bot is not sharded, so this is always `1/1` when ready).
     Not ready → `down`; a shard down → `degraded`; otherwise `ok`.
 
-## Environment variables
-
-```env
-HM_URL=https://<monitor>            # no trailing slash
-HM_INGEST_TOKEN=<shared secret>     # identical across every monitored service
-```
-
-Either missing disables the heartbeat cleanly with a `logger.warning` — never
-a crash, never a delayed startup. See [RAILWAY.md](RAILWAY.md).
-
-## `incident_active`
+### `incident_active`
 
 Every heartbeat response sets `self.heartbeat.incident_active`. Nothing in
 the bot currently branches on it — it is exposed for future use (e.g. cutting
 non-critical notifications during an incident), matching the "optional to
 consume" wording of the monitor's integration contract.
+
+## Better Stack heartbeat monitor
+
+A separate, external cron/heartbeat monitor: Better Stack expects a request
+to a secret URL at least once per configured frequency + grace period, or it
+raises an incident to the on-call team. No JSON body, no token header — the
+URL itself is the secret.
+
+### Contract
+
+```
+GET https://uptime.betterstack.com/api/v1/heartbeat/<TOKEN>        # healthy
+GET https://uptime.betterstack.com/api/v1/heartbeat/<TOKEN>/fail   # explicit failure
+```
+
+### Implementation
+
+- `services/betterstack_heartbeat.py` — `BetterStackHeartbeat`: same
+  fire-and-forget shape as `HeartbeatClient` (background task, 5s timeout,
+  never blocks, never retries aggressively). Every 3 minutes it calls an
+  optional `healthy` coroutine and pings the plain URL when it returns
+  `True`, `/fail` otherwise. With no `healthy` callback every ping reports
+  success.
+- `bot.py`:
+  - `ModdyBot.__init__` constructs `self.betterstack_heartbeat =
+    BetterStackHeartbeat(url=BETTERSTACK_HEARTBEAT_URL, healthy=self._is_bot_healthy)`.
+  - `ModdyBot._is_bot_healthy()` reuses `_build_heartbeat_checks()` and
+    reports healthy iff its `status` is `"ok"` — the two heartbeats never
+    disagree about whether the bot is fine.
+  - Started in `on_ready()` right after `self.heartbeat.start()`, stopped in
+    `close()` right after `self.heartbeat.stop()`.
+
+## Environment variables
+
+```env
+HM_URL=https://<monitor>                                        # no trailing slash
+HM_INGEST_TOKEN=<shared secret>                                 # identical across every monitored service
+BETTERSTACK_HEARTBEAT_URL=https://uptime.betterstack.com/api/v1/heartbeat/<TOKEN>
+```
+
+Any of them missing disables the corresponding heartbeat cleanly with a
+`logger.warning` — never a crash, never a delayed startup. See
+[RAILWAY.md](RAILWAY.md).

--- a/docs/RAILWAY.md
+++ b/docs/RAILWAY.md
@@ -110,6 +110,14 @@ sans elle, le heartbeat se désactive proprement avec un warning)
 (optionnel, même comportement que `HM_URL` si absent) — voir
 [HEALTH_MONITOR.md](HEALTH_MONITOR.md)
 
+### BETTERSTACK_HEARTBEAT_URL
+**Valeur :** URL secrète complète de la page « Heartbeat » Better Stack
+(ex. `https://uptime.betterstack.com/api/v1/heartbeat/<TOKEN>`) — un simple
+GET dessus toutes les 3 minutes signale que le bot va bien, `.../fail` un
+échec explicite. Optionnel — sans elle, ce ping se désactive proprement
+avec un warning (indépendant de `HM_URL`/`HM_INGEST_TOKEN` ci-dessus) — voir
+[HEALTH_MONITOR.md](HEALTH_MONITOR.md)
+
 ## Notifications centralisées
 
 Les deux salons vivent dans le serveur de l'équipe Moddy. Défauts dans
@@ -144,6 +152,7 @@ pris en charge, accepté, refusé) est journalisée
 - [ ] `MODDY_NOTIF_REPORT_LOG_CHANNEL_ID` (optionnel, défaut en dur dans `config.py`)
 - [ ] `HM_URL` (optionnel, désactive le heartbeat si absent)
 - [ ] `HM_INGEST_TOKEN` (optionnel, désactive le heartbeat si absent, identique sur tous les services)
+- [ ] `BETTERSTACK_HEARTBEAT_URL` (optionnel, désactive le ping Better Stack si absent)
 
 ## Dépannage
 

--- a/docs/sessions/2026-08-24_betterstack-heartbeat.md
+++ b/docs/sessions/2026-08-24_betterstack-heartbeat.md
@@ -1,0 +1,65 @@
+# Session: Better Stack heartbeat integration
+
+**Date:** 2026-08-24
+**Agent:** Claude Code
+
+## Summary
+
+Added a second, independent heartbeat next to the Moddy Health Monitor one
+(#357): a plain ping to a Better Stack cron/heartbeat monitor every 3
+minutes. Isolated addition, no behavior change to existing features.
+
+What shipped:
+
+- `services/betterstack_heartbeat.py` — `BetterStackHeartbeat`: same
+  fire-and-forget shape as `HeartbeatClient` (background task, 5s timeout,
+  never blocks). Every 3 minutes it calls an optional `healthy` coroutine and
+  GETs the plain heartbeat URL when healthy, `<url>/fail` otherwise — Better
+  Stack's contract has no JSON body and no token header, the URL is the
+  secret.
+- `bot.py`: `self.betterstack_heartbeat` constructed in `__init__` with
+  `healthy=self._is_bot_healthy`; started in `on_ready()` right after the
+  Moddy Health Monitor heartbeat, stopped in `close()` right after it.
+  `ModdyBot._is_bot_healthy()` reuses `_build_heartbeat_checks()` — healthy
+  iff `status == "ok"` — so the two heartbeats never disagree about whether
+  the bot is fine.
+- `config.py`: `BETTERSTACK_HEARTBEAT_URL`, optional — missing disables the
+  ping with a `logger.warning`, never a crash.
+- `docs/HEALTH_MONITOR.md` restructured into two sections (Moddy Health
+  Monitor / Better Stack) with a comparison table up top; `docs/RAILWAY.md`
+  gets the new env var; `CLAUDE.md` project structure updated.
+- `tests/test_heartbeat.py` extended: `BetterStackHeartbeat` start()/stop()
+  lifecycle, plain-vs-`/fail` URL selection, and `_is_bot_healthy` against
+  the same down/degraded/ok stand-in bot used for `_build_heartbeat_checks`.
+
+## Files modified
+
+- `services/betterstack_heartbeat.py` (new)
+- `bot.py`
+- `config.py`
+- `docs/HEALTH_MONITOR.md`
+- `docs/RAILWAY.md`
+- `CLAUDE.md`
+- `tests/test_heartbeat.py`
+
+## Decisions made and why
+
+- **Separate client file, not folded into `HeartbeatClient`**: the two
+  protocols don't share a body shape (JSON+token vs. bare GET) or a status
+  vocabulary (`ok`/`degraded`/`down` vs. success/`/fail`) — forcing one class
+  to cover both would need more branching than just having two small,
+  single-purpose clients.
+- **`_is_bot_healthy` reuses `_build_heartbeat_checks`** rather than
+  recomputing its own notion of "healthy": one status decision, consumed by
+  both heartbeats, so they can't drift apart on what "fine" means.
+- **Started/stopped alongside the existing heartbeat** in `on_ready()`/
+  `close()` rather than on a separate lifecycle hook — same reasoning as
+  #357 (nothing worth reporting before the bot is ready), and keeps both
+  heartbeats' lifecycle in one obvious place.
+
+## Known issues and follow-ups
+
+- `BETTERSTACK_HEARTBEAT_URL` still needs to be set in the Railway
+  environment (the actual heartbeat is created on the Better Stack side
+  first, per their step-by-step setup) — until then this heartbeat stays
+  silently disabled (by design).

--- a/services/betterstack_heartbeat.py
+++ b/services/betterstack_heartbeat.py
@@ -1,0 +1,90 @@
+"""
+Better Stack cron/heartbeat monitor ping.
+
+Unlike the Moddy Health Monitor (services/heartbeat.py, checks-driven,
+JSON body, 20s), Better Stack's heartbeat contract is a bare URL: a plain
+GET on the heartbeat URL means "alive", a GET on ``<url>/fail`` reports a
+failure explicitly. No body is required either way — see
+docs/HEALTH_MONITOR.md for the full contract and rationale.
+
+Fire-and-forget like the other heartbeat: a failed push only logs, the loop
+never blocks anything else and never stops itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Optional
+
+import aiohttp
+
+logger = logging.getLogger("moddy.services.betterstack_heartbeat")
+
+IsHealthy = Callable[[], Awaitable[bool]]
+
+
+class BetterStackHeartbeat:
+    """Pings a Better Stack heartbeat monitor on a fixed interval.
+
+    ``healthy`` is an optional coroutine returning whether the service is
+    currently healthy; when it returns ``False`` the ping goes to
+    ``<url>/fail`` instead of ``<url>``, reporting the failure explicitly
+    rather than just going silent. With no ``healthy`` callback, every ping
+    reports success (the monitor only cares that *some* request arrives
+    within the expected frequency + grace period).
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        healthy: Optional[IsHealthy] = None,
+        interval: int = 180,
+    ) -> None:
+        self.url = (url or "").rstrip("/")
+        self._healthy = healthy
+        self._interval = interval
+        self._task: Optional[asyncio.Task] = None
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    def start(self) -> None:
+        """Start the background ping loop. Safe to call once; a no-op
+        (with a warning) when no heartbeat URL is configured."""
+        if self._task is not None:
+            return
+        if not self.url:
+            logger.warning("BETTERSTACK_HEARTBEAT_URL missing: Better Stack heartbeat disabled")
+            return
+        self._task = asyncio.create_task(self._loop(), name="betterstack-heartbeat")
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._task = None
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def _loop(self) -> None:
+        timeout = aiohttp.ClientTimeout(total=5)
+        self._session = aiohttp.ClientSession(timeout=timeout)
+        while True:
+            try:
+                healthy = await self._healthy() if self._healthy else True
+                target = self.url if healthy else f"{self.url}/fail"
+                async with self._session.get(target) as response:
+                    if response.status >= 400:
+                        logger.warning(
+                            "Better Stack heartbeat rejected (HTTP %s)", response.status,
+                        )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Better Stack heartbeat failed: %s", exc)
+            await asyncio.sleep(self._interval)

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,9 +1,10 @@
-"""Tests for the Moddy Health Monitor heartbeat (see docs/HEALTH_MONITOR.md).
+"""Tests for the two Health Monitor heartbeats (see docs/HEALTH_MONITOR.md).
 
-Nothing here talks to the network: ``HeartbeatClient`` is tested on its pure
-payload-building logic and its start()/stop() lifecycle, and the bot's own
-``_build_heartbeat_checks`` is tested against a bare stand-in object so no
-live Discord gateway is required.
+Nothing here talks to the network: ``HeartbeatClient`` and
+``BetterStackHeartbeat`` are tested on their pure payload-building logic and
+their start()/stop() lifecycle, and the bot's own ``_build_heartbeat_checks``
+/ ``_is_bot_healthy`` are tested against a bare stand-in object so no live
+Discord gateway is required.
 
     pytest tests/test_heartbeat.py -q
 """
@@ -13,6 +14,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from services.betterstack_heartbeat import BetterStackHeartbeat
 from services.heartbeat import HeartbeatClient
 
 
@@ -76,15 +78,88 @@ def test_incident_active_defaults_to_false():
     assert client.incident_active is False
 
 
+# --------------------------------------------------------------- BetterStackHeartbeat
+
+def test_betterstack_start_is_noop_without_url():
+    client = BetterStackHeartbeat(url="")
+
+    async def run():
+        client.start()
+        assert client._task is None
+        await client.stop()  # must not raise even though it never started
+
+    asyncio.run(run())
+
+
+def test_betterstack_start_creates_task_when_configured():
+    async def run():
+        client = BetterStackHeartbeat(url="https://uptime.betterstack.com/api/v1/heartbeat/tok")
+        client.start()
+        assert client._task is not None
+        await client.stop()
+        assert client._task is None
+
+    asyncio.run(run())
+
+
+def test_betterstack_pings_plain_url_without_healthy_callback():
+    calls = []
+
+    class FakeResponse:
+        status = 200
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *exc):
+            return False
+
+    class FakeSession:
+        def get(self, url):
+            calls.append(url)
+            return FakeResponse()
+        async def close(self):
+            pass
+
+    async def run():
+        client = BetterStackHeartbeat(url="https://uptime.betterstack.com/api/v1/heartbeat/tok")
+        client._session = FakeSession()
+        # Exercise a single iteration of the loop body directly rather than
+        # the infinite loop: call the same request logic it awaits each tick.
+        healthy = await client._healthy() if client._healthy else True
+        target = client.url if healthy else f"{client.url}/fail"
+        async with client._session.get(target) as response:
+            assert response.status == 200
+
+    asyncio.run(run())
+    assert calls == ["https://uptime.betterstack.com/api/v1/heartbeat/tok"]
+
+
+def test_betterstack_pings_fail_url_when_unhealthy():
+    async def unhealthy():
+        return False
+
+    client = BetterStackHeartbeat(
+        url="https://uptime.betterstack.com/api/v1/heartbeat/tok", healthy=unhealthy,
+    )
+    healthy = asyncio.run(client._healthy())
+    target = client.url if healthy else f"{client.url}/fail"
+    assert target == "https://uptime.betterstack.com/api/v1/heartbeat/tok/fail"
+
+
 # --------------------------------------------------------------- bot checks
 
 def _fake_bot(*, ready: bool, latency: float, guild_count: int = 3, shards=None):
-    return SimpleNamespace(
+    from bot import ModdyBot
+
+    fake = SimpleNamespace(
         is_ready=lambda: ready,
         latency=latency,
         shards=shards or {},
         guilds=[object()] * guild_count,
     )
+    # _is_bot_healthy calls self._build_heartbeat_checks() as a bound method;
+    # a bare SimpleNamespace has no such attribute, so wire one up here too.
+    fake._build_heartbeat_checks = lambda: ModdyBot._build_heartbeat_checks(fake)
+    return fake
 
 
 def test_build_bot_checks_down_when_not_ready():
@@ -120,3 +195,19 @@ def test_build_bot_checks_degraded_when_a_shard_is_down():
 
     assert result["status"] == "degraded"
     assert result["checks"]["shards"] == {"ok": False, "connected": 1, "total": 2}
+
+
+def test_is_bot_healthy_matches_build_heartbeat_checks_status():
+    from bot import ModdyBot
+
+    ready_bot = _fake_bot(ready=True, latency=0.01)
+    assert asyncio.run(ModdyBot._is_bot_healthy(ready_bot)) is True
+
+    down_bot = _fake_bot(ready=False, latency=float("nan"))
+    assert asyncio.run(ModdyBot._is_bot_healthy(down_bot)) is False
+
+    degraded_bot = _fake_bot(
+        ready=True, latency=0.01,
+        shards={0: SimpleNamespace(is_closed=lambda: True)},
+    )
+    assert asyncio.run(ModdyBot._is_bot_healthy(degraded_bot)) is False


### PR DESCRIPTION
## Summary

Adds a second, independent heartbeat next to the Moddy Health Monitor one (#357/#358): a plain ping to a Better Stack cron/heartbeat monitor every 3 minutes. Isolated addition, no behavior change to existing features.

## Key Changes

- **`services/betterstack_heartbeat.py` (new)**: `BetterStackHeartbeat` — same fire-and-forget shape as `HeartbeatClient` (background task, 5s timeout, never blocks, never retries aggressively)
  - Every 3 minutes: calls an optional `healthy` coroutine, GETs the plain heartbeat URL when healthy, `<url>/fail` otherwise
  - No JSON body, no token header — Better Stack's contract is a bare secret URL
  - `start()` is a no-op (with a warning) when `BETTERSTACK_HEARTBEAT_URL` is missing

- **`bot.py`**:
  - `self.betterstack_heartbeat` constructed in `__init__` with `healthy=self._is_bot_healthy`
  - `ModdyBot._is_bot_healthy()` (new): reuses `_build_heartbeat_checks()` and reports healthy iff `status == "ok"` — so the two heartbeats can't disagree about whether the bot is fine
  - Started in `on_ready()` right after the Moddy Health Monitor heartbeat, stopped in `close()` right after it

- **`config.py`**: `BETTERSTACK_HEARTBEAT_URL` (optional) — the full secret heartbeat URL from the Better Stack heartbeat detail page

- **`docs/HEALTH_MONITOR.md`**: restructured into two sections (Moddy Health Monitor / Better Stack) with a comparison table up top

- **`docs/RAILWAY.md`**: added `BETTERSTACK_HEARTBEAT_URL` to the env var list and deployment checklist

- **`tests/test_heartbeat.py`**: extended with `BetterStackHeartbeat` start()/stop() lifecycle, plain-vs-`/fail` URL selection, and `_is_bot_healthy` against the same down/degraded/ok stand-in bot used for `_build_heartbeat_checks`

- **`CLAUDE.md`**: project structure + doc index updated

## Implementation Notes

- Kept as a separate client file rather than folded into `HeartbeatClient`: the two protocols don't share a body shape (JSON+token vs. bare GET) or a status vocabulary (`ok`/`degraded`/`down` vs. success/`/fail`)
- Started/stopped alongside the existing heartbeat in `on_ready()`/`close()` — nothing worth reporting before the bot is ready, same reasoning as the first heartbeat integration

## Environment variable to add

- `BETTERSTACK_HEARTBEAT_URL` — full secret URL from the Better Stack heartbeat detail page (e.g. `https://uptime.betterstack.com/api/v1/heartbeat/<TOKEN>`), optional (disables the ping cleanly if unset)

https://claude.ai/code/session_01FG3kCinrkHeEAiqrX6YRBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG3kCinrkHeEAiqrX6YRBW)_