### PR TITLE
Fix attribution wording, command formatting and link-button icons

### DIFF
--- a/cogs/config.py
+++ b/cogs/config.py
@@ -18,9 +18,9 @@ from discord.ext import commands
 from typing import Optional
 import logging
 
-from config import COLORS
+from config import COLORS, DASHBOARD_URL, DOCS_URL, SUPPORT_URL
 from utils.i18n import i18n, t
-from utils.emojis import EMOJIS, SETTINGS, SUPPORT, WEB, BOOK
+from utils.emojis import EMOJIS, SETTINGS
 from utils import global_sanctions
 from utils.components_v2 import create_limited_message
 from cogs.error_handler import BaseView
@@ -33,11 +33,6 @@ _CID_MODULE_SELECT = "moddy:config:main:module_select"
 #: Value of the dropdown entry that opens the server-wide settings screen.
 #: Prefixed so it can never collide with a module id.
 SETTINGS_OPTION = "__server_settings__"
-
-#: Links shown under the panel. Outside the container, as link buttons.
-SUPPORT_URL = "https://moddy.app/support"
-DASHBOARD_URL = "https://dashboard.moddy.app"
-DOCS_URL = "https://docs.moddy.app"
 
 
 class ConfigMainView(BaseView):
@@ -170,17 +165,14 @@ class ConfigMainView(BaseView):
         row = ui.ActionRow()
         row.add_item(ui.Button(
             label=t('modules.config.main.links.dashboard', locale=self.locale),
-            emoji=discord.PartialEmoji.from_str(WEB),
             style=discord.ButtonStyle.link, url=DASHBOARD_URL,
         ))
         row.add_item(ui.Button(
             label=t('modules.config.main.links.support', locale=self.locale),
-            emoji=discord.PartialEmoji.from_str(SUPPORT),
             style=discord.ButtonStyle.link, url=SUPPORT_URL,
         ))
         row.add_item(ui.Button(
             label=t('modules.config.main.links.docs', locale=self.locale),
-            emoji=discord.PartialEmoji.from_str(BOOK),
             style=discord.ButtonStyle.link, url=DOCS_URL,
         ))
         return row

--- a/config.py
+++ b/config.py
@@ -51,11 +51,12 @@ SUPPORT_URL: str = os.environ.get("MODDY_SUPPORT_URL", "https://moddy.app/suppor
 DASHBOARD_URL: str = os.environ.get("MODDY_DASHBOARD_URL", "https://dashboard.moddy.app")
 DOCS_URL: str = os.environ.get("MODDY_DOCS_URL", "https://docs.moddy.app")
 
-# Clickable mention of /config, used inside notification bodies. A command
-# mention needs the registered command id, which is stable for the application
-# but changes if the command is ever re-created — hence the override.
-CONFIG_COMMAND_MENTION: str = os.environ.get(
-    "MODDY_CONFIG_COMMAND_MENTION", "</config:1444430277970497653>")
+# How a command is written inside a message Moddy sends: bold + inline code,
+# e.g. **`/config`**. Not a clickable </config:id> mention — that id changes if
+# the command is ever re-registered, and a stale mention renders as raw text.
+def command_label(name: str) -> str:
+    """Format a command name the way every Moddy message writes one."""
+    return f"**`/{name.lstrip('/')}`**"
 
 # =============================================================================
 # BASE DE DONNÉES

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -40,7 +40,7 @@ Three answers, one system:
 |---|---|
 | **Official** — account suspension, leaked-token alert | *none* |
 | **Service** — a Moddy feature acting alone (reminder, appeal outcome) | `-# Sent by **Reminders**` |
-| **Moddy itself** — the `moddy` / `moddy_team` services (install welcome, support reply, campaigns) | `-# Sent by **the Moddy Team**<:verified:…>` |
+| **Moddy itself** — the `moddy`, `moddy_team` and `support` services (install welcome, support reply, campaigns) | `-# Sent by the **Moddy Team**<:verified:…>` |
 | **Server** — a server's own words (welcome DM, sanction reason) | `-# Sent by [**Server**](link) (`id`)` |
 | **Service + server** — a feature acting for a server (AltGuard, tickets, automod) | same as above: the **server** is the origin |
 
@@ -51,10 +51,18 @@ names the Moddy service instead, so there is always exactly one origin.
 An official notice carries no line: a suspension **is** Moddy speaking, there is
 no third party to name.
 
-The two services that *are* Moddy (`OFFICIAL_SERVICES` in
-`notifications/render.py`: `moddy` and `moddy_team`) carry the verification
-check on their own line, without any database read — it is true by
+The services that *are* Moddy (`OFFICIAL_SERVICES` in
+`notifications/render.py`: `moddy`, `moddy_team`, `support`) carry the
+verification check on their own line, without any database read — it is true by
 construction, and it is what tells a member the DM is not an impersonation.
+Those of them that read as a named entity (`ARTICLE_SERVICES`: `moddy_team`,
+`support`) use `sent_by_moddy`, whose article sits **outside** the bold —
+"Sent by the **Moddy Team**", never "**the Moddy Team**".
+
+A card rebuilt *after* delivery (the beta announcement's Translate button)
+re-appends the same line through `NotificationService.attribution_line()` +
+`append_attribution()`: a re-render that drops it would leave a message stating
+no origin at all.
 
 A verified server (`VERIFIED`, `VERIFIED_ORG` or `PARTNER`) gets the
 verification check right after its name, as the plain emoji — **not**

--- a/docs/RAILWAY.md
+++ b/docs/RAILWAY.md
@@ -155,11 +155,6 @@ envoyées depuis le bouton sous les annonces de Moddy
 **Description :** Liens publics affichés sous `/config`, les cartes de support
 et les notifications
 
-### MODDY_CONFIG_COMMAND_MENTION
-**Valeur :** mention de commande (défaut : `</config:1444430277970497653>`)
-**Description :** Mention cliquable de `/config` insérée dans le corps des
-notifications. À mettre à jour si la commande est recréée (son id change)
-
 ## Checklist Railway
 
 - [ ] `DISCORD_TOKEN`
@@ -178,7 +173,6 @@ notifications. À mettre à jour si la commande est recréée (son id change)
 - [ ] `MODDY_NOTIF_REPORT_LOG_CHANNEL_ID` (optionnel, défaut en dur dans `config.py`)
 - [ ] `MODDY_BUG_REPORT_CHANNEL_ID` (optionnel, défaut en dur dans `config.py`)
 - [ ] `MODDY_CONFIG_HELP_CHANNEL_ID` (optionnel, défaut en dur dans `config.py`)
-- [ ] `MODDY_CONFIG_COMMAND_MENTION` (optionnel, défaut en dur dans `config.py`)
 - [ ] `HM_URL` (optionnel, désactive le heartbeat si absent)
 - [ ] `HM_INGEST_TOKEN` (optionnel, désactive le heartbeat si absent, identique sur tous les services)
 - [ ] `BETTERSTACK_HEARTBEAT_URL` (optionnel, désactive le ping Better Stack si absent)

--- a/docs/SUPPORT_REQUESTS.md
+++ b/docs/SUPPORT_REQUESTS.md
@@ -144,7 +144,10 @@ docs/PERSISTENT_VIEWS.md.
 | `MODDY_SUPPORT_URL` | `https://moddy.app/support` | shown on every card |
 | `MODDY_DASHBOARD_URL` | `https://dashboard.moddy.app` | idem |
 | `MODDY_DOCS_URL` | `https://docs.moddy.app` | idem |
-| `MODDY_CONFIG_COMMAND_MENTION` | `</config:1444430277970497653>` | the clickable `/config` mention used inside notification bodies |
+
+Commands named inside a message are written with `config.command_label()`
+(**`` `/config` ``**), never as a `</config:id>` mention: that id changes if the
+command is re-registered, and a stale mention renders as raw text.
 
 ---
 

--- a/docs/sessions/2026-08-26_config-bug-report-beta-launch.md
+++ b/docs/sessions/2026-08-26_config-bug-report-beta-launch.md
@@ -119,8 +119,6 @@ coroutine`). One missing `await`.
 
 ## Follow-ups
 
-- `MODDY_CONFIG_COMMAND_MENTION` must be updated if `/config` is ever
-  re-registered (the command id changes and the mention stops resolving).
 - Delete `utils/beta_announcement.py`, `staff/commands/com/beta.py` and the
   `notifications.beta` / `staff.com.beta` i18n blocks once the campaign is over.
 - The email and dashboard halves of the campaign depend on the backend serving

--- a/docs/sessions/2026-08-26_config-bug-report-beta-launch.md
+++ b/docs/sessions/2026-08-26_config-bug-report-beta-launch.md
@@ -97,6 +97,26 @@ coroutine`). One missing `await`.
 - **No em dashes in user-facing strings** (explicit request): every new locale
   string uses commas or colons instead.
 
+## Review pass (same session)
+
+- `sent_by_moddy`: the article sits outside the bold ("Sent by the **Moddy
+  Team**✓"), and `support` joined `OFFICIAL_SERVICES` so a team reply carries
+  the check too. Service names are brand names now: *Moddy Team*, *Moddy
+  Support*.
+- The Translate button re-appends the attribution line
+  (`NotificationService.attribution_line()` / `append_attribution()`) — a
+  rebuilt card was dropping it — and is blue (`ButtonStyle.primary`).
+- Commands inside a message are written `**\`/config\`**` via
+  `config.command_label()`, replacing the `</config:id>` mention (a stale id
+  renders as raw text). `MODDY_CONFIG_COMMAND_MENTION` is gone.
+- References always render as code: `support.reply.reference` carries its own
+  backticks.
+- Link buttons carry no icon anywhere (`/config`, support cards, beta card,
+  install welcome).
+- Verified **servers**: the guild badge path was checked and is unchanged; a
+  guild carrying `VERIFIED` / `VERIFIED_ORG` / `PARTNER` / `OFFICIAL` still gets
+  its check, and a regression test now pins it.
+
 ## Follow-ups
 
 - `MODDY_CONFIG_COMMAND_MENTION` must be updated if `/config` is ever

--- a/locales/de.json
+++ b/locales/de.json
@@ -4035,13 +4035,14 @@
       "token_detector": "Token-Erkennung",
       "global_sanctions": "Globale Sanktionen",
       "expirations": "Sanktionsende",
-      "support": "Support",
-      "moddy_team": "dem Moddy-Team"
+      "support": "Moddy Support",
+      "moddy_team": "Moddy Team"
     },
     "attribution": {
       "unknown_guild": "Unbekannter Server",
       "sent_by": "Gesendet von [**{guild}**]({guild_url}){badge} (`{guild_id}`)",
-      "sent_by_service": "Gesendet von **{service}**{badge}"
+      "sent_by_service": "Gesendet von **{service}**{badge}",
+      "sent_by_moddy": "Gesendet von **{service}**{badge}"
     },
     "source": {
       "uuid_label": "Benachrichtigung:"
@@ -4143,13 +4144,13 @@
     },
     "beta": {
       "title": "Moddy geht in die Beta",
-      "body": "Hallo **{user}**!\n\nDu hast **Moddy** zu {servers} hinzugefügt, als der Bot noch in Entwicklung war und kaum etwas konnte. Das hat sich geändert: Moddy geht jetzt in die **Beta**, und ein großer Teil der Funktionen ist aktiv.\n\nWeil du vor allen anderen dabei warst, **schenken wir dir 2 Monate Moddy Max**, kostenlos und ohne Kreditkarte. Öffne einfach ein Ticket auf unserem [**Support-Server**]({support}), um es zu aktivieren.\n\nZum Einrichten der Module nimmst du {config} oder unser Dashboard auf [**dashboard.moddy.app**]({dashboard}). Und wenn du dich lieber nicht damit beschäftigen möchtest, richtet es jemand aus dem Team für dich ein: einfach den Knopf unten drücken. Unsere [**Dokumentation**]({docs}) gibt es auch.\n\nWir sind in der Beta, also wird es Fehler geben. Das ist normal. Melde sie mit **/bug-report** oder auf dem Support-Server: Das hilft uns wirklich weiter.\n\nDanke, dass du Moddy die ganze Zeit in einer Ecke deines Servers behalten hast.",
+      "body": "Hallo **{user}**!\n\nDu hast **Moddy** zu {servers} hinzugefügt, als der Bot noch in Entwicklung war und kaum etwas konnte. Das hat sich geändert: Moddy geht jetzt in die **Beta**, und ein großer Teil der Funktionen ist aktiv.\n\nWeil du vor allen anderen dabei warst, **schenken wir dir 2 Monate Moddy Max**, kostenlos und ohne Kreditkarte. Öffne einfach ein Ticket auf unserem [**Support-Server**]({support}), um es zu aktivieren.\n\nZum Einrichten der Module nimmst du {config} oder unser Dashboard auf [**dashboard.moddy.app**]({dashboard}). Und wenn du dich lieber nicht damit beschäftigen möchtest, richtet es jemand aus dem Team für dich ein: einfach den Knopf unten drücken. Unsere [**Dokumentation**]({docs}) gibt es auch.\n\nWir sind in der Beta, also wird es Fehler geben. Das ist normal. Melde sie mit {bug_report} oder auf dem Support-Server: Das hilft uns wirklich weiter.\n\nDanke, dass du Moddy die ganze Zeit in einer Ecke deines Servers behalten hast.",
       "translate": "Übersetzen",
       "your_server": "**deinen Server**"
     },
     "install": {
       "title": "Willkommen bei Moddy",
-      "body": "Danke, dass du **Moddy** zu **{server}** hinzugefügt hast!\n\nAlles wird an einer Stelle eingerichtet: {config} auf deinem Server oder das Dashboard auf [**dashboard.moddy.app**]({dashboard}). Moderation, Logs, Willkommensnachrichten, Tickets: Modul auswählen, einstellen, fertig.\n\n**Einen Monat Premium schenken wir dir** für diesen Server, kostenlos und ohne Kreditkarte. Komm auf unseren [**Support-Server**]({support}) und öffne ein Ticket, um es zu aktivieren.\n\nLieber nicht selbst einrichten? Drück den Knopf unten und jemand aus dem Team macht es mit dir. Unsere [**Dokumentation**]({docs}) erklärt jedes Modul.\n\nModdy ist derzeit in der **Beta**, es kann also Fehler geben. Das ist normal: sag uns mit **/bug-report** oder auf dem Support-Server Bescheid, und wir beheben sie."
+      "body": "Danke, dass du **Moddy** zu **{server}** hinzugefügt hast!\n\nAlles wird an einer Stelle eingerichtet: {config} auf deinem Server oder das Dashboard auf [**dashboard.moddy.app**]({dashboard}). Moderation, Logs, Willkommensnachrichten, Tickets: Modul auswählen, einstellen, fertig.\n\n**Einen Monat Premium schenken wir dir** für diesen Server, kostenlos und ohne Kreditkarte. Komm auf unseren [**Support-Server**]({support}) und öffne ein Ticket, um es zu aktivieren.\n\nLieber nicht selbst einrichten? Drück den Knopf unten und jemand aus dem Team macht es mit dir. Unsere [**Dokumentation**]({docs}) erklärt jedes Modul.\n\nModdy ist derzeit in der **Beta**, es kann also Fehler geben. Das ist normal: sag uns mit {bug_report} oder auf dem Support-Server Bescheid, und wir beheben sie."
     }
   },
   "support": {
@@ -4255,7 +4256,7 @@
       "config_help": {
         "title": "Zu deiner Einrichtungsanfrage"
       },
-      "reference": "Referenz: {reference}",
+      "reference": "Referenz: `{reference}`",
       "modal": {
         "title": "Dem Melder antworten",
         "body": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -4035,13 +4035,14 @@
       "token_detector": "Token detector",
       "global_sanctions": "Global sanctions",
       "expirations": "Sanction expiry",
-      "support": "Support",
-      "moddy_team": "the Moddy Team"
+      "support": "Moddy Support",
+      "moddy_team": "Moddy Team"
     },
     "attribution": {
       "unknown_guild": "Unknown server",
       "sent_by": "Sent by [**{guild}**]({guild_url}){badge} (`{guild_id}`)",
-      "sent_by_service": "Sent by **{service}**{badge}"
+      "sent_by_service": "Sent by **{service}**{badge}",
+      "sent_by_moddy": "Sent by the **{service}**{badge}"
     },
     "source": {
       "uuid_label": "Notification:"
@@ -4143,13 +4144,13 @@
     },
     "beta": {
       "title": "Moddy is entering beta",
-      "body": "Hi **{user}**!\n\nYou added **Moddy** to {servers} back when it was still in development, at a time when it did not do much yet. That has changed: the bot is entering **beta**, and most of its features are now live.\n\nBecause you were here before everyone else, **Moddy Max is yours for 2 months**, free and without a card. Just open a ticket on our [**support server**]({support}) to activate it.\n\nTo set the modules up, use {config} or our dashboard on [**dashboard.moddy.app**]({dashboard}). And if you would rather not deal with it, someone from the team can come and configure it for you: press the button below. Our [**documentation**]({docs}) is there too.\n\nWe are in beta, so there will be bugs. That is normal. Report them with **/bug-report** or on our support server: it genuinely helps us move forward.\n\nThanks for keeping Moddy in a corner of your server all this time.",
+      "body": "Hi **{user}**!\n\nYou added **Moddy** to {servers} back when it was still in development, at a time when it did not do much yet. That has changed: the bot is entering **beta**, and most of its features are now live.\n\nBecause you were here before everyone else, **Moddy Max is yours for 2 months**, free and without a card. Just open a ticket on our [**support server**]({support}) to activate it.\n\nTo set the modules up, use {config} or our dashboard on [**dashboard.moddy.app**]({dashboard}). And if you would rather not deal with it, someone from the team can come and configure it for you: press the button below. Our [**documentation**]({docs}) is there too.\n\nWe are in beta, so there will be bugs. That is normal. Report them with {bug_report} or on our support server: it genuinely helps us move forward.\n\nThanks for keeping Moddy in a corner of your server all this time.",
       "translate": "Translate",
       "your_server": "**your server**"
     },
     "install": {
       "title": "Welcome to Moddy",
-      "body": "Thanks for adding **Moddy** to **{server}**!\n\nEverything is configured from one place: run {config} on your server, or use the dashboard on [**dashboard.moddy.app**]({dashboard}). Moderation, logs, welcome messages, tickets: pick a module, set it up, done.\n\n**One month of premium is on us**, free and without a card, for this server. Join our [**support server**]({support}) and open a ticket to activate it.\n\nRather not set things up yourself? Press the button below and someone from the team will configure it with you. Our [**documentation**]({docs}) walks through every module.\n\nModdy is currently in **beta**, so you may run into bugs. That is expected: tell us with **/bug-report** or on the support server, and we will fix them."
+      "body": "Thanks for adding **Moddy** to **{server}**!\n\nEverything is configured from one place: run {config} on your server, or use the dashboard on [**dashboard.moddy.app**]({dashboard}). Moderation, logs, welcome messages, tickets: pick a module, set it up, done.\n\n**One month of premium is on us**, free and without a card, for this server. Join our [**support server**]({support}) and open a ticket to activate it.\n\nRather not set things up yourself? Press the button below and someone from the team will configure it with you. Our [**documentation**]({docs}) walks through every module.\n\nModdy is currently in **beta**, so you may run into bugs. That is expected: tell us with {bug_report} or on the support server, and we will fix them."
     }
   },
   "support": {
@@ -4255,7 +4256,7 @@
       "config_help": {
         "title": "About your configuration request"
       },
-      "reference": "Reference: {reference}",
+      "reference": "Reference: `{reference}`",
       "modal": {
         "title": "Reply to the reporter",
         "body": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -4035,13 +4035,14 @@
       "token_detector": "Detector de tokens",
       "global_sanctions": "Sanciones globales",
       "expirations": "Fin de sanción",
-      "support": "Soporte",
-      "moddy_team": "el equipo de Moddy"
+      "support": "Moddy Support",
+      "moddy_team": "Moddy Team"
     },
     "attribution": {
       "unknown_guild": "Servidor desconocido",
       "sent_by": "Enviado por [**{guild}**]({guild_url}){badge} (`{guild_id}`)",
-      "sent_by_service": "Enviado por **{service}**{badge}"
+      "sent_by_service": "Enviado por **{service}**{badge}",
+      "sent_by_moddy": "Enviado por **{service}**{badge}"
     },
     "source": {
       "uuid_label": "Notificación:"
@@ -4143,13 +4144,13 @@
     },
     "beta": {
       "title": "Moddy entra en beta",
-      "body": "¡Hola **{user}**!\n\nAñadiste **Moddy** a {servers} cuando todavía estaba en desarrollo, en una época en la que aún no hacía gran cosa. Eso ha cambiado: el bot entra en **beta** y buena parte de sus funciones ya están activas.\n\nComo estabas aquí antes que nadie, **Moddy Max es tuyo durante 2 meses**: gratis y sin tarjeta. Solo tienes que abrir un ticket en nuestro [**servidor de soporte**]({support}) para activarlo.\n\nPara configurar los módulos puedes usar {config} o nuestro panel en [**dashboard.moddy.app**]({dashboard}). Y si prefieres no ocuparte tú, alguien del equipo puede configurarlo por ti: pulsa el botón de abajo. También tienes nuestra [**documentación**]({docs}).\n\nEstamos en beta, así que habrá errores; es normal. Repórtalos con **/bug-report** o en el servidor de soporte: nos ayuda de verdad.\n\nGracias por haber mantenido a Moddy en un rincón de tu servidor todo este tiempo.",
+      "body": "¡Hola **{user}**!\n\nAñadiste **Moddy** a {servers} cuando todavía estaba en desarrollo, en una época en la que aún no hacía gran cosa. Eso ha cambiado: el bot entra en **beta** y buena parte de sus funciones ya están activas.\n\nComo estabas aquí antes que nadie, **Moddy Max es tuyo durante 2 meses**: gratis y sin tarjeta. Solo tienes que abrir un ticket en nuestro [**servidor de soporte**]({support}) para activarlo.\n\nPara configurar los módulos puedes usar {config} o nuestro panel en [**dashboard.moddy.app**]({dashboard}). Y si prefieres no ocuparte tú, alguien del equipo puede configurarlo por ti: pulsa el botón de abajo. También tienes nuestra [**documentación**]({docs}).\n\nEstamos en beta, así que habrá errores; es normal. Repórtalos con {bug_report} o en el servidor de soporte: nos ayuda de verdad.\n\nGracias por haber mantenido a Moddy en un rincón de tu servidor todo este tiempo.",
       "translate": "Traducir",
       "your_server": "**tu servidor**"
     },
     "install": {
       "title": "Bienvenido a Moddy",
-      "body": "¡Gracias por añadir **Moddy** a **{server}**!\n\nTodo se configura en un solo sitio: usa {config} en tu servidor o el panel en [**dashboard.moddy.app**]({dashboard}). Moderación, registros, mensajes de bienvenida, tickets: eliges un módulo, lo ajustas y listo.\n\n**Te regalamos un mes de premium** para este servidor, gratis y sin tarjeta. Entra en nuestro [**servidor de soporte**]({support}) y abre un ticket para activarlo.\n\n¿Prefieres no hacerlo tú? Pulsa el botón de abajo y alguien del equipo lo configurará contigo. Nuestra [**documentación**]({docs}) explica cada módulo.\n\nModdy está actualmente en **beta**, así que puedes encontrar errores. Es normal: cuéntanoslo con **/bug-report** o en el servidor de soporte y lo corregimos."
+      "body": "¡Gracias por añadir **Moddy** a **{server}**!\n\nTodo se configura en un solo sitio: usa {config} en tu servidor o el panel en [**dashboard.moddy.app**]({dashboard}). Moderación, registros, mensajes de bienvenida, tickets: eliges un módulo, lo ajustas y listo.\n\n**Te regalamos un mes de premium** para este servidor, gratis y sin tarjeta. Entra en nuestro [**servidor de soporte**]({support}) y abre un ticket para activarlo.\n\n¿Prefieres no hacerlo tú? Pulsa el botón de abajo y alguien del equipo lo configurará contigo. Nuestra [**documentación**]({docs}) explica cada módulo.\n\nModdy está actualmente en **beta**, así que puedes encontrar errores. Es normal: cuéntanoslo con {bug_report} o en el servidor de soporte y lo corregimos."
     }
   },
   "support": {
@@ -4255,7 +4256,7 @@
       "config_help": {
         "title": "Sobre tu solicitud de configuración"
       },
-      "reference": "Referencia: {reference}",
+      "reference": "Referencia: `{reference}`",
       "modal": {
         "title": "Responder al autor",
         "body": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -4034,13 +4034,14 @@
       "token_detector": "Détecteur de tokens",
       "global_sanctions": "Sanctions globales",
       "expirations": "Fin de sanction",
-      "support": "Support",
-      "moddy_team": "l'équipe Moddy"
+      "support": "Moddy Support",
+      "moddy_team": "Moddy Team"
     },
     "attribution": {
       "unknown_guild": "Serveur inconnu",
       "sent_by": "Envoyé par [**{guild}**]({guild_url}){badge} (`{guild_id}`)",
-      "sent_by_service": "Envoyé par **{service}**{badge}"
+      "sent_by_service": "Envoyé par **{service}**{badge}",
+      "sent_by_moddy": "Envoyé par **{service}**{badge}"
     },
     "source": {
       "uuid_label": "Notification :"
@@ -4142,13 +4143,13 @@
     },
     "beta": {
       "title": "Moddy passe en bêta",
-      "body": "Salut **{user}** !\n\nTu avais ajouté **Moddy** sur {servers} pendant sa phase de développement, à une époque où il ne faisait pas encore grand-chose. Ça a changé : le bot passe aujourd'hui en **bêta** et une grande partie des fonctionnalités sont désormais actives.\n\nComme tu étais là avant tout le monde, **Moddy Max t'est offert pendant 2 mois** : gratuitement et sans carte bancaire. Il te suffit d'ouvrir un ticket sur notre [**serveur support**]({support}) pour l'activer.\n\nSi tu souhaites configurer les modules, tu peux utiliser la commande {config} ou notre dashboard sur [**dashboard.moddy.app**]({dashboard}). Et si tu préfères ne pas t'en occuper, un membre de l'équipe peut venir le configurer pour toi : il suffit d'appuyer sur le bouton ci-dessous. Tu peux aussi t'aider de notre [**documentation**]({docs}).\n\nOn est en bêta, donc il y a des bugs, c'est normal. Signale-les avec **/bug-report** ou sur notre serveur support : ça nous aide vraiment à avancer.\n\nMerci d'avoir gardé Moddy dans un coin de ton serveur tout ce temps.",
+      "body": "Salut **{user}** !\n\nTu avais ajouté **Moddy** sur {servers} pendant sa phase de développement, à une époque où il ne faisait pas encore grand-chose. Ça a changé : le bot passe aujourd'hui en **bêta** et une grande partie des fonctionnalités sont désormais actives.\n\nComme tu étais là avant tout le monde, **Moddy Max t'est offert pendant 2 mois** : gratuitement et sans carte bancaire. Il te suffit d'ouvrir un ticket sur notre [**serveur support**]({support}) pour l'activer.\n\nSi tu souhaites configurer les modules, tu peux utiliser la commande {config} ou notre dashboard sur [**dashboard.moddy.app**]({dashboard}). Et si tu préfères ne pas t'en occuper, un membre de l'équipe peut venir le configurer pour toi : il suffit d'appuyer sur le bouton ci-dessous. Tu peux aussi t'aider de notre [**documentation**]({docs}).\n\nOn est en bêta, donc il y a des bugs, c'est normal. Signale-les avec {bug_report} ou sur notre serveur support : ça nous aide vraiment à avancer.\n\nMerci d'avoir gardé Moddy dans un coin de ton serveur tout ce temps.",
       "translate": "Traduire",
       "your_server": "**ton serveur**"
     },
     "install": {
       "title": "Bienvenue chez Moddy",
-      "body": "Merci d'avoir ajouté **Moddy** sur **{server}** !\n\nTout se configure au même endroit : la commande {config} sur ton serveur, ou le dashboard sur [**dashboard.moddy.app**]({dashboard}). Modération, logs, messages de bienvenue, tickets : tu choisis un module, tu le règles, c'est fait.\n\n**Un mois de premium t'est offert** pour ce serveur, gratuitement et sans carte bancaire. Rejoins notre [**serveur support**]({support}) et ouvre un ticket pour l'activer.\n\nTu préfères ne pas t'en occuper ? Appuie sur le bouton ci-dessous et un membre de l'équipe le configurera avec toi. Notre [**documentation**]({docs}) détaille chaque module.\n\nModdy est actuellement en **bêta**, donc tu peux rencontrer des bugs. C'est normal : signale-les avec **/bug-report** ou sur le serveur support, et on les corrige."
+      "body": "Merci d'avoir ajouté **Moddy** sur **{server}** !\n\nTout se configure au même endroit : la commande {config} sur ton serveur, ou le dashboard sur [**dashboard.moddy.app**]({dashboard}). Modération, logs, messages de bienvenue, tickets : tu choisis un module, tu le règles, c'est fait.\n\n**Un mois de premium t'est offert** pour ce serveur, gratuitement et sans carte bancaire. Rejoins notre [**serveur support**]({support}) et ouvre un ticket pour l'activer.\n\nTu préfères ne pas t'en occuper ? Appuie sur le bouton ci-dessous et un membre de l'équipe le configurera avec toi. Notre [**documentation**]({docs}) détaille chaque module.\n\nModdy est actuellement en **bêta**, donc tu peux rencontrer des bugs. C'est normal : signale-les avec {bug_report} ou sur le serveur support, et on les corrige."
     }
   },
   "support": {
@@ -4254,7 +4255,7 @@
       "config_help": {
         "title": "À propos de ta demande de configuration"
       },
-      "reference": "Référence : {reference}",
+      "reference": "Référence : `{reference}`",
       "modal": {
         "title": "Répondre à l'auteur",
         "body": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -4035,13 +4035,14 @@
       "token_detector": "Detector de tokens",
       "global_sanctions": "Sanções globais",
       "expirations": "Fim de sanção",
-      "support": "Suporte",
-      "moddy_team": "a equipe do Moddy"
+      "support": "Moddy Support",
+      "moddy_team": "Moddy Team"
     },
     "attribution": {
       "unknown_guild": "Servidor desconhecido",
       "sent_by": "Enviado por [**{guild}**]({guild_url}){badge} (`{guild_id}`)",
-      "sent_by_service": "Enviado por **{service}**{badge}"
+      "sent_by_service": "Enviado por **{service}**{badge}",
+      "sent_by_moddy": "Enviado por **{service}**{badge}"
     },
     "source": {
       "uuid_label": "Notificação:"
@@ -4143,13 +4144,13 @@
     },
     "beta": {
       "title": "O Moddy entra em beta",
-      "body": "Olá **{user}**!\n\nVocê adicionou o **Moddy** em {servers} quando ele ainda estava em desenvolvimento, numa época em que não fazia grande coisa. Isso mudou: o bot entra em **beta** e boa parte dos recursos já está ativa.\n\nComo você estava aqui antes de todo mundo, **o Moddy Max é seu por 2 meses**: de graça e sem cartão. Basta abrir um ticket no nosso [**servidor de suporte**]({support}) para ativar.\n\nPara configurar os módulos, use {config} ou o nosso painel em [**dashboard.moddy.app**]({dashboard}). E se preferir não cuidar disso, alguém da equipe pode configurar para você: é só apertar o botão abaixo. A nossa [**documentação**]({docs}) também está aí.\n\nEstamos em beta, então vai ter bug; é normal. Relate com **/bug-report** ou no servidor de suporte: ajuda muito.\n\nObrigado por ter mantido o Moddy num canto do seu servidor todo esse tempo.",
+      "body": "Olá **{user}**!\n\nVocê adicionou o **Moddy** em {servers} quando ele ainda estava em desenvolvimento, numa época em que não fazia grande coisa. Isso mudou: o bot entra em **beta** e boa parte dos recursos já está ativa.\n\nComo você estava aqui antes de todo mundo, **o Moddy Max é seu por 2 meses**: de graça e sem cartão. Basta abrir um ticket no nosso [**servidor de suporte**]({support}) para ativar.\n\nPara configurar os módulos, use {config} ou o nosso painel em [**dashboard.moddy.app**]({dashboard}). E se preferir não cuidar disso, alguém da equipe pode configurar para você: é só apertar o botão abaixo. A nossa [**documentação**]({docs}) também está aí.\n\nEstamos em beta, então vai ter bug; é normal. Relate com {bug_report} ou no servidor de suporte: ajuda muito.\n\nObrigado por ter mantido o Moddy num canto do seu servidor todo esse tempo.",
       "translate": "Traduzir",
       "your_server": "**o seu servidor**"
     },
     "install": {
       "title": "Bem-vindo ao Moddy",
-      "body": "Obrigado por adicionar o **Moddy** em **{server}**!\n\nTudo se configura em um só lugar: use {config} no seu servidor ou o painel em [**dashboard.moddy.app**]({dashboard}). Moderação, logs, mensagens de boas-vindas, tickets: escolha um módulo, ajuste e pronto.\n\n**Um mês de premium é por nossa conta** para este servidor, de graça e sem cartão. Entre no nosso [**servidor de suporte**]({support}) e abra um ticket para ativar.\n\nPrefere não cuidar disso? Aperte o botão abaixo e alguém da equipe configura com você. A nossa [**documentação**]({docs}) explica cada módulo.\n\nO Moddy está atualmente em **beta**, então você pode encontrar bugs. É esperado: conte para a gente com **/bug-report** ou no servidor de suporte, e a gente corrige."
+      "body": "Obrigado por adicionar o **Moddy** em **{server}**!\n\nTudo se configura em um só lugar: use {config} no seu servidor ou o painel em [**dashboard.moddy.app**]({dashboard}). Moderação, logs, mensagens de boas-vindas, tickets: escolha um módulo, ajuste e pronto.\n\n**Um mês de premium é por nossa conta** para este servidor, de graça e sem cartão. Entre no nosso [**servidor de suporte**]({support}) e abra um ticket para ativar.\n\nPrefere não cuidar disso? Aperte o botão abaixo e alguém da equipe configura com você. A nossa [**documentação**]({docs}) explica cada módulo.\n\nO Moddy está atualmente em **beta**, então você pode encontrar bugs. É esperado: conte para a gente com {bug_report} ou no servidor de suporte, e a gente corrige."
     }
   },
   "support": {
@@ -4255,7 +4256,7 @@
       "config_help": {
         "title": "Sobre o seu pedido de configuração"
       },
-      "reference": "Referência: {reference}",
+      "reference": "Referência: `{reference}`",
       "modal": {
         "title": "Responder ao autor",
         "body": {

--- a/notifications/render.py
+++ b/notifications/render.py
@@ -39,7 +39,12 @@ logger = logging.getLogger("moddy.notifications.render")
 VERIFIED_GUILD_ATTRIBUTES = ("VERIFIED", "VERIFIED_ORG", "PARTNER")
 
 #: Services that ARE Moddy: their attribution line carries the check mark.
-OFFICIAL_SERVICES = ("moddy", "moddy_team")
+OFFICIAL_SERVICES = ("moddy", "moddy_team", "support")
+
+#: Among those, the ones read as a named entity rather than as Moddy itself
+#: ("Sent by the **Moddy Team**", not "Sent by the **Moddy**"). The article sits
+#: outside the bold, in the localized template.
+ARTICLE_SERVICES = ("moddy_team", "support")
 
 #: Guild attribute marking one of Moddy's own servers. Reporting a message from
 #: Moddy's own server to Moddy's abuse team is a loop with no exit, so the flag
@@ -205,8 +210,10 @@ def build_attribution_line(ctx: Dict[str, Any], *, locale: str = "en-US") -> Opt
             badge=ctx.get("badge") or "",
         )
     if ctx.get("service_name"):
-        return "-# " + t("notifications.attribution.sent_by_service",
-                         locale=locale, service=ctx["service_name"],
+        key = ("notifications.attribution.sent_by_moddy"
+               if ctx.get("service_id") in ARTICLE_SERVICES
+               else "notifications.attribution.sent_by_service")
+        return "-# " + t(key, locale=locale, service=ctx["service_name"],
                          badge=ctx.get("badge") or "")
     return None
 

--- a/notifications/service.py
+++ b/notifications/service.py
@@ -305,6 +305,27 @@ class NotificationService:
             allowed_mentions=allowed_mentions,
         )
 
+    async def attribution_line(self, record: Optional[Dict[str, Any]],
+                               locale: Optional[str] = None) -> Optional[str]:
+        """The ``sent by`` line of a stored notification.
+
+        Public because a card can be **rebuilt** after delivery — the beta
+        announcement's Translate button re-renders the message in the reader's
+        language — and a rebuilt card that drops its origin line is a message
+        that suddenly says nothing about who wrote it.
+        """
+        if not record:
+            return None
+        ctx = await self.source_context(
+            record, locale=locale or record.get("locale") or "en-US")
+        return build_attribution_line(ctx, locale=locale or "en-US")
+
+    @staticmethod
+    def append_attribution(view: discord.ui.LayoutView, line: Optional[str]) -> None:
+        """Close a rebuilt card with the line :meth:`attribution_line` returned."""
+        if line:
+            _append_footer_line(view, line)
+
     async def _build_view(self, record, content, source, variables, view, locale,
                           attribution: bool = True):
         """Render (or take) the view and close it with the attribution line.

--- a/tests/test_support_requests.py
+++ b/tests/test_support_requests.py
@@ -231,12 +231,48 @@ def test_install_welcome_offers_the_config_help_button():
 # --------------------------------------------------------------------------- #
 
 @pytest.mark.asyncio
-async def test_team_attribution_carries_the_badge():
-    """"Sent by the Moddy Team" is the one line proving a DM is not a fake."""
-    source = NotificationSource.service("moddy_team", author=ContentAuthor.STAFF)
+@pytest.mark.parametrize("service, name", [
+    ("moddy_team", "Moddy Team"),
+    ("support", "Moddy Support"),
+])
+async def test_moddy_attribution_carries_the_badge(service, name):
+    """"Sent by the Moddy Team✓" is the one line proving a DM is not a fake."""
+    source = NotificationSource.service(service, author=ContentAuthor.STAFF)
     ctx = await resolve_source_context(None, source, locale="en-US")
     line = build_attribution_line(ctx, locale="en-US")
     assert ctx["badge"]
+    assert line and ctx["badge"] in line
+    # The article stays outside the bold: "the **Moddy Team**", not "**the …**".
+    assert f"the **{name}**" in line
+
+
+@pytest.mark.asyncio
+async def test_a_plain_service_gets_no_badge_and_no_article():
+    source = NotificationSource.service("reminder")
+    ctx = await resolve_source_context(None, source, locale="en-US")
+    line = build_attribution_line(ctx, locale="en-US")
+    assert not ctx["badge"]
+    assert line and "the **" not in line
+
+
+@pytest.mark.asyncio
+async def test_a_verified_server_still_gets_its_check():
+    """The guild badge is the oldest half of the attribution line; the
+    Moddy-service badge must not have displaced it."""
+    class DB:
+        async def get_guild(self, guild_id):
+            return {"attributes": {"VERIFIED": True}}
+
+    class Bot:
+        db = DB()
+
+        def get_guild(self, guild_id):
+            return FakeGuild(guild_id, "Verified server", 1)
+
+    ctx = await resolve_source_context(Bot(), NotificationSource.guild(42),
+                                       locale="en-US")
+    line = build_attribution_line(ctx, locale="en-US")
+    assert ctx["verified"] and ctx["badge"]
     assert line and ctx["badge"] in line
 
 
@@ -246,3 +282,45 @@ async def test_staff_authored_notifications_are_not_reportable():
     source = NotificationSource.service("support", author=ContentAuthor.STAFF)
     ctx = await resolve_source_context(None, source, locale="en-US")
     assert ctx["reportable"] is False
+
+
+# --------------------------------------------------------------------------- #
+# House style
+# --------------------------------------------------------------------------- #
+
+def _link_buttons(view):
+    return [child.item if hasattr(child, "item") else child
+            for row in view.children
+            for child in getattr(row, "children", [])
+            if getattr(getattr(child, "item", child), "style", None)
+            is discord.ButtonStyle.link]
+
+
+@pytest.mark.parametrize("view", [
+    build_beta_view(variables={"user": "J", "servers": "**S**"}),
+    build_welcome_view(guild=FakeGuild(1, "Test", 1), locale="en-US"),
+    views.build_reply_dm(request=make_request(), body="ok", locale="en-US"),
+    views.build_receipt(kind=KIND_BUG, request=make_request(), locale="en-US"),
+])
+def test_link_buttons_carry_no_icon(view):
+    """House rule: a link button is its label, nothing else."""
+    buttons = _link_buttons(view)
+    assert buttons
+    assert all(button.emoji is None for button in buttons)
+
+
+@pytest.mark.parametrize("locale", ["fr", "en-US", "es-ES", "pt-BR", "de"])
+def test_commands_are_written_in_the_house_format(locale):
+    """**`/config`**, never a </config:id> mention: the id dies on a
+    re-registration and renders as raw text."""
+    for content in (welcome_content(locale), beta_content(locale)):
+        assert "**`/config`**" in content.body
+        assert "**`/bug-report`**" in content.body
+        assert "</config:" not in content.body
+
+
+@pytest.mark.parametrize("locale", ["fr", "en-US", "es-ES", "pt-BR", "de"])
+def test_references_are_always_code(locale):
+    from utils.i18n import t
+    assert "`{reference}`" in t("support.reply.reference", locale=locale,
+                                reference="{reference}")

--- a/utils/beta_announcement.py
+++ b/utils/beta_announcement.py
@@ -36,7 +36,7 @@ from discord import ui
 import config
 from cogs.error_handler import BaseView
 from notifications.models import NotificationContent
-from utils.emojis import BOOK, MODDY_SQUARE_MIN, SUPPORT, TRANSLATE, WEB
+from utils.emojis import MODDY_SQUARE_MIN, TRANSLATE
 from utils.i18n import i18n, t
 from utils.support_request_views import ConfigHelpButton, shorten
 
@@ -48,10 +48,11 @@ DEFAULT_LOCALE = "en-US"
 #: Accent of the card — Moddy blue, as asked for the campaign.
 ACCENT = 0x3661FF
 
-#: The ``/config`` mention, so the message opens the command in one click.
-#: A command mention needs the *registered* command id, which is stable per
-#: application: it lives in config so it survives a re-registration.
-CONFIG_MENTION = config.CONFIG_COMMAND_MENTION
+#: How ``/config`` is written in the body (see ``config.command_label``).
+CONFIG_LABEL = config.command_label("config")
+
+#: Same for ``/bug-report``, named in the last paragraph.
+BUG_REPORT_LABEL = config.command_label("bug-report")
 
 #: UUID fragment used by the translate button's custom_id.
 _UUID = r"[0-9a-fA-F-]{36}"
@@ -68,7 +69,7 @@ def beta_content(locale: str = DEFAULT_LOCALE) -> NotificationContent:
         title=t("notifications.beta.title", locale=locale),
         body=t("notifications.beta.body", locale=locale,
                user="{user}", servers="{servers}",
-               config=CONFIG_MENTION,
+               config=CONFIG_LABEL, bug_report=BUG_REPORT_LABEL,
                support=config.SUPPORT_URL,
                dashboard=config.DASHBOARD_URL,
                docs=config.DOCS_URL),
@@ -104,15 +105,12 @@ def build_beta_view(*, variables: Dict[str, Any], locale: str = DEFAULT_LOCALE,
     row.add_item(ConfigHelpButton(locale=locale))
     row.add_item(ui.Button(
         label=shorten(t("support.links.support", locale=locale)),
-        emoji=discord.PartialEmoji.from_str(SUPPORT),
         style=discord.ButtonStyle.link, url=config.SUPPORT_URL))
     row.add_item(ui.Button(
         label=shorten(t("support.links.docs", locale=locale)),
-        emoji=discord.PartialEmoji.from_str(BOOK),
         style=discord.ButtonStyle.link, url=config.DOCS_URL))
     row.add_item(ui.Button(
         label=shorten(t("support.links.dashboard", locale=locale)),
-        emoji=discord.PartialEmoji.from_str(WEB),
         style=discord.ButtonStyle.link, url=config.DASHBOARD_URL))
     view.add_item(row)
     return view
@@ -132,7 +130,7 @@ class BetaTranslateButton(
     def __init__(self, notification_id: str, *, locale: str = DEFAULT_LOCALE):
         super().__init__(ui.Button(
             label=shorten(t("notifications.beta.translate", locale=locale)),
-            style=discord.ButtonStyle.secondary,
+            style=discord.ButtonStyle.primary,
             emoji=discord.PartialEmoji.from_str(TRANSLATE),
             custom_id=f"moddy:beta:translate:{notification_id}",
         ))
@@ -145,19 +143,28 @@ class BetaTranslateButton(
     async def callback(self, interaction: discord.Interaction):
         try:
             locale = i18n.get_user_locale(interaction)
-            variables = await self._variables(interaction)
-            await interaction.response.edit_message(view=build_beta_view(
-                variables=variables, locale=locale,
-                notification_id=self.notification_id))
+            service = getattr(interaction.client, "notifications", None)
+            record = await service.get(self.notification_id) if service else None
+            variables = self._variables(record, interaction)
+
+            view = build_beta_view(variables=variables, locale=locale,
+                                   notification_id=self.notification_id)
+            # A translated card is the same notification, so it closes the same
+            # way: dropping the "sent by" line would leave a message with no
+            # stated origin.
+            if service is not None:
+                service.append_attribution(
+                    view, await service.attribution_line(record, locale))
+            await interaction.response.edit_message(view=view)
         except Exception as exc:  # noqa: BLE001 — dynamic items have no BaseView
             from cogs.error_handler import report_component_error
             await report_component_error(interaction, exc, self.__class__.__name__)
 
-    async def _variables(self, interaction: discord.Interaction) -> Dict[str, Any]:
+    @staticmethod
+    def _variables(record: Optional[Dict[str, Any]],
+                   interaction: discord.Interaction) -> Dict[str, Any]:
         """The values this copy was sent with — falling back to what the
         interaction itself knows, so a translation never renders `{user}`."""
-        service = getattr(interaction.client, "notifications", None)
-        record = await service.get(self.notification_id) if service else None
         variables = dict((record or {}).get("variables") or {})
         variables.setdefault(
             "user", interaction.user.global_name or interaction.user.name)

--- a/utils/install_welcome.py
+++ b/utils/install_welcome.py
@@ -22,7 +22,7 @@ import config
 from cogs.error_handler import BaseView
 from discord import ui
 from notifications.models import ContentAuthor, NotificationContent, NotificationSource
-from utils.emojis import BOOK, MODDY_SQUARE_MIN, SUPPORT, WEB
+from utils.emojis import MODDY_SQUARE_MIN
 from utils.i18n import t
 from utils.support_request_views import ConfigHelpButton, shorten
 
@@ -37,7 +37,8 @@ def welcome_content(locale: str = "en-US") -> NotificationContent:
     return NotificationContent(
         title=t("notifications.install.title", locale=locale),
         body=t("notifications.install.body", locale=locale,
-               server="{server}", config=config.CONFIG_COMMAND_MENTION,
+               server="{server}", config=config.command_label("config"),
+               bug_report=config.command_label("bug-report"),
                dashboard=config.DASHBOARD_URL, support=config.SUPPORT_URL,
                docs=config.DOCS_URL),
         icon=MODDY_SQUARE_MIN,
@@ -65,15 +66,12 @@ def build_welcome_view(*, guild: discord.Guild, locale: str = "en-US") -> BaseVi
     row.add_item(ConfigHelpButton(guild_id=guild.id, locale=locale))
     row.add_item(ui.Button(
         label=shorten(t("support.links.dashboard", locale=locale)),
-        emoji=discord.PartialEmoji.from_str(WEB),
         style=discord.ButtonStyle.link, url=config.DASHBOARD_URL))
     row.add_item(ui.Button(
         label=shorten(t("support.links.support", locale=locale)),
-        emoji=discord.PartialEmoji.from_str(SUPPORT),
         style=discord.ButtonStyle.link, url=config.SUPPORT_URL))
     row.add_item(ui.Button(
         label=shorten(t("support.links.docs", locale=locale)),
-        emoji=discord.PartialEmoji.from_str(BOOK),
         style=discord.ButtonStyle.link, url=config.DOCS_URL))
     view.add_item(row)
     return view

--- a/utils/support_request_views.py
+++ b/utils/support_request_views.py
@@ -39,7 +39,7 @@ from db.repositories.support_requests import (
 )
 from utils.components_v2 import create_error_message, create_success_message
 from utils.emojis import (
-    BOOK, BUG, BUILD, DONE, GROUPS, HAND, NOTE, REPLY, SUPPORT, TIME, USER, WEB,
+    BUG, BUILD, DONE, GROUPS, HAND, NOTE, REPLY, SUPPORT, TIME, USER,
 )
 from utils.i18n import i18n, t
 
@@ -218,7 +218,6 @@ def build_reply_dm(*, request: Dict[str, Any], body: str,
     row.add_item(SupportUserReplyButton(str(request["id"]), locale=locale))
     row.add_item(ui.Button(
         label=_short(t("support.links.support", locale=locale)),
-        emoji=discord.PartialEmoji.from_str(SUPPORT),
         style=discord.ButtonStyle.link, url=config.SUPPORT_URL))
     view.add_item(row)
     return view
@@ -622,17 +621,14 @@ def build_receipt(*, kind: str, request: Dict[str, Any], locale: str) -> BaseVie
     row = ui.ActionRow()
     row.add_item(ui.Button(
         label=_short(t("support.links.support", locale=locale)),
-        emoji=discord.PartialEmoji.from_str(SUPPORT),
         style=discord.ButtonStyle.link, url=config.SUPPORT_URL))
     if kind == KIND_CONFIG_HELP:
         row.add_item(ui.Button(
             label=_short(t("support.links.dashboard", locale=locale)),
-            emoji=discord.PartialEmoji.from_str(WEB),
             style=discord.ButtonStyle.link, url=config.DASHBOARD_URL))
     else:
         row.add_item(ui.Button(
             label=_short(t("support.links.docs", locale=locale)),
-            emoji=discord.PartialEmoji.from_str(BOOK),
             style=discord.ButtonStyle.link, url=config.DOCS_URL))
     view.add_item(row)
     return view


### PR DESCRIPTION
## Summary

Follow-up fixes on top of #361 (already merged), addressing review feedback:

- **Attribution line**: `Sent by the **Moddy Team**` / `**Moddy Support**` — the article now sits outside the bold, and the `support` service joined the services that *are* Moddy, so a team reply carries the verification check too. Service names read as brand names: *Moddy Team*, *Moddy Support*.
- **Translate button**: now re-appends the `sent by` line instead of dropping it on a rebuilt card, through two new public methods on `NotificationService` (`attribution_line()` / `append_attribution()`). The button is blue (`ButtonStyle.primary`) like the rest of the row.
- **Commands in message bodies**: written `**\`/config\`**` / `**\`/bug-report\`**` via a new `config.command_label()` helper, replacing the `</config:id>` mention — that id breaks if the command is ever re-registered and silently renders as raw text.
- **References**: always rendered as inline code (`` `{reference}` ``).
- **Link buttons**: carry no icon anywhere (`/config`, support cards, beta card, install welcome) — a link button is its label, nothing else.
- Verified-server badge: confirmed unaffected (the guild half of the attribution line was never touched) and pinned with a regression test.

## Test plan
- [x] `pytest tests/` (1050 passed, 1 skipped — no fastapi in this sandbox)
- [x] `pytest tests/automod` (283 passed)
- [x] `pytest tests/test_command_localizations.py`, `tests/test_persistent_views.py`, `tests/test_support_requests.py` individually
- [x] Manual render check of the attribution line for `moddy`, `moddy_team`, `support` and a verified guild

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01UjMEm3BxA3EGcLuoTqhDsC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjMEm3BxA3EGcLuoTqhDsC)_