### PR TITLE
AltGuard: unverified role must outrank stale verified DB row

### DIFF
--- a/docs/ALTGUARD.md
+++ b/docs/ALTGUARD.md
@@ -32,9 +32,14 @@ would move personal data into the bot is a compliance regression.
    click a button.
 2. **The panel.** One permanent message in the verification channel, with one
    button. Its wording ships with Moddy; a server picks only the language.
-3. **Consent.** A member who already carries the verified role (or is verified
-   in `altguard_members`) is told so and goes no further — no data collected for
-   an answer the server already has. Otherwise the button opens a Modal V2
+3. **Consent.** A member who already carries the verified role (or, absent that
+   role, is verified in `altguard_members`) is told so and goes no further — no
+   data collected for an answer the server already has. The **unverified role**
+   outranks the database the other way: a member still wearing it is let
+   through to consent even if `altguard_members` still says `verified` (e.g. a
+   manual unverify or a reconciliation gap left a stale row) — the role is what
+   the gate actually enforces, and the stale row is corrected to `pending` on
+   the way out. Otherwise the button opens a Modal V2
    stating exactly what is collected (browser characteristics, technical cookie,
    Discord email, server list, IP address), that the data is encrypted, and
    linking the data notice

--- a/docs/sessions/2026-08-29_altguard-unverify-recheck.md
+++ b/docs/sessions/2026-08-29_altguard-unverify-recheck.md
@@ -1,0 +1,36 @@
+# 2026-08-29 — AltGuard: unverified role must outrank a stale `verified` DB row
+
+## What was done
+
+Fixed a bug reported by the user: a member who still carries the
+**unverified** Discord role (e.g. after a manual `/altguard unverify`, or any
+other reconciliation gap) but whose `altguard_members` row still said
+`verified` was told "you already passed" when clicking the verification
+panel button, and could not re-verify.
+
+- `modules/altguard.py`: added `has_unverified_role()` (mirrors
+  `has_verified_role()`) and `resync_stale_verified_status()`, which resets a
+  stale `verified` row back to `pending`.
+- `utils/altguard_views.py::_already_verified()`: now checks the unverified
+  role *before* falling back to the DB. If the member wears that role, the
+  answer is always "not verified" — and if the DB disagreed, it is corrected
+  on the spot (`resync_stale_verified_status`).
+- `docs/ALTGUARD.md`: documented the role-outranks-DB rule in the "Member
+  journey" §3 (Consent).
+- `tests/test_altguard.py`: added
+  `test_the_unverified_role_outranks_a_stale_verified_db_row`.
+
+## Decisions made and why
+
+The unverified/verified **role** is the authority the server (and the gate)
+actually enforces — `has_verified_role()` already treated it that way for the
+"yes" case (a hand-granted role with no DB row still skips the gate). The fix
+makes the "no" case symmetric: the unverified role also outranks a `verified`
+DB row, since only the role decides what channels the member can actually
+see. Silently correcting the stale row (rather than just returning `False`)
+keeps `altguard_members` from repeating the same lie on the next check.
+
+## Known issues / follow-ups
+
+None. All 46 tests in `tests/test_altguard.py` and 283 in
+`tests/test_persistent_views.py` pass.

--- a/modules/altguard.py
+++ b/modules/altguard.py
@@ -258,6 +258,31 @@ class AltGuardModule(ModuleBase):
             return False
         return any(role.id == self.verified_role_id for role in member.roles)
 
+    def has_unverified_role(self, member: discord.Member) -> bool:
+        """True when the member carries the unverified (held-back) role.
+
+        Same authority as :meth:`has_verified_role`, the other way round: the
+        role is what the gate actually enforces on the server. A stale
+        ``altguard_members`` row (e.g. left over from before a manual
+        unverify was reconciled) must never outrank it.
+        """
+        if not self.unverified_role_id:
+            return False
+        return any(role.id == self.unverified_role_id for role in member.roles)
+
+    async def resync_stale_verified_status(self, user_id: int) -> None:
+        """Bring a stale ``verified`` DB row back to ``pending``.
+
+        Called when a member still carries the unverified role but the stored
+        status says ``verified`` — the role is the ground truth, so the row
+        must not be left to block them from clicking through the gate again.
+        """
+        if not self.bot.db:
+            return
+        await self.bot.db.set_altguard_member_status(
+            self.guild_id, user_id, STATUS_PENDING, source=SOURCE_SERVICE,
+        )
+
     async def resolve_member(self, user_id: int) -> Optional[discord.Member]:
         """Get a member, falling back to the API when the cache misses.
 

--- a/tests/test_altguard.py
+++ b/tests/test_altguard.py
@@ -618,6 +618,21 @@ def test_the_verified_role_alone_proves_a_member_is_through_the_gate():
     assert module.has_verified_role(FakeMember(member_id=43, roles=[])) is False
 
 
+def test_the_unverified_role_outranks_a_stale_verified_db_row():
+    """A member the gate still holds back must not be told they already passed."""
+    unverified = FakeRole(10, "unverified")
+    verified = FakeRole(11, "verified")
+    db = FakeDB()
+    module = build_module(unverified=unverified, verified=verified, db=db)
+
+    asyncio.run(db.set_altguard_member_status(1, 42, STATUS_VERIFIED))
+
+    assert module.has_unverified_role(FakeMember(member_id=42, roles=[unverified])) is True
+
+    asyncio.run(module.resync_stale_verified_status(42))
+    assert db.members[(1, 42)]["status"] == STATUS_PENDING
+
+
 # ------------------------------------------------- pushed config (dashboard)
 
 class RecordingModule(AltGuardModule):

--- a/utils/altguard_views.py
+++ b/utils/altguard_views.py
@@ -142,10 +142,18 @@ def build_verification_panel(locale: str = "en-US") -> AltGuardPanelView:
 async def _already_verified(interaction: discord.Interaction) -> bool:
     """Whether the clicker is already through the gate in this guild.
 
-    Two authorities, either one is enough: the verified **role** (what the
-    server actually enforces, and what a manual grant leaves behind) and the
-    stored state. A lookup failure answers ``False`` — being asked to verify
-    once too often is a far smaller problem than a gate that cannot be passed.
+    The **role** is the authority the server actually enforces, both ways:
+    holding the verified role is enough to answer yes without asking the
+    database. Holding the unverified role answers no even if the stored
+    status still says ``verified`` — a member sent back behind the gate
+    (manual unverify, or any other reconciliation gap) must be able to click
+    through again, not be told by a stale row that they already passed. That
+    stale row is corrected on the way out so it stops lying to the next check.
+
+    Only when the member isn't wearing either role (e.g. the interaction
+    object isn't a ``discord.Member``) does the stored state get the final
+    word. A lookup failure answers ``False`` — being asked to verify once too
+    often is a far smaller problem than a gate that cannot be passed.
     """
     bot = interaction.client
     member = interaction.user
@@ -154,8 +162,13 @@ async def _already_verified(interaction: discord.Interaction) -> bool:
             interaction.guild_id, "altguard")
         if module is None or not module.enabled:
             return False
-        if isinstance(member, discord.Member) and module.has_verified_role(member):
-            return True
+        if isinstance(member, discord.Member):
+            if module.has_verified_role(member):
+                return True
+            if module.has_unverified_role(member):
+                if await module.is_verified(member.id):
+                    await module.resync_stale_verified_status(member.id)
+                return False
         return await module.is_verified(member.id)
     except Exception as e:
         logger.error(f"[AltGuard] Verified-state lookup failed for {member.id}: {e}")


### PR DESCRIPTION
## Summary

Fixed a bug where members carrying the **unverified** Discord role (e.g., after manual `/altguard unverify` or reconciliation gaps) but with a stale `verified` database row were incorrectly told "you already passed" and blocked from re-verifying.

## Changes

- **modules/altguard.py**
  - Added `has_unverified_role()` method to check if a member carries the unverified role (mirrors `has_verified_role()`)
  - Added `resync_stale_verified_status()` to reset stale `verified` rows back to `pending` when the role is the ground truth

- **utils/altguard_views.py**
  - Updated `_already_verified()` to check the unverified role **before** consulting the database
  - If a member wears the unverified role, they are always considered "not verified" — even if the DB says otherwise
  - Stale rows are automatically corrected via `resync_stale_verified_status()` to prevent repeated false positives

- **docs/ALTGUARD.md**
  - Documented the role-outranks-DB rule in the "Member journey" §3 (Consent) section
  - Clarified that the unverified role is the authority the gate actually enforces

- **tests/test_altguard.py**
  - Added `test_the_unverified_role_outranks_a_stale_verified_db_row()` to verify the fix

## Implementation Details

The unverified/verified **role** is the source of truth for what the server actually enforces. Previously, `has_verified_role()` treated the verified role as authoritative for the "yes" case (a hand-granted role with no DB row still skips the gate). This fix makes the "no" case symmetric: the unverified role now outranks a `verified` DB row, since only the role determines what channels a member can actually access.

Silently correcting stale rows (rather than just returning `False`) prevents `altguard_members` from repeating the same lie on subsequent checks.

All 46 tests in `tests/test_altguard.py` and 283 in `tests/test_persistent_views.py` pass.

https://claude.ai/code/session_016Y5rWfndBcshQhBpKTMguz