### PR TITLE
Add exclude_guild to /com beta owners

### DIFF
--- a/docs/SUPPORT_REQUESTS.md
+++ b/docs/SUPPORT_REQUESTS.md
@@ -183,6 +183,10 @@ naming all of their servers). The mass send is confirmed through a **Modal**
 where the sender types `SEND`: a campaign cannot be recalled, so it must not be
 one mis-click away.
 
+`owners` accepts `exclude_guild`: a server id whose **owner** should not
+receive the campaign at all — not just that one server left out of their list,
+the whole person skipped, even if they own other servers Moddy is in.
+
 ---
 
 ## Related

--- a/locales/de.json
+++ b/locales/de.json
@@ -3829,7 +3829,8 @@
           "field": {
             "label": "Confirmation",
             "description": "Type {word} to launch the campaign."
-          }
+          },
+          "excluded": "Excluding the owner of server `{id}` from this run."
         },
         "progress": {
           "title": "Sending the beta announcement",
@@ -3855,6 +3856,14 @@
           "not_confirmed": {
             "title": "Not sent",
             "description": "The campaign was not launched: type `{word}` to confirm."
+          },
+          "bad_guild_id": {
+            "title": "Invalid id",
+            "description": "`exclude_guild` needs a Discord server id."
+          },
+          "unknown_guild": {
+            "title": "Unknown server",
+            "description": "No server matches `{id}`, or Moddy could not resolve its owner."
           }
         }
       }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -3829,7 +3829,8 @@
           "field": {
             "label": "Confirmation",
             "description": "Type {word} to launch the campaign."
-          }
+          },
+          "excluded": "Excluding the owner of server `{id}` from this run."
         },
         "progress": {
           "title": "Sending the beta announcement",
@@ -3855,6 +3856,14 @@
           "not_confirmed": {
             "title": "Not sent",
             "description": "The campaign was not launched: type `{word}` to confirm."
+          },
+          "bad_guild_id": {
+            "title": "Invalid id",
+            "description": "`exclude_guild` needs a Discord server id."
+          },
+          "unknown_guild": {
+            "title": "Unknown server",
+            "description": "No server matches `{id}`, or Moddy could not resolve its owner."
           }
         }
       }

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -3829,7 +3829,8 @@
           "field": {
             "label": "Confirmation",
             "description": "Type {word} to launch the campaign."
-          }
+          },
+          "excluded": "Excluding the owner of server `{id}` from this run."
         },
         "progress": {
           "title": "Sending the beta announcement",
@@ -3855,6 +3856,14 @@
           "not_confirmed": {
             "title": "Not sent",
             "description": "The campaign was not launched: type `{word}` to confirm."
+          },
+          "bad_guild_id": {
+            "title": "Invalid id",
+            "description": "`exclude_guild` needs a Discord server id."
+          },
+          "unknown_guild": {
+            "title": "Unknown server",
+            "description": "No server matches `{id}`, or Moddy could not resolve its owner."
           }
         }
       }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3828,7 +3828,8 @@
           "field": {
             "label": "Confirmation",
             "description": "Tape {word} pour lancer la campagne."
-          }
+          },
+          "excluded": "Excluding the owner of server `{id}` from this run."
         },
         "progress": {
           "title": "Envoi de l'annonce bêta",
@@ -3854,6 +3855,14 @@
           "not_confirmed": {
             "title": "Pas envoyée",
             "description": "La campagne n'a pas été lancée : tape `{word}` pour confirmer."
+          },
+          "bad_guild_id": {
+            "title": "Invalid id",
+            "description": "`exclude_guild` needs a Discord server id."
+          },
+          "unknown_guild": {
+            "title": "Unknown server",
+            "description": "No server matches `{id}`, or Moddy could not resolve its owner."
           }
         }
       }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -3829,7 +3829,8 @@
           "field": {
             "label": "Confirmation",
             "description": "Type {word} to launch the campaign."
-          }
+          },
+          "excluded": "Excluding the owner of server `{id}` from this run."
         },
         "progress": {
           "title": "Sending the beta announcement",
@@ -3855,6 +3856,14 @@
           "not_confirmed": {
             "title": "Not sent",
             "description": "The campaign was not launched: type `{word}` to confirm."
+          },
+          "bad_guild_id": {
+            "title": "Invalid id",
+            "description": "`exclude_guild` needs a Discord server id."
+          },
+          "unknown_guild": {
+            "title": "Unknown server",
+            "description": "No server matches `{id}`, or Moddy could not resolve its owner."
           }
         }
       }

--- a/staff/commands/com/beta.py
+++ b/staff/commands/com/beta.py
@@ -61,6 +61,9 @@ class ComBetaCommand(StaffCommand):
                     choices=["preview", "test", "owners"]),
         SlashOption("recipient", "string", "Target 'test': the user id to send to.",
                     required=False),
+        SlashOption("exclude_guild", "string",
+                    "Target 'owners': a server id whose owner should NOT receive it.",
+                    required=False),
     ]
 
     def parse_message(self, raw: str) -> dict:
@@ -68,11 +71,13 @@ class ComBetaCommand(StaffCommand):
         return {
             "target": parts[0] if parts else None,
             "recipient": parts[1] if len(parts) > 1 else None,
+            "exclude_guild": parts[1] if len(parts) > 1 and parts[0] == "owners" else None,
         }
 
     async def execute(self, ctx):
         target = (ctx.opt("target") or "").lower()
         recipient = (ctx.opt("recipient") or "").strip()
+        exclude_guild = (ctx.opt("exclude_guild") or "").strip()
 
         if target not in ("preview", "test", "owners"):
             await ctx.send(view=design.invalid_usage(
@@ -98,6 +103,18 @@ class ComBetaCommand(StaffCommand):
 
         # --- the real thing --------------------------------------------- #
         owners = owner_server_map(ctx.bot)
+        excluded_owner_id = None
+        if exclude_guild:
+            excluded_owner_id, error = await _resolve_excluded_owner(
+                ctx.bot, exclude_guild, ctx.locale)
+            if error is not None:
+                await ctx.send(view=error)
+                return
+            # The whole owner is skipped, not just that one server: someone
+            # asking to leave a server's owner alone means leave them alone,
+            # whatever else they run.
+            owners.pop(excluded_owner_id, None)
+
         audience: List[Tuple[int, List[discord.Guild]]] = sorted(
             owners.items(), key=lambda item: len(item[1]), reverse=True)
         if not audience:
@@ -115,7 +132,9 @@ class ComBetaCommand(StaffCommand):
             emoji=emojis.MESSAGE,
             prompt_title=t("staff.com.beta.confirm.title", locale=ctx.locale),
             prompt_description=t("staff.com.beta.confirm.description", locale=ctx.locale,
-                                 owners=len(audience), guilds=len(ctx.bot.guilds)),
+                                 owners=len(audience), guilds=len(ctx.bot.guilds))
+                                + (f"\n\n{t('staff.com.beta.confirm.excluded', locale=ctx.locale, id=excluded_owner_id)}"
+                                   if excluded_owner_id else ""),
         )
 
 
@@ -177,6 +196,21 @@ class BetaConfirmModal(BaseModal):
 
 def _owned(bot, user_id: int) -> List[discord.Guild]:
     return [g for g in bot.guilds if g.owner_id == user_id]
+
+
+async def _resolve_excluded_owner(bot, guild_id: str, locale: str):
+    """The owner id to leave out of the ``owners`` campaign, from a guild id."""
+    if not guild_id.isdigit():
+        return None, design.error(
+            t("staff.com.beta.errors.bad_guild_id.title", locale=locale),
+            t("staff.com.beta.errors.bad_guild_id.description", locale=locale))
+    guild = bot.get_guild(int(guild_id))
+    if guild is None or guild.owner_id is None:
+        return None, design.error(
+            t("staff.com.beta.errors.unknown_guild.title", locale=locale),
+            t("staff.com.beta.errors.unknown_guild.description", locale=locale,
+              id=guild_id))
+    return guild.owner_id, None
 
 
 async def _resolve_user(bot, recipient: str, locale: str):

--- a/tests/test_support_requests.py
+++ b/tests/test_support_requests.py
@@ -25,6 +25,7 @@ from utils.beta_announcement import (
     owner_server_map,
 )
 from utils.install_welcome import build_welcome_view, welcome_content
+from staff.commands.com.beta import _resolve_excluded_owner
 
 
 # --------------------------------------------------------------------------- #
@@ -324,3 +325,43 @@ def test_references_are_always_code(locale):
     from utils.i18n import t
     assert "`{reference}`" in t("support.reply.reference", locale=locale,
                                 reference="{reference}")
+
+
+# --------------------------------------------------------------------------- #
+# /com beta exclude_guild
+# --------------------------------------------------------------------------- #
+
+class _ExcludeBot:
+    def __init__(self, guilds):
+        self._guilds = {g.id: g for g in guilds}
+
+    def get_guild(self, guild_id):
+        return self._guilds.get(guild_id)
+
+
+@pytest.mark.asyncio
+async def test_exclude_guild_resolves_its_owner():
+    bot = _ExcludeBot([FakeGuild(42, "Excluded", 999)])
+    owner_id, error = await _resolve_excluded_owner(bot, "42", "en-US")
+    assert owner_id == 999 and error is None
+
+
+@pytest.mark.asyncio
+async def test_exclude_guild_rejects_a_non_numeric_id():
+    owner_id, error = await _resolve_excluded_owner(_ExcludeBot([]), "not-an-id", "en-US")
+    assert owner_id is None and error is not None
+
+
+@pytest.mark.asyncio
+async def test_exclude_guild_rejects_an_unknown_guild():
+    owner_id, error = await _resolve_excluded_owner(_ExcludeBot([]), "1", "en-US")
+    assert owner_id is None and error is not None
+
+
+def test_owner_map_excludes_the_whole_owner_not_just_that_guild():
+    """Asking to leave a server's owner alone means leave them alone, even on
+    their other servers — not just skip the one server named."""
+    bot = FakeBot([FakeGuild(1, "A", 10), FakeGuild(2, "B", 10)])
+    owners = owner_server_map(bot)
+    owners.pop(10, None)
+    assert 10 not in owners


### PR DESCRIPTION
## Summary

Follow-up on top of #362 (already merged).

- `/com beta owners` gains an optional `exclude_guild` parameter: a server id whose **owner** should not receive the beta campaign at all.
- The exclusion drops the whole owner from the audience, not just that one server from their list — someone asking to leave a server's owner alone means leave them alone, even if they run other servers Moddy is in.
- The confirmation modal (the one requiring `SEND` to be typed) now names the excluded owner's id before launch.
- New errors: an invalid/non-numeric guild id, or a guild Moddy cannot resolve (unknown server / no owner).

## Test plan
- [x] `pytest tests/` (1054 passed, 1 skipped — no fastapi in this sandbox)
- [x] `pytest tests/automod` (283 passed)
- [x] Manual check of `_resolve_excluded_owner` (valid guild, non-numeric id, unknown guild)
- [x] New unit tests in `tests/test_support_requests.py` covering the exclusion

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01UjMEm3BxA3EGcLuoTqhDsC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjMEm3BxA3EGcLuoTqhDsC)_