### PR TITLE
Use plain emoji for verification badge in notification DMs

### DIFF
--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -51,8 +51,10 @@ An official notice carries no line: a suspension **is** Moddy speaking, there is
 no third party to name.
 
 A verified server (`VERIFIED`, `VERIFIED_ORG` or `PARTNER`) gets the
-verification check right after its name, hyperlinked like everywhere else in
-Moddy (CLAUDE.md rule #7).
+verification check right after its name, as the plain emoji — **not**
+hyperlinked like everywhere else in Moddy (CLAUDE.md rule #7). The hyperlinked
+form broke in this context, so `resolve_source_context()` sets `ctx["badge"]`
+to the bare `VERIFIED` emoji instead of `format_verification_badge(VERIFIED)`.
 
 The line goes **inside the last container** of the card, not under it: a `-#`
 floating as its own component reads as a separate message.

--- a/notifications/render.py
+++ b/notifications/render.py
@@ -30,7 +30,7 @@ from cogs.error_handler import BaseView
 from notifications.models import (
     ContentAuthor, NotificationContent, NotificationSource, get_service,
 )
-from utils.emojis import MODDY_SQUARE_MIN, VERIFIED, format_verification_badge
+from utils.emojis import MODDY_SQUARE_MIN, VERIFIED
 from utils.i18n import t
 
 logger = logging.getLogger("moddy.notifications.render")
@@ -158,7 +158,7 @@ async def resolve_source_context(
             attributes.get(attr) for attr in VERIFIED_GUILD_ATTRIBUTES
         )
         if ctx["verified"]:
-            ctx["badge"] = format_verification_badge(VERIFIED)
+            ctx["badge"] = VERIFIED
 
         # Moddy's own servers are not reportable to Moddy.
         if ctx["official"] and ctx["reportable"]:
@@ -179,7 +179,8 @@ def build_attribution_line(ctx: Dict[str, Any], *, locale: str = "en-US") -> Opt
     have always used (``commands.moderation.dm.sent_by``), so a member sees one
     consistent sentence at the bottom of anything Moddy sends them, whatever
     feature produced it. The verification badge is appended right after the
-    name when the server carries one, per the badge rule in CLAUDE.md.
+    name when the server carries one — as the plain emoji, not the hyperlinked
+    form from CLAUDE.md's badge rule, since the link breaks in this context.
 
     A notification with no server (a reminder, an appeal outcome) names the
     Moddy service instead. An official notice gets no line at all — the caller

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -211,7 +211,7 @@ async def test_a_verified_server_gets_the_check():
     ctx = await resolve_source_context(
         FakeBot(FakeGuild(), {"VERIFIED": True}), NotificationSource.guild(42))
     assert ctx["verified"] is True
-    assert ctx["badge"]  # a hyperlinked badge, per the CLAUDE.md rule
+    assert ctx["badge"]  # the plain badge emoji, no link (Discord DM previews break on it)
     assert ctx["reportable"] is True
     # …and it is the badge that reaches the attribution line.
     assert ctx["badge"] in build_attribution_line(ctx, locale="en-US")


### PR DESCRIPTION
## Summary
Changed the verification badge in notification attribution lines from a hyperlinked format to a plain emoji. The hyperlinked form was breaking Discord's DM preview feature, so we now use the bare `VERIFIED` emoji instead.

## Changes
- **notifications/render.py**: Removed import of `format_verification_badge()` and changed `resolve_source_context()` to set `ctx["badge"]` directly to `VERIFIED` instead of wrapping it with `format_verification_badge()`
- **docs/NOTIFICATIONS.md**: Updated documentation to explain that the verification badge is now a plain emoji (not hyperlinked) due to Discord DM preview compatibility issues
- **tests/test_notifications.py**: Updated test comment to clarify that the badge is now plain, not hyperlinked, and explain why (Discord DM previews break on the hyperlinked form)

## Implementation Details
The verification badge still appears in the attribution line for verified servers, but it's now rendered as a simple emoji character rather than a hyperlinked element. This maintains the visual indicator while avoiding the Discord DM preview rendering issue that occurred with the hyperlinked format from CLAUDE.md's badge rule #7.

https://claude.ai/code/session_018zQsb5CcyahvXkNqvzpqBc