### PR TITLE
Allow multiple comma-separated ids in /com beta's exclude_guilds

### DIFF
--- a/docs/SUPPORT_REQUESTS.md
+++ b/docs/SUPPORT_REQUESTS.md
@@ -183,9 +183,11 @@ naming all of their servers). The mass send is confirmed through a **Modal**
 where the sender types `SEND`: a campaign cannot be recalled, so it must not be
 one mis-click away.
 
-`owners` accepts `exclude_guild`: a server id whose **owner** should not
-receive the campaign at all — not just that one server left out of their list,
-the whole person skipped, even if they own other servers Moddy is in.
+`owners` accepts `exclude_guilds`: one or more server ids, comma-separated
+(`123, 456`), whose **owners** should not receive the campaign at all — not
+just those servers left out of their list, the whole person skipped, even if
+they own other servers Moddy is in. A single bad id in the list refuses the
+whole exclusion rather than guessing which ones were meant.
 
 ---
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -3830,7 +3830,7 @@
             "label": "Confirmation",
             "description": "Type {word} to launch the campaign."
           },
-          "excluded": "Excluding the owner of server `{id}` from this run."
+          "excluded": "Excluding the owner(s) of server(s) {ids} from this run."
         },
         "progress": {
           "title": "Sending the beta announcement",
@@ -3859,7 +3859,7 @@
           },
           "bad_guild_id": {
             "title": "Invalid id",
-            "description": "`exclude_guild` needs a Discord server id."
+            "description": "`{id}` is not a valid Discord server id."
           },
           "unknown_guild": {
             "title": "Unknown server",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -3830,7 +3830,7 @@
             "label": "Confirmation",
             "description": "Type {word} to launch the campaign."
           },
-          "excluded": "Excluding the owner of server `{id}` from this run."
+          "excluded": "Excluding the owner(s) of server(s) {ids} from this run."
         },
         "progress": {
           "title": "Sending the beta announcement",
@@ -3859,7 +3859,7 @@
           },
           "bad_guild_id": {
             "title": "Invalid id",
-            "description": "`exclude_guild` needs a Discord server id."
+            "description": "`{id}` is not a valid Discord server id."
           },
           "unknown_guild": {
             "title": "Unknown server",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -3830,7 +3830,7 @@
             "label": "Confirmation",
             "description": "Type {word} to launch the campaign."
           },
-          "excluded": "Excluding the owner of server `{id}` from this run."
+          "excluded": "Excluding the owner(s) of server(s) {ids} from this run."
         },
         "progress": {
           "title": "Sending the beta announcement",
@@ -3859,7 +3859,7 @@
           },
           "bad_guild_id": {
             "title": "Invalid id",
-            "description": "`exclude_guild` needs a Discord server id."
+            "description": "`{id}` is not a valid Discord server id."
           },
           "unknown_guild": {
             "title": "Unknown server",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3829,7 +3829,7 @@
             "label": "Confirmation",
             "description": "Tape {word} pour lancer la campagne."
           },
-          "excluded": "Excluding the owner of server `{id}` from this run."
+          "excluded": "Excluding the owner(s) of server(s) {ids} from this run."
         },
         "progress": {
           "title": "Envoi de l'annonce bêta",
@@ -3858,7 +3858,7 @@
           },
           "bad_guild_id": {
             "title": "Invalid id",
-            "description": "`exclude_guild` needs a Discord server id."
+            "description": "`{id}` is not a valid Discord server id."
           },
           "unknown_guild": {
             "title": "Unknown server",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -3830,7 +3830,7 @@
             "label": "Confirmation",
             "description": "Type {word} to launch the campaign."
           },
-          "excluded": "Excluding the owner of server `{id}` from this run."
+          "excluded": "Excluding the owner(s) of server(s) {ids} from this run."
         },
         "progress": {
           "title": "Sending the beta announcement",
@@ -3859,7 +3859,7 @@
           },
           "bad_guild_id": {
             "title": "Invalid id",
-            "description": "`exclude_guild` needs a Discord server id."
+            "description": "`{id}` is not a valid Discord server id."
           },
           "unknown_guild": {
             "title": "Unknown server",

--- a/staff/commands/com/beta.py
+++ b/staff/commands/com/beta.py
@@ -61,8 +61,9 @@ class ComBetaCommand(StaffCommand):
                     choices=["preview", "test", "owners"]),
         SlashOption("recipient", "string", "Target 'test': the user id to send to.",
                     required=False),
-        SlashOption("exclude_guild", "string",
-                    "Target 'owners': a server id whose owner should NOT receive it.",
+        SlashOption("exclude_guilds", "string",
+                    "Target 'owners': server id(s) whose owner should NOT receive it, "
+                    "comma-separated.",
                     required=False),
     ]
 
@@ -71,13 +72,13 @@ class ComBetaCommand(StaffCommand):
         return {
             "target": parts[0] if parts else None,
             "recipient": parts[1] if len(parts) > 1 else None,
-            "exclude_guild": parts[1] if len(parts) > 1 and parts[0] == "owners" else None,
+            "exclude_guilds": parts[1] if len(parts) > 1 and parts[0] == "owners" else None,
         }
 
     async def execute(self, ctx):
         target = (ctx.opt("target") or "").lower()
         recipient = (ctx.opt("recipient") or "").strip()
-        exclude_guild = (ctx.opt("exclude_guild") or "").strip()
+        exclude_guilds = (ctx.opt("exclude_guilds") or "").strip()
 
         if target not in ("preview", "test", "owners"):
             await ctx.send(view=design.invalid_usage(
@@ -103,17 +104,18 @@ class ComBetaCommand(StaffCommand):
 
         # --- the real thing --------------------------------------------- #
         owners = owner_server_map(ctx.bot)
-        excluded_owner_id = None
-        if exclude_guild:
-            excluded_owner_id, error = await _resolve_excluded_owner(
-                ctx.bot, exclude_guild, ctx.locale)
+        excluded_owner_ids: List[int] = []
+        if exclude_guilds:
+            excluded_owner_ids, error = await _resolve_excluded_owners(
+                ctx.bot, exclude_guilds, ctx.locale)
             if error is not None:
                 await ctx.send(view=error)
                 return
             # The whole owner is skipped, not just that one server: someone
             # asking to leave a server's owner alone means leave them alone,
             # whatever else they run.
-            owners.pop(excluded_owner_id, None)
+            for owner_id in excluded_owner_ids:
+                owners.pop(owner_id, None)
 
         audience: List[Tuple[int, List[discord.Guild]]] = sorted(
             owners.items(), key=lambda item: len(item[1]), reverse=True)
@@ -133,8 +135,8 @@ class ComBetaCommand(StaffCommand):
             prompt_title=t("staff.com.beta.confirm.title", locale=ctx.locale),
             prompt_description=t("staff.com.beta.confirm.description", locale=ctx.locale,
                                  owners=len(audience), guilds=len(ctx.bot.guilds))
-                                + (f"\n\n{t('staff.com.beta.confirm.excluded', locale=ctx.locale, id=excluded_owner_id)}"
-                                   if excluded_owner_id else ""),
+                                + (f"\n\n{t('staff.com.beta.confirm.excluded', locale=ctx.locale, ids=', '.join(f'`{o}`' for o in excluded_owner_ids))}"
+                                   if excluded_owner_ids else ""),
         )
 
 
@@ -198,19 +200,27 @@ def _owned(bot, user_id: int) -> List[discord.Guild]:
     return [g for g in bot.guilds if g.owner_id == user_id]
 
 
-async def _resolve_excluded_owner(bot, guild_id: str, locale: str):
-    """The owner id to leave out of the ``owners`` campaign, from a guild id."""
-    if not guild_id.isdigit():
-        return None, design.error(
-            t("staff.com.beta.errors.bad_guild_id.title", locale=locale),
-            t("staff.com.beta.errors.bad_guild_id.description", locale=locale))
-    guild = bot.get_guild(int(guild_id))
-    if guild is None or guild.owner_id is None:
-        return None, design.error(
-            t("staff.com.beta.errors.unknown_guild.title", locale=locale),
-            t("staff.com.beta.errors.unknown_guild.description", locale=locale,
-              id=guild_id))
-    return guild.owner_id, None
+async def _resolve_excluded_owners(bot, raw: str, locale: str):
+    """The owner ids to leave out of the ``owners`` campaign, from a
+    comma-separated list of server ids (same convention as ``/manage badge``'s
+    ``orgs`` option)."""
+    owner_ids: List[int] = []
+    for guild_id in (part.strip() for part in raw.split(",")):
+        if not guild_id:
+            continue
+        if not guild_id.isdigit():
+            return None, design.error(
+                t("staff.com.beta.errors.bad_guild_id.title", locale=locale),
+                t("staff.com.beta.errors.bad_guild_id.description", locale=locale,
+                  id=guild_id))
+        guild = bot.get_guild(int(guild_id))
+        if guild is None or guild.owner_id is None:
+            return None, design.error(
+                t("staff.com.beta.errors.unknown_guild.title", locale=locale),
+                t("staff.com.beta.errors.unknown_guild.description", locale=locale,
+                  id=guild_id))
+        owner_ids.append(guild.owner_id)
+    return owner_ids, None
 
 
 async def _resolve_user(bot, recipient: str, locale: str):

--- a/tests/test_support_requests.py
+++ b/tests/test_support_requests.py
@@ -25,7 +25,7 @@ from utils.beta_announcement import (
     owner_server_map,
 )
 from utils.install_welcome import build_welcome_view, welcome_content
-from staff.commands.com.beta import _resolve_excluded_owner
+from staff.commands.com.beta import _resolve_excluded_owners
 
 
 # --------------------------------------------------------------------------- #
@@ -340,22 +340,38 @@ class _ExcludeBot:
 
 
 @pytest.mark.asyncio
-async def test_exclude_guild_resolves_its_owner():
+async def test_exclude_guilds_resolves_a_single_owner():
     bot = _ExcludeBot([FakeGuild(42, "Excluded", 999)])
-    owner_id, error = await _resolve_excluded_owner(bot, "42", "en-US")
-    assert owner_id == 999 and error is None
+    owner_ids, error = await _resolve_excluded_owners(bot, "42", "en-US")
+    assert owner_ids == [999] and error is None
 
 
 @pytest.mark.asyncio
-async def test_exclude_guild_rejects_a_non_numeric_id():
-    owner_id, error = await _resolve_excluded_owner(_ExcludeBot([]), "not-an-id", "en-US")
-    assert owner_id is None and error is not None
+async def test_exclude_guilds_accepts_a_comma_separated_list():
+    bot = _ExcludeBot([FakeGuild(1, "A", 100), FakeGuild(2, "B", 200)])
+    owner_ids, error = await _resolve_excluded_owners(bot, "1, 2", "en-US")
+    assert owner_ids == [100, 200] and error is None
 
 
 @pytest.mark.asyncio
-async def test_exclude_guild_rejects_an_unknown_guild():
-    owner_id, error = await _resolve_excluded_owner(_ExcludeBot([]), "1", "en-US")
-    assert owner_id is None and error is not None
+async def test_exclude_guilds_rejects_a_non_numeric_id():
+    owner_ids, error = await _resolve_excluded_owners(_ExcludeBot([]), "not-an-id", "en-US")
+    assert owner_ids is None and error is not None
+
+
+@pytest.mark.asyncio
+async def test_exclude_guilds_rejects_an_unknown_guild():
+    owner_ids, error = await _resolve_excluded_owners(_ExcludeBot([]), "1", "en-US")
+    assert owner_ids is None and error is not None
+
+
+@pytest.mark.asyncio
+async def test_exclude_guilds_stops_at_the_first_bad_entry():
+    """One bad id in the list refuses the whole exclusion rather than silently
+    dropping it — a campaign is not the place to guess what staff meant."""
+    bot = _ExcludeBot([FakeGuild(1, "A", 100)])
+    owner_ids, error = await _resolve_excluded_owners(bot, "1, 999", "en-US")
+    assert owner_ids is None and error is not None
 
 
 def test_owner_map_excludes_the_whole_owner_not_just_that_guild():


### PR DESCRIPTION
## Summary

Follow-up on top of #364 (already merged).

- Renamed `exclude_guild` (singular) to `exclude_guilds` (plural) and taught it to accept a comma-separated list of server ids, matching the existing convention in `staff/commands/manage/badge.py`'s `orgs` option.
- Each id resolves to its server's owner, and every one of those owners is dropped from the campaign audience — not just those servers removed from their list.
- A single invalid or unknown id anywhere in the list refuses the whole exclusion rather than silently dropping the bad one and guessing what staff meant.
- The confirmation modal now lists every excluded owner id.

## Test plan
- [x] `pytest tests/` (1056 passed, 1 skipped — no fastapi in this sandbox)
- [x] `pytest tests/automod` (283 passed)
- [x] New unit tests: single id, comma-separated list, non-numeric id, unknown guild, and a list where the second id is bad (whole exclusion refused)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01UjMEm3BxA3EGcLuoTqhDsC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjMEm3BxA3EGcLuoTqhDsC)_