### PR TITLE
Invoice DM as Stripe receipt: English-only, formal, attributed to Stripe

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -455,16 +455,21 @@ class ModdyBot(ModdyFrameworkBot):
                     "### <a:GemStone_animated:1509243505845731389> Welcome to Moddy Max !\n"
                     "Your Moddy Max subscription is now active ! Your servers are in good hands.\n"
                     "Your support truly warms our hearts <3\n"
+                    "\n"
+                    "**One last step: pick your servers.**\n"
+                    "Premium is not active on any server until you choose them — "
+                    f"open [Select premium servers]({SELECT_URL}) and pick up to **5** "
+                    "of the servers you want it on.\n"
                 ),
                 ui.MediaGallery(
                     discord.MediaGalleryItem(
-                        media="https://files.catbox.moe/vdqse1.gif",
+                        media="https://media.tenor.com/FjVZaTai9TwAAAAC/peach-cat-kiss.gif",
                     ),
                 ),
                 ui.Separator(visible=True, spacing=discord.SeparatorSpacing.small),
                 ui.TextDisplay(
-                    "-# You now have access to premium features everywhere on Discord as a personal app "
-                    "and on 5 servers of your choice. Use </subscription:1459599678139011357> for details. "
+                    "-# Premium features are yours everywhere on Discord as a personal app right away, "
+                    "and on the 5 servers you select. Use </subscription:1459599678139011357> for details. "
                     "Need help? Contact our [support](https://moddy.app/support).\n"
                 ),
                 accent_colour=ACCENT,

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -52,9 +52,13 @@ An official notice carries no line: a suspension **is** Moddy speaking, there is
 no third party to name.
 
 The services that *are* Moddy (`OFFICIAL_SERVICES` in
-`notifications/render.py`: `moddy`, `moddy_team`, `support`) carry the
-verification check on their own line, without any database read — it is true by
-construction, and it is what tells a member the DM is not an impersonation.
+`notifications/render.py`: `moddy`, `moddy_team`, `support`, `subscription`)
+carry the verification check on their own line, without any database read — it
+is true by construction, and it is what tells a member the DM is not an
+impersonation. `stripe` is in that list too and is the one entry that is *not*
+Moddy: it is Moddy's payment provider, it issues the invoices, and the invoice
+DM (`services/invoice_notifier.py`) is attributed to it rather than to Moddy —
+see [SUBSCRIPTION_SCHEMA.md §3](SUBSCRIPTION_SCHEMA.md).
 Those of them that read as a named entity (`ARTICLE_SERVICES`: `moddy_team`,
 `support`) use `sent_by_moddy`, whose article sits **outside** the bold —
 "Sent by the **Moddy Team**", never "**the Moddy Team**".

--- a/docs/SUBSCRIPTION_SCHEMA.md
+++ b/docs/SUBSCRIPTION_SCHEMA.md
@@ -149,12 +149,12 @@ Bot action:
 
 Bot action:
 1. Invalidate Redis cache.
-2. Send DM to user:
-
-> ### ✨ Abonnement activé
-> Ton abonnement **Moddy Max** est maintenant actif. Merci pour ton soutien !
->
-> *[Gérer mon abonnement → https://dashboard.moddy.app/billing]*
+2. Send the welcome DM (`bot.py::_send_subscription_dm`). It is the one
+   celebratory message of the set, and it carries the **only call to action**
+   of the whole subscription flow: premium is not active on any server until
+   the customer picks them, so the card says so in the body and offers a
+   *Select servers* button to
+   `https://dashboard.moddy.app/select-premium-servers` (up to 5).
 
 ---
 
@@ -232,9 +232,9 @@ Bot action (`services/invoice_notifier.py`, `bot.invoices`):
 
 | `variant` | Meaning | What the DM says |
 |---|---|---|
-| `paid` | An amount was charged | "The payment of **€4.99** has been received" |
-| `trial` | 0 at the opening of the subscription — the **free trial** | "Your trial has started: **no amount was charged**" |
-| `free` | 0 on a later period (full discount, credit note) | "**No amount was charged** for this period" |
+| `paid` | An amount was charged | "A payment of **€4.99** has been processed successfully" |
+| `trial` | 0 at the opening of the subscription — the **free trial** | "**No amount has been charged.** Your trial ends on **2026-09-29**, the date on which the first payment will be taken" |
+| `free` | 0 on a later period (full discount, credit note) | "**No amount has been charged** for the current period" |
 
 The backend computes it (`invoices.variant_of`): `amount_paid > 0` → `paid`;
 else `billing_reason == "subscription_create"` → `trial`; else `free`. The bot
@@ -244,11 +244,15 @@ nothing was charged when something was is the one error a billing message must
 never make. The opposite error costs as much: "payment received" on a 0 invoice
 sends someone hunting for a debit that does not exist on their statement.
 
-⚠️ **On a `trial`, `period_end` is the date of the first charge, not a
-renewal.** It is labelled *First charge* (`field_first_charge`), exactly like
-the mail — same date, opposite meaning.
+⚠️ **On a `trial`, `period_end` is the date the trial ends and the first
+charge is taken, not a renewal.** Same date as a renewal, opposite meaning, so
+it is said twice: in the body ("Your trial ends on **{period_end}**, the date
+on which the first payment will be taken") and as its own field, labelled
+*Trial ends — first charge* (`field_trial_end`). The mail says the same thing,
+and the two must not contradict. There is no separate "trial end" field on the
+payload and none is needed — `period_end` **is** that date.
 
-##### Four rules the DM obeys
+##### Five rules the DM obeys
 
 1. **Amounts as reported, never recomputed.** `amount_paid` is the currency's
    smallest unit, except for the zero-decimal currencies
@@ -264,13 +268,31 @@ the mail — same date, opposite meaning.
    (`SET NX`, TTL 7 days) is a second belt against a replayed event, on top of
    the backend's own de-duplication; Redis being unavailable costs a possible
    duplicate, never the DM.
+5. **It is a receipt, not a thank-you note.** Formal wording, Stripe's indigo
+   accent (`0x635BFF`), a document icon rather than the premium gem — nothing
+   like the celebratory subscription lifecycle DMs, on purpose. A customer must
+   be able to tell a receipt from a marketing message at a glance.
+
+##### Attributed to Stripe, and written in English
 
 The DM goes through the notification system like everything else
-([NOTIFICATIONS.md](NOTIFICATIONS.md)) under the `subscription` service, which
-is one of the `OFFICIAL_SERVICES`: its attribution line carries the
-verification check, because a billing DM is precisely what a scam impersonates.
-Its language is the account's `LANG` attribute — the same one the backend's
-mail reads, so the two halves of one invoice never arrive in two languages.
+([NOTIFICATIONS.md](NOTIFICATIONS.md)), but under the **`stripe`** service, not
+`subscription`: Stripe issues the invoice, takes the payment and holds the card
+details, so `-# Sent by **Stripe**<:verified:…>` is simply what happened.
+`stripe` is in `OFFICIAL_SERVICES`, so that line carries the verification
+check — a billing DM is precisely what a scam impersonates, and the check is
+the tell. It is also the **only** message in Moddy that names Stripe: the
+footer (`footer_stripe`) states that Stripe is Moddy's billing and payment
+provider and that Moddy never handles card details, which is what makes the
+attribution read as a fact rather than as a stray brand name.
+
+Its language is **always English** (`INVOICE_LOCALE` in
+`services/invoice_notifier.py`), whatever the account's `LANG`. The invoice,
+its PDF and Stripe's hosted page are English documents, and a receipt that
+half-translates the document it describes reads as a forgery. The localized
+`commands.subscription.invoice.*` keys are kept in the five locales for the
+mail and dashboard renderings of a stored row; `build_content(locale=…)` still
+honours them, only the DM path pins English.
 
 ---
 

--- a/docs/sessions/2026-08-30_subscription-and-invoice-messages.md
+++ b/docs/sessions/2026-08-30_subscription-and-invoice-messages.md
@@ -1,0 +1,81 @@
+# 2026-08-30 — Subscription welcome DM, Stripe invoice receipt, unlimited trial length
+
+## What was done
+
+### 1. The welcome DM (`notify_subscription_started`)
+
+- New GIF (`https://media.tenor.com/FjVZaTai9TwAAAAC/peach-cat-kiss.gif`,
+  from Tenor's *mwa* search as requested). The previous `files.catbox.moe`
+  link stays dead in history only.
+- The card now **says out loud that servers have to be selected**. This was the
+  one thing missing: premium is not active on any server until the customer
+  picks them, and the DM only hinted at it in the grey footnote. It is now a
+  bolded paragraph in the body with an inline link, next to the existing
+  *Select servers* button.
+
+### 2. The invoice DM is now a Stripe receipt
+
+`services/invoice_notifier.py` — the message is deliberately unlike the
+celebratory lifecycle DMs:
+
+| | Before | After |
+|---|---|---|
+| Language | account `LANG` | **always English** (`INVOICE_LOCALE`) |
+| Attribution | `Sent by **Moddy Subscription**` | `Sent by **Stripe**<:verified:…>` |
+| Icon / accent | `PREMIUM` gem / `0x245F9F` | `NOTE` / Stripe indigo `0x635BFF` |
+| Wording | "Thanks for supporting Moddy!" | formal receipt, no thanks, no exclamation |
+| Footer | none | Stripe is Moddy's billing/payment provider, Moddy never holds card details |
+| Trial | `First charge: 2026-09-29` | end date **in the body** + `Trial ends — first charge` field |
+| Buttons | Manage my subscription | Manage billing |
+
+- **The trial end date was already available** — `period_end` on a trial
+  invoice *is* the end of the trial and the date of the first charge. Nothing
+  new had to be asked of the backend; it is now stated in the body sentence
+  rather than only as a field label, since it is the whole point of a €0
+  invoice.
+- New notification service **`stripe`** (`notifications/models.py`), added to
+  `OFFICIAL_SERVICES` so the attribution line carries the verification check.
+  It is the first entry in that list that is not Moddy itself.
+- `InvoiceNotifier.user_locale()` deleted — dead once the DM pins English.
+
+### 3. `/manage stripe trial` — no more day cap
+
+`staff/commands/manage/stripe/trial.py`: the Moddy-side `1-30` clamp is gone.
+The only bound left is Stripe's own `trial_period_days` maximum (**730**),
+kept as a clamp so an out-of-range value becomes the largest legal trial
+instead of an opaque Stripe API error.
+
+## Files modified
+
+- `bot.py` — welcome DM (GIF + server selection)
+- `services/invoice_notifier.py` — English-only, Stripe source, footer, trial end, accent/icon
+- `notifications/models.py` — `stripe` service
+- `notifications/render.py` — `stripe` in `OFFICIAL_SERVICES`
+- `locales/{en-US,fr,es-ES,pt-BR,de}.json` — invoice block rewritten, `services.stripe`
+- `staff/commands/manage/stripe/trial.py` — trial length cap
+- `tests/test_invoice_notifications.py` — updated + new cases (English-only, Stripe footer/attribution, trial end in body)
+- `docs/SUBSCRIPTION_SCHEMA.md`, `docs/NOTIFICATIONS.md`
+
+## Decisions and why
+
+- **English-only invoice DM, against the previous "same language as the mail"
+  rule.** The invoice, its PDF and Stripe's hosted page are English documents;
+  a receipt that half-translates the document it describes reads as a forgery,
+  and billing wording is one text to review rather than five. The localized
+  keys were kept (updated, not deleted) so the mail/dashboard renderings of a
+  stored row still work and the decision stays reversible in one constant.
+- **Attributed to `stripe`, not `subscription`.** Stripe issues the invoice,
+  takes the payment and holds the card details. The footer naming Stripe is
+  what makes that attribution read as a fact instead of a stray brand name, and
+  it is the only place in Moddy that names Stripe to a customer.
+- **730-day clamp rather than none at all.** "No limit" is about Moddy not
+  imposing one; Stripe still refuses anything above 730, and clamping turns
+  that into the trial the staff member asked for.
+
+## Follow-ups
+
+- `utils/emojis.py` has no Stripe emoji: the `stripe` service reuses `NOTE`
+  with a `TODO`. Replace it once a `<:stripe:…>` emoji exists.
+- The lifecycle DMs in `bot.py::_send_subscription_dm` are still hardcoded
+  English strings outside i18n — untouched here, but they are the obvious next
+  cleanup.

--- a/locales/de.json
+++ b/locales/de.json
@@ -14,23 +14,24 @@
       "error": "Dein Abonnementstatus konnte nicht abgerufen werden. Bitte versuche es später erneut.",
       "invoice": {
         "title": {
-          "paid": "Zahlung erhalten",
-          "trial": "Deine Testphase hat begonnen",
+          "paid": "Zahlungsbeleg",
+          "trial": "Bestätigung der kostenlosen Testphase",
           "free": "Rechnung verfügbar"
         },
         "body": {
-          "paid": "Die Zahlung von **{amount}** für dein **{tier}** Abonnement ist eingegangen. Danke, dass du Moddy unterstützt!",
-          "trial": "Deine **{tier}** Testphase hat begonnen: **es wurde kein Betrag abgebucht**. Hier ist die zugehörige Rechnung über **{amount}**. Danke, dass du Moddy ausprobierst!",
-          "free": "**Es wurde kein Betrag abgebucht** für diesen Zeitraum deines **{tier}** Abonnements. Hier ist deine Rechnung über **{amount}**."
+          "paid": "Dies ist Ihr Beleg für das Moddy Max Abonnement (**{tier}**). Eine Zahlung über **{amount}** wurde erfolgreich verarbeitet. Es ist keine Aktion Ihrerseits erforderlich.",
+          "trial": "Ihre kostenlose Testphase von Moddy Max (**{tier}**) ist jetzt aktiv. **Es wurde kein Betrag abgebucht.** Die nachstehende Rechnung wird über **{amount}** für Ihre Unterlagen ausgestellt.\nIhre Testphase endet am **{period_end}**, an diesem Datum wird die erste Zahlung abgebucht. Sie können bis dahin jederzeit kostenlos kündigen.",
+          "free": "**Es wurde kein Betrag abgebucht** für den laufenden Zeitraum Ihres Moddy Max Abonnements (**{tier}**). Die zugehörige Rechnung über **{amount}** finden Sie unten."
         },
         "field_number": "Rechnungsnummer",
         "field_amount": "Betrag",
-        "field_date": "Datum",
+        "field_date": "Rechnungsdatum",
         "field_next_renewal": "Nächste Verlängerung",
-        "field_first_charge": "Erste Abbuchung",
+        "field_trial_end": "Ende der Testphase — erste Abbuchung",
+        "footer_stripe": "Rechnung ausgestellt und Zahlung verarbeitet von Stripe, dem Abrechnungs- und Zahlungsdienstleister von Moddy. Moddy verarbeitet und speichert Ihre Kartendaten zu keinem Zeitpunkt.",
         "button_view": "Rechnung ansehen",
         "button_pdf": "PDF herunterladen",
-        "button_manage": "Mein Abonnement verwalten",
+        "button_manage": "Abrechnung verwalten",
         "tier": {
           "monthly": "monatlich",
           "yearly": "jährlich"
@@ -4096,7 +4097,8 @@
       "expirations": "Sanktionsende",
       "support": "Moddy Support",
       "moddy_team": "Moddy Team",
-      "subscription": "Moddy-Abonnement"
+      "subscription": "Moddy-Abonnement",
+      "stripe": "Stripe"
     },
     "attribution": {
       "unknown_guild": "Unbekannter Server",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -14,26 +14,27 @@
       "error": "Unable to retrieve your subscription status. Please try again later.",
       "invoice": {
         "title": {
-          "paid": "Payment received",
-          "trial": "Your trial has started",
+          "paid": "Payment receipt",
+          "trial": "Free trial confirmation",
           "free": "Invoice available"
         },
         "body": {
-          "paid": "The payment of **{amount}** for your **{tier}** subscription has been received. Thanks for supporting Moddy!",
-          "trial": "Your **{tier}** trial has started: **no amount was charged**. Here is the matching invoice, for **{amount}**. Thanks for trying Moddy!",
-          "free": "**No amount was charged** for this period of your **{tier}** subscription. Here is your invoice, for **{amount}**."
+          "paid": "This is your receipt for the **{tier}** Moddy Max subscription. A payment of **{amount}** has been processed successfully. No action is required on your part.",
+          "trial": "Your **{tier}** Moddy Max free trial is now active. **No amount has been charged.** The invoice below is issued at **{amount}** for your records.\nYour trial ends on **{period_end}**, the date on which the first payment will be taken. You may cancel at any time before that date at no cost.",
+          "free": "**No amount has been charged** for the current period of your **{tier}** Moddy Max subscription. The corresponding invoice, issued at **{amount}**, is available below."
         },
         "field_number": "Invoice number",
         "field_amount": "Amount",
-        "field_date": "Date",
+        "field_date": "Invoice date",
         "field_next_renewal": "Next renewal",
-        "field_first_charge": "First charge",
+        "field_trial_end": "Trial ends — first charge",
+        "footer_stripe": "Invoice issued and payment processed by Stripe, Moddy's billing and payment provider. Moddy never handles or stores your card details.",
         "button_view": "View invoice",
         "button_pdf": "Download PDF",
-        "button_manage": "Manage my subscription",
+        "button_manage": "Manage billing",
         "tier": {
           "monthly": "monthly",
-          "yearly": "yearly"
+          "yearly": "annual"
         }
       }
     },
@@ -4096,7 +4097,8 @@
       "expirations": "Sanction expiry",
       "support": "Moddy Support",
       "moddy_team": "Moddy Team",
-      "subscription": "Moddy Subscription"
+      "subscription": "Moddy Subscription",
+      "stripe": "Stripe"
     },
     "attribution": {
       "unknown_guild": "Unknown server",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -14,23 +14,24 @@
       "error": "No se pudo obtener el estado de tu suscripción. Inténtalo de nuevo más tarde.",
       "invoice": {
         "title": {
-          "paid": "Pago recibido",
-          "trial": "Tu prueba ha comenzado",
+          "paid": "Recibo de pago",
+          "trial": "Confirmación de prueba gratuita",
           "free": "Factura disponible"
         },
         "body": {
-          "paid": "El pago de **{amount}** de tu suscripción **{tier}** se ha recibido correctamente. ¡Gracias por apoyar a Moddy!",
-          "trial": "Tu prueba **{tier}** ha comenzado: **no se ha cobrado ningún importe**. Aquí tienes la factura correspondiente, de **{amount}**. ¡Gracias por probar Moddy!",
-          "free": "**No se ha cobrado ningún importe** por este periodo de tu suscripción **{tier}**. Aquí tienes tu factura, de **{amount}**."
+          "paid": "Este es el recibo de su suscripción Moddy Max **{tier}**. Se ha procesado correctamente un pago de **{amount}**. No es necesaria ninguna acción por su parte.",
+          "trial": "Su prueba gratuita de Moddy Max **{tier}** ya está activa. **No se ha cobrado ningún importe.** La factura siguiente se emite por **{amount}** para su archivo.\nSu prueba finaliza el **{period_end}**, fecha en la que se realizará el primer cobro. Puede cancelar sin coste alguno en cualquier momento antes de esa fecha.",
+          "free": "**No se ha cobrado ningún importe** por el periodo actual de su suscripción Moddy Max **{tier}**. La factura correspondiente, emitida por **{amount}**, está disponible a continuación."
         },
         "field_number": "Número de factura",
         "field_amount": "Importe",
-        "field_date": "Fecha",
+        "field_date": "Fecha de factura",
         "field_next_renewal": "Próxima renovación",
-        "field_first_charge": "Primer cobro",
+        "field_trial_end": "Fin de la prueba — primer cobro",
+        "footer_stripe": "Factura emitida y pago procesado por Stripe, proveedor de facturación y pagos de Moddy. Moddy nunca gestiona ni almacena los datos de su tarjeta.",
         "button_view": "Ver la factura",
         "button_pdf": "Descargar el PDF",
-        "button_manage": "Gestionar mi suscripción",
+        "button_manage": "Gestionar la facturación",
         "tier": {
           "monthly": "mensual",
           "yearly": "anual"
@@ -4096,7 +4097,8 @@
       "expirations": "Fin de sanción",
       "support": "Moddy Support",
       "moddy_team": "Moddy Team",
-      "subscription": "Suscripción Moddy"
+      "subscription": "Suscripción Moddy",
+      "stripe": "Stripe"
     },
     "attribution": {
       "unknown_guild": "Servidor desconocido",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -14,23 +14,24 @@
       "error": "Impossible de récupérer ton statut d'abonnement. Réessaie plus tard.",
       "invoice": {
         "title": {
-          "paid": "Paiement reçu",
-          "trial": "Ton essai a démarré",
+          "paid": "Reçu de paiement",
+          "trial": "Confirmation d'essai gratuit",
           "free": "Facture disponible"
         },
         "body": {
-          "paid": "Le paiement de **{amount}** pour ton abonnement **{tier}** a bien été reçu. Merci de soutenir Moddy !",
-          "trial": "Ton essai **{tier}** a démarré : **aucun montant n'a été prélevé**. Voici la facture correspondante, à **{amount}**. Merci d'essayer Moddy !",
-          "free": "**Aucun montant n'a été prélevé** pour cette période de ton abonnement **{tier}**. Voici ta facture, à **{amount}**."
+          "paid": "Voici le reçu de votre abonnement Moddy Max **{tier}**. Un paiement de **{amount}** a été traité avec succès. Aucune action n'est requise de votre part.",
+          "trial": "Votre essai gratuit Moddy Max **{tier}** est désormais actif. **Aucun montant n'a été prélevé.** La facture ci-dessous est émise à **{amount}** pour vos archives.\nVotre essai prend fin le **{period_end}**, date à laquelle le premier paiement sera prélevé. Vous pouvez résilier sans frais à tout moment avant cette date.",
+          "free": "**Aucun montant n'a été prélevé** pour la période en cours de votre abonnement Moddy Max **{tier}**. La facture correspondante, émise à **{amount}**, est disponible ci-dessous."
         },
         "field_number": "Numéro de facture",
         "field_amount": "Montant",
-        "field_date": "Date",
+        "field_date": "Date de facture",
         "field_next_renewal": "Prochain renouvellement",
-        "field_first_charge": "Premier prélèvement",
+        "field_trial_end": "Fin de l'essai — premier prélèvement",
+        "footer_stripe": "Facture émise et paiement traité par Stripe, prestataire de facturation et de paiement de Moddy. Moddy ne manipule ni ne conserve vos données bancaires.",
         "button_view": "Voir la facture",
         "button_pdf": "Télécharger le PDF",
-        "button_manage": "Gérer mon abonnement",
+        "button_manage": "Gérer la facturation",
         "tier": {
           "monthly": "mensuel",
           "yearly": "annuel"
@@ -4095,7 +4096,8 @@
       "expirations": "Fin de sanction",
       "support": "Moddy Support",
       "moddy_team": "Moddy Team",
-      "subscription": "Abonnement Moddy"
+      "subscription": "Abonnement Moddy",
+      "stripe": "Stripe"
     },
     "attribution": {
       "unknown_guild": "Serveur inconnu",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -14,23 +14,24 @@
       "error": "Não foi possível obter o status da sua assinatura. Tente novamente mais tarde.",
       "invoice": {
         "title": {
-          "paid": "Pagamento recebido",
-          "trial": "Seu teste começou",
+          "paid": "Recibo de pagamento",
+          "trial": "Confirmação de teste gratuito",
           "free": "Fatura disponível"
         },
         "body": {
-          "paid": "O pagamento de **{amount}** da sua assinatura **{tier}** foi recebido. Obrigado por apoiar o Moddy!",
-          "trial": "Seu teste **{tier}** começou: **nenhum valor foi cobrado**. Aqui está a fatura correspondente, de **{amount}**. Obrigado por experimentar o Moddy!",
-          "free": "**Nenhum valor foi cobrado** neste período da sua assinatura **{tier}**. Aqui está a sua fatura, de **{amount}**."
+          "paid": "Este é o recibo da sua assinatura Moddy Max **{tier}**. Um pagamento de **{amount}** foi processado com sucesso. Nenhuma ação é necessária da sua parte.",
+          "trial": "Seu teste gratuito do Moddy Max **{tier}** está ativo. **Nenhum valor foi cobrado.** A fatura abaixo é emitida no valor de **{amount}** para os seus registros.\nSeu teste termina em **{period_end}**, data em que a primeira cobrança será realizada. Você pode cancelar sem custo a qualquer momento antes dessa data.",
+          "free": "**Nenhum valor foi cobrado** no período atual da sua assinatura Moddy Max **{tier}**. A fatura correspondente, emitida no valor de **{amount}**, está disponível abaixo."
         },
         "field_number": "Número da fatura",
         "field_amount": "Valor",
-        "field_date": "Data",
+        "field_date": "Data da fatura",
         "field_next_renewal": "Próxima renovação",
-        "field_first_charge": "Primeira cobrança",
+        "field_trial_end": "Fim do teste — primeira cobrança",
+        "footer_stripe": "Fatura emitida e pagamento processado pela Stripe, provedora de faturamento e pagamentos do Moddy. O Moddy nunca manipula nem armazena os dados do seu cartão.",
         "button_view": "Ver a fatura",
         "button_pdf": "Baixar o PDF",
-        "button_manage": "Gerenciar minha assinatura",
+        "button_manage": "Gerenciar o faturamento",
         "tier": {
           "monthly": "mensal",
           "yearly": "anual"
@@ -4096,7 +4097,8 @@
       "expirations": "Fim de sanção",
       "support": "Moddy Support",
       "moddy_team": "Moddy Team",
-      "subscription": "Assinatura Moddy"
+      "subscription": "Assinatura Moddy",
+      "stripe": "Stripe"
     },
     "attribution": {
       "unknown_guild": "Servidor desconhecido",

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -161,7 +161,12 @@ SERVICES: Dict[str, ServiceInfo] = {
         _svc("global_sanctions", "EXCLAMATION"),     # services/global_sanction_service.py
         _svc("expirations", "TIME"),                 # services/expiration_notifier.py
         _svc("support", "SUPPORT"),                  # services/support_request_service.py
-        _svc("subscription", "PREMIUM"),             # services/invoice_notifier.py
+        _svc("subscription", "PREMIUM"),             # bot.py::_send_subscription_dm
+        # Stripe is Moddy's payment provider: it issues the invoices and it is
+        # its name — not Moddy's — that belongs on a receipt, so the invoice DM
+        # attributes itself to Stripe rather than to the subscription service.
+        # TODO: replace NOTE with a proper <:stripe:…> emoji once one exists.
+        _svc("stripe", "NOTE"),                      # services/invoice_notifier.py
     )
 }
 

--- a/notifications/render.py
+++ b/notifications/render.py
@@ -38,10 +38,12 @@ logger = logging.getLogger("moddy.notifications.render")
 #: Guild attributes that earn the verification check on the attribution panel.
 VERIFIED_GUILD_ATTRIBUTES = ("VERIFIED", "VERIFIED_ORG", "PARTNER")
 
-#: Services that ARE Moddy: their attribution line carries the check mark.
-#: ``subscription`` is here for one reason: a billing DM is what a scam
-#: impersonates, and the check is what tells the recipient this one is ours.
-OFFICIAL_SERVICES = ("moddy", "moddy_team", "support", "subscription")
+#: Services whose attribution line carries the check mark. ``subscription`` and
+#: ``stripe`` are here for one reason: a billing DM is what a scam impersonates,
+#: and the check is what tells the recipient this one is genuine. ``stripe`` is
+#: the only entry that is not Moddy itself — it is Moddy's payment provider, and
+#: it is the name printed on the invoice the DM is about.
+OFFICIAL_SERVICES = ("moddy", "moddy_team", "support", "subscription", "stripe")
 
 #: Among those, the ones read as a named entity rather than as Moddy itself
 #: ("Sent by the **Moddy Team**", not "Sent by the **Moddy**"). The article sits

--- a/services/invoice_notifier.py
+++ b/services/invoice_notifier.py
@@ -8,16 +8,23 @@ on ``moddy:subscription:updates``::
 
     {"type": "notify_invoice", "user_id": "…", "invoice": {…}}
 
-Two rules carry the design, and both exist to keep the DM honest:
+Three rules carry the design, and all three exist to keep the DM honest:
 
 * **The wording is chosen on ``variant``, never on the amount.** A free trial
   produces a real Stripe invoice at 0. Saying "payment received" on it sends
   the person hunting for a charge that does not exist on their bank statement —
   the worst possible outcome for a billing message. An unknown variant is read
   as ``paid``, the conservative default the backend's own rule falls back to.
-* **On a trial, ``period_end`` is the date of the *first* charge**, not a
-  renewal. It is the most useful line of the message, so it is labelled as
-  such; the mail says the same thing, and the two must not contradict.
+* **On a trial, ``period_end`` is the date the trial ends and the *first*
+  charge is taken**, not a renewal. It is the most useful line of the message,
+  so it is said twice: in the body and as its own field. The mail says the same
+  thing, and the two must not contradict.
+* **This DM is a receipt, not a thank-you note.** It is deliberately unlike the
+  subscription lifecycle DMs (``bot.py::_send_subscription_dm``): formal, in
+  English whatever the account's language (:data:`INVOICE_LOCALE`), attributed
+  to **Stripe** rather than to Moddy, and carrying Stripe's accent colour. The
+  attribution is the truth of the matter — Stripe issues the invoice, processes
+  the payment and holds the card details; Moddy only relays it.
 
 Amounts arrive in the currency's smallest unit and are printed as they are:
 no conversion, no VAT reconstruction, no hardcoded catalogue price. Anything
@@ -63,8 +70,16 @@ VARIANTS = ("paid", "trial", "free")
 DEDUP_KEY = "invoice:dm:{invoice_id}"
 DEDUP_TTL = 7 * 86400  # 7 days, same window as the backend's
 
-#: Accent of the subscription DMs (bot.py::_send_subscription_dm).
-ACCENT_COLOR = 0x245F9F
+#: Stripe's own indigo, not Moddy's subscription blue: this card is a receipt
+#: issued by the payment provider, and looking different from the celebratory
+#: subscription DMs is the point.
+ACCENT_COLOR = 0x635BFF
+
+#: Billing messages are written in English, whatever the account's ``LANG``.
+#: The invoice itself, its PDF and Stripe's hosted page are English documents;
+#: a receipt that half-translates the document it describes reads as a forgery,
+#: and a legal/billing wording is one text to review rather than five.
+INVOICE_LOCALE = "en-US"
 
 BILLING_URL = "https://dashboard.moddy.app/billing"
 
@@ -203,7 +218,7 @@ class InvoiceNotifier:
         if user is None:
             return False
 
-        locale = await self.user_locale(user_id)
+        locale = INVOICE_LOCALE
         variant = variant_of(invoice)
         content, variables = self.build_content(invoice, variant, locale=locale)
 
@@ -213,10 +228,11 @@ class InvoiceNotifier:
             result = await self.bot.notifications.send_dm(
                 user,
                 content=content,
-                # Billing is Moddy speaking as itself: the attribution line
-                # carries the check, which is what tells someone this invoice
-                # DM is not one of the many that impersonate a bot's billing.
-                source=NotificationSource.service("subscription"),
+                # Attributed to Stripe, which is who actually issued the
+                # invoice, and an official service so the line carries the
+                # check — the one thing that tells someone this billing DM is
+                # not one of the many that impersonate a bot's billing.
+                source=NotificationSource.service("stripe"),
                 variables=variables,
                 locale=locale,
             )
@@ -235,14 +251,16 @@ class InvoiceNotifier:
 
     # --------------------------------------------------------------- content
     def build_content(self, invoice: Dict[str, Any], variant: str, *,
-                      locale: str = "en-US"):
+                      locale: str = INVOICE_LOCALE):
         """The uniform payload behind an invoice DM, plus its variables.
 
         Kept separate from :meth:`handle` so the wording of the three variants
-        is testable without a bot, a user or a Discord connection.
+        is testable without a bot, a user or a Discord connection. ``locale``
+        is a parameter for the dashboard and mail renderings of a stored row;
+        the DM itself always passes :data:`INVOICE_LOCALE`.
         """
         from notifications.models import NotificationContent
-        from utils.emojis import PREMIUM
+        from utils.emojis import NOTE
         from utils.i18n import t
 
         tier = invoice.get("tier")
@@ -271,10 +289,10 @@ class InvoiceNotifier:
                 "body": "`{paid_at}`",
             })
         if period_end:
-            # On a trial this date is the first charge, not a renewal. Naming
-            # it "next renewal" would hide the only thing the customer needs
-            # to know about a 0 invoice.
-            label = ("field_first_charge" if variant == "trial"
+            # On a trial this date is the end of the trial and the first
+            # charge, not a renewal. Naming it "next renewal" would hide the
+            # only thing the customer needs to know about a 0 invoice.
+            label = ("field_trial_end" if variant == "trial"
                      else "field_next_renewal")
             sections.append({
                 "title": t(f"commands.subscription.invoice.{label}", locale=locale),
@@ -300,10 +318,14 @@ class InvoiceNotifier:
         content = NotificationContent(
             title=t(f"commands.subscription.invoice.title.{variant}", locale=locale),
             body=t(f"commands.subscription.invoice.body.{variant}", locale=locale),
-            icon=PREMIUM,
+            icon=NOTE,
             accent_color=ACCENT_COLOR,
             sections=sections,
             links=links,
+            # The one message that names Stripe: a receipt has to say who
+            # issued it, and this is also what makes the Stripe attribution
+            # line above read as a fact rather than as a stray brand name.
+            footer=t("commands.subscription.invoice.footer_stripe", locale=locale),
             template_id=f"subscription.invoice.{variant}",
         )
         variables = {
@@ -335,35 +357,3 @@ class InvoiceNotifier:
             logger.warning("[Invoice] Redis de-duplication unavailable: %s", exc)
             return False
         return not claimed
-
-    async def user_locale(self, user_id: int) -> str:
-        """The language this person's billing messages are written in.
-
-        The ``LANG`` account attribute, the very same one the backend's mail
-        reads, so the DM and the mail about one invoice never arrive in two
-        different languages. Unknown or unset falls back to English.
-        """
-        from utils.i18n import i18n
-
-        try:
-            user_data = await self.bot.db.get_user(user_id)
-        except Exception as exc:  # noqa: BLE001 — a DM is worth more than its locale
-            logger.warning("[Invoice] Could not read user %s: %s", user_id, exc)
-            return "en-US"
-
-        raw = ((user_data or {}).get("attributes") or {}).get("LANG")
-        if not isinstance(raw, str) or not raw.strip():
-            return "en-US"
-
-        candidate = raw.strip()
-        supported = i18n.supported_locales or set()
-        if candidate in supported:
-            return candidate
-        for locale in supported:
-            if locale.lower() == candidate.lower():
-                return locale
-        base = candidate.split("-")[0].lower()
-        for locale in supported:
-            if locale.split("-")[0].lower() == base:
-                return locale
-        return "en-US"

--- a/staff/commands/manage/stripe/trial.py
+++ b/staff/commands/manage/stripe/trial.py
@@ -4,6 +4,10 @@ from staff.framework import StaffCommand, SlashOption, staff_command, design, Co
 from staff.commands.manage.stripe._shared import GROUP, GROUP_DESCRIPTION, resolve_target, send_result_panel
 from staff.commands.manage.stripe_create import EMAIL_RE
 
+#: Stripe's own ceiling on ``trial_period_days``; anything above is refused by
+#: the API. https://docs.stripe.com/api/subscriptions/create
+MAX_TRIAL_DAYS = 730
+
 
 @staff_command
 class StripeTrialCommand(StaffCommand):
@@ -19,7 +23,8 @@ class StripeTrialCommand(StaffCommand):
         SlashOption("plan", "string", "Billing plan.", required=False,
                     default="monthly", choices=["monthly", "yearly"]),
         SlashOption("trial_days", "integer",
-                    "Trial length in days (1-30, defaults to 7).", required=False),
+                    "Trial length in days (defaults to 7, up to Stripe's 730-day maximum).",
+                    required=False),
     ]
 
     def parse_message(self, raw: str) -> dict:
@@ -48,7 +53,11 @@ class StripeTrialCommand(StaffCommand):
         plan = ctx.opt("plan") or "monthly"
         trial_days = ctx.opt("trial_days")
         if trial_days is not None:
-            trial_days = max(1, min(30, trial_days))
+            # No Moddy-side cap any more: a staff member may grant a trial of
+            # any length. The only bounds left are Stripe's own — a trial is at
+            # least a day, and `trial_period_days` is rejected above 730 — so
+            # clamping here turns an opaque API error into the value asked for.
+            trial_days = max(1, min(MAX_TRIAL_DAYS, trial_days))
 
         await ctx.defer()
         result = await ctx.bot.stripe_admin.start_trial(

--- a/tests/test_invoice_notifications.py
+++ b/tests/test_invoice_notifications.py
@@ -10,8 +10,12 @@ What these guard, in order of how badly they would hurt a paying customer:
 * **Amounts are printed as Stripe reported them.** Minor units everywhere
   except the zero-decimal currencies, where dividing by 100 would understate
   an invoice a hundredfold. ``0`` is a legitimate amount.
-* **A trial's ``period_end`` is the first charge, not a renewal.** Same date,
-  opposite meaning; the mail says "first charge" and the DM must agree.
+* **A trial's ``period_end`` is the end of the trial and the first charge,
+  not a renewal.** Same date, opposite meaning; the mail says the same thing
+  and the DM must agree.
+* **The DM is a Stripe receipt.** English whatever the account's language,
+  attributed to Stripe, and saying so — that attribution is the only thing
+  separating it from the scams that impersonate a bot's billing.
 * **Missing halves stay missing.** ``number``, ``invoice_pdf``,
   ``hosted_invoice_url`` and the dates are all nullable on a fresh invoice; a
   null must not become a dead button or the string "None".
@@ -27,8 +31,8 @@ import pytest
 from notifications.models import SERVICES, NotificationSource, get_service
 from notifications.render import OFFICIAL_SERVICES, build_attribution_line, resolve_source_context
 from services.invoice_notifier import (
-    ZERO_DECIMAL_CURRENCIES, InvoiceNotifier, format_amount, format_date,
-    parse_timestamp, variant_of,
+    INVOICE_LOCALE, ZERO_DECIMAL_CURRENCIES, InvoiceNotifier, format_amount,
+    format_date, parse_timestamp, variant_of,
 )
 
 PAID = {
@@ -60,7 +64,7 @@ class FakeBot:
         self.db = None
 
 
-def _content(invoice, *, locale="en-US"):
+def _content(invoice, *, locale=INVOICE_LOCALE):
     variant = variant_of(invoice)
     return InvoiceNotifier(FakeBot()).build_content(invoice, variant, locale=locale)
 
@@ -149,29 +153,36 @@ def test_a_trial_never_claims_a_payment():
     content, variables = _content(TRIAL)
     assert content.template_id == "subscription.invoice.trial"
     rendered = content.render(variables).body
-    assert "no amount was charged" in rendered.lower()
+    assert "no amount has been charged" in rendered.lower()
     assert "payment of" not in rendered.lower()
 
 
 def test_a_free_period_never_claims_a_payment():
     content, variables = _content(FREE)
     rendered = content.render(variables).body
-    assert "no amount was charged" in rendered.lower()
+    assert "no amount has been charged" in rendered.lower()
 
 
-def test_a_trial_labels_period_end_as_the_first_charge():
-    """Same date as a renewal, opposite meaning — and the mail says 'first charge'."""
+def test_a_trial_labels_period_end_as_the_end_of_the_trial():
+    """Same date as a renewal, opposite meaning — and the mail says so too."""
     content, _ = _content(TRIAL)
     titles = [s["title"] for s in content.sections]
-    assert "First charge" in titles
+    assert "Trial ends — first charge" in titles
     assert "Next renewal" not in titles
+
+
+def test_a_trial_spells_out_when_it_ends_in_the_body_too():
+    """The end date is the whole point of a 0 invoice: a field alone buries it."""
+    content, variables = _content(TRIAL)
+    assert "{period_end}" in content.body
+    assert "2026-09-29" in content.render(variables).body
 
 
 def test_a_paid_invoice_labels_period_end_as_the_next_renewal():
     content, _ = _content(PAID)
     titles = [s["title"] for s in content.sections]
     assert "Next renewal" in titles
-    assert "First charge" not in titles
+    assert all("Trial ends" not in title for title in titles)
 
 
 def test_the_body_keeps_its_placeholders_so_one_row_serves_every_invoice():
@@ -180,11 +191,20 @@ def test_the_body_keeps_its_placeholders_so_one_row_serves_every_invoice():
     assert variables["amount"] == "€4.99"
 
 
-def test_the_wording_is_translated():
-    content, variables = _content(PAID, locale="fr")
+def test_the_dm_is_written_in_english():
+    """A receipt describes an English Stripe document; half-translating it reads
+    as a forgery, so the account language does not apply to this one DM."""
+    assert INVOICE_LOCALE == "en-US"
+    content, variables = _content(PAID)
     rendered = content.render(variables)
-    assert "4,99 €" in rendered.body
-    assert "mensuel" in rendered.body
+    assert "€4.99" in rendered.body
+    assert "monthly" in rendered.body
+
+
+def test_the_dm_names_stripe_as_the_issuer():
+    """The one message that says who bills: it is the receipt's own credential."""
+    content, _ = _content(PAID)
+    assert "Stripe" in (content.footer or "")
 
 
 # --------------------------------------------------------------------------- #
@@ -206,7 +226,7 @@ def test_a_fresh_invoice_without_a_number_simply_omits_the_line():
 def test_a_missing_period_end_omits_the_date_line_entirely():
     content, _ = _content(dict(PAID, period_end=None, paid_at=None))
     titles = [s["title"] for s in content.sections]
-    assert "Next renewal" not in titles and "Date" not in titles
+    assert "Next renewal" not in titles and "Invoice date" not in titles
 
 
 def test_an_unknown_tier_never_prints_a_translation_key():
@@ -257,15 +277,23 @@ async def test_no_redis_at_all_still_lets_the_dm_through():
 # Attribution
 # --------------------------------------------------------------------------- #
 
-def test_the_subscription_service_is_registered():
-    assert "subscription" in SERVICES
-    assert get_service("subscription").emoji.startswith("<")
+@pytest.mark.parametrize("service_id", ["subscription", "stripe"])
+def test_the_billing_services_are_registered(service_id):
+    assert service_id in SERVICES
+    assert get_service(service_id).emoji.startswith("<")
+
+
+async def test_an_invoice_dm_is_attributed_to_stripe():
+    """Stripe issues the invoice and takes the payment — the receipt says so."""
+    ctx = await resolve_source_context(None, NotificationSource.service("stripe"))
+    assert ctx["service_name"] == "Stripe"
+    assert "Stripe" in build_attribution_line(ctx, locale=INVOICE_LOCALE)
 
 
 async def test_a_billing_dm_carries_the_verification_check():
     """A billing DM is what a scam impersonates: the check is the tell."""
-    assert "subscription" in OFFICIAL_SERVICES
-    ctx = await resolve_source_context(None, NotificationSource.service("subscription"))
+    assert "stripe" in OFFICIAL_SERVICES
+    ctx = await resolve_source_context(None, NotificationSource.service("stripe"))
     assert ctx["verified"] is True
     assert ctx["reportable"] is False  # Moddy wrote it; there is nothing to judge
-    assert ctx["badge"] in build_attribution_line(ctx, locale="en-US")
+    assert ctx["badge"] in build_attribution_line(ctx, locale=INVOICE_LOCALE)


### PR DESCRIPTION
## Summary

Transforms the invoice notification from a celebratory Moddy message into a formal receipt attributed to Stripe. The DM is now always in English (regardless of account language), uses Stripe's indigo accent colour, carries a document icon, and explicitly names Stripe as the issuer and payment processor. This makes it visually and tonally distinct from subscription lifecycle messages and harder to impersonate.

## Key Changes

**Invoice notifier (`services/invoice_notifier.py`)**
- Removed `user_locale()` method; invoice DM now always uses `INVOICE_LOCALE = "en-US"` instead of account `LANG`
- Changed accent colour from Moddy blue (`0x245F9F`) to Stripe indigo (`0x635BFF`)
- Changed icon from `PREMIUM` gem to `NOTE` document
- Changed notification source from `subscription` to `stripe` service
- Added footer naming Stripe as issuer and clarifying Moddy never handles card details
- Updated trial label from `field_first_charge` to `field_trial_end` ("Trial ends — first charge")
- Trial end date now appears in message body as well as field, since it is the critical information on a €0 invoice
- Rewrote all three variant bodies (paid/trial/free) to be formal receipts without thank-you language

**Notification services (`notifications/models.py`, `notifications/render.py`)**
- Added `stripe` service to registry with `NOTE` emoji
- Added `stripe` to `OFFICIAL_SERVICES` so attribution line carries verification check (the tell that separates legitimate billing DMs from scams)

**Localization (`locales/*.json`)**
- Updated all five locales (en-US, fr, es-ES, pt-BR, de) with new formal invoice wording
- Added `footer_stripe` key explaining Stripe's role
- Renamed `field_first_charge` → `field_trial_end`
- Changed button label "Manage my subscription" → "Manage billing"

**Staff trial command (`staff/commands/manage/stripe/trial.py`)**
- Removed Moddy-side 1–30 day cap; now clamps to Stripe's 730-day maximum only
- Updated help text to reflect no upper limit from Moddy

**Welcome DM (`bot.py`)**
- Added explicit call-to-action in body: "One last step: pick your servers" with inline link to server selection
- Changed GIF from dead `files.catbox.moe` link to Tenor (`peach-cat-kiss.gif`)
- Clarified that premium is not active until servers are selected

**Tests (`tests/test_invoice_notifications.py`)**
- Updated assertions to expect English-only output
- Added test for Stripe footer presence
- Added test for `stripe` service attribution
- Renamed trial label test to reflect new "Trial ends — first charge" wording
- Added test that trial end date appears in body

**Documentation**
- Added session notes (`docs/sessions/2026-08-30_subscription-and-invoice-messages.md`) explaining all three changes
- Updated `SUBSCRIPTION_SCHEMA.md` with new invoice rules and Stripe attribution details
- Updated `NOTIFICATIONS.md` to document `stripe` as an official service

## Design Rationale

- **English-only**: The invoice, PDF, and Stripe's hosted page are English documents. A receipt that half-translates the source document reads as a forgery; billing wording is one text to review rather than five.
- **Stripe attribution**: Stripe issues the invoice, processes the payment, and holds card details. Moddy only relays it. The footer makes this attribution read as fact rather than stray branding.
- **Formal tone & distinct appearance**: Billing DMs are what scams impersonate. Making this one visually and tonally different from celebratory lifecycle messages (and from Moddy's own voice) is a security feature.
- **Trial end in body**: On a €0 invoice, the trial end date is the only information that matters. Burying it in a field label alone loses it; stating it in the body ensures it is seen.

https://claude.ai/code/session_01VvrQCrsopqQ5ByPpJwYd7Z