### PR TITLE
Refactor interaction response handling to guarantee error delivery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,24 @@ moddy/
 ### 8. Error Handling
 - For "unexpected" errors in cogs/modules: let the global error handler manage them
 - For expected errors: use `create_error_message()` / `create_success_message()` from `utils/components_v2.py`
+- **The user must NEVER end up on Discord's "The application did not respond".**
+  An interaction has 3 seconds to be acknowledged: call
+  `await safe_defer(interaction, ...)` (`utils/interaction_response.py`) as the
+  **first awaited statement** of any handler that queries the database, calls an
+  API or fetches from Discord. The only exception is a handler that opens a
+  Modal — Discord refuses one on an acknowledged interaction, so it must stay
+  un-deferred and do no slow work at all (staff commands declare this with
+  `StaffCommand.opens_modal = True`).
+- Show errors with `await deliver(interaction, view=..., ephemeral=True)`, never a
+  hand-rolled `if interaction.response.is_done()` branch: `deliver` falls back to
+  a channel message when the interaction token is already dead.
+- **A bare "an error occurred" with no error code is a bug.** Outside a
+  `BaseView` / `BaseModal` / app command (listeners, background tasks, message
+  commands, `DynamicItem` callbacks), route unexpected exceptions through
+  `report_error()` / `report_component_error()` from `cogs/error_handler.py` and
+  show the returned code. Expected errors — the user's mistake or a known
+  condition — keep their specific translated message and get no code.
+- See → [docs/ERROR_HANDLING.md](docs/ERROR_HANDLING.md)
 
 ### 8. Persistent Views — **MANDATORY, NO EXCEPTIONS**
 - **You MUST use persistent views for EVERY interactive Discord component,

--- a/cogs/altguard.py
+++ b/cogs/altguard.py
@@ -35,6 +35,7 @@ from services.altguard_client import (
 from utils.altguard_views import format_member_name
 from utils.components_v2 import create_error_message, create_success_message
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger('moddy.cogs.altguard')
 
@@ -300,8 +301,12 @@ class AltGuard(commands.Cog):
                                member: discord.Member, *, verify: bool):
         locale = i18n.get_user_locale(interaction)
 
+        # The module lookup below is a database read, and verify/unverify then
+        # calls the AltGuard service: acknowledge before any of it.
+        await safe_defer(interaction, ephemeral=True, thinking=True)
+
         if not interaction.user.guild_permissions.manage_roles:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 view=create_error_message(
                     t('modules.altguard.errors.no_perms.title', locale=locale),
                     t('modules.altguard.errors.no_perms.description', locale=locale),
@@ -312,7 +317,7 @@ class AltGuard(commands.Cog):
 
         module = await self._module(interaction.guild_id)
         if module is None:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 view=create_error_message(
                     t('modules.altguard.errors.not_configured.title', locale=locale),
                     t('modules.altguard.errors.not_configured.description', locale=locale),
@@ -322,7 +327,7 @@ class AltGuard(commands.Cog):
             return
 
         if member.bot:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 view=create_error_message(
                     t('modules.altguard.errors.bot_target.title', locale=locale),
                     t('modules.altguard.errors.bot_target.description', locale=locale),
@@ -330,8 +335,6 @@ class AltGuard(commands.Cog):
                 ephemeral=True,
             )
             return
-
-        await interaction.response.defer(ephemeral=True, thinking=True)
 
         if verify:
             await module.verify_member(member, actor_id=interaction.user.id)

--- a/cogs/auto_restore_roles_commands.py
+++ b/cogs/auto_restore_roles_commands.py
@@ -9,6 +9,7 @@ from typing import Optional
 import logging
 
 from utils.i18n import t
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger('moddy.cogs.auto_restore_roles_commands')
 
@@ -41,100 +42,96 @@ class AutoRestoreRolesCommands(commands.Cog):
         """
         locale = str(interaction.locale)
 
+        # Module lookup and role reads hit the database: acknowledge first so
+        # the 3s window can never close on us.
+        await safe_defer(interaction, ephemeral=True)
+
         # Vérifie que le module est activé
         if not self.bot.module_manager:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t('modules.auto_restore_roles.commands.error.no_manager', locale=locale),
                 ephemeral=True
             )
             return
 
-        try:
-            # Récupère l'instance du module
-            auto_restore_module = await self.bot.module_manager.get_module_instance(
-                interaction.guild.id,
-                'auto_restore_roles'
+        # Récupère l'instance du module
+        auto_restore_module = await self.bot.module_manager.get_module_instance(
+            interaction.guild.id,
+            'auto_restore_roles'
+        )
+
+        if not auto_restore_module:
+            await interaction.followup.send(
+                t('modules.auto_restore_roles.commands.error.not_configured', locale=locale),
+                ephemeral=True
             )
+            return
 
-            if not auto_restore_module:
-                await interaction.response.send_message(
-                    t('modules.auto_restore_roles.commands.error.not_configured', locale=locale),
-                    ephemeral=True
-                )
-                return
-
-            if not auto_restore_module.enabled:
-                await interaction.response.send_message(
-                    t('modules.auto_restore_roles.commands.error.not_enabled', locale=locale),
-                    ephemeral=True
-                )
-                return
-
-            # Vérifie si l'utilisateur a des rôles sauvegardés
-            saved_info = await auto_restore_module.get_saved_roles_info(user.id)
-            if not saved_info:
-                await interaction.response.send_message(
-                    t('modules.auto_restore_roles.commands.clear.no_roles', locale=locale, user=user.mention),
-                    ephemeral=True
-                )
-                return
-
-            # Récupère les informations sur les rôles sauvegardés
-            role_count = len(saved_info['roles'])
-            guild = interaction.guild
-
-            # Crée un embed avec les informations
-            embed = discord.Embed(
-                title=f"<:history:1519796822963392755> {t('modules.auto_restore_roles.commands.clear.confirm_title', locale=locale)}",
-                description=t('modules.auto_restore_roles.commands.clear.confirm_description', locale=locale, user=user.mention),
-                color=0xFF5555
+        if not auto_restore_module.enabled:
+            await interaction.followup.send(
+                t('modules.auto_restore_roles.commands.error.not_enabled', locale=locale),
+                ephemeral=True
             )
-            embed.add_field(
-                name=t('modules.auto_restore_roles.commands.clear.user_field', locale=locale),
-                value=f"{user.mention} (`{user.id}`)",
-                inline=False
+            return
+
+        # Vérifie si l'utilisateur a des rôles sauvegardés
+        saved_info = await auto_restore_module.get_saved_roles_info(user.id)
+        if not saved_info:
+            await interaction.followup.send(
+                t('modules.auto_restore_roles.commands.clear.no_roles', locale=locale, user=user.mention),
+                ephemeral=True
             )
+            return
 
-            # Affiche les rôles qui seront supprimés
-            role_mentions = []
-            for role_id in saved_info['roles']:
-                role = guild.get_role(role_id)
-                if role:
-                    role_mentions.append(role.mention)
-                else:
-                    role_mentions.append(f"<@&{role_id}> (supprimé)")
+        # Récupère les informations sur les rôles sauvegardés
+        role_count = len(saved_info['roles'])
+        guild = interaction.guild
 
-            embed.add_field(
-                name=t('modules.auto_restore_roles.commands.clear.roles_field', locale=locale, count=role_count),
-                value=", ".join(role_mentions) if role_mentions else t('modules.auto_restore_roles.commands.clear.no_roles_found', locale=locale),
-                inline=False
-            )
+        # Crée un embed avec les informations
+        embed = discord.Embed(
+            title=f"<:history:1519796822963392755> {t('modules.auto_restore_roles.commands.clear.confirm_title', locale=locale)}",
+            description=t('modules.auto_restore_roles.commands.clear.confirm_description', locale=locale, user=user.mention),
+            color=0xFF5555
+        )
+        embed.add_field(
+            name=t('modules.auto_restore_roles.commands.clear.user_field', locale=locale),
+            value=f"{user.mention} (`{user.id}`)",
+            inline=False
+        )
 
-            embed.add_field(
-                name=t('modules.auto_restore_roles.commands.clear.saved_at_field', locale=locale),
-                value=f"<t:{int(discord.utils.parse_time(saved_info['saved_at']).timestamp())}:R>",
-                inline=False
-            )
-
-            # Supprime les rôles sauvegardés
-            success = await auto_restore_module.clear_saved_roles(user.id)
-
-            if success:
-                embed.color = 0x00FF00
-                embed.title = f"<:done:1519800188925902881> {t('modules.auto_restore_roles.commands.clear.success_title', locale=locale)}"
-                embed.description = t('modules.auto_restore_roles.commands.clear.success_description', locale=locale, user=user.mention)
-                await interaction.response.send_message(embed=embed, ephemeral=True)
-                logger.info(f"Cleared saved roles for user {user.id} in guild {interaction.guild.id} by admin {interaction.user.id}")
+        # Affiche les rôles qui seront supprimés
+        role_mentions = []
+        for role_id in saved_info['roles']:
+            role = guild.get_role(role_id)
+            if role:
+                role_mentions.append(role.mention)
             else:
-                await interaction.response.send_message(
-                    t('modules.auto_restore_roles.commands.clear.error', locale=locale),
-                    ephemeral=True
-                )
+                role_mentions.append(f"<@&{role_id}> (supprimé)")
 
-        except Exception as e:
-            logger.error(f"Error clearing saved roles: {e}", exc_info=True)
-            await interaction.response.send_message(
-                t('modules.auto_restore_roles.commands.error.internal', locale=locale),
+        embed.add_field(
+            name=t('modules.auto_restore_roles.commands.clear.roles_field', locale=locale, count=role_count),
+            value=", ".join(role_mentions) if role_mentions else t('modules.auto_restore_roles.commands.clear.no_roles_found', locale=locale),
+            inline=False
+        )
+
+        embed.add_field(
+            name=t('modules.auto_restore_roles.commands.clear.saved_at_field', locale=locale),
+            value=f"<t:{int(discord.utils.parse_time(saved_info['saved_at']).timestamp())}:R>",
+            inline=False
+        )
+
+        # Supprime les rôles sauvegardés
+        success = await auto_restore_module.clear_saved_roles(user.id)
+
+        if success:
+            embed.color = 0x00FF00
+            embed.title = f"<:done:1519800188925902881> {t('modules.auto_restore_roles.commands.clear.success_title', locale=locale)}"
+            embed.description = t('modules.auto_restore_roles.commands.clear.success_description', locale=locale, user=user.mention)
+            await interaction.followup.send(embed=embed, ephemeral=True)
+            logger.info(f"Cleared saved roles for user {user.id} in guild {interaction.guild.id} by admin {interaction.user.id}")
+        else:
+            await interaction.followup.send(
+                t('modules.auto_restore_roles.commands.clear.error', locale=locale),
                 ephemeral=True
             )
 
@@ -150,92 +147,88 @@ class AutoRestoreRolesCommands(commands.Cog):
         """
         locale = str(interaction.locale)
 
-        # Vérifie que le module est activé
-        if not self.bot.module_manager:
-            await interaction.response.send_message(
-                t('modules.auto_restore_roles.commands.error.no_manager', locale=locale),
+        # Module lookup and role reads hit the database: acknowledge first so
+        # the 3s window can never close on us.
+    await safe_defer(interaction, ephemeral=True)
+
+    # Vérifie que le module est activé
+    if not self.bot.module_manager:
+        await interaction.followup.send(
+            t('modules.auto_restore_roles.commands.error.no_manager', locale=locale),
+            ephemeral=True
+        )
+        return
+
+        # Récupère l'instance du module
+        auto_restore_module = await self.bot.module_manager.get_module_instance(
+            interaction.guild.id,
+            'auto_restore_roles'
+        )
+
+        if not auto_restore_module:
+            await interaction.followup.send(
+                t('modules.auto_restore_roles.commands.error.not_configured', locale=locale),
                 ephemeral=True
             )
             return
 
-        try:
-            # Récupère l'instance du module
-            auto_restore_module = await self.bot.module_manager.get_module_instance(
-                interaction.guild.id,
-                'auto_restore_roles'
-            )
-
-            if not auto_restore_module:
-                await interaction.response.send_message(
-                    t('modules.auto_restore_roles.commands.error.not_configured', locale=locale),
-                    ephemeral=True
-                )
-                return
-
-            if not auto_restore_module.enabled:
-                await interaction.response.send_message(
-                    t('modules.auto_restore_roles.commands.error.not_enabled', locale=locale),
-                    ephemeral=True
-                )
-                return
-
-            # Récupère les rôles sauvegardés
-            all_saved_roles = await auto_restore_module.get_all_saved_roles()
-
-            if not all_saved_roles:
-                await interaction.response.send_message(
-                    t('modules.auto_restore_roles.commands.view.no_saved_roles', locale=locale),
-                    ephemeral=True
-                )
-                return
-
-            # Crée un embed avec la liste
-            saved_count = len(all_saved_roles)
-            embed = discord.Embed(
-                title=f"<:history:1519796822963392755> {t('modules.auto_restore_roles.commands.view.title', locale=locale)}",
-                description=t('modules.auto_restore_roles.commands.view.description', locale=locale, count=saved_count),
-                color=0x5865F2
-            )
-
-            # Ajoute chaque utilisateur
-            guild = interaction.guild
-            for saved_info in all_saved_roles:
-                user_id = saved_info['user_id']
-                username = saved_info.get('username', 'Unknown User')
-                role_count = len(saved_info['roles'])
-                saved_at = saved_info.get('saved_at')
-
-                # Essaie de récupérer l'utilisateur
-                try:
-                    user = await self.bot.fetch_user(user_id)
-                    user_display = f"{user.mention} (`{user.id}`)"
-                except:
-                    user_display = f"`{username}` (`{user_id}`)"
-
-                field_value = t(
-                    'modules.auto_restore_roles.commands.view.user_info',
-                    locale=locale,
-                    role_count=role_count
-                )
-
-                if saved_at:
-                    timestamp = int(discord.utils.parse_time(saved_at).timestamp())
-                    field_value += f"\n-# {t('modules.auto_restore_roles.commands.view.saved_at', locale=locale)} <t:{timestamp}:R>"
-
-                embed.add_field(
-                    name=user_display,
-                    value=field_value,
-                    inline=False
-                )
-
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-
-        except Exception as e:
-            logger.error(f"Error viewing saved roles: {e}", exc_info=True)
-            await interaction.response.send_message(
-                t('modules.auto_restore_roles.commands.error.internal', locale=locale),
+        if not auto_restore_module.enabled:
+            await interaction.followup.send(
+                t('modules.auto_restore_roles.commands.error.not_enabled', locale=locale),
                 ephemeral=True
             )
+            return
+
+        # Récupère les rôles sauvegardés
+        all_saved_roles = await auto_restore_module.get_all_saved_roles()
+
+        if not all_saved_roles:
+            await interaction.followup.send(
+                t('modules.auto_restore_roles.commands.view.no_saved_roles', locale=locale),
+                ephemeral=True
+            )
+            return
+
+        # Crée un embed avec la liste
+        saved_count = len(all_saved_roles)
+        embed = discord.Embed(
+            title=f"<:history:1519796822963392755> {t('modules.auto_restore_roles.commands.view.title', locale=locale)}",
+            description=t('modules.auto_restore_roles.commands.view.description', locale=locale, count=saved_count),
+            color=0x5865F2
+        )
+
+        # Ajoute chaque utilisateur
+        guild = interaction.guild
+        for saved_info in all_saved_roles:
+            user_id = saved_info['user_id']
+            username = saved_info.get('username', 'Unknown User')
+            role_count = len(saved_info['roles'])
+            saved_at = saved_info.get('saved_at')
+
+            # Essaie de récupérer l'utilisateur
+            try:
+                user = await self.bot.fetch_user(user_id)
+                user_display = f"{user.mention} (`{user.id}`)"
+            except:
+                user_display = f"`{username}` (`{user_id}`)"
+
+            field_value = t(
+                'modules.auto_restore_roles.commands.view.user_info',
+                locale=locale,
+                role_count=role_count
+            )
+
+            if saved_at:
+                timestamp = int(discord.utils.parse_time(saved_at).timestamp())
+                field_value += f"\n-# {t('modules.auto_restore_roles.commands.view.saved_at', locale=locale)} <t:{timestamp}:R>"
+
+            embed.add_field(
+                name=user_display,
+                value=field_value,
+                inline=False
+            )
+
+        await interaction.followup.send(embed=embed, ephemeral=True)
 
 
 async def setup(bot):

--- a/cogs/auto_restore_roles_commands.py
+++ b/cogs/auto_restore_roles_commands.py
@@ -149,15 +149,15 @@ class AutoRestoreRolesCommands(commands.Cog):
 
         # Module lookup and role reads hit the database: acknowledge first so
         # the 3s window can never close on us.
-    await safe_defer(interaction, ephemeral=True)
+        await safe_defer(interaction, ephemeral=True)
 
-    # Vérifie que le module est activé
-    if not self.bot.module_manager:
-        await interaction.followup.send(
-            t('modules.auto_restore_roles.commands.error.no_manager', locale=locale),
-            ephemeral=True
-        )
-        return
+        # Vérifie que le module est activé
+        if not self.bot.module_manager:
+            await interaction.followup.send(
+                t('modules.auto_restore_roles.commands.error.no_manager', locale=locale),
+                ephemeral=True
+            )
+            return
 
         # Récupère l'instance du module
         auto_restore_module = await self.bot.module_manager.get_module_instance(

--- a/cogs/auto_restore_roles_commands.py
+++ b/cogs/auto_restore_roles_commands.py
@@ -209,7 +209,7 @@ class AutoRestoreRolesCommands(commands.Cog):
             try:
                 user = await self.bot.fetch_user(user_id)
                 user_display = f"{user.mention} (`{user.id}`)"
-            except:
+            except discord.HTTPException:
                 user_display = f"`{username}` (`{user_id}`)"
 
             field_value = t(

--- a/cogs/case_sync.py
+++ b/cogs/case_sync.py
@@ -85,7 +85,12 @@ class CaseSync(commands.Cog):
             elif action == A.member_update:
                 await self._handle_timeout(entry, guild, target_id, reason, issuer_type, issuer_id)
         except Exception as e:
-            logger.error(f"case_sync: failed to record {action} in guild {guild.id}: {e}", exc_info=True)
+            # A dropped sanction is a hole in the audit trail: it must be
+            # traceable, not just visible on stdout.
+            from cogs.error_handler import report_error
+            await report_error(
+                self.bot, e, source=f"Cog:CaseSync.record({action})", guild=guild,
+            )
 
     async def _handle_timeout(self, entry, guild, target_id, reason, issuer_type, issuer_id):
         """A member_update entry may set or clear a communication timeout (mute)."""

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -25,6 +25,7 @@ from utils import global_sanctions
 from utils.components_v2 import create_limited_message
 from utils.interaction_response import safe_defer
 from cogs.error_handler import BaseView
+from utils.incognito import resolve_incognito
 from modules.configs._common import check_guild_perms
 
 logger = logging.getLogger('moddy.cogs.config')
@@ -391,15 +392,8 @@ class Config(commands.Cog):
         """
 
         # Gestion du mode incognito
-        if incognito is None and self.bot.db:
-            try:
-                user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
-                ephemeral = True if user_pref is None else user_pref
-            except Exception:
-                # Visibility preference is a nicety: default to private.
-                ephemeral = True
-        else:
-            ephemeral = incognito if incognito is not None else True
+        ephemeral = (incognito if incognito is not None
+                     else await resolve_incognito(self.bot, interaction.user.id))
 
         # Everything below reads the database (global sanctions, module
         # configs): acknowledge now so the 3s window cannot close on us.

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -23,6 +23,7 @@ from utils.i18n import i18n, t
 from utils.emojis import EMOJIS, SETTINGS
 from utils import global_sanctions
 from utils.components_v2 import create_limited_message
+from utils.interaction_response import safe_defer
 from cogs.error_handler import BaseView
 from modules.configs._common import check_guild_perms
 
@@ -193,15 +194,17 @@ class ConfigMainView(BaseView):
 
         module_id = interaction.data['values'][0]
 
+        # Building any of the screens below reads the guild config from the
+        # database. Acknowledge first (this also disables the select while the
+        # screen is built, which stops double-clicks).
+        await safe_defer(interaction, ephemeral=False, thinking=False)
+
         if module_id == SETTINGS_OPTION:
             from modules.configs.server_settings_config import ServerSettingsConfigView
 
             view = await ServerSettingsConfigView.create(bot, guild_id, user_id, locale)
-            await interaction.response.edit_message(view=view)
+            await interaction.edit_original_response(view=view)
             return
-
-        # Désactive temporairement pour éviter les double-clics
-        await interaction.response.defer()
 
         # Récupère la configuration actuelle du module
         module_config = await bot.module_manager.get_module_config(guild_id, module_id)
@@ -392,14 +395,19 @@ class Config(commands.Cog):
             try:
                 user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
                 ephemeral = True if user_pref is None else user_pref
-            except:
+            except Exception:
+                # Visibility preference is a nicety: default to private.
                 ephemeral = True
         else:
             ephemeral = incognito if incognito is not None else True
 
+        # Everything below reads the database (global sanctions, module
+        # configs): acknowledge now so the 3s window cannot close on us.
+        await safe_defer(interaction, ephemeral=ephemeral, thinking=True)
+
         # Vérifie que c'est bien dans un serveur
         if not interaction.guild:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t('modules.config.errors.guild_only', interaction),
                 ephemeral=True
             )
@@ -407,7 +415,7 @@ class Config(commands.Cog):
 
         # Vérifie que le bot est bien membre du serveur
         if not interaction.guild.me:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t('modules.config.errors.bot_not_in_guild', interaction),
                 ephemeral=True
             )
@@ -439,7 +447,7 @@ class Config(commands.Cog):
             button_row.add_item(reinvite_btn)
             error_view.add_item(button_row)
 
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 view=error_view,
                 ephemeral=True
             )
@@ -447,7 +455,7 @@ class Config(commands.Cog):
 
         # Vérifie que l'utilisateur a les permissions de gérer le serveur
         if not interaction.user.guild_permissions.manage_guild:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t('modules.config.errors.no_user_perms', interaction),
                 ephemeral=True
             )
@@ -468,7 +476,7 @@ class Config(commands.Cog):
             limited=limited,
         )
 
-        await interaction.response.send_message(
+        await interaction.followup.send(
             view=main_view,
             ephemeral=ephemeral
         )

--- a/cogs/dev_logger.py
+++ b/cogs/dev_logger.py
@@ -249,7 +249,7 @@ class LoggingSystem(commands.Cog):
 
         try:
             await channel.send(embed=embed)
-        except:
+        except discord.HTTPException:
             pass
 
     async def log_critical(self, title: str, description: str, ping_dev: bool = True):
@@ -274,7 +274,7 @@ class LoggingSystem(commands.Cog):
 
         try:
             await channel.send(content=content, embed=embed)
-        except:
+        except discord.HTTPException:
             pass
 
 

--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -17,6 +17,7 @@ from collections import deque
 import os
 
 from config import COLORS
+from utils.interaction_response import deliver, safe_defer, is_expired_interaction
 import logging
 
 logger = logging.getLogger('moddy.error_handler')
@@ -296,29 +297,17 @@ class BaseView(ui.LayoutView):
             # ALWAYS show error to user
             error_view = ErrorView(error_code)
 
-            try:
-                if interaction.response.is_done():
-                    try:
-                        await interaction.followup.send(view=error_view, ephemeral=True)
-                    except:
-                        try:
-                            await interaction.edit_original_response(view=error_view)
-                        except Exception as edit_error:
-                            logger.error(f"Failed to edit response: {edit_error}")
-                else:
-                    await interaction.response.send_message(view=error_view, ephemeral=True)
-            except Exception as send_error:
-                logger.error(f"CRITICAL: Failed to send error view to user: {send_error}")
+            # `deliver` walks every transport, including a plain channel
+            # message when the interaction token itself is dead (10062), so
+            # the user never ends up on Discord's "did not respond".
+            await deliver(interaction, view=error_view, ephemeral=True)
         else:
             # FALLBACK: No error tracker, but STILL show error to user
             logger.error(f"ERROR TRACKER NOT AVAILABLE - Falling back to basic error message")
             try:
                 error_msg = f"❌ **An error occurred**\n\n`{type(error).__name__}: {str(error)}`\n\nThis error has been logged."
 
-                if interaction.response.is_done():
-                    await interaction.followup.send(error_msg, ephemeral=True)
-                else:
-                    await interaction.response.send_message(error_msg, ephemeral=True)
+                await deliver(interaction, content=error_msg, ephemeral=True)
             except Exception as fallback_error:
                 logger.error(f"CRITICAL: Failed to send even fallback error message: {fallback_error}")
 
@@ -399,27 +388,15 @@ class BaseModal(ui.Modal):
 
             error_view = ErrorView(error_code)
 
-            try:
-                if interaction.response.is_done():
-                    try:
-                        await interaction.followup.send(view=error_view, ephemeral=True)
-                    except:
-                        try:
-                            await interaction.edit_original_response(view=error_view)
-                        except:
-                            pass
-                else:
-                    await interaction.response.send_message(view=error_view, ephemeral=True)
-            except Exception as send_error:
-                logger.error(f"CRITICAL: Failed to send error view to user: {send_error}")
+            # `deliver` walks every transport, including a plain channel
+            # message when the interaction token itself is dead (10062), so
+            # the user never ends up on Discord's "did not respond".
+            await deliver(interaction, view=error_view, ephemeral=True)
         else:
             try:
                 error_msg = f"❌ **An error occurred**\n\n`{type(error).__name__}: {str(error)}`\n\nThis error has been logged."
 
-                if interaction.response.is_done():
-                    await interaction.followup.send(error_msg, ephemeral=True)
-                else:
-                    await interaction.response.send_message(error_msg, ephemeral=True)
+                await deliver(interaction, content=error_msg, ephemeral=True)
             except Exception as fallback_error:
                 logger.error(f"CRITICAL: Failed to send fallback error message: {fallback_error}")
 
@@ -885,13 +862,7 @@ class ErrorTracker(commands.Cog):
                     container.add_item(button_row)
                     self.add_item(container)
 
-            try:
-                if interaction.response.is_done():
-                    await interaction.followup.send(view=PermissionErrorView(), ephemeral=True)
-                else:
-                    await interaction.response.send_message(view=PermissionErrorView(), ephemeral=True)
-            except:
-                pass
+            await deliver(interaction, view=PermissionErrorView(), ephemeral=True)
             return
 
         if isinstance(error, discord.app_commands.CommandOnCooldown):
@@ -908,13 +879,7 @@ class ErrorTracker(commands.Cog):
                     )
                     self.add_item(container)
 
-            try:
-                if interaction.response.is_done():
-                    await interaction.followup.send(view=CooldownErrorView(error.retry_after), ephemeral=True)
-                else:
-                    await interaction.response.send_message(view=CooldownErrorView(error.retry_after), ephemeral=True)
-            except:
-                pass
+            await deliver(interaction, view=CooldownErrorView(error.retry_after), ephemeral=True)
             return
 
         # Argument that couldn't be resolved (e.g. a username typed where a
@@ -932,13 +897,7 @@ class ErrorTracker(commands.Cog):
                         f"Try mentioning them or using their ID."))
                     self.add_item(container)
 
-            try:
-                if interaction.response.is_done():
-                    await interaction.followup.send(view=NotFoundView(), ephemeral=True)
-                else:
-                    await interaction.response.send_message(view=NotFoundView(), ephemeral=True)
-            except discord.HTTPException:
-                pass
+            await deliver(interaction, view=NotFoundView(), ephemeral=True)
             return
 
         # For all other errors, log them
@@ -991,22 +950,72 @@ class ErrorTracker(commands.Cog):
         # Send error to user with Components V2 (no embed needed)
         error_view = ErrorView(error_code)
 
-        try:
-            if interaction.response.is_done():
-                # Try to send a followup message first (preferred)
-                try:
-                    await interaction.followup.send(view=error_view, ephemeral=True)
-                except:
-                    # If followup fails, edit the original response as fallback
-                    await interaction.edit_original_response(content=None, view=error_view)
-            else:
-                # Send the error as the initial response
-                await interaction.response.send_message(view=error_view, ephemeral=True)
-        except Exception as send_error:
-            # Last resort: log the failure
-            import logging
-            logger = logging.getLogger('moddy')
-            logger.error(f"Failed to send app command error to user: {send_error}")
+        # `deliver` never raises and never gives up while a transport is
+        # left — including a channel message when the interaction token
+        # has expired, which is exactly the case that used to surface as
+        # Discord's own "The application did not respond".
+        await deliver(interaction, view=error_view, ephemeral=True)
+
+
+async def report_error(
+    bot,
+    error: Exception,
+    *,
+    source: str,
+    user: "Optional[discord.abc.User]" = None,
+    guild: "Optional[discord.Guild]" = None,
+    channel=None,
+    error_type: str = "Handled Error",
+) -> Optional[str]:
+    """Route an unexpected error through the central handler and return its code.
+
+    This is the transport-agnostic half of the error pipeline: it logs the
+    traceback, captures to Sentry, stores the error in memory and in the
+    database, and posts the internal Discord log — exactly what
+    :class:`BaseView` and the app-command handler do — then hands back the
+    error code so the caller can show it to the user.
+
+    Use it anywhere an unexpected exception is caught outside a View, a Modal
+    or an app command: a message command, a background task, a service
+    callback. **Never** swallow an unexpected exception behind a bare
+    "an error occurred" message: without a code, neither the user nor the
+    team can trace what happened.
+
+    Returns ``None`` when the tracker cog is unavailable, in which case the
+    caller should still tell the user something went wrong.
+    """
+    error_tb = ''.join(traceback.format_exception(type(error), error, error.__traceback__))
+    logger.error(f"Error in {source} - {error_tb.replace(chr(10), ' ⮐ ')}")
+
+    tracker = bot.get_cog('ErrorTracker') if bot else None
+    if not tracker:
+        return None
+
+    error_code = tracker.generate_error_code(error)
+    error_details = tracker.format_error_details(error)
+    error_details.update({
+        "command": source,
+        "user": f"{user} ({user.id})" if user else "Unknown",
+        "guild": f"{guild.name} ({guild.id})" if guild else "DM",
+        "channel": f"#{channel.name}" if hasattr(channel, 'name') else "DM",
+    })
+
+    sentry_event_id = capture_error_to_sentry(error, {
+        'error_type': error_type,
+        'error_code': error_code,
+        'source': source,
+        'user_id': user.id if user else None,
+        'guild_id': guild.id if guild else None,
+    })
+    if sentry_event_id:
+        error_details['sentry_event_id'] = sentry_event_id
+
+    tracker.store_error(error_code, error_details)
+    await tracker.store_error_db(error_code, error_details)
+    if sentry_event_id and bot.db:
+        asyncio.create_task(tracker._update_sentry_issue_id(error_code, sentry_event_id))
+    await tracker.send_error_log(error_code, error_details, False)
+    return error_code
 
 
 async def report_component_error(
@@ -1020,44 +1029,18 @@ async def report_component_error(
     unknown error still gets an error code, a Sentry capture, a Discord log and
     a user-facing ``ErrorView`` — exactly like every other UI error.
     """
-    error_tb = ''.join(traceback.format_exception(type(error), error, error.__traceback__))
-    logger.error(f"Component error in {source} - {error_tb.replace(chr(10), ' ⮐ ')}")
-
-    bot = interaction.client
-    tracker = bot.get_cog('ErrorTracker') if bot else None
-    if tracker:
-        error_code = tracker.generate_error_code(error)
-        error_details = tracker.format_error_details(error)
-        error_details.update({
-            "command": f"Component:{source}",
-            "user": f"{interaction.user} ({interaction.user.id})",
-            "guild": f"{interaction.guild.name} ({interaction.guild.id})" if interaction.guild else "DM",
-            "channel": f"#{interaction.channel.name}" if hasattr(interaction.channel, 'name') else "DM",
-        })
-        sentry_event_id = capture_error_to_sentry(error, {
-            'error_type': 'Component Error', 'error_code': error_code, 'source': source,
-            'user_id': interaction.user.id if interaction.user else None,
-            'guild_id': interaction.guild.id if interaction.guild else None,
-        })
-        if sentry_event_id:
-            error_details['sentry_event_id'] = sentry_event_id
-        tracker.store_error(error_code, error_details)
-        await tracker.store_error_db(error_code, error_details)
-        if sentry_event_id and bot.db:
-            asyncio.create_task(tracker._update_sentry_issue_id(error_code, sentry_event_id))
-        await tracker.send_error_log(error_code, error_details, False)
-        view = ErrorView(error_code)
-    else:
-        view = None
-
-    try:
-        if view is not None:
-            if interaction.response.is_done():
-                await interaction.followup.send(view=view, ephemeral=True)
-            else:
-                await interaction.response.send_message(view=view, ephemeral=True)
-    except discord.HTTPException as send_error:
-        logger.error(f"CRITICAL: Failed to send component error view: {send_error}")
+    error_code = await report_error(
+        interaction.client,
+        error,
+        source=f"Component:{source}",
+        user=interaction.user,
+        guild=interaction.guild,
+        channel=interaction.channel,
+        error_type="Component Error",
+    )
+    view = ErrorView(error_code) if error_code else None
+    if view is not None:
+        await deliver(interaction, view=view, ephemeral=True)
 
 
 async def setup(bot):

--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -404,8 +404,12 @@ class BaseModal(ui.Modal):
 class ErrorView(ui.LayoutView):
     """Error display view using Components V2"""
 
-    def __init__(self, error_code: str):
+    def __init__(self, error_code: Optional[str] = None):
         super().__init__(timeout=None)
+        #: ``None`` when the tracker cog is unavailable (a reload, a failed
+        #: startup) and no code could be minted. The card is still shown —
+        #: telling the user nothing is never an option — it just cannot
+        #: offer a reference to quote to support.
         self.error_code = error_code
         self.build_view()
 
@@ -414,14 +418,22 @@ class ErrorView(ui.LayoutView):
         container.add_item(ui.TextDisplay(
             "### <:FrameBug:1519805334988787843> Something went wrong..."
         ))
-        container.add_item(ui.TextDisplay(
-            f"**Error Code:** ``{self.error_code}``"
-        ))
+        if self.error_code:
+            container.add_item(ui.TextDisplay(
+                f"**Error Code:** ``{self.error_code}``"
+            ))
         container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
-        container.add_item(ui.TextDisplay(
-            "-# This error has been automatically logged and will be reviewed by our team.\n"
-            "-# If the problem persists, please contact support with this error code."
-        ))
+        if self.error_code:
+            container.add_item(ui.TextDisplay(
+                "-# This error has been automatically logged and will be reviewed by our team.\n"
+                "-# If the problem persists, please contact support with this error code."
+            ))
+        else:
+            container.add_item(ui.TextDisplay(
+                "-# The error could not be assigned a code — our tracking system is "
+                "unavailable right now.\n"
+                "-# Please try again in a moment, and contact support if it keeps happening."
+            ))
         self.add_item(container)
 
         btn_row = ui.ActionRow()
@@ -1038,9 +1050,11 @@ async def report_component_error(
         channel=interaction.channel,
         error_type="Component Error",
     )
-    view = ErrorView(error_code) if error_code else None
-    if view is not None:
-        await deliver(interaction, view=view, ephemeral=True)
+    # ``error_code`` is ``None`` when the tracker cog is not loaded. The card
+    # goes out regardless: falling silent here would hand the user back to
+    # Discord's own "the application did not respond", which is the exact
+    # outcome this pipeline exists to prevent.
+    await deliver(interaction, view=ErrorView(error_code), ephemeral=True)
 
 
 async def setup(bot):

--- a/cogs/interserver_commands.py
+++ b/cogs/interserver_commands.py
@@ -11,6 +11,7 @@ import logging
 from datetime import datetime, timezone
 
 from utils.i18n import t
+from utils.interaction_response import safe_defer
 from utils.emojis import EMOJIS
 from utils.components_v2 import create_error_message, create_info_message, create_success_message
 from cogs.error_handler import BaseView, BaseModal
@@ -72,24 +73,21 @@ class InterServerCommands(commands.GroupCog, name="interserver", description="Ma
         message_id: str
     ):
         """Signale un message inter-serveur à l'équipe de modération"""
-        try:
-            # Récupère les informations du message (supporte Moddy ID et snowflake)
-            msg_data = await self._get_message_by_id(message_id)
+        # The lookup and the report post both hit the database and the API:
+        # acknowledge before doing any of it.
+        await safe_defer(interaction, ephemeral=True)
 
-            if not msg_data:
-                view = create_error_message(
-                    "Message Not Found",
-                    f"No inter-server message found with ID `{message_id}`.\n\nMake sure the ID is correct (Moddy ID like `F6ZEU3VS` or Discord message ID) and the message hasn't been deleted."
-                )
-                await interaction.response.send_message(view=view, ephemeral=True)
-                return
-        except Exception as e:
-            logger.error(f"Error validating/fetching message {message_id}: {e}", exc_info=True)
+        # Récupère les informations du message (supporte Moddy ID et snowflake).
+        # An unexpected failure here is a bug, not a user mistake: let the
+        # global app-command handler turn it into a coded error card.
+        msg_data = await self._get_message_by_id(message_id)
+
+        if not msg_data:
             view = create_error_message(
-                "Error",
-                f"An error occurred while fetching the message. Please verify the ID and try again."
+                "Message Not Found",
+                f"No inter-server message found with ID `{message_id}`.\n\nMake sure the ID is correct (Moddy ID like `F6ZEU3VS` or Discord message ID) and the message hasn't been deleted."
             )
-            await interaction.response.send_message(view=view, ephemeral=True)
+            await interaction.followup.send(view=view, ephemeral=True)
             return
 
         # Récupère le Moddy ID réel du message
@@ -101,172 +99,163 @@ class InterServerCommands(commands.GroupCog, name="interserver", description="Ma
                 "Message Already Deleted",
                 f"The message `{moddy_id}` has already been deleted."
             )
-            await interaction.response.send_message(view=view, ephemeral=True)
+            await interaction.followup.send(view=view, ephemeral=True)
             return
 
         # Crée le rapport dans le salon de rapports
-        try:
-            report_channel = self.bot.get_channel(REPORT_CHANNEL_ID)
-            if not report_channel:
-                view = create_error_message(
-                    "Error",
-                    "Could not access the report channel. Please contact the Moddy team."
-                )
-                await interaction.response.send_message(view=view, ephemeral=True)
-                return
-
-            # Récupère l'auteur du message
-            try:
-                author = await self.bot.fetch_user(msg_data['author_id'])
-                author_mention = f"{author.mention} (`{author.id}`)"
-            except:
-                author_mention = f"Unknown User (`{msg_data['author_id']}`)"
-
-            # Crée le rapport avec Components V2
-            class ReportView(BaseView):
-                def __init__(self, bot, moddy_id: str, reporter_id: int, author_mention: str, guild_name: str, guild_id: int, reporter_mention: str, content: str):
-                    super().__init__()
-                    self.bot = bot
-                    self.moddy_id = moddy_id
-                    self.reporter_id = reporter_id
-                    self.claimed_by = None
-                    self.author_mention = author_mention
-                    self.guild_name = guild_name
-                    self.guild_id = guild_id
-                    self.reporter_mention = reporter_mention
-                    self.content = content
-
-                    self._build_view()
-
-                def _build_view(self):
-                    """Construit la vue avec containers et boutons"""
-                    # Clear items
-                    self.clear_items()
-
-                    # Container avec les informations
-                    container = ui.Container(
-                        ui.TextDisplay(content=f"### <:warning:1398729560895422505> Inter-Server Report"),
-                        ui.TextDisplay(content=f"**Moddy ID:** `{self.moddy_id}`\n**Author:** {self.author_mention}\n**Server:** {self.guild_name} (`{self.guild_id}`)\n**Reported by:** {self.reporter_mention}\n{f'**Claimed by:** {self.claimed_by.mention}' if self.claimed_by else ''}\n**Content:**\n{self.content[:1000] if self.content else '*No content*'}"),
-                    )
-                    self.add_item(container)
-
-                    # ActionRow avec les boutons
-                    button_row = ui.ActionRow()
-
-                    # Claim button
-                    claim_btn = ui.Button(
-                        label="Claim",
-                        style=discord.ButtonStyle.primary,
-                        emoji="👋",
-                        custom_id="claim_btn",
-                        disabled=self.claimed_by is not None
-                    )
-                    claim_btn.callback = self.on_claim
-                    button_row.add_item(claim_btn)
-
-                    # Processed button
-                    processed_btn = ui.Button(
-                        label="Processed",
-                        style=discord.ButtonStyle.success,
-                        emoji="✅",
-                        custom_id="processed_btn",
-                        disabled=self.claimed_by is None
-                    )
-                    processed_btn.callback = self.on_processed
-                    button_row.add_item(processed_btn)
-
-                    # Skip button
-                    skip_btn = ui.Button(
-                        label="Skip",
-                        style=discord.ButtonStyle.secondary,
-                        emoji="⏭️",
-                        custom_id="skip_btn",
-                        disabled=self.claimed_by is not None
-                    )
-                    skip_btn.callback = self.on_skip
-                    button_row.add_item(skip_btn)
-
-                    self.add_item(button_row)
-
-                async def on_claim(self, interaction: discord.Interaction):
-                    """Permet à un modérateur de claim le rapport"""
-                    # Vérifie les permissions
-                    from utils.staff_permissions import staff_permissions, StaffRole
-                    user_roles = await staff_permissions.get_user_roles(interaction.user.id)
-
-                    # Vérifie si l'utilisateur est au moins modérateur
-                    allowed_roles = [StaffRole.DEV, StaffRole.MANAGER, StaffRole.SUPERVISOR_MOD, StaffRole.MODERATOR]
-                    if not any(role in allowed_roles for role in user_roles):
-                        await interaction.response.send_message(
-                            "You don't have permission to claim reports.",
-                            ephemeral=True
-                        )
-                        return
-
-                    self.claimed_by = interaction.user
-                    self._build_view()
-                    await interaction.response.edit_message(view=self)
-
-                async def on_processed(self, interaction: discord.Interaction):
-                    """Marque le rapport comme traité avec un formulaire pour les actions prises"""
-                    # Ouvre un modal pour les actions prises
-                    modal = ProcessedModal(self.moddy_id)
-                    modal.bot = self.bot
-                    await interaction.response.send_modal(modal)
-
-                async def on_skip(self, interaction: discord.Interaction):
-                    """Skip le rapport sans raison"""
-                    # Vérifie les permissions
-                    from utils.staff_permissions import staff_permissions, StaffRole
-                    user_roles = await staff_permissions.get_user_roles(interaction.user.id)
-
-                    allowed_roles = [StaffRole.DEV, StaffRole.MANAGER, StaffRole.SUPERVISOR_MOD, StaffRole.MODERATOR]
-                    if not any(role in allowed_roles for role in user_roles):
-                        await interaction.response.send_message(
-                            "You don't have permission to skip reports.",
-                            ephemeral=True
-                        )
-                        return
-
-                    # Clear and rebuild view with skipped message
-                    self.clear_items()
-                    container = ui.Container(
-                        ui.TextDisplay(content=f"### <:warning:1398729560895422505> Inter-Server Report - Skipped"),
-                        ui.TextDisplay(content=f"**Moddy ID:** `{self.moddy_id}`\n**Skipped by:** {interaction.user.mention}\n**Reason:** No action required"),
-                    )
-                    self.add_item(container)
-
-                    await interaction.response.edit_message(view=self)
-
-            # Envoie le rapport
-            report_view = ReportView(
-                self.bot,
-                moddy_id,
-                interaction.user.id,
-                author_mention,
-                interaction.guild.name,
-                interaction.guild.id,
-                interaction.user.mention,
-                msg_data['content']
-            )
-            await report_channel.send(view=report_view)
-
-            # Confirme à l'utilisateur
-            view = create_success_message(
-                "Report Sent",
-                f"Your report for message `{moddy_id}` has been sent to the moderation team.\n\nThank you for helping keep the inter-server chat safe!"
-            )
-            await interaction.response.send_message(view=view, ephemeral=True)
-
-            logger.info(f"Report sent for message {moddy_id} by {interaction.user} ({interaction.user.id})")
-
-        except Exception as e:
-            logger.error(f"Error sending report: {e}", exc_info=True)
+        report_channel = self.bot.get_channel(REPORT_CHANNEL_ID)
+        if not report_channel:
             view = create_error_message(
                 "Error",
-                f"An error occurred while sending your report. Please try again later."
+                "Could not access the report channel. Please contact the Moddy team."
             )
-            await interaction.response.send_message(view=view, ephemeral=True)
+            await interaction.followup.send(view=view, ephemeral=True)
+            return
+
+        # Récupère l'auteur du message
+        try:
+            author = await self.bot.fetch_user(msg_data['author_id'])
+            author_mention = f"{author.mention} (`{author.id}`)"
+        except:
+            author_mention = f"Unknown User (`{msg_data['author_id']}`)"
+
+        # Crée le rapport avec Components V2
+        class ReportView(BaseView):
+            def __init__(self, bot, moddy_id: str, reporter_id: int, author_mention: str, guild_name: str, guild_id: int, reporter_mention: str, content: str):
+                super().__init__()
+                self.bot = bot
+                self.moddy_id = moddy_id
+                self.reporter_id = reporter_id
+                self.claimed_by = None
+                self.author_mention = author_mention
+                self.guild_name = guild_name
+                self.guild_id = guild_id
+                self.reporter_mention = reporter_mention
+                self.content = content
+
+                self._build_view()
+
+            def _build_view(self):
+                """Construit la vue avec containers et boutons"""
+                # Clear items
+                self.clear_items()
+
+                # Container avec les informations
+                container = ui.Container(
+                    ui.TextDisplay(content=f"### <:warning:1398729560895422505> Inter-Server Report"),
+                    ui.TextDisplay(content=f"**Moddy ID:** `{self.moddy_id}`\n**Author:** {self.author_mention}\n**Server:** {self.guild_name} (`{self.guild_id}`)\n**Reported by:** {self.reporter_mention}\n{f'**Claimed by:** {self.claimed_by.mention}' if self.claimed_by else ''}\n**Content:**\n{self.content[:1000] if self.content else '*No content*'}"),
+                )
+                self.add_item(container)
+
+                # ActionRow avec les boutons
+                button_row = ui.ActionRow()
+
+                # Claim button
+                claim_btn = ui.Button(
+                    label="Claim",
+                    style=discord.ButtonStyle.primary,
+                    emoji="👋",
+                    custom_id="claim_btn",
+                    disabled=self.claimed_by is not None
+                )
+                claim_btn.callback = self.on_claim
+                button_row.add_item(claim_btn)
+
+                # Processed button
+                processed_btn = ui.Button(
+                    label="Processed",
+                    style=discord.ButtonStyle.success,
+                    emoji="✅",
+                    custom_id="processed_btn",
+                    disabled=self.claimed_by is None
+                )
+                processed_btn.callback = self.on_processed
+                button_row.add_item(processed_btn)
+
+                # Skip button
+                skip_btn = ui.Button(
+                    label="Skip",
+                    style=discord.ButtonStyle.secondary,
+                    emoji="⏭️",
+                    custom_id="skip_btn",
+                    disabled=self.claimed_by is not None
+                )
+                skip_btn.callback = self.on_skip
+                button_row.add_item(skip_btn)
+
+                self.add_item(button_row)
+
+            async def on_claim(self, interaction: discord.Interaction):
+                """Permet à un modérateur de claim le rapport"""
+                # Vérifie les permissions
+                from utils.staff_permissions import staff_permissions, StaffRole
+                user_roles = await staff_permissions.get_user_roles(interaction.user.id)
+
+                # Vérifie si l'utilisateur est au moins modérateur
+                allowed_roles = [StaffRole.DEV, StaffRole.MANAGER, StaffRole.SUPERVISOR_MOD, StaffRole.MODERATOR]
+                if not any(role in allowed_roles for role in user_roles):
+                    await interaction.response.send_message(
+                        "You don't have permission to claim reports.",
+                        ephemeral=True
+                    )
+                    return
+
+                self.claimed_by = interaction.user
+                self._build_view()
+                await interaction.response.edit_message(view=self)
+
+            async def on_processed(self, interaction: discord.Interaction):
+                """Marque le rapport comme traité avec un formulaire pour les actions prises"""
+                # Ouvre un modal pour les actions prises
+                modal = ProcessedModal(self.moddy_id)
+                modal.bot = self.bot
+                await interaction.response.send_modal(modal)
+
+            async def on_skip(self, interaction: discord.Interaction):
+                """Skip le rapport sans raison"""
+                # Vérifie les permissions
+                from utils.staff_permissions import staff_permissions, StaffRole
+                user_roles = await staff_permissions.get_user_roles(interaction.user.id)
+
+                allowed_roles = [StaffRole.DEV, StaffRole.MANAGER, StaffRole.SUPERVISOR_MOD, StaffRole.MODERATOR]
+                if not any(role in allowed_roles for role in user_roles):
+                    await interaction.response.send_message(
+                        "You don't have permission to skip reports.",
+                        ephemeral=True
+                    )
+                    return
+
+                # Clear and rebuild view with skipped message
+                self.clear_items()
+                container = ui.Container(
+                    ui.TextDisplay(content=f"### <:warning:1398729560895422505> Inter-Server Report - Skipped"),
+                    ui.TextDisplay(content=f"**Moddy ID:** `{self.moddy_id}`\n**Skipped by:** {interaction.user.mention}\n**Reason:** No action required"),
+                )
+                self.add_item(container)
+
+                await interaction.response.edit_message(view=self)
+
+        # Envoie le rapport
+        report_view = ReportView(
+            self.bot,
+            moddy_id,
+            interaction.user.id,
+            author_mention,
+            interaction.guild.name,
+            interaction.guild.id,
+            interaction.user.mention,
+            msg_data['content']
+        )
+        await report_channel.send(view=report_view)
+
+        # Confirme à l'utilisateur
+        view = create_success_message(
+            "Report Sent",
+            f"Your report for message `{moddy_id}` has been sent to the moderation team.\n\nThank you for helping keep the inter-server chat safe!"
+        )
+        await interaction.followup.send(view=view, ephemeral=True)
+
+        logger.info(f"Report sent for message {moddy_id} by {interaction.user} ({interaction.user.id})")
 
     @app_commands.command(
         name="info",
@@ -284,24 +273,17 @@ class InterServerCommands(commands.GroupCog, name="interserver", description="Ma
         incognito: bool = False
     ):
         """Obtient des informations sur un message inter-serveur"""
-        try:
-            # Récupère les informations du message (supporte Moddy ID et snowflake)
-            msg_data = await self._get_message_by_id(message_id)
+        # DB lookup + user fetch before the card can be built.
+        await safe_defer(interaction, ephemeral=True)
 
-            if not msg_data:
-                view = create_error_message(
-                    "Message Not Found",
-                    f"No inter-server message found with ID `{message_id}`.\n\nMake sure the ID is correct (Moddy ID like `F6ZEU3VS` or Discord message ID) and the message hasn't been deleted."
-                )
-                await interaction.response.send_message(view=view, ephemeral=True)
-                return
-        except Exception as e:
-            logger.error(f"Error validating/fetching message {message_id}: {e}", exc_info=True)
+        msg_data = await self._get_message_by_id(message_id)
+
+        if not msg_data:
             view = create_error_message(
-                "Error",
-                f"An error occurred while fetching the message. Please verify the ID and try again."
+                "Message Not Found",
+                f"No inter-server message found with ID `{message_id}`.\n\nMake sure the ID is correct (Moddy ID like `F6ZEU3VS` or Discord message ID) and the message hasn't been deleted."
             )
-            await interaction.response.send_message(view=view, ephemeral=True)
+            await interaction.followup.send(view=view, ephemeral=True)
             return
 
         # Récupère le Moddy ID réel du message
@@ -341,7 +323,7 @@ class InterServerCommands(commands.GroupCog, name="interserver", description="Ma
         if not incognito:
             logger.info(f"Info request for message {moddy_id} by {interaction.user} ({interaction.user.id})")
 
-        await interaction.response.send_message(view=view, ephemeral=True)
+        await interaction.followup.send(view=view, ephemeral=True)
 
 
 class ProcessedModal(BaseModal, title="Report Processing"):

--- a/cogs/interserver_commands.py
+++ b/cogs/interserver_commands.py
@@ -116,7 +116,7 @@ class InterServerCommands(commands.GroupCog, name="interserver", description="Ma
         try:
             author = await self.bot.fetch_user(msg_data['author_id'])
             author_mention = f"{author.mention} (`{author.id}`)"
-        except:
+        except discord.HTTPException:
             author_mention = f"Unknown User (`{msg_data['author_id']}`)"
 
         # Crée le rapport avec Components V2
@@ -293,7 +293,7 @@ class InterServerCommands(commands.GroupCog, name="interserver", description="Ma
         try:
             author = await self.bot.fetch_user(msg_data['author_id'])
             author_info = f"{author.mention} (`{author.id}`)"
-        except:
+        except discord.HTTPException:
             author_info = f"Unknown User (`{msg_data['author_id']}`)"
 
         # Récupère le serveur d'origine

--- a/cogs/invite.py
+++ b/cogs/invite.py
@@ -15,6 +15,7 @@ from datetime import datetime
 
 from utils.i18n import i18n, t
 from utils.emojis import EMOJIS
+from utils.incognito import resolve_incognito
 
 
 class InviteView(BaseView):
@@ -539,16 +540,8 @@ class Invite(commands.Cog):
     ):
         """Lookup a Discord invite"""
         # Get the ephemeral mode
-        if incognito is None and self.bot.db:
-            try:
-                user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
-                ephemeral = True if user_pref is None else user_pref
-            except Exception:
-                # Visibility preference is a nicety: fall back to private
-                # rather than failing the whole lookup.
-                ephemeral = True
-        else:
-            ephemeral = incognito if incognito is not None else True
+        ephemeral = (incognito if incognito is not None
+                     else await resolve_incognito(self.bot, interaction.user.id))
 
         # Get the user's locale
         locale = i18n.get_user_locale(interaction)

--- a/cogs/invite.py
+++ b/cogs/invite.py
@@ -147,7 +147,8 @@ class InviteView(BaseView):
                 expires_dt = datetime.fromisoformat(expires_at.replace('Z', '+00:00'))
                 expires_ts = int(expires_dt.timestamp())
                 info_lines.append(f"**{t('commands.invite.view.guild.expires', locale=self.locale)}:** <t:{expires_ts}:F> (<t:{expires_ts}:R>)")
-            except:
+            except (ValueError, TypeError, AttributeError):
+                # Malformed timestamp from the API — just omit the line.
                 pass
 
         # Add all info as a single text block
@@ -212,7 +213,8 @@ class InviteView(BaseView):
                 expires_dt = datetime.fromisoformat(expires_at.replace('Z', '+00:00'))
                 expires_ts = int(expires_dt.timestamp())
                 info_lines.append(f"**{t('commands.invite.view.guild.expires', locale=self.locale)}:** <t:{expires_ts}:F> (<t:{expires_ts}:R>)")
-            except:
+            except (ValueError, TypeError, AttributeError):
+                # Malformed timestamp from the API — just omit the line.
                 pass
 
         container.add_item(ui.TextDisplay("\n".join(info_lines)))
@@ -246,7 +248,8 @@ class InviteView(BaseView):
                 expires_dt = datetime.fromisoformat(expires_at.replace('Z', '+00:00'))
                 expires_ts = int(expires_dt.timestamp())
                 info_lines.append(f"**{t('commands.invite.view.guild.expires', locale=self.locale)}:** <t:{expires_ts}:F> (<t:{expires_ts}:R>)")
-            except:
+            except (ValueError, TypeError, AttributeError):
+                # Malformed timestamp from the API — just omit the line.
                 pass
 
         container.add_item(ui.TextDisplay("\n".join(info_lines)))
@@ -540,7 +543,9 @@ class Invite(commands.Cog):
             try:
                 user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
                 ephemeral = True if user_pref is None else user_pref
-            except:
+            except Exception:
+                # Visibility preference is a nicety: fall back to private
+                # rather than failing the whole lookup.
                 ephemeral = True
         else:
             ephemeral = incognito if incognito is not None else True
@@ -583,10 +588,6 @@ class Invite(commands.Cog):
 
         except aiohttp.ClientError as e:
             error_msg = t("commands.invite.errors.network_error", locale=locale)
-            await interaction.edit_original_response(content=error_msg)
-            return
-        except Exception as e:
-            error_msg = t("commands.invite.errors.generic", locale=locale, error=str(e))
             await interaction.edit_original_response(content=error_msg)
             return
 

--- a/cogs/moddy.py
+++ b/cogs/moddy.py
@@ -319,7 +319,8 @@ class Moddy(commands.Cog):
             try:
                 user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
                 ephemeral = True if user_pref is None else user_pref
-            except:
+            except Exception:
+                # Visibility preference is a nicety: default to private.
                 ephemeral = True
         else:
             ephemeral = incognito if incognito is not None else True

--- a/cogs/moddy.py
+++ b/cogs/moddy.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from cogs.error_handler import BaseView
 from utils.i18n import i18n, t
 from utils.emojis import EMOJIS
+from utils.incognito import resolve_incognito
 
 
 # Namespaced custom_id constants for persistent dispatch.
@@ -315,15 +316,8 @@ class Moddy(commands.Cog):
     ):
         """Display information about Moddy"""
         # Get the ephemeral mode
-        if incognito is None and self.bot.db:
-            try:
-                user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
-                ephemeral = True if user_pref is None else user_pref
-            except Exception:
-                # Visibility preference is a nicety: default to private.
-                ephemeral = True
-        else:
-            ephemeral = incognito if incognito is not None else True
+        ephemeral = (incognito if incognito is not None
+                     else await resolve_incognito(self.bot, interaction.user.id))
 
         # Get the user's locale
         locale = i18n.get_user_locale(interaction)

--- a/cogs/moderation_commands.py
+++ b/cogs/moderation_commands.py
@@ -19,11 +19,12 @@ import discord
 from discord import app_commands, ui
 from discord.ext import commands
 
-from cogs.error_handler import BaseModal, BaseView
+from cogs.error_handler import BaseModal, BaseView, ErrorView, report_error
 from config import COLORS
 from notifications.models import NotificationContent, NotificationSource
 from utils import emojis
 from utils.i18n import t, get_locale
+from utils.interaction_response import deliver
 
 logger = logging.getLogger("moddy.moderation_commands")
 
@@ -307,7 +308,15 @@ _LOCALE_TO_LANGUAGE: dict[str, str] = {
 
 _AI_SENTINEL_NO_REASON = "NO_REASON"
 _AI_SENTINEL_INJECTION = "INJECTION_DETECTED"
-_AI_TOTAL_TIMEOUT = 2.8  # seconds — must leave room for send_modal within the 3 s window
+_AI_TOTAL_TIMEOUT = 2.8  # seconds — hard ceiling for the whole suggestion
+# Discord closes the acknowledgement window 3 s after the interaction was
+# created, and a modal cannot be preceded by a defer: the suggestion has to fit
+# in whatever is left of that window. The margin covers the round-trip of the
+# send_modal call itself, so a slow suggestion degrades into "no prefill"
+# instead of into Discord's own "The application did not respond".
+_ACK_WINDOW = 3.0
+_MODAL_SAFETY_MARGIN = 0.8
+_AI_MIN_BUDGET = 0.3  # below this, do not even start the suggestion
 _AI_FETCH_TIMEOUT = 1.2  # seconds — budget for the message-history scan
 _AI_CHAT_MIN_TIMEOUT = 1.0  # seconds — floor left for the OpenAI call, even if the fetch was slow
 _AI_MODEL = "gpt-4.1-nano"
@@ -487,15 +496,28 @@ async def _ai_reason_safe(
     guild: discord.Guild,
     user: Union[discord.Member, discord.User],
     action: str,
+    budget: Optional[float] = None,
 ) -> Optional[str]:
     """Wrapper that silences all errors and enforces the global timeout budget."""
+    timeout = _AI_TOTAL_TIMEOUT if budget is None else min(_AI_TOTAL_TIMEOUT, budget)
+    if timeout < _AI_MIN_BUDGET:
+        return None
     try:
         return await asyncio.wait_for(
             _get_ai_suggested_reason(bot, guild, user, action),
-            timeout=_AI_TOTAL_TIMEOUT,
+            timeout=timeout,
         )
     except Exception:
         return None
+
+
+def _ack_budget(interaction: discord.Interaction) -> float:
+    """Seconds of Discord's acknowledgement window still safely available."""
+    created = getattr(interaction, "created_at", None)
+    if created is None:
+        return _ACK_WINDOW - _MODAL_SAFETY_MARGIN
+    elapsed = (datetime.now(timezone.utc) - created).total_seconds()
+    return max(0.0, _ACK_WINDOW - elapsed - _MODAL_SAFETY_MARGIN)
 
 
 # ---------------------------------------------------------------------------
@@ -919,6 +941,62 @@ class ModerationCommands(commands.Cog):
             return
         _cache_deleted(message.guild.id, message.author.id, message.content)
 
+    # ── Shared entry point for /ban /kick /mute /warn ───────────────────────
+
+    async def _open_sanction_modal(
+        self,
+        interaction: discord.Interaction,
+        user: discord.Member,
+        action: str,
+        incognito: Optional[bool],
+    ) -> None:
+        """Open the sanction modal, prefilled with an AI reason when there is time.
+
+        A modal cannot be preceded by a defer, so everything awaited here eats
+        into Discord's 3-second window. The suggestion therefore runs on
+        whatever is left of that window (`_ack_budget`) and simply yields no
+        prefill when the budget is gone — the modal always opens.
+        """
+        locale = get_locale(interaction)
+        err = _hierarchy_check(interaction.guild, interaction.user, user, action, locale)
+        if err is not None:
+            await interaction.response.send_message(view=err, ephemeral=True)
+            return
+
+        budget = _ack_budget(interaction)
+        if incognito is None:
+            incognito, prefill_reason = await asyncio.gather(
+                _resolve_incognito(self.bot, interaction.user.id, default=True),
+                _ai_reason_safe(self.bot, interaction.guild, user, action, budget=budget),
+            )
+        else:
+            prefill_reason = await _ai_reason_safe(
+                self.bot, interaction.guild, user, action, budget=budget)
+
+        modal = SanctionModal(
+            action=action,
+            initial_users=[user],
+            incognito=incognito,
+            guild=interaction.guild,
+            mod=interaction.user,
+            bot=self.bot,
+            locale=locale,
+            prefill_reason=prefill_reason,
+        )
+        try:
+            await interaction.response.send_modal(modal)
+        except discord.HTTPException as exc:
+            # The window closed anyway (a very cold gateway, a slow database).
+            # Surface Moddy's own error card with a code instead of leaving
+            # Discord to show "The application did not respond".
+            error_code = await report_error(
+                self.bot, exc, source=f"Cog:ModerationCommands.{action}",
+                user=interaction.user, guild=interaction.guild,
+                channel=interaction.channel,
+            )
+            if error_code:
+                await deliver(interaction, view=ErrorView(error_code), ephemeral=True)
+
     # ── /ban ─────────────────────────────────────────────────────────────────
 
     @app_commands.command(
@@ -937,29 +1015,7 @@ class ModerationCommands(commands.Cog):
         user: discord.Member,
         incognito: Optional[bool] = None,
     ):
-        locale = get_locale(interaction)
-        err = _hierarchy_check(interaction.guild, interaction.user, user, "ban", locale)
-        if err is not None:
-            await interaction.response.send_message(view=err, ephemeral=True)
-            return
-        if incognito is None:
-            incognito, prefill_reason = await asyncio.gather(
-                _resolve_incognito(self.bot, interaction.user.id, default=True),
-                _ai_reason_safe(self.bot, interaction.guild, user, "ban"),
-            )
-        else:
-            prefill_reason = await _ai_reason_safe(self.bot, interaction.guild, user, "ban")
-        modal = SanctionModal(
-            action="ban",
-            initial_users=[user],
-            incognito=incognito,
-            guild=interaction.guild,
-            mod=interaction.user,
-            bot=self.bot,
-            locale=locale,
-            prefill_reason=prefill_reason,
-        )
-        await interaction.response.send_modal(modal)
+        await self._open_sanction_modal(interaction, user, "ban", incognito)
 
     # ── /kick ────────────────────────────────────────────────────────────────
 
@@ -979,29 +1035,7 @@ class ModerationCommands(commands.Cog):
         user: discord.Member,
         incognito: Optional[bool] = None,
     ):
-        locale = get_locale(interaction)
-        err = _hierarchy_check(interaction.guild, interaction.user, user, "kick", locale)
-        if err is not None:
-            await interaction.response.send_message(view=err, ephemeral=True)
-            return
-        if incognito is None:
-            incognito, prefill_reason = await asyncio.gather(
-                _resolve_incognito(self.bot, interaction.user.id, default=True),
-                _ai_reason_safe(self.bot, interaction.guild, user, "kick"),
-            )
-        else:
-            prefill_reason = await _ai_reason_safe(self.bot, interaction.guild, user, "kick")
-        modal = SanctionModal(
-            action="kick",
-            initial_users=[user],
-            incognito=incognito,
-            guild=interaction.guild,
-            mod=interaction.user,
-            bot=self.bot,
-            locale=locale,
-            prefill_reason=prefill_reason,
-        )
-        await interaction.response.send_modal(modal)
+        await self._open_sanction_modal(interaction, user, "kick", incognito)
 
     # ── /mute ────────────────────────────────────────────────────────────────
 
@@ -1021,29 +1055,7 @@ class ModerationCommands(commands.Cog):
         user: discord.Member,
         incognito: Optional[bool] = None,
     ):
-        locale = get_locale(interaction)
-        err = _hierarchy_check(interaction.guild, interaction.user, user, "mute", locale)
-        if err is not None:
-            await interaction.response.send_message(view=err, ephemeral=True)
-            return
-        if incognito is None:
-            incognito, prefill_reason = await asyncio.gather(
-                _resolve_incognito(self.bot, interaction.user.id, default=True),
-                _ai_reason_safe(self.bot, interaction.guild, user, "mute"),
-            )
-        else:
-            prefill_reason = await _ai_reason_safe(self.bot, interaction.guild, user, "mute")
-        modal = SanctionModal(
-            action="mute",
-            initial_users=[user],
-            incognito=incognito,
-            guild=interaction.guild,
-            mod=interaction.user,
-            bot=self.bot,
-            locale=locale,
-            prefill_reason=prefill_reason,
-        )
-        await interaction.response.send_modal(modal)
+        await self._open_sanction_modal(interaction, user, "mute", incognito)
 
     # ── /warn ────────────────────────────────────────────────────────────────
 
@@ -1063,29 +1075,7 @@ class ModerationCommands(commands.Cog):
         user: discord.Member,
         incognito: Optional[bool] = None,
     ):
-        locale = get_locale(interaction)
-        err = _hierarchy_check(interaction.guild, interaction.user, user, "warn", locale)
-        if err is not None:
-            await interaction.response.send_message(view=err, ephemeral=True)
-            return
-        if incognito is None:
-            incognito, prefill_reason = await asyncio.gather(
-                _resolve_incognito(self.bot, interaction.user.id, default=True),
-                _ai_reason_safe(self.bot, interaction.guild, user, "warn"),
-            )
-        else:
-            prefill_reason = await _ai_reason_safe(self.bot, interaction.guild, user, "warn")
-        modal = SanctionModal(
-            action="warn",
-            initial_users=[user],
-            incognito=incognito,
-            guild=interaction.guild,
-            mod=interaction.user,
-            bot=self.bot,
-            locale=locale,
-            prefill_reason=prefill_reason,
-        )
-        await interaction.response.send_modal(modal)
+        await self._open_sanction_modal(interaction, user, "warn", incognito)
 
     # ── Backend dashboard tasks (moddy:tasks) ───────────────────────────────
     # A dashboard sanction on a guild case is executed here, exactly like a

--- a/cogs/moderation_commands.py
+++ b/cogs/moderation_commands.py
@@ -25,6 +25,7 @@ from notifications.models import NotificationContent, NotificationSource
 from utils import emojis
 from utils.i18n import t, get_locale
 from utils.interaction_response import deliver
+from utils.incognito import resolve_incognito
 
 logger = logging.getLogger("moddy.moderation_commands")
 
@@ -838,16 +839,10 @@ async def _guild_locale(bot, guild: discord.Guild) -> str:
     return await guild_locale(bot, guild)
 
 
-async def _resolve_incognito(bot, user_id: int, default: bool = True) -> bool:
-    """Resolve incognito from user preference or the given default."""
-    try:
-        if bot.db:
-            pref = await bot.db.get_attribute("user", user_id, "DEFAULT_INCOGNITO")
-            if pref is not None:
-                return bool(pref)
-    except Exception:
-        pass
-    return default
+#: The sanction commands answer with a Modal, which cannot be deferred, so
+#: this lookup sits directly in front of the 3-second window. It goes through
+#: the shared cached resolver rather than hitting the database every time.
+_resolve_incognito = resolve_incognito
 
 
 # ---------------------------------------------------------------------------

--- a/cogs/module_events.py
+++ b/cogs/module_events.py
@@ -10,6 +10,21 @@ import logging
 logger = logging.getLogger('moddy.cogs.module_events')
 
 
+async def _report(bot, error: Exception, source: str, guild=None) -> None:
+    """File a module dispatch failure through the central error pipeline.
+
+    Every ``try`` in this cog is an isolation boundary: one broken module must
+    not stop the others from receiving the event. That isolation used to mean a
+    module could fail on every single join and only ever say so on stdout —
+    ``report_error`` gives the failure an error code, a Sentry event and an
+    entry in the internal log, exactly like an error raised from a command.
+    """
+    from cogs.error_handler import report_error
+
+    # report_error already logs the full traceback, so no second log line here.
+    await report_error(bot, error, source=f"Cog:ModuleEvents.{source}", guild=guild)
+
+
 class ModuleEvents(commands.Cog):
     """
     Cog qui écoute les événements Discord et les transmet aux modules concernés
@@ -39,10 +54,7 @@ class ModuleEvents(commands.Cog):
                 await altguard_module.on_member_join(member)
 
         except Exception as e:
-            logger.error(
-                f"Error in on_member_join (altguard) for guild {member.guild.id}: {e}",
-                exc_info=True
-            )
+            await _report(self.bot, e, "on_member_join (altguard)", member.guild)
 
         # Welcome Channel + Welcome DM. The channel module used to be dispatched
         # under the id 'welcome', which no registered module has ever answered to
@@ -59,10 +71,7 @@ class ModuleEvents(commands.Cog):
                     await welcome_module.on_member_join(member)
 
             except Exception as e:
-                logger.error(
-                    f"Error in on_member_join ({module_id}) for guild {member.guild.id}: {e}",
-                    exc_info=True
-                )
+                await _report(self.bot, e, f"on_member_join ({module_id})", member.guild)
 
         try:
             # Récupère l'instance du module Auto Restore Roles pour ce serveur
@@ -76,7 +85,7 @@ class ModuleEvents(commands.Cog):
                 await auto_restore_module.on_member_join(member)
 
         except Exception as e:
-            logger.error(f"Error in on_member_join (auto_restore_roles) for guild {member.guild.id}: {e}", exc_info=True)
+            await _report(self.bot, e, "on_member_join (auto_restore_roles)", member.guild)
 
         try:
             # Récupère l'instance du module Auto Role pour ce serveur
@@ -90,7 +99,7 @@ class ModuleEvents(commands.Cog):
                 await auto_role_module.on_member_join(member)
 
         except Exception as e:
-            logger.error(f"Error in on_member_join (auto_role) for guild {member.guild.id}: {e}", exc_info=True)
+            await _report(self.bot, e, "on_member_join (auto_role)", member.guild)
 
     @commands.Cog.listener()
     async def on_member_remove(self, member: discord.Member):
@@ -113,7 +122,7 @@ class ModuleEvents(commands.Cog):
                 await auto_restore_module.on_member_remove(member)
 
         except Exception as e:
-            logger.error(f"Error in on_member_remove (auto_restore_roles) for guild {member.guild.id}: {e}", exc_info=True)
+            await _report(self.bot, e, "on_member_remove (auto_restore_roles)", member.guild)
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -144,7 +153,7 @@ class ModuleEvents(commands.Cog):
                 await interserver_module.on_message(message)
 
         except Exception as e:
-            logger.error(f"Error in on_message for guild {message.guild.id}: {e}", exc_info=True)
+            await _report(self.bot, e, "on_message (interserver)", message.guild)
 
         try:
             # Adaptive Slowmode: record the message in the rolling window
@@ -157,7 +166,7 @@ class ModuleEvents(commands.Cog):
                 await slowmode_module.on_message(message)
 
         except Exception as e:
-            logger.error(f"Error in on_message (adaptive_slowmode) for guild {message.guild.id}: {e}", exc_info=True)
+            await _report(self.bot, e, "on_message (adaptive_slowmode)", message.guild)
 
         try:
             # Automod: run the message through the AI moderation pipeline
@@ -170,7 +179,7 @@ class ModuleEvents(commands.Cog):
                 await automod_module.on_message(message)
 
         except Exception as e:
-            logger.error(f"Error in on_message (automod) for guild {message.guild.id}: {e}", exc_info=True)
+            await _report(self.bot, e, "on_message (automod)", message.guild)
 
         try:
             # Voice Transcription: offer (or post) a transcription under a
@@ -184,7 +193,7 @@ class ModuleEvents(commands.Cog):
                 await transcription_module.on_message(message)
 
         except Exception as e:
-            logger.error(f"Error in on_message (voice_transcription) for guild {message.guild.id}: {e}", exc_info=True)
+            await _report(self.bot, e, "on_message (voice_transcription)", message.guild)
 
     @commands.Cog.listener()
     async def on_reaction_add(self, reaction: discord.Reaction, user):
@@ -206,9 +215,7 @@ class ModuleEvents(commands.Cog):
             if automod_module and automod_module.enabled:
                 await automod_module.on_reaction(reaction, user)
         except Exception as e:
-            logger.error(
-                f"Error in on_reaction_add (automod) for guild {msg.guild.id}: {e}",
-                exc_info=True)
+            await _report(self.bot, e, "on_reaction_add (automod)", msg.guild)
 
     @commands.Cog.listener()
     async def on_message_delete(self, message: discord.Message):
@@ -259,7 +266,8 @@ class ModuleEvents(commands.Cog):
             logger.info(f"Deleted inter-server message {interserver_msg['moddy_id']} and all relayed copies")
 
         except Exception as e:
-            logger.error(f"Error in on_message_delete for inter-server: {e}", exc_info=True)
+            await _report(self.bot, e, "on_message_delete (interserver)",
+                          getattr(message, "guild", None))
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
@@ -290,7 +298,8 @@ class ModuleEvents(commands.Cog):
                 await starboard_module.on_reaction_add(payload)
 
         except Exception as e:
-            logger.error(f"Error in on_raw_reaction_add for guild {payload.guild_id}: {e}", exc_info=True)
+            await _report(self.bot, e, "on_raw_reaction_add (starboard)",
+                          self.bot.get_guild(payload.guild_id))
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
@@ -321,7 +330,8 @@ class ModuleEvents(commands.Cog):
                 await starboard_module.on_reaction_remove(payload)
 
         except Exception as e:
-            logger.error(f"Error in on_raw_reaction_remove for guild {payload.guild_id}: {e}", exc_info=True)
+            await _report(self.bot, e, "on_raw_reaction_remove (starboard)",
+                          self.bot.get_guild(payload.guild_id))
 
 
 async def setup(bot):

--- a/cogs/ping.py
+++ b/cogs/ping.py
@@ -37,7 +37,8 @@ class PublicPing(Cog):
             try:
                 user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
                 ephemeral = True if user_pref is None else user_pref
-            except:
+            except Exception:
+                # Visibility preference is a nicety: default to private.
                 ephemeral = True
         else:
             ephemeral = incognito if incognito is not None else True

--- a/cogs/ping.py
+++ b/cogs/ping.py
@@ -12,6 +12,7 @@ from discord import SeparatorSpacing
 from config import COLORS
 from utils.emojis import GREEN_STATUS, YELLOW_STATUS, RED_STATUS
 from utils.i18n import i18n, t
+from utils.incognito import resolve_incognito
 from moddy import Cog, app_commands
 from moddy.ui import ActionRow, Button, Container, LayoutView, Separator, TextDisplay
 
@@ -33,15 +34,8 @@ class PublicPing(Cog):
         """Commande slash /ping avec i18n automatique et Components V2"""
 
         # === BLOC INCOGNITO ===
-        if incognito is None and self.bot.db:
-            try:
-                user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
-                ephemeral = True if user_pref is None else user_pref
-            except Exception:
-                # Visibility preference is a nicety: default to private.
-                ephemeral = True
-        else:
-            ephemeral = incognito if incognito is not None else True
+        ephemeral = (incognito if incognito is not None
+                     else await resolve_incognito(self.bot, interaction.user.id))
 
         # Mesure du temps de début
         start = time.perf_counter()

--- a/cogs/preferences.py
+++ b/cogs/preferences.py
@@ -14,6 +14,7 @@ from cogs.error_handler import BaseView
 from utils.components_v2 import create_error_message
 from utils.i18n import i18n, t
 from utils.interaction_response import safe_defer
+from utils.incognito import resolve_incognito
 
 # --------------------------------------------------------------------------- #
 # custom_id templates
@@ -324,15 +325,8 @@ class Preferences(commands.Cog):
     ):
         """Open preferences menu"""
         # Handle incognito setting
-        if incognito is None and self.bot.db:
-            try:
-                user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
-                ephemeral = True if user_pref is None else user_pref
-            except Exception:
-                # Visibility preference is a nicety: default to private.
-                ephemeral = True
-        else:
-            ephemeral = incognito if incognito is not None else True
+        ephemeral = (incognito if incognito is not None
+                     else await resolve_incognito(self.bot, interaction.user.id))
 
         # Reading the user row is a database round-trip: acknowledge first.
         await safe_defer(interaction, ephemeral=ephemeral)

--- a/cogs/preferences.py
+++ b/cogs/preferences.py
@@ -13,6 +13,7 @@ from typing import Optional
 from cogs.error_handler import BaseView
 from utils.components_v2 import create_error_message
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 
 # --------------------------------------------------------------------------- #
 # custom_id templates
@@ -153,9 +154,11 @@ class TimezoneSelect(ui.DynamicItem[ui.Select], template=_CID_SELECT_TEMPLATE):
         locale = i18n.get_user_locale(interaction)
         selected_tz = self.item.values[0]
 
+        # The write is a database round-trip: acknowledge before it.
+        await safe_defer(interaction, ephemeral=True)
         await bot.db.update_user_data(interaction.user.id, "reminder_timezone", selected_tz)
 
-        await interaction.response.send_message(
+        await interaction.followup.send(
             t("commands.preferences.timezone.success", locale=locale,
               timezone=TIMEZONE_NAMES.get(selected_tz, selected_tz)),
             ephemeral=True,
@@ -201,10 +204,12 @@ class PreferencesManageButton(ui.DynamicItem[ui.Button], template=_CID_BTN_TEMPL
 
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
+        # Reading the user row is a database round-trip: acknowledge first.
+        await safe_defer(interaction, ephemeral=False, thinking=False)
         user_data = await bot.db.get_user(interaction.user.id)
         page = "timezone" if self.action == "timezone" else "home"
         view = PreferencesView(bot, interaction.user.id, locale, user_data, page=page)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
 
 class PreferencesView(BaseView):
@@ -323,10 +328,14 @@ class Preferences(commands.Cog):
             try:
                 user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
                 ephemeral = True if user_pref is None else user_pref
-            except:
+            except Exception:
+                # Visibility preference is a nicety: default to private.
                 ephemeral = True
         else:
             ephemeral = incognito if incognito is not None else True
+
+        # Reading the user row is a database round-trip: acknowledge first.
+        await safe_defer(interaction, ephemeral=ephemeral)
 
         # Get user data
         user_data = await self.bot.db.get_user(interaction.user.id)
@@ -339,7 +348,7 @@ class Preferences(commands.Cog):
             user_data,
         )
 
-        await interaction.response.send_message(view=view, ephemeral=ephemeral)
+        await interaction.followup.send(view=view, ephemeral=ephemeral)
 
 
 async def setup(bot):

--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -18,6 +18,7 @@ from cogs.error_handler import BaseView
 
 from utils.i18n import i18n, t
 from utils.components_v2 import create_error_message
+from utils.interaction_response import safe_defer
 from cogs.error_handler import BaseModal
 
 logger = logging.getLogger('moddy.reminder')
@@ -367,6 +368,10 @@ class ReminderAddModal(BaseModal):
         self.add_item(self.time_input)
 
     async def on_submit(self, interaction: discord.Interaction):
+        # Resolving the timezone and writing the reminder are database
+        # round-trips: acknowledge before any of them.
+        await safe_defer(interaction, ephemeral=True)
+
         message = self.message_input.value
         time_str = self.time_input.value
 
@@ -375,14 +380,14 @@ class ReminderAddModal(BaseModal):
         remind_at = parse_time_string(time_str, user_tz)
 
         if not remind_at:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t("commands.reminder.errors.invalid_time", interaction),
                 ephemeral=True
             )
             return
 
         if remind_at <= datetime.now(ZoneInfo('UTC')):
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t("commands.reminder.errors.past_time", interaction),
                 ephemeral=True
             )
@@ -391,7 +396,7 @@ class ReminderAddModal(BaseModal):
         # Check max reminders
         existing = await self.bot.db.get_user_reminders(interaction.user.id)
         if len(existing) >= 50:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t("commands.reminder.errors.max_reminders", interaction),
                 ephemeral=True
             )
@@ -408,7 +413,7 @@ class ReminderAddModal(BaseModal):
         )
 
         # Simple confirmation message
-        await interaction.response.send_message(
+        await interaction.followup.send(
             t("commands.reminder.success.created", interaction, id=reminder_id),
             ephemeral=True
         )
@@ -451,6 +456,9 @@ class ReminderEditModal(BaseModal):
         self.add_item(self.time_input)
 
     async def on_submit(self, interaction: discord.Interaction):
+        # Same as the add modal: database work follows, acknowledge first.
+        await safe_defer(interaction, ephemeral=True)
+
         message = self.message_input.value
         time_str = self.time_input.value.strip() if self.time_input.value else None
 
@@ -460,14 +468,14 @@ class ReminderEditModal(BaseModal):
             new_remind_at = parse_time_string(time_str, user_tz)
 
             if not new_remind_at:
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     t("commands.reminder.errors.invalid_time", interaction),
                     ephemeral=True
                 )
                 return
 
             if new_remind_at <= datetime.now(ZoneInfo('UTC')):
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     t("commands.reminder.errors.past_time", interaction),
                     ephemeral=True
                 )
@@ -482,7 +490,7 @@ class ReminderEditModal(BaseModal):
         )
 
         # Simple confirmation message
-        await interaction.response.send_message(
+        await interaction.followup.send(
             t("commands.reminder.success.edited", interaction, id=self.reminder['id']),
             ephemeral=True
         )
@@ -562,10 +570,12 @@ class ReminderSelectForDelete(ui.Select):
 
     async def callback(self, interaction: discord.Interaction):
         reminder_id = int(self.values[0])
+        # The delete is a database round-trip: acknowledge before it.
+        await safe_defer(interaction, ephemeral=True)
         await self.bot.db.delete_reminder(reminder_id, interaction.user.id)
 
         # Simple confirmation message
-        await interaction.response.send_message(
+        await interaction.followup.send(
             t("commands.reminder.success.deleted", interaction, id=reminder_id),
             ephemeral=True
         )
@@ -655,6 +665,11 @@ class ReminderManageButton(ui.DynamicItem[ui.Button], template=_CID_REM_TEMPLATE
             )
             return
 
+        # Every remaining branch reads the database before it can answer, so
+        # the interaction is acknowledged first (as a silent update: the card
+        # is edited in place, or an ephemeral follow-up is sent).
+        await safe_defer(interaction, ephemeral=False, thinking=False)
+
         if self.action in ("edit", "delete"):
             reminders = await bot.db.get_user_reminders(owner_id)
             if not reminders:
@@ -672,14 +687,14 @@ class ReminderManageButton(ui.DynamicItem[ui.Button], template=_CID_REM_TEMPLATE
             ))
             container.add_item(row)
             select_view.add_item(container)
-            await interaction.response.send_message(view=select_view, ephemeral=True)
+            await interaction.followup.send(view=select_view, ephemeral=True)
             return
 
         # "history" and "back" both just re-render the card in place.
         view = await RemindersManageView.build_for(
             bot, owner_id, locale, show_history=(self.action == "history")
         )
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
 
 class RemindersManageView(BaseView):
@@ -970,14 +985,19 @@ class Reminder(commands.Cog):
             try:
                 user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
                 ephemeral = True if user_pref is None else user_pref
-            except:
+            except Exception:
+                # Visibility preference is a nicety: default to private.
                 ephemeral = True
         else:
             ephemeral = incognito if incognito is not None else True
 
+        # Timezone resolution and the reminder queries below are database
+        # round-trips: acknowledge before any of them.
+        await safe_defer(interaction, ephemeral=ephemeral)
+
         # Validate message length
         if len(message) > 1000:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t("commands.reminder.errors.too_long", interaction),
                 ephemeral=True
             )
@@ -993,14 +1013,14 @@ class Reminder(commands.Cog):
         remind_at = parse_time_string(time, user_tz)
 
         if not remind_at:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t("commands.reminder.errors.invalid_time", interaction),
                 ephemeral=True
             )
             return
 
         if remind_at <= datetime.now(ZoneInfo('UTC')):
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t("commands.reminder.errors.past_time", interaction),
                 ephemeral=True
             )
@@ -1009,7 +1029,7 @@ class Reminder(commands.Cog):
         # Check max reminders
         existing = await self.bot.db.get_user_reminders(interaction.user.id)
         if len(existing) >= 50:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t("commands.reminder.errors.max_reminders", interaction),
                 ephemeral=True
             )
@@ -1026,7 +1046,7 @@ class Reminder(commands.Cog):
         )
 
         # Simple confirmation message
-        await interaction.response.send_message(
+        await interaction.followup.send(
             t("commands.reminder.success.created", interaction, id=reminder_id),
             ephemeral=ephemeral
         )
@@ -1051,10 +1071,15 @@ class Reminder(commands.Cog):
             try:
                 user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
                 ephemeral = True if user_pref is None else user_pref
-            except:
+            except Exception:
+                # Visibility preference is a nicety: default to private.
                 ephemeral = True
         else:
             ephemeral = incognito if incognito is not None else True
+
+        # Timezone resolution and the reminder queries below are database
+        # round-trips: acknowledge before any of them.
+        await safe_defer(interaction, ephemeral=ephemeral)
 
         # Get user timezone (auto-detected or from preferences)
         user_tz = await get_user_timezone(self.bot, interaction.user.id, str(interaction.locale))
@@ -1071,7 +1096,7 @@ class Reminder(commands.Cog):
             user_tz,
         )
 
-        await interaction.response.send_message(view=view, ephemeral=ephemeral)
+        await interaction.followup.send(view=view, ephemeral=ephemeral)
 
 
 async def setup(bot):

--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -20,6 +20,7 @@ from utils.i18n import i18n, t
 from utils.components_v2 import create_error_message
 from utils.interaction_response import safe_defer
 from cogs.error_handler import BaseModal
+from utils.incognito import resolve_incognito
 
 logger = logging.getLogger('moddy.reminder')
 
@@ -986,15 +987,8 @@ class Reminder(commands.Cog):
     ):
         """Add a new reminder"""
         # Handle incognito setting
-        if incognito is None and self.bot.db:
-            try:
-                user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
-                ephemeral = True if user_pref is None else user_pref
-            except Exception:
-                # Visibility preference is a nicety: default to private.
-                ephemeral = True
-        else:
-            ephemeral = incognito if incognito is not None else True
+        ephemeral = (incognito if incognito is not None
+                     else await resolve_incognito(self.bot, interaction.user.id))
 
         # Timezone resolution and the reminder queries below are database
         # round-trips: acknowledge before any of them.
@@ -1072,15 +1066,8 @@ class Reminder(commands.Cog):
     ):
         """Manage reminders"""
         # Handle incognito setting
-        if incognito is None and self.bot.db:
-            try:
-                user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
-                ephemeral = True if user_pref is None else user_pref
-            except Exception:
-                # Visibility preference is a nicety: default to private.
-                ephemeral = True
-        else:
-            ephemeral = incognito if incognito is not None else True
+        ephemeral = (incognito if incognito is not None
+                     else await resolve_incognito(self.bot, interaction.user.id))
 
         # Timezone resolution and the reminder queries below are database
         # round-trips: acknowledge before any of them.

--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -841,7 +841,10 @@ class Reminder(commands.Cog):
             for reminder in pending:
                 await self.send_reminder(reminder)
         except Exception as e:
-            logger.error(f"Error checking reminders: {e}")
+            # A silently broken loop means nobody's reminders ever fire again:
+            # file it centrally so it surfaces with an error code.
+            from cogs.error_handler import report_error
+            await report_error(self.bot, e, source="Cog:Reminder.check_reminders")
 
     @check_reminders.before_loop
     async def before_check_reminders(self):
@@ -860,7 +863,9 @@ class Reminder(commands.Cog):
                 for reminder in pending:
                     await self.send_reminder(reminder, is_late=True)
             except Exception as e:
-                logger.error(f"Error sending missed reminders: {e}")
+                from cogs.error_handler import report_error
+                await report_error(
+                    self.bot, e, source="Cog:Reminder.before_check_reminders")
 
     async def send_reminder(self, reminder: Dict, is_late: bool = False):
         """Send a reminder to the user"""

--- a/cogs/saved_messages.py
+++ b/cogs/saved_messages.py
@@ -9,7 +9,7 @@ from discord import app_commands, ui
 from discord.ext import commands
 from discord.ui import Container, TextDisplay, Separator
 from discord import SeparatorSpacing
-from cogs.error_handler import BaseView
+from cogs.error_handler import BaseModal, BaseView
 from typing import Optional, List, Dict, Any
 from datetime import datetime
 import logging
@@ -18,6 +18,7 @@ import io
 
 from utils.components_v2 import create_error_message
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 from utils.incognito import get_incognito_setting
 
 logger = logging.getLogger('moddy.saved_messages')
@@ -139,7 +140,7 @@ def message_to_raw_data(message: discord.Message) -> Dict:
     }
 
 
-class AddNoteModal(ui.Modal):
+class AddNoteModal(BaseModal):
     """Modal for adding a note to a saved message"""
 
     def __init__(self, locale: str, bot, message: discord.Message):
@@ -158,6 +159,9 @@ class AddNoteModal(ui.Modal):
         self.add_item(self.note_input)
 
     async def on_submit(self, interaction: discord.Interaction):
+        # Saving the message is a database round-trip: acknowledge first.
+        await safe_defer(interaction, ephemeral=True)
+
         note = self.note_input.value if self.note_input.value else None
 
         # Préparer les données du message
@@ -195,7 +199,7 @@ class AddNoteModal(ui.Modal):
         )
 
         success_msg = t("commands.saved_messages.success.saved", interaction, id=saved_id)
-        await interaction.response.send_message(success_msg, ephemeral=True)
+        await interaction.followup.send(success_msg, ephemeral=True)
 
 
 async def _refresh_library_card(bot, owner_id: int, locale: str,
@@ -236,7 +240,7 @@ async def _refresh_library_card(bot, owner_id: int, locale: str,
         pass
 
 
-class EditNoteModal(ui.Modal):
+class EditNoteModal(BaseModal):
     """Modal for editing a note on a saved message"""
 
     def __init__(self, locale: str, bot, saved_msg: Dict, owner_id: int,
@@ -261,6 +265,9 @@ class EditNoteModal(ui.Modal):
         self.add_item(self.note_input)
 
     async def on_submit(self, interaction: discord.Interaction):
+        # The note update is a database round-trip: acknowledge first.
+        await safe_defer(interaction, ephemeral=True)
+
         note = self.note_input.value if self.note_input.value else None
 
         # Les erreurs imprévues seront gérées par le système global
@@ -271,7 +278,7 @@ class EditNoteModal(ui.Modal):
         )
 
         success_msg = t("commands.saved_messages.success.note_updated", interaction)
-        await interaction.response.send_message(success_msg, ephemeral=True)
+        await interaction.followup.send(success_msg, ephemeral=True)
 
         await _refresh_library_card(
             self.bot, self.owner_id, self.locale, self.card_channel_id, self.card_message_id,
@@ -279,7 +286,7 @@ class EditNoteModal(ui.Modal):
         )
 
 
-class ViewMessageModal(ui.Modal):
+class ViewMessageModal(BaseModal):
     """Modal for entering a message ID to view"""
 
     def __init__(self, locale: str, bot, owner_id: int,
@@ -303,12 +310,15 @@ class ViewMessageModal(ui.Modal):
         self.add_item(self.id_input)
 
     async def on_submit(self, interaction: discord.Interaction):
+        # The lookup below is a database round-trip: acknowledge first.
+        await safe_defer(interaction, ephemeral=True)
+
         # Gestion de l'erreur attendue (ID invalide)
         try:
             msg_id = int(self.id_input.value.strip().replace('#', ''))
         except ValueError:
             error_msg = t("commands.saved_messages.errors.invalid_id", interaction)
-            await interaction.response.send_message(error_msg, ephemeral=True)
+            await interaction.followup.send(error_msg, ephemeral=True)
             return
 
         # Les erreurs imprévues seront gérées par le système global
@@ -316,7 +326,7 @@ class ViewMessageModal(ui.Modal):
 
         if not saved_msg:
             error_msg = t("commands.saved_messages.errors.not_found", interaction)
-            await interaction.response.send_message(error_msg, ephemeral=True)
+            await interaction.followup.send(error_msg, ephemeral=True)
             return
 
         await _refresh_library_card(

--- a/cogs/saved_messages.py
+++ b/cogs/saved_messages.py
@@ -310,8 +310,10 @@ class ViewMessageModal(BaseModal):
         self.add_item(self.id_input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        # The lookup below is a database round-trip: acknowledge first.
-        await safe_defer(interaction, ephemeral=True)
+        # The lookup below is a database round-trip: acknowledge first. Silent
+        # (thinking=False) because the success path only edits the library card
+        # in place and sends nothing back.
+        await safe_defer(interaction, ephemeral=True, thinking=False)
 
         # Gestion de l'erreur attendue (ID invalide)
         try:
@@ -653,23 +655,32 @@ class SavedMessagesDetailButton(ui.DynamicItem[ui.Button], template=_CID_DETAIL_
         channel_id = interaction.channel_id
         message_id = interaction.message.id if interaction.message else None
 
+        if self.action == "edit_note":
+            # A modal cannot follow a defer, so this branch stays un-acknowledged
+            # and does the one lookup the form needs to be prefilled.
+            detail_msg = await bot.db.get_saved_message(self.saved_id, owner_id)
+            if not detail_msg:
+                return
+            await interaction.response.send_modal(
+                EditNoteModal(locale, bot, detail_msg, owner_id,
+                              card_channel_id=channel_id, card_message_id=message_id, page=self.page)
+            )
+            return
+
+        # Every other branch reads the database before it can answer: acknowledge
+        # silently first, then edit the card or follow up.
+        await safe_defer(interaction, ephemeral=False, thinking=False)
+
         if self.action == "back":
             offset = self.page * 10
             messages = await bot.db.get_saved_messages(owner_id, limit=10, offset=offset)
             total_count = await bot.db.count_saved_messages(owner_id)
             view = SavedMessagesLibraryView(bot, owner_id, messages, locale, page=self.page, total_count=total_count)
-            await interaction.response.edit_message(view=view)
+            await interaction.edit_original_response(view=view)
             return
 
         detail_msg = await bot.db.get_saved_message(self.saved_id, owner_id)
         if not detail_msg:
-            return
-
-        if self.action == "edit_note":
-            await interaction.response.send_modal(
-                EditNoteModal(locale, bot, detail_msg, owner_id,
-                              card_channel_id=channel_id, card_message_id=message_id, page=self.page)
-            )
             return
 
         if self.action == "export":
@@ -679,7 +690,7 @@ class SavedMessagesDetailButton(ui.DynamicItem[ui.Button], template=_CID_DETAIL_
                     io.BytesIO(json_data.encode('utf-8')),
                     filename=f"message_{detail_msg['id']}_raw_data.json"
                 )
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     content=t("commands.saved_messages.success.exported", locale=locale),
                     file=file,
                     ephemeral=True,
@@ -689,7 +700,7 @@ class SavedMessagesDetailButton(ui.DynamicItem[ui.Button], template=_CID_DETAIL_
         if self.action == "delete":
             success = await bot.db.delete_saved_message(detail_msg['id'], owner_id)
             if success:
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     t("commands.saved_messages.success.deleted", locale=locale),
                     ephemeral=True,
                 )
@@ -699,7 +710,7 @@ class SavedMessagesDetailButton(ui.DynamicItem[ui.Button], template=_CID_DETAIL_
                     show_detail=False, page=self.page,
                 )
             else:
-                await interaction.response.send_message(t("common.error", locale=locale), ephemeral=True)
+                await interaction.followup.send(t("common.error", locale=locale), ephemeral=True)
 
 
 class SavedMessages(commands.Cog):
@@ -750,10 +761,14 @@ class SavedMessages(commands.Cog):
             try:
                 user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
                 ephemeral = True if user_pref is None else user_pref
-            except:
+            except Exception:
+                # Visibility preference is a nicety: default to private.
                 ephemeral = True
         else:
             ephemeral = incognito if incognito is not None else True
+
+        # Listing the library is two database round-trips: acknowledge first.
+        await safe_defer(interaction, ephemeral=ephemeral)
 
         # Get saved messages
         messages = await self.bot.db.get_saved_messages(interaction.user.id, limit=10, offset=0)
@@ -769,7 +784,7 @@ class SavedMessages(commands.Cog):
             total_count=total_count,
         )
 
-        await interaction.response.send_message(view=view, ephemeral=ephemeral)
+        await interaction.followup.send(view=view, ephemeral=ephemeral)
 
     async def cog_unload(self):
         """Remove context menu when cog is unloaded"""

--- a/cogs/saved_messages.py
+++ b/cogs/saved_messages.py
@@ -19,7 +19,7 @@ import io
 from utils.components_v2 import create_error_message
 from utils.i18n import i18n, t
 from utils.interaction_response import safe_defer
-from utils.incognito import get_incognito_setting
+from utils.incognito import get_incognito_setting, resolve_incognito
 
 logger = logging.getLogger('moddy.saved_messages')
 
@@ -757,15 +757,8 @@ class SavedMessages(commands.Cog):
     ):
         """View saved messages library"""
         # Handle incognito setting
-        if incognito is None and self.bot.db:
-            try:
-                user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
-                ephemeral = True if user_pref is None else user_pref
-            except Exception:
-                # Visibility preference is a nicety: default to private.
-                ephemeral = True
-        else:
-            ephemeral = incognito if incognito is not None else True
+        ephemeral = (incognito if incognito is not None
+                     else await resolve_incognito(self.bot, interaction.user.id))
 
         # Listing the library is two database round-trips: acknowledge first.
         await safe_defer(interaction, ephemeral=ephemeral)

--- a/cogs/subscription.py
+++ b/cogs/subscription.py
@@ -12,7 +12,6 @@ from discord import app_commands, ui
 from discord.ext import commands
 
 from cogs.error_handler import BaseView
-from utils.components_v2 import create_error_message
 from utils.emojis import PREMIUM
 from utils.i18n import t
 from utils.subscription import get_subscription
@@ -134,21 +133,13 @@ class Subscription(commands.Cog):
         locale = str(interaction.locale)
         user_id = interaction.user.id
 
-        try:
-            sub = await get_subscription(self.bot, user_id)
-            servers = []
-            if self.bot.db and sub and sub.get('is_active'):
-                servers = await self.bot.db.get_subscription_servers(user_id)
-        except Exception as e:
-            logger.error(f"Subscription fetch error for {user_id}: {e}", exc_info=True)
-            await interaction.followup.send(
-                view=create_error_message(
-                    "Error",
-                    t('commands.subscription.error', locale=locale),
-                ),
-                ephemeral=True,
-            )
-            return
+        # An unexpected failure here is a bug: let it reach the centralized
+        # app-command handler, which files an error code instead of showing a
+        # generic message the user cannot report.
+        sub = await get_subscription(self.bot, user_id)
+        servers = []
+        if self.bot.db and sub and sub.get('is_active'):
+            servers = await self.bot.db.get_subscription_servers(user_id)
 
         view = SubscriptionView(self.bot, user_id, sub, servers, locale)
         await interaction.followup.send(view=view, ephemeral=True)

--- a/cogs/text_tools.py
+++ b/cogs/text_tools.py
@@ -36,6 +36,7 @@ from config import COLORS
 from utils.emojis import EMOJIS
 from utils.i18n import i18n
 from utils.incognito import add_incognito_option, get_incognito_setting
+from utils.interaction_response import deliver
 
 logger = logging.getLogger("moddy.text_tools")
 
@@ -325,10 +326,7 @@ class TextTools(commands.Cog):
             i18n.get("common.error", locale=locale),
             i18n.get(message_key, locale=locale, **kwargs),
         )
-        if interaction.response.is_done():
-            await interaction.followup.send(view=view, ephemeral=True)
-        else:
-            await interaction.response.send_message(view=view, ephemeral=True)
+        await deliver(interaction, view=view, ephemeral=True)
 
     async def _preflight(self, interaction: discord.Interaction, text: str,
                          locale: str, *, strip_mentions: bool) -> Optional[str]:
@@ -363,6 +361,7 @@ class TextTools(commands.Cog):
                           max_tokens: int, strip_mentions: bool) -> Optional[str]:
         """Single gateway call. Returns the model output, or None on failure."""
         from gateway import QuotaTarget
+        from gateway.errors import GatewayError
 
         quota = [QuotaTarget.user(interaction.user.id, call_type)]
         if interaction.guild:
@@ -389,7 +388,10 @@ class TextTools(commands.Cog):
         except asyncio.TimeoutError:
             logger.warning("[%s] OpenAI call timed out for user %s", call_type, interaction.user.id)
             return None
-        except Exception as exc:
+        except GatewayError as exc:
+            # Expected provider-side conditions (quota, rate limit, outage):
+            # the caller shows the friendly "AI unavailable" card. Anything
+            # else is a bug and must reach the global handler with a code.
             logger.warning("[%s] OpenAI call failed: %s", call_type, exc)
             return None
 

--- a/cogs/tickets.py
+++ b/cogs/tickets.py
@@ -34,6 +34,7 @@ from modules.tickets import (
 from services.ticket_service import TicketError
 from utils.components_v2 import create_success_message
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 from utils.ticket_views import (
     TicketRenameModal,
     handle_ticket_error,
@@ -58,12 +59,21 @@ ticket_group = app_commands.Group(
 )
 
 
-async def _service_and_ticket(interaction: discord.Interaction):
+async def _service_and_ticket(interaction: discord.Interaction, *,
+                              defer: bool = False):
     """``(service, ticket, panel, category)`` for the channel the command ran in.
 
     Answers the user and returns ``None`` when the channel is not a ticket —
     the check every single subcommand starts with.
+
+    ``defer=True`` acknowledges the interaction *before* the resolve, which is
+    a database read: a subcommand that ends in a plain answer must never let
+    that read eat its 3-second window. Subcommands that open a modal (or hand
+    over to a helper that acknowledges by itself) leave it off.
     """
+    if defer:
+        await safe_defer(interaction, ephemeral=True, thinking=True)
+
     service = getattr(interaction.client, 'tickets', None)
     locale = i18n.get_user_locale(interaction)
     if service is None or not isinstance(interaction.channel, discord.TextChannel):
@@ -84,13 +94,11 @@ async def _service_and_ticket(interaction: discord.Interaction):
 @ticket_group.command(name="close", description="Close this ticket")
 @app_commands.describe(reason="Why the ticket is being closed")
 async def ticket_close(interaction: discord.Interaction, reason: Optional[str] = None):
-    resolved = await _service_and_ticket(interaction)
+    resolved = await _service_and_ticket(interaction, defer=True)
     if not resolved:
         return
     service = resolved[0]
     locale = i18n.get_user_locale(interaction)
-
-    await interaction.response.defer(ephemeral=True, thinking=True)
     try:
         await service.close_ticket(interaction.channel, interaction.user, reason)
     except TicketError as e:
@@ -103,13 +111,11 @@ async def ticket_close(interaction: discord.Interaction, reason: Optional[str] =
 
 @ticket_group.command(name="reopen", description="Reopen this closed ticket")
 async def ticket_reopen(interaction: discord.Interaction):
-    resolved = await _service_and_ticket(interaction)
+    resolved = await _service_and_ticket(interaction, defer=True)
     if not resolved:
         return
     service = resolved[0]
     locale = i18n.get_user_locale(interaction)
-
-    await interaction.response.defer(ephemeral=True, thinking=True)
     try:
         await service.reopen_ticket(interaction.channel, interaction.user)
     except TicketError as e:
@@ -125,13 +131,11 @@ async def ticket_reopen(interaction: discord.Interaction):
 @app_commands.describe(reason="Why you would like the ticket closed")
 async def ticket_close_request(interaction: discord.Interaction,
                                reason: Optional[str] = None):
-    resolved = await _service_and_ticket(interaction)
+    resolved = await _service_and_ticket(interaction, defer=True)
     if not resolved:
         return
     service = resolved[0]
     locale = i18n.get_user_locale(interaction)
-
-    await interaction.response.defer(ephemeral=True, thinking=True)
     try:
         await service.request_close(interaction.channel, interaction.user, reason)
     except TicketError as e:
@@ -160,13 +164,11 @@ async def ticket_escalate(interaction: discord.Interaction,
 
 @ticket_group.command(name="deescalate", description="Undo the escalation")
 async def ticket_deescalate(interaction: discord.Interaction):
-    resolved = await _service_and_ticket(interaction)
+    resolved = await _service_and_ticket(interaction, defer=True)
     if not resolved:
         return
     service = resolved[0]
     locale = i18n.get_user_locale(interaction)
-
-    await interaction.response.defer(ephemeral=True, thinking=True)
     try:
         await service.deescalate(interaction.channel, interaction.user)
     except TicketError as e:
@@ -215,7 +217,7 @@ async def _category_autocomplete(interaction: discord.Interaction, current: str
 @app_commands.describe(category="The category the ticket should move to")
 @app_commands.autocomplete(category=_category_autocomplete)
 async def ticket_move(interaction: discord.Interaction, category: str):
-    resolved = await _service_and_ticket(interaction)
+    resolved = await _service_and_ticket(interaction, defer=True)
     if not resolved:
         return
     service = resolved[0]
@@ -227,8 +229,6 @@ async def ticket_move(interaction: discord.Interaction, category: str):
                          t('modules.tickets.errors.unknown_category', locale=locale),
                          locale)
         return
-
-    await interaction.response.defer(ephemeral=True, thinking=True)
     try:
         await service.move_ticket(interaction.channel, interaction.user,
                                   panel_id, category_id)
@@ -298,13 +298,11 @@ async def ticket_remove(interaction: discord.Interaction,
 async def _participant_action(interaction: discord.Interaction,
                               target: Union[discord.Member, discord.Role],
                               *, add: bool):
-    resolved = await _service_and_ticket(interaction)
+    resolved = await _service_and_ticket(interaction, defer=True)
     if not resolved:
         return
     service = resolved[0]
     locale = i18n.get_user_locale(interaction)
-
-    await interaction.response.defer(ephemeral=True, thinking=True)
     try:
         if add:
             await service.add_participant(interaction.channel, interaction.user, target)
@@ -371,7 +369,7 @@ async def ticket_staff_thread(interaction: discord.Interaction):
 # --------------------------------------------------------------------------- #
 @ticket_group.command(name="info", description="Show this ticket's details")
 async def ticket_info(interaction: discord.Interaction):
-    resolved = await _service_and_ticket(interaction)
+    resolved = await _service_and_ticket(interaction, defer=True)
     if not resolved:
         return
     service, ticket, panel, category = resolved
@@ -412,7 +410,7 @@ async def ticket_info(interaction: discord.Interaction):
         ) or t('modules.tickets.fields.none', locale=locale),
     })
 
-    await interaction.response.send_message(
+    await interaction.followup.send(
         view=create_success_message(
             t('modules.tickets.info.title', locale=locale, number=ticket['number']),
             t('modules.tickets.info.description', locale=locale),

--- a/cogs/tickets.py
+++ b/cogs/tickets.py
@@ -444,7 +444,13 @@ class Tickets(commands.Cog):
                 logger.info(f"[Tickets] #{ticket['number']} forgotten "
                             f"(channel {channel.id} deleted)")
         except Exception as e:
-            logger.error(f"[Tickets] Cleanup failed for channel {channel.id}: {e}")
+            # A row left behind burns the member's open-ticket quota forever,
+            # so this failure needs an error code, not just a log line.
+            from cogs.error_handler import report_error
+            await report_error(
+                self.bot, e, source="Cog:Tickets.on_guild_channel_delete",
+                guild=getattr(channel, "guild", None),
+            )
 
     @commands.Cog.listener()
     async def on_thread_member_join(self, member: discord.ThreadMember):
@@ -484,8 +490,13 @@ class Tickets(commands.Cog):
             # Not a ticket any more, or the member left in the meantime.
             return
         except Exception as e:
-            logger.error(f"[Tickets] Staff-thread guard failed on thread "
-                         f"{thread.id}: {e}")
+            # This guard is what keeps a ticket's staff thread staff-only:
+            # a silent failure is a privacy leak, so it is filed centrally.
+            from cogs.error_handler import report_error
+            await report_error(
+                self.bot, e, source="Cog:Tickets.on_thread_member_join",
+                guild=thread.guild,
+            )
 
 
 async def setup(bot):

--- a/cogs/tickets.py
+++ b/cogs/tickets.py
@@ -337,7 +337,7 @@ async def ticket_participants(interaction: discord.Interaction):
 # --------------------------------------------------------------------------- #
 @ticket_group.command(name="claim", description="Take this ticket in charge")
 async def ticket_claim(interaction: discord.Interaction):
-    resolved = await _service_and_ticket(interaction)
+    resolved = await _service_and_ticket(interaction, defer=True)
     if not resolved:
         return
     await run_claim(interaction, resolved[0], force=True)
@@ -346,7 +346,7 @@ async def ticket_claim(interaction: discord.Interaction):
 @ticket_group.command(name="unclaim",
                       description="Release this ticket so anyone can take it")
 async def ticket_unclaim(interaction: discord.Interaction):
-    resolved = await _service_and_ticket(interaction)
+    resolved = await _service_and_ticket(interaction, defer=True)
     if not resolved:
         return
     await run_claim(interaction, resolved[0], force=False)
@@ -358,7 +358,7 @@ async def ticket_unclaim(interaction: discord.Interaction):
 @ticket_group.command(name="staff-thread",
                       description="Open or join the private staff thread")
 async def ticket_staff_thread(interaction: discord.Interaction):
-    resolved = await _service_and_ticket(interaction)
+    resolved = await _service_and_ticket(interaction, defer=True)
     if not resolved:
         return
     await run_staff_thread(interaction, resolved[0])

--- a/cogs/token_detector.py
+++ b/cogs/token_detector.py
@@ -32,8 +32,8 @@ from discord import ui
 from discord.ext import commands
 
 
-from cogs.error_handler import BaseView, ErrorView, report_error
-from utils.interaction_response import deliver, safe_defer
+from cogs.error_handler import BaseView, report_component_error
+from utils.interaction_response import safe_defer
 from utils.emojis import (
     WARNING, ERROR, DONE, INFO, DELETE, LOGOUT,
 )
@@ -54,32 +54,12 @@ async def _route_error(
 ) -> None:
     """Route an unexpected exception to the centralized error pipeline.
 
-    ``report_error`` does the whole job (traceback log, Sentry, in-memory and
-    database storage, internal Discord log) and hands back the error code, and
-    ``deliver`` gets the card in front of the user whatever state the
-    interaction is in — including a channel message when its token has
-    already expired.
+    ``report_component_error`` does the whole job — traceback log, Sentry,
+    in-memory and database storage, internal Discord log — and puts the coded
+    error card in front of the user whatever state the interaction is in,
+    including a channel message once its token has expired.
     """
-    error_code = await report_error(
-        interaction.client,
-        error,
-        source=f"TokenDetector:{context}",
-        user=interaction.user,
-        guild=interaction.guild,
-        channel=interaction.channel,
-        error_type="DynamicItem Error",
-    )
-
-    if error_code:
-        await deliver(interaction, view=ErrorView(error_code), ephemeral=True)
-    else:
-        # No ErrorTracker cog loaded: there is no code to show, but the user
-        # must still learn that the click failed.
-        await deliver(
-            interaction,
-            content="An unexpected error occurred and has been logged.",
-            ephemeral=True,
-        )
+    await report_component_error(interaction, error, f"TokenDetector:{context}")
 
 
 class _ErrorRoutingMixin:

--- a/cogs/token_detector.py
+++ b/cogs/token_detector.py
@@ -31,9 +31,9 @@ import discord
 from discord import ui
 from discord.ext import commands
 
-import traceback
 
-from cogs.error_handler import BaseView, ErrorView, capture_error_to_sentry
+from cogs.error_handler import BaseView, ErrorView, report_error
+from utils.interaction_response import deliver, safe_defer
 from utils.emojis import (
     WARNING, ERROR, DONE, INFO, DELETE, LOGOUT,
 )
@@ -52,62 +52,34 @@ async def _route_error(
     error: Exception,
     context: str,
 ) -> None:
-    """Route an unexpected exception to the centralized ErrorTracker cog."""
-    compact_tb = "".join(
-        traceback.format_exception(type(error), error, error.__traceback__)
-    ).replace("\n", " ⮐ ")
-    logger.error(f"Unexpected error in TokenDetector/{context}: {compact_tb}")
+    """Route an unexpected exception to the centralized error pipeline.
 
-    bot = interaction.client
-    error_tracker = bot.get_cog("ErrorTracker") if bot else None
+    ``report_error`` does the whole job (traceback log, Sentry, in-memory and
+    database storage, internal Discord log) and hands back the error code, and
+    ``deliver`` gets the card in front of the user whatever state the
+    interaction is in — including a channel message when its token has
+    already expired.
+    """
+    error_code = await report_error(
+        interaction.client,
+        error,
+        source=f"TokenDetector:{context}",
+        user=interaction.user,
+        guild=interaction.guild,
+        channel=interaction.channel,
+        error_type="DynamicItem Error",
+    )
 
-    if error_tracker:
-        error_code = error_tracker.generate_error_code(error)
-        error_details = error_tracker.format_error_details(error)
-        error_details.update({
-            "command": f"TokenDetector:{context}",
-            "user": f"{interaction.user} ({interaction.user.id})",
-            "guild": (
-                f"{interaction.guild.name} ({interaction.guild.id})"
-                if interaction.guild else "DM"
-            ),
-            "channel": (
-                f"#{interaction.channel.name}"
-                if hasattr(interaction.channel, "name") else "DM"
-            ),
-        })
-
-        sentry_id = capture_error_to_sentry(error, {
-            "error_type": "DynamicItem Error",
-            "error_code": error_code,
-            "context": context,
-            "user_id": interaction.user.id if interaction.user else None,
-            "guild_id": interaction.guild.id if interaction.guild else None,
-        })
-        if sentry_id:
-            error_details["sentry_event_id"] = sentry_id
-
-        error_tracker.store_error(error_code, error_details)
-        await error_tracker.store_error_db(error_code, error_details)
-        await error_tracker.send_error_log(error_code, error_details, is_fatal=False)
-
-        error_view = ErrorView(error_code)
-        try:
-            if interaction.response.is_done():
-                await interaction.followup.send(view=error_view, ephemeral=True)
-            else:
-                await interaction.response.send_message(view=error_view, ephemeral=True)
-        except Exception:
-            pass
+    if error_code:
+        await deliver(interaction, view=ErrorView(error_code), ephemeral=True)
     else:
-        try:
-            msg = "An unexpected error occurred and has been logged."
-            if interaction.response.is_done():
-                await interaction.followup.send(msg, ephemeral=True)
-            else:
-                await interaction.response.send_message(msg, ephemeral=True)
-        except Exception:
-            pass
+        # No ErrorTracker cog loaded: there is no code to show, but the user
+        # must still learn that the click failed.
+        await deliver(
+            interaction,
+            content="An unexpected error occurred and has been logged.",
+            ephemeral=True,
+        )
 
 
 class _ErrorRoutingMixin:
@@ -452,9 +424,11 @@ class UserDetailsButton(
         return cls(match.group("ck"), int(match.group("mid")), int(match.group("cid")))
 
     async def callback(self, interaction: discord.Interaction) -> None:
+        # The alert lookup falls back to the database: acknowledge first.
+        await safe_defer(interaction, ephemeral=True)
         data = await peek_alert_with_db_fallback(self.ck, interaction.client)
         if data is None:
-            await interaction.response.send_message(view=_expired_view(), ephemeral=True)
+            await interaction.followup.send(view=_expired_view(), ephemeral=True)
             return
 
         ts = data.get("timestamp", 0)
@@ -473,7 +447,7 @@ class UserDetailsButton(
         c.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
         c.add_item(ui.TextDisplay(body))
         view.add_item(c)
-        await interaction.response.send_message(view=view, ephemeral=True)
+        await interaction.followup.send(view=view, ephemeral=True)
 
 
 # =============================================================================
@@ -504,12 +478,14 @@ class UserInvalidateButton(
         return cls(match.group("ck"))
 
     async def callback(self, interaction: discord.Interaction) -> None:
+        # The alert lookup falls back to the database: acknowledge first.
+        await safe_defer(interaction, ephemeral=True)
         data = await peek_alert_with_db_fallback(self.ck, interaction.client)
         if data is None:
-            await interaction.response.send_message(view=_expired_view(), ephemeral=True)
+            await interaction.followup.send(view=_expired_view(), ephemeral=True)
             return
         if data.get("state", {}).get("invalidated"):
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 view=_already_done_view("token invalidation"), ephemeral=True
             )
             return
@@ -530,7 +506,7 @@ class UserInvalidateButton(
         row.add_item(UserCancelButton())
         view.add_item(row)
 
-        await interaction.response.send_message(view=view, ephemeral=True)
+        await interaction.followup.send(view=view, ephemeral=True)
 
 
 # =============================================================================
@@ -560,7 +536,7 @@ class UserConfirmInvalidateButton(
         return cls(match.group("ck"))
 
     async def callback(self, interaction: discord.Interaction) -> None:
-        await interaction.response.defer(ephemeral=True)
+        await safe_defer(interaction, ephemeral=True)
         bot = interaction.client
         data = await peek_alert_with_db_fallback(self.ck, bot)
         if data is None:
@@ -691,7 +667,7 @@ class UserDeleteMsgButton(
         return cls(match.group("ck"), int(match.group("mid")), int(match.group("cid")))
 
     async def callback(self, interaction: discord.Interaction) -> None:
-        await interaction.response.defer(ephemeral=True)
+        await safe_defer(interaction, ephemeral=True)
         bot = interaction.client
         data = await peek_alert_with_db_fallback(self.ck, bot)
         if data is None:
@@ -808,9 +784,11 @@ class BotDetailsButton(
         return cls(match.group("ck"), int(match.group("mid")), int(match.group("cid")))
 
     async def callback(self, interaction: discord.Interaction) -> None:
+        # The alert lookup falls back to the database: acknowledge first.
+        await safe_defer(interaction, ephemeral=True)
         data = await peek_alert_with_db_fallback(self.ck, interaction.client)
         if data is None:
-            await interaction.response.send_message(view=_expired_view(), ephemeral=True)
+            await interaction.followup.send(view=_expired_view(), ephemeral=True)
             return
 
         ts = data.get("timestamp", 0)
@@ -829,7 +807,7 @@ class BotDetailsButton(
         c.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
         c.add_item(ui.TextDisplay(body))
         view.add_item(c)
-        await interaction.response.send_message(view=view, ephemeral=True)
+        await interaction.followup.send(view=view, ephemeral=True)
 
 
 # =============================================================================
@@ -860,7 +838,7 @@ class BotDeleteMsgButton(
         return cls(match.group("ck"), int(match.group("mid")), int(match.group("cid")))
 
     async def callback(self, interaction: discord.Interaction) -> None:
-        await interaction.response.defer(ephemeral=True)
+        await safe_defer(interaction, ephemeral=True)
         bot = interaction.client
         data = await peek_alert_with_db_fallback(self.ck, bot)
         if data is None:

--- a/cogs/translate.py
+++ b/cogs/translate.py
@@ -11,11 +11,14 @@ from typing import Optional
 import re
 from datetime import datetime, timedelta
 import asyncio
+import logging
 
 from utils.embeds import ModdyEmbed, ModdyResponse, ModdyColors
 from utils.incognito import add_incognito_option, get_incognito_setting
 from config import COLORS
 from utils.i18n import i18n
+
+logger = logging.getLogger('moddy.translate')
 
 
 class TranslateView(BaseView):
@@ -313,8 +316,10 @@ class Translate(commands.Cog):
         user_id: int,
     ) -> Optional[dict]:
         """Translate using the gateway. Returns {'text': ..., 'detected_source_language': ...}."""
+        from gateway import QuotaTarget
+        from gateway.errors import GatewayError
+
         try:
-            from gateway import QuotaTarget
             return await self.bot.gateway.translation.translate(
                 text,
                 target_lang,
@@ -322,9 +327,12 @@ class Translate(commands.Cog):
                 call_type="translation",
                 metadata={"user_id": user_id},
             )
-        except Exception as exc:
-            import logging
-            logging.getLogger("moddy.translate").error("Gateway translate failed: %s", exc)
+        except GatewayError as exc:
+            # Expected provider-side conditions (quota, rate limit, provider
+            # outage): the caller shows the friendly "translation unavailable"
+            # card. Anything else is a bug and must bubble up to the global
+            # handler so the user gets a traceable error code.
+            logger.error("Gateway translate failed: %s", exc)
             return None
 
     def locale_to_deepl_lang(self, locale: str) -> str:

--- a/cogs/user.py
+++ b/cogs/user.py
@@ -19,6 +19,7 @@ from utils.emojis import (
     get_user_verification_badge, format_verification_badge,
 )
 from utils.i18n import i18n
+from utils.incognito import resolve_incognito
 
 def _format_org_names(orgs: list, locale: str) -> str:
     """Format a list of org names into a readable string with locale-aware joining."""
@@ -680,15 +681,8 @@ class User(commands.Cog):
         """Display user information"""
 
         # === BLOC INCOGNITO ===
-        if incognito is None and self.bot.db:
-            try:
-                user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
-                ephemeral = True if user_pref is None else user_pref
-            except Exception:
-                # Visibility preference is a nicety: default to private.
-                ephemeral = True
-        else:
-            ephemeral = incognito if incognito is not None else True
+        ephemeral = (incognito if incognito is not None
+                     else await resolve_incognito(self.bot, interaction.user.id))
 
         # Get locale
         locale = i18n.get_user_locale(interaction)

--- a/cogs/user.py
+++ b/cogs/user.py
@@ -9,6 +9,7 @@ from cogs.error_handler import BaseView
 from discord.ext import commands
 from typing import Optional
 import aiohttp
+import asyncio
 from datetime import datetime
 from config import COLORS
 from utils.emojis import (
@@ -135,7 +136,7 @@ class UserInfoView(BaseView):
             timestamp = ((snowflake_id >> 22) + 1420070400000) // 1000
             created_label = i18n.get("commands.user.view.created", locale=self.locale)
             info_lines.append(f"> **{created_label}:** <t:{timestamp}:R>")
-        except:
+        except (ValueError, TypeError):
             pass
 
         # Banner color
@@ -353,7 +354,7 @@ class UserInfoView(BaseView):
                             if "discord.gg/" in invite_url:
                                 result["invite_code"] = invite_url.split("discord.gg/")[-1]
                         return result
-            except:
+            except (aiohttp.ClientError, asyncio.TimeoutError, ValueError):
                 pass
 
             # Try 2: Guild Preview (requires bot token, works for Discovery servers)
@@ -367,7 +368,7 @@ class UserInfoView(BaseView):
                         preview_data = await resp.json()
                         result["name"] = preview_data.get("name")
                         return result
-            except:
+            except (aiohttp.ClientError, asyncio.TimeoutError, ValueError):
                 pass
 
         return result
@@ -683,7 +684,8 @@ class User(commands.Cog):
             try:
                 user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
                 ephemeral = True if user_pref is None else user_pref
-            except:
+            except Exception:
+                # Visibility preference is a nicety: default to private.
                 ephemeral = True
         else:
             ephemeral = incognito if incognito is not None else True

--- a/cogs/webhook.py
+++ b/cogs/webhook.py
@@ -8,6 +8,7 @@ from discord import app_commands, ui
 from discord.ext import commands
 from typing import Optional
 import aiohttp
+import asyncio
 import re
 
 from utils.embeds import ModdyEmbed, ModdyResponse, ModdyColors
@@ -147,35 +148,29 @@ class WebhookView(BaseView):
         # Confirm deletion
         await interaction.response.defer(ephemeral=True)
 
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.delete(webhook_url) as response:
-                    if response.status == 204:
-                        # Success
-                        success_title = i18n.get("commands.webhook.delete.success.title", locale=self.locale)
-                        success_desc = i18n.get("commands.webhook.delete.success.description", locale=self.locale, name=self.webhook_data.get('name'))
-                        success_embed = ModdyResponse.success(success_title, success_desc)
+        async with aiohttp.ClientSession() as session:
+            async with session.delete(webhook_url) as response:
+                if response.status == 204:
+                    # Success
+                    success_title = i18n.get("commands.webhook.delete.success.title", locale=self.locale)
+                    success_desc = i18n.get("commands.webhook.delete.success.description", locale=self.locale, name=self.webhook_data.get('name'))
+                    success_embed = ModdyResponse.success(success_title, success_desc)
 
-                        # Disable all buttons (they're inside an ActionRow)
-                        for item in self.children:
-                            if isinstance(item, ui.ActionRow):
-                                for button in item.children:
-                                    if isinstance(button, ui.Button):
-                                        button.disabled = True
+                    # Disable all buttons (they're inside an ActionRow)
+                    for item in self.children:
+                        if isinstance(item, ui.ActionRow):
+                            for button in item.children:
+                                if isinstance(button, ui.Button):
+                                    button.disabled = True
 
-                        await interaction.edit_original_response(view=self)
-                        await interaction.followup.send(embed=success_embed, ephemeral=True)
-                    else:
-                        error_text = await response.text()
-                        error_title = i18n.get("commands.webhook.delete.failed.title", locale=self.locale)
-                        error_desc = i18n.get("commands.webhook.delete.failed.description", locale=self.locale, status=response.status, error=error_text[:100])
-                        error_embed = ModdyResponse.error(error_title, error_desc)
-                        await interaction.followup.send(embed=error_embed, ephemeral=True)
-        except Exception as e:
-            error_title = i18n.get("commands.webhook.errors.generic.title", locale=self.locale)
-            error_desc = i18n.get("commands.webhook.errors.generic.description", locale=self.locale, error=str(e)[:100])
-            error_embed = ModdyResponse.error(error_title, error_desc)
-            await interaction.followup.send(embed=error_embed, ephemeral=True)
+                    await interaction.edit_original_response(view=self)
+                    await interaction.followup.send(embed=success_embed, ephemeral=True)
+                else:
+                    error_text = await response.text()
+                    error_title = i18n.get("commands.webhook.delete.failed.title", locale=self.locale)
+                    error_desc = i18n.get("commands.webhook.delete.failed.description", locale=self.locale, status=response.status, error=error_text[:100])
+                    error_embed = ModdyResponse.error(error_title, error_desc)
+                    await interaction.followup.send(embed=error_embed, ephemeral=True)
 
     async def show_edit_modal(self, interaction: discord.Interaction):
         """Shows modal to edit webhook"""
@@ -202,30 +197,24 @@ class WebhookView(BaseView):
             )
             return
 
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(webhook_url) as response:
-                    if response.status == 200:
-                        self.webhook_data = await response.json()
-                        self.build_view()
-                        await interaction.edit_original_response(view=self)
+        async with aiohttp.ClientSession() as session:
+            async with session.get(webhook_url) as response:
+                if response.status == 200:
+                    self.webhook_data = await response.json()
+                    self.build_view()
+                    await interaction.edit_original_response(view=self)
 
-                        success_title = i18n.get("commands.webhook.refresh.success.title", locale=self.locale)
-                        success_desc = i18n.get("commands.webhook.refresh.success.description", locale=self.locale)
-                        await interaction.followup.send(
-                            embed=ModdyResponse.success(success_title, success_desc),
-                            ephemeral=True
-                        )
-                    else:
-                        error_title = i18n.get("commands.webhook.refresh.failed.title", locale=self.locale)
-                        error_desc = i18n.get("commands.webhook.refresh.failed.description", locale=self.locale, status=response.status)
-                        error_embed = ModdyResponse.error(error_title, error_desc)
-                        await interaction.followup.send(embed=error_embed, ephemeral=True)
-        except Exception as e:
-            error_title = i18n.get("commands.webhook.errors.generic.title", locale=self.locale)
-            error_desc = i18n.get("commands.webhook.errors.generic.description", locale=self.locale, error=str(e)[:100])
-            error_embed = ModdyResponse.error(error_title, error_desc)
-            await interaction.followup.send(embed=error_embed, ephemeral=True)
+                    success_title = i18n.get("commands.webhook.refresh.success.title", locale=self.locale)
+                    success_desc = i18n.get("commands.webhook.refresh.success.description", locale=self.locale)
+                    await interaction.followup.send(
+                        embed=ModdyResponse.success(success_title, success_desc),
+                        ephemeral=True
+                    )
+                else:
+                    error_title = i18n.get("commands.webhook.refresh.failed.title", locale=self.locale)
+                    error_desc = i18n.get("commands.webhook.refresh.failed.description", locale=self.locale, status=response.status)
+                    error_embed = ModdyResponse.error(error_title, error_desc)
+                    await interaction.followup.send(embed=error_embed, ephemeral=True)
 
 
 class EditWebhookModal(BaseModal):
@@ -264,31 +253,25 @@ class EditWebhookModal(BaseModal):
             )
             return
 
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.patch(webhook_url, json={"name": new_name}) as response:
-                    if response.status == 200:
-                        updated_data = await response.json()
-                        self.view.webhook_data = updated_data
-                        self.view.build_view()
+        async with aiohttp.ClientSession() as session:
+            async with session.patch(webhook_url, json={"name": new_name}) as response:
+                if response.status == 200:
+                    updated_data = await response.json()
+                    self.view.webhook_data = updated_data
+                    self.view.build_view()
 
-                        await interaction.edit_original_response(view=self.view)
+                    await interaction.edit_original_response(view=self.view)
 
-                        success_title = i18n.get("commands.webhook.edit.success.title", locale=self.locale)
-                        success_desc = i18n.get("commands.webhook.edit.success.description", locale=self.locale, name=new_name)
-                        success_embed = ModdyResponse.success(success_title, success_desc)
-                        await interaction.followup.send(embed=success_embed, ephemeral=True)
-                    else:
-                        error_text = await response.text()
-                        error_title = i18n.get("commands.webhook.edit.failed.title", locale=self.locale)
-                        error_desc = i18n.get("commands.webhook.edit.failed.description", locale=self.locale, status=response.status, error=error_text[:100])
-                        error_embed = ModdyResponse.error(error_title, error_desc)
-                        await interaction.followup.send(embed=error_embed, ephemeral=True)
-        except Exception as e:
-            error_title = i18n.get("commands.webhook.errors.generic.title", locale=self.locale)
-            error_desc = i18n.get("commands.webhook.errors.generic.description", locale=self.locale, error=str(e)[:100])
-            error_embed = ModdyResponse.error(error_title, error_desc)
-            await interaction.followup.send(embed=error_embed, ephemeral=True)
+                    success_title = i18n.get("commands.webhook.edit.success.title", locale=self.locale)
+                    success_desc = i18n.get("commands.webhook.edit.success.description", locale=self.locale, name=new_name)
+                    success_embed = ModdyResponse.success(success_title, success_desc)
+                    await interaction.followup.send(embed=success_embed, ephemeral=True)
+                else:
+                    error_text = await response.text()
+                    error_title = i18n.get("commands.webhook.edit.failed.title", locale=self.locale)
+                    error_desc = i18n.get("commands.webhook.edit.failed.description", locale=self.locale, status=response.status, error=error_text[:100])
+                    error_embed = ModdyResponse.error(error_title, error_desc)
+                    await interaction.followup.send(embed=error_embed, ephemeral=True)
 
 
 class SendMessageModal(BaseModal):
@@ -341,25 +324,19 @@ class SendMessageModal(BaseModal):
         if username:
             payload["username"] = username
 
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(webhook_url, json=payload) as response:
-                    if response.status in [200, 204]:
-                        success_title = i18n.get("commands.webhook.send.success.title", locale=self.locale)
-                        success_desc = i18n.get("commands.webhook.send.success.description", locale=self.locale)
-                        success_embed = ModdyResponse.success(success_title, success_desc)
-                        await interaction.followup.send(embed=success_embed, ephemeral=True)
-                    else:
-                        error_text = await response.text()
-                        error_title = i18n.get("commands.webhook.send.failed.title", locale=self.locale)
-                        error_desc = i18n.get("commands.webhook.send.failed.description", locale=self.locale, status=response.status, error=error_text[:100])
-                        error_embed = ModdyResponse.error(error_title, error_desc)
-                        await interaction.followup.send(embed=error_embed, ephemeral=True)
-        except Exception as e:
-            error_title = i18n.get("commands.webhook.errors.generic.title", locale=self.locale)
-            error_desc = i18n.get("commands.webhook.errors.generic.description", locale=self.locale, error=str(e)[:100])
-            error_embed = ModdyResponse.error(error_title, error_desc)
-            await interaction.followup.send(embed=error_embed, ephemeral=True)
+        async with aiohttp.ClientSession() as session:
+            async with session.post(webhook_url, json=payload) as response:
+                if response.status in [200, 204]:
+                    success_title = i18n.get("commands.webhook.send.success.title", locale=self.locale)
+                    success_desc = i18n.get("commands.webhook.send.success.description", locale=self.locale)
+                    success_embed = ModdyResponse.success(success_title, success_desc)
+                    await interaction.followup.send(embed=success_embed, ephemeral=True)
+                else:
+                    error_text = await response.text()
+                    error_title = i18n.get("commands.webhook.send.failed.title", locale=self.locale)
+                    error_desc = i18n.get("commands.webhook.send.failed.description", locale=self.locale, status=response.status, error=error_text[:100])
+                    error_embed = ModdyResponse.error(error_title, error_desc)
+                    await interaction.followup.send(embed=error_embed, ephemeral=True)
 
 
 class Webhook(commands.Cog):
@@ -402,7 +379,10 @@ class Webhook(commands.Cog):
                         return await response.json()
                     else:
                         return None
-        except Exception:
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            # Network-level failure only: anything else is a bug and must
+            # reach the global handler as a coded error, not be reported to
+            # the user as "webhook not found".
             return None
 
     @app_commands.command(name="webhook", description="Inspect and manage Discord webhooks")

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -4,9 +4,11 @@
 1. [Overview](#overview)
 2. [Error Handler System](#error-handler-system)
 3. [How to Use BaseView and BaseModal](#how-to-use-baseview-and-basemodal)
-4. [Best Practices](#best-practices)
-5. [Logging](#logging)
-6. [Troubleshooting](#troubleshooting)
+4. [The 3-Second Window](#the-3-second-window)
+5. [Reaching the User No Matter What](#reaching-the-user-no-matter-what)
+6. [Best Practices](#best-practices)
+7. [Logging](#logging)
+8. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -130,6 +132,108 @@ async def on_edit_button(self, interaction: discord.Interaction):
 **Don't worry!** `BaseView` and `BaseModal` will automatically use `interaction.client` as a fallback.
 
 However, it's **strongly recommended** to always set `self.bot` when possible for consistency.
+
+---
+
+## The 3-Second Window
+
+Discord gives an interaction **3 seconds** to receive its first response.
+Miss it and the token is dead: every later call fails with `10062 Unknown
+interaction`, the error handler itself cannot answer, and the user sees
+Discord's own **"The application did not respond"** — no message, no error
+code, nothing to trace. It looks like Moddy is broken, and there is no
+recovering the interaction afterwards.
+
+**So acknowledge before you work.** Any handler that awaits a database
+query, an HTTP or gateway call, a `fetch_*`, or Redis must acknowledge
+first:
+
+```python
+from utils.interaction_response import safe_defer
+
+async def callback(self, interaction: discord.Interaction):
+    await safe_defer(interaction, ephemeral=True)   # ← first awaited statement
+    data = await self.bot.db.get_something(...)     # now you have 15 minutes
+    await interaction.followup.send(view=build(data))
+```
+
+`safe_defer` never raises. It returns `False` when the token was already
+dead, and it picks `thinking` from the interaction type — a slash command
+gets the "thinking…" placeholder, a component re-rendering its own panel
+does not. Pass `thinking=` explicitly only when you need to override that.
+
+**Two things do not fit this pattern:**
+
+- **Modals.** Discord refuses `send_modal()` on an acknowledged
+  interaction, so a handler that opens a modal must stay un-deferred —
+  which means it must do **no** slow work first. Move the lookups into the
+  modal's `on_submit`, or cache them. Staff commands declare this with
+  `StaffCommand.opens_modal = True`, which tells the router not to defer.
+- **Work that cannot be moved.** If a value is genuinely needed before
+  acknowledging (visibility, a permission), cache it and put a hard timeout
+  on the lookup — see `utils/incognito.py::resolve_incognito`. Degrading
+  one reply beats killing the interaction.
+
+---
+
+## Reaching the User No Matter What
+
+**An unexpected error must always surface as Moddy's error card with an
+error code.** Never as Discord's failure message, and never as a bare "an
+error occurred" that the team cannot trace.
+
+`utils/interaction_response.py::deliver` is how that is guaranteed. It
+walks every transport until one works — followup, then editing the original
+response, then the initial response, then a plain channel message
+mentioning the user when the token itself is dead — and it never raises,
+because a second exception on the error path would silence the first.
+
+```python
+from utils.interaction_response import deliver
+
+await deliver(interaction, view=ErrorView(error_code), ephemeral=True)
+```
+
+Use it instead of hand-rolling `if interaction.response.is_done(): ... else: ...`.
+
+### Getting an error code outside a View, Modal or app command
+
+`BaseView.on_error`, `BaseModal.on_error` and `on_app_command_error`
+already run the full pipeline. Everywhere else — a listener, a background
+task, a message command, a service callback — call `report_error`:
+
+```python
+from cogs.error_handler import ErrorView, report_error
+from utils.interaction_response import deliver
+
+except Exception as exc:
+    error_code = await report_error(
+        self.bot, exc, source="Cog:reminders.check_loop",
+        user=interaction.user, guild=interaction.guild, channel=interaction.channel,
+    )
+    if error_code:
+        await deliver(interaction, view=ErrorView(error_code), ephemeral=True)
+```
+
+For a `DynamicItem` callback dispatched without a live `BaseView`, use
+`report_component_error(interaction, exc, source)` — it reports **and**
+delivers.
+
+### Expected errors keep their own message
+
+None of this applies to errors that are the user's fault or a known
+condition: missing permissions, member not found, invalid input, module
+disabled, premium required, quota exhausted. Those keep a specific,
+translated message via `create_error_message()` and get **no** error code —
+a code there is noise that trains people to ignore codes.
+
+The test to apply: *could the team act on this?* If yes it is a bug and
+needs a code; if the user simply has to do something differently, it needs
+a sentence.
+
+**Never report a bug as an expected error.** A catch-all around an API
+call that answers "the service is unavailable" hides real crashes — catch
+the provider's own error type instead.
 
 ---
 
@@ -295,6 +399,12 @@ When creating new UI components:
 - [ ] `modal.bot = self.bot` is called before `send_modal()`
 - [ ] No unnecessary `try/except` blocks that hide errors
 - [ ] Using `logger.error(..., exc_info=True)` for manual exception logging
+- [ ] `safe_defer()` before any awaited work, unless the handler opens a modal
+- [ ] A handler that opens a modal does no slow work first
+- [ ] Error paths use `deliver()`, never a hand-rolled `is_done()` branch
+- [ ] Unexpected errors reach the user with an error code (`report_error` /
+      `report_component_error` where no global handler covers the path)
+- [ ] Expected errors keep a specific translated message and no code
 
 ---
 

--- a/docs/sessions/2026-08-31_interaction-error-handling.md
+++ b/docs/sessions/2026-08-31_interaction-error-handling.md
@@ -1,0 +1,110 @@
+# 2026-08-31 — Never let an interaction die on Discord's own failure message
+
+## The report
+
+`/manage stripe trial` produced, in production:
+
+```
+moddy.staff.router - ERROR - Error in staff command m.trial: 404 Not Found (error code: 10062): Unknown interaction
+  File "/app/staff/commands/manage/stripe/trial.py", line 62, in execute
+    await ctx.defer()
+moddy - ERROR - Failed to send app command error to user: 404 Not Found (error code: 10062): Unknown interaction
+```
+
+Sentry received the error. The user saw only Discord's **"The application
+did not respond"** — no message, no error code.
+
+## Why both halves failed
+
+The error pipeline has two halves, and only the first ran.
+
+1. **Why the token died.** The staff router did a permission lookup (DB) and
+   an audit-log write (DB + webhook) *before* the command body reached
+   `ctx.defer()`. Two round-trips is enough to burn the 3-second
+   acknowledgement window, so `defer()` itself raised 10062.
+2. **Why the user saw nothing.** `on_app_command_error` reported correctly
+   (log, Sentry, DB, internal Discord log) and then tried to show `ErrorView`
+   **on the same dead token**. That second 404 fell into a last-resort
+   `except` that only logged — the second line above. Delivery had no plan B,
+   so it gave up.
+
+The same two shapes were everywhere in the codebase, plus a third the user
+called out: modules answering an unexpected exception with a bare "une erreur
+s'est produite" carrying no code and no central report.
+
+## What was built
+
+**`utils/interaction_response.py` (new)** — the single place that knows how to
+reach a user:
+- `safe_defer()` — acknowledges without ever raising; returns `False` on a dead
+  token; picks `thinking` from the interaction type (a slash command needs the
+  placeholder, a component re-rendering in place must not get one).
+- `deliver()` — walks followup → edit original → initial response → **plain
+  channel message mentioning the user**, so a dead token still gets the card in
+  front of the user. Never raises: a second exception on the error path would
+  silence the first.
+
+**`cogs/error_handler.py`** — every delivery now goes through `deliver`
+(BaseView, BaseModal, app commands, components, permission/cooldown/transformer).
+New `report_error()` exposes the transport-agnostic half of the pipeline
+(log → Sentry → DB → Discord log → **error code**) for paths with no global
+handler above them. `ErrorView` accepts `error_code=None` and still renders, so
+a missing `ErrorTracker` cog no longer means delivering nothing at all.
+
+**Staff framework** — the router defers before any awaited work;
+`StaffCommand.opens_modal = True` opts out the commands that answer with a
+Modal (Discord refuses one on a deferred interaction). Its error path reports
+centrally and shows the code instead of a generic card.
+
+**Codebase sweep** (four parallel agents, disjoint directories):
+- *Late acknowledgement*: `/ban /kick /mute /warn` (a 2.8s OpenAI call in front
+  of an un-deferrable `send_modal` — the budget is now derived from
+  `interaction.created_at` and degrades to "no prefill"), `/ticket*`, `/config`,
+  `/altguard`, `/report`, `/reminder*`, `/library`, `/preferences`, the
+  saved-roles commands, and the ticket / cases / appeals / notifications /
+  support / automod-shadow view callbacks.
+- *Bugs disguised as expected errors*: the translate and text-tools gateway
+  wrappers answered "API unavailable" for **any** exception;
+  `webhook.fetch_webhook_data` turned a crash into "webhook not found". Both
+  narrowed to their real error types.
+- *Errors reaching nothing*: three modals in `saved_messages.py` inherited
+  `ui.Modal` instead of `BaseModal`; `token_detector._route_error` was a
+  hand-rolled copy of the central pipeline. Listener paths with no handler above
+  them (module events, case sync, ticket cleanup, the reminder loop) now report
+  centrally.
+
+**Root cause of a whole class of late acks** — `add_incognito_option` read
+`DEFAULT_INCOGNITO` from the database before every command body ran, and the
+same block was copy-pasted across ten call sites. `resolve_incognito()` now owns
+it: 5-minute cache (the value is set from the dashboard, never by the bot), a
+1-second ceiling, private as the fallback. Timeouts are deliberately not cached.
+
+## Decisions worth keeping
+
+- **`deliver`'s channel fallback is public.** An ephemeral error posted in
+  channel reveals that the user ran a command. Accepted: silence is worse, and
+  it only happens on an already-dead interaction.
+- **No DM fallback.** Every DM goes through `bot.notifications`
+  (CLAUDE.md rule 11); an error card is not a notification.
+- **`serverlogs/` and `notifications/` were deliberately left alone.** Their
+  failure mode is "cannot post to Discord", and the central handler also posts
+  to Discord and writes to the DB — routing them there would turn a channel
+  outage into an error storm. Same for `cogs/logs.py` (163 event types on the
+  hottest gateway path) and the console/dev loggers (recursion risk).
+- **Expected errors keep their own message.** Missing permissions, invalid
+  input, premium required, quota exhausted: a specific translated sentence, no
+  error code. A code there is noise that trains people to ignore codes.
+
+## Known follow-ups
+
+- **`AltGuardPanelView.on_verify`** does a module lookup plus up to two DB reads
+  and *then* opens the consent modal, so it cannot be fixed by deferring. The
+  only real fix is reordering (open the modal first, check verified state on
+  submit), which changes the UX for already-verified members. **Product call.**
+- **`cogs/bug_report.py` (`is_rate_limited`)** and
+  **`saved_messages.save_message_context_menu` (`count_saved_messages`)** each
+  run one query in front of an un-deferrable `send_modal`. Currently fast, but
+  structurally fragile — same shape as the bug this session fixed.
+- **`utils/global_sanction_views.py::_may_manage`** turns an unexpected failure
+  into a "permission denied" card with no code. Fail-closed is right for an
+  authorization check, but the failure is currently invisible.

--- a/modules/configs/adaptive_slowmode_config.py
+++ b/modules/configs/adaptive_slowmode_config.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Dict, Optional
 import logging
 
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 from cogs.error_handler import BaseView, BaseModal
 from utils.emojis import TIME, REQUIRED_FIELDS, EDIT, BACK, SAVE, UNDONE, DELETE, ADD
 from modules.configs._common import check_guild_perms
@@ -618,6 +619,10 @@ class AdaptiveSlowmodeConfigView(BaseView):
     async def on_add_channel(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+
+        # The stored config is read below: acknowledge before the round-trip.
+        await safe_defer(interaction, thinking=False)
+
         working_config = await self._fresh_working_config(interaction)
         locale = i18n.get_user_locale(interaction)
         channel_view = AdaptiveSlowmodeChannelConfigView(
@@ -628,7 +633,7 @@ class AdaptiveSlowmodeConfigView(BaseView):
             working_config=working_config,
             has_existing_config=self.has_existing_config if self._is_live_for(interaction) else bool(working_config.get("channels")),
         )
-        await interaction.response.edit_message(view=channel_view)
+        await interaction.edit_original_response(view=channel_view)
 
     async def on_back(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
@@ -666,11 +671,14 @@ class AdaptiveSlowmodeConfigView(BaseView):
     async def on_cancel(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+
+        await safe_defer(interaction, thinking=False)
+
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         saved = await bot.module_manager.get_module_config(interaction.guild_id, "adaptive_slowmode")
         view = AdaptiveSlowmodeConfigView(bot, interaction.guild_id, interaction.user.id, locale, current_config=saved)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_delete(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
@@ -737,6 +745,8 @@ class SlowmodeListButton(ui.DynamicItem[ui.Button], template=_CID_LIST_ITEM_TEMP
         if not await check_guild_perms(interaction):
             return
 
+        await safe_defer(interaction, thinking=False)
+
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         saved = await bot.module_manager.get_module_config(interaction.guild_id, "adaptive_slowmode")
@@ -754,7 +764,7 @@ class SlowmodeListButton(ui.DynamicItem[ui.Button], template=_CID_LIST_ITEM_TEMP
                 working_config=working_config, has_existing_config=has_existing_config,
                 channel_id=self.channel_id, channel_config=dict(ch_cfg),
             )
-            await interaction.response.edit_message(view=channel_view)
+            await interaction.edit_original_response(view=channel_view)
             return
 
         # remove
@@ -764,4 +774,4 @@ class SlowmodeListButton(ui.DynamicItem[ui.Button], template=_CID_LIST_ITEM_TEMP
         view.working_config = working_config
         view.has_changes = True
         view._build_view()
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)

--- a/modules/configs/altguard_config.py
+++ b/modules/configs/altguard_config.py
@@ -26,6 +26,7 @@ from modules.altguard import MODULE_ID
 from modules.configs._common import check_guild_perms
 from utils.emojis import ALTGUARD, BACK, DELETE, SAVE, UNDONE
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger("moddy.modules.altguard_config")
 
@@ -365,13 +366,16 @@ class AltGuardConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        # The stored config is read below: acknowledge before the round-trip.
+        await safe_defer(interaction, thinking=False)
+
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         saved = await bot.module_manager.get_module_config(interaction.guild_id, MODULE_ID)
         view = AltGuardConfigView(
             bot, interaction.guild_id, interaction.user.id, locale, current_config=saved,
         )
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_delete(self, interaction: discord.Interaction) -> None:
         if not await check_guild_perms(interaction):

--- a/modules/configs/altguard_config.py
+++ b/modules/configs/altguard_config.py
@@ -271,10 +271,13 @@ class AltGuardConfigView(BaseView):
 
     async def _set_and_refresh(self, interaction: discord.Interaction,
                                key: str, value: Any) -> None:
+        # Reads the stored config twice (fresh copy + rebuild): acknowledge
+        # before the first round-trip.
+        await safe_defer(interaction, thinking=False)
         working_config = await self._fresh_working_config(interaction)
         working_config[key] = value
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     @staticmethod
     def _first_id(interaction: discord.Interaction) -> Optional[int]:

--- a/modules/configs/auto_restore_roles_config.py
+++ b/modules/configs/auto_restore_roles_config.py
@@ -9,6 +9,7 @@ from typing import Optional, Dict, Any
 import logging
 
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 from cogs.error_handler import BaseView
 from utils.emojis import HISTORY, REQUIRED_FIELDS, DONE, DELETE, BACK, SAVE, UNDONE
 from modules.configs._common import check_guild_perms
@@ -338,6 +339,9 @@ class AutoRestoreRolesConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        # The stored config is read below: acknowledge before the round-trip.
+        await safe_defer(interaction, thinking=False)
+
         working_config = await self._fresh_working_config(interaction)
         selected_mode = interaction.data['values'][0]
         working_config['mode'] = selected_mode
@@ -347,12 +351,14 @@ class AutoRestoreRolesConfigView(BaseView):
             working_config['included_roles'] = []
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_excluded_roles_select(self, interaction: discord.Interaction):
         """Callback quand les rôles exclus sont sélectionnés"""
         if not await check_guild_perms(interaction):
             return
+
+        await safe_defer(interaction, thinking=False)
 
         working_config = await self._fresh_working_config(interaction)
         if interaction.data['values']:
@@ -361,12 +367,14 @@ class AutoRestoreRolesConfigView(BaseView):
             working_config['excluded_roles'] = []
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_included_roles_select(self, interaction: discord.Interaction):
         """Callback quand les rôles inclus sont sélectionnés"""
         if not await check_guild_perms(interaction):
             return
+
+        await safe_defer(interaction, thinking=False)
 
         working_config = await self._fresh_working_config(interaction)
         if interaction.data['values']:
@@ -375,12 +383,14 @@ class AutoRestoreRolesConfigView(BaseView):
             working_config['included_roles'] = []
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_log_channel_select(self, interaction: discord.Interaction):
         """Callback quand le salon de logs est sélectionné"""
         if not await check_guild_perms(interaction):
             return
+
+        await safe_defer(interaction, thinking=False)
 
         working_config = await self._fresh_working_config(interaction)
         if interaction.data['values']:
@@ -389,7 +399,7 @@ class AutoRestoreRolesConfigView(BaseView):
             working_config['log_channel_id'] = None
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_save(self, interaction: discord.Interaction):
         """Sauvegarde la configuration"""
@@ -422,11 +432,13 @@ class AutoRestoreRolesConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        await safe_defer(interaction, thinking=False)
+
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         saved = await bot.module_manager.get_module_config(interaction.guild_id, 'auto_restore_roles')
         view = AutoRestoreRolesConfigView(bot, interaction.guild_id, interaction.user.id, locale, current_config=saved)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_delete(self, interaction: discord.Interaction):
         """Supprime la configuration"""

--- a/modules/configs/auto_role_config.py
+++ b/modules/configs/auto_role_config.py
@@ -9,6 +9,7 @@ from typing import Optional, Dict, Any
 import logging
 
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 from cogs.error_handler import BaseView
 from utils.emojis import MANAGE_USER, BACK, SAVE, UNDONE, DELETE
 from modules.configs._common import check_guild_perms
@@ -235,6 +236,9 @@ class AutoRoleConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        # The stored config is read below: acknowledge before the round-trip.
+        await safe_defer(interaction, thinking=False)
+
         working_config = await self._fresh_working_config(interaction)
         if interaction.data['values']:
             working_config['member_roles'] = [int(role_id) for role_id in interaction.data['values']]
@@ -242,12 +246,14 @@ class AutoRoleConfigView(BaseView):
             working_config['member_roles'] = []
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_bot_roles_select(self, interaction: discord.Interaction):
         """Callback quand les rôles bots sont sélectionnés"""
         if not await check_guild_perms(interaction):
             return
+
+        await safe_defer(interaction, thinking=False)
 
         working_config = await self._fresh_working_config(interaction)
         if interaction.data['values']:
@@ -256,7 +262,7 @@ class AutoRoleConfigView(BaseView):
             working_config['bot_roles'] = []
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_save(self, interaction: discord.Interaction):
         """Sauvegarde la configuration"""
@@ -289,11 +295,13 @@ class AutoRoleConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        await safe_defer(interaction, thinking=False)
+
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         saved = await bot.module_manager.get_module_config(interaction.guild_id, 'auto_role')
         view = AutoRoleConfigView(bot, interaction.guild_id, interaction.user.id, locale, current_config=saved)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_delete(self, interaction: discord.Interaction):
         """Supprime la configuration"""

--- a/modules/configs/automod_ai_config.py
+++ b/modules/configs/automod_ai_config.py
@@ -24,6 +24,7 @@ import discord
 from discord import ui
 
 from utils.i18n import t, i18n
+from utils.interaction_response import safe_defer
 from cogs.error_handler import BaseView, BaseModal
 from utils.emojis import (
     SHIELD, BOOK, BACK, DELETE, MESSAGE, GROUPS, SETTINGS, WARNING, SAVE,
@@ -134,13 +135,16 @@ class IndicationsModal(BaseModal):
         locale = self.locale
         text = (self.field.component.value or "").strip()
 
+        # Both branches below make a round-trip (a DB read, or the rules check
+        # against the AI gateway): acknowledge the submit before either.
+        await safe_defer(interaction, thinking=False)
+
         if not text:  # clearing needs no AI call
             self.working_config["indications"] = ""
             view = await self._rebuild(interaction, self.working_config, True)
-            await interaction.response.edit_message(view=view)
+            await interaction.edit_original_response(view=view)
             return
 
-        await interaction.response.defer()
         safe, reason = await validate_rules(self.bot, self.guild_id, text)
         if not safe:
             if reason == "too_long":
@@ -576,66 +580,74 @@ class AutomodAIConfigView(BaseView):
     async def on_toggle_module(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        # The stored config is read below: acknowledge before the round-trip.
+        await safe_defer(interaction, thinking=False)
         working_config = await self._fresh_working_config(interaction)
         working_config["enabled"] = not working_config["enabled"]
         view = await self._rebuild(interaction, working_config, True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_activations(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         working_config = await self._fresh_working_config(interaction)
         selected = set(interaction.data.get("values", []))
         self._content_of(working_config)["enabled"] = "content" in selected
         working_config["ignore_moderators"] = "ignore" in selected
         working_config["dry_run"] = "dry_run" in selected
         view = await self._rebuild(interaction, working_config, True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_notify_channel(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         working_config = await self._fresh_working_config(interaction)
         values = interaction.data.get("values", [])
         working_config["notify_channel_id"] = int(values[0]) if values else None
         view = await self._rebuild(interaction, working_config, True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_severity(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         working_config = await self._fresh_working_config(interaction)
         values = interaction.data.get("values", [])
         if values:
             working_config["severity"] = ac.clamp_severity(values[0])
         view = await self._rebuild(interaction, working_config, True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_max_action(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         working_config = await self._fresh_working_config(interaction)
         values = interaction.data.get("values", [])
         if values and values[0] in ("warn", "mute", "ban"):
             working_config["max_action"] = values[0]
         view = await self._rebuild(interaction, working_config, True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_exempt_roles(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         working_config = await self._fresh_working_config(interaction)
         self._content_of(working_config)["exempt_roles"] = [int(v) for v in interaction.data.get("values", [])]
         view = await self._rebuild(interaction, working_config, True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_exempt_channels(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         working_config = await self._fresh_working_config(interaction)
         self._content_of(working_config)["exempt_channels"] = [int(v) for v in interaction.data.get("values", [])]
         view = await self._rebuild(interaction, working_config, True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_edit_indications(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
@@ -650,17 +662,19 @@ class AutomodAIConfigView(BaseView):
     async def on_view_precedents(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         from modules.configs.automod_ai_precedents_view import AutomodAIPrecedentsView
         view = AutomodAIPrecedentsView(bot, interaction.guild_id, interaction.user.id, locale)
         await view.load()
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     # -- action buttons -------------------------------------------------- #
     async def on_save(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         working_config = await self._fresh_working_config(interaction)
@@ -670,12 +684,12 @@ class AutomodAIConfigView(BaseView):
             actor_id=interaction.user.id,
         )
         if not success:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t("modules.config.save.error", locale=locale, error=error), ephemeral=True
             )
             return
         view = await self._rebuild(interaction, working_config, False)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
         await interaction.followup.send(
             t("modules.config.save.success", locale=locale), ephemeral=True
         )
@@ -683,22 +697,24 @@ class AutomodAIConfigView(BaseView):
     async def on_cancel(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         saved = await bot.module_manager.get_module_config(interaction.guild_id, "automod_ai")
         view = AutomodAIConfigView(bot, interaction.guild_id, interaction.user.id, locale, current_config=saved)
         await view.load_precedent_stats()
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_delete(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         await bot.module_manager.delete_module_config(interaction.guild_id, "automod_ai")
         view = AutomodAIConfigView(bot, interaction.guild_id, interaction.user.id, locale, current_config=None)
         await view.load_precedent_stats()
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
         await interaction.followup.send(
             t("modules.config.delete.success", locale=locale), ephemeral=True
         )

--- a/modules/configs/automod_ai_precedents_view.py
+++ b/modules/configs/automod_ai_precedents_view.py
@@ -20,6 +20,7 @@ from discord import ui
 
 from cogs.error_handler import BaseView
 from utils.i18n import t, i18n
+from utils.interaction_response import safe_defer
 from utils.emojis import SHIELD, SEARCH, BACK, NEXT, DELETE
 
 logger = logging.getLogger("moddy.modules.automod_precedents")
@@ -43,13 +44,14 @@ class AutomodAIPrecedentsView(BaseView):
         self.rows: List[Dict[str, Any]] = []
 
     async def load(self):
-        """Fetch the guild's precedents and (re)build the view."""
-        try:
-            self.rows = await self.bot.db.list_precedents(
-                self.guild_id, with_vectors=False)
-        except Exception as e:  # noqa: BLE001
-            logger.debug("precedent list load failed: %s", e)
-            self.rows = []
+        """Fetch the guild's precedents and (re)build the view.
+
+        A read failure is not caught here on purpose: an empty list would lie
+        about what the server has learned. It propagates to the caller's
+        ``BaseView.on_error``, which shows the error card and its code.
+        """
+        self.rows = await self.bot.db.list_precedents(
+            self.guild_id, with_vectors=False)
         self._clamp_page()
         self._build_view()
 
@@ -184,11 +186,10 @@ class AutomodAIPrecedentsView(BaseView):
         if not values:
             await self._rerender(interaction)
             return
-        ok = False
-        try:
-            ok = await self.bot.db.delete_precedent(self.guild_id, values[0])
-        except Exception as e:  # noqa: BLE001
-            logger.debug("precedent delete failed: %s", e)
+        # The delete is a round-trip, and a failure must reach the error
+        # handler rather than be reported as a deletion that never happened.
+        await safe_defer(interaction, thinking=False)
+        ok = await self.bot.db.delete_precedent(self.guild_id, values[0])
         if ok:
             svc = getattr(self.bot, "precedents", None)
             if svc is not None:
@@ -196,7 +197,7 @@ class AutomodAIPrecedentsView(BaseView):
             self.rows = [r for r in self.rows if str(r.get("id")) != values[0]]
             self._clamp_page()
         self._build_view()
-        await interaction.response.edit_message(view=self)
+        await interaction.edit_original_response(view=self)
         await interaction.followup.send(
             t("modules.automod_ai.config.precedents.deleted", locale=self.locale),
             ephemeral=True)
@@ -211,5 +212,8 @@ class AutomodAIPrecedentsView(BaseView):
                                        self.locale)
         # Refresh the count shown on the parent panel after any deletions.
         if hasattr(parent, "load_precedent_stats"):
+            await safe_defer(interaction, thinking=False)
             await parent.load_precedent_stats()
+            await interaction.edit_original_response(view=parent)
+            return
         await interaction.response.edit_message(view=parent)

--- a/modules/configs/interserver_config.py
+++ b/modules/configs/interserver_config.py
@@ -9,6 +9,7 @@ from typing import Optional, Dict, Any
 import logging
 
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 from cogs.error_handler import BaseView
 from utils.emojis import GROUPS, REQUIRED_FIELDS, WARNING, BACK, SAVE, UNDONE, DELETE
 from modules.configs._common import check_guild_perms
@@ -258,6 +259,9 @@ class InterServerConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        # The stored config is read below: acknowledge before the round-trip.
+        await safe_defer(interaction, thinking=False)
+
         working_config = await self._fresh_working_config(interaction)
         if interaction.data['values']:
             working_config['channel_id'] = int(interaction.data['values'][0])
@@ -265,18 +269,20 @@ class InterServerConfigView(BaseView):
             working_config['channel_id'] = None
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_type_select(self, interaction: discord.Interaction):
         """Callback quand un type d'inter-serveur est sélectionné"""
         if not await check_guild_perms(interaction):
             return
 
+        await safe_defer(interaction, thinking=False)
+
         working_config = await self._fresh_working_config(interaction)
         working_config['interserver_type'] = interaction.data['values'][0]
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_back(self, interaction: discord.Interaction):
         """Retour au menu principal"""
@@ -319,11 +325,13 @@ class InterServerConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        await safe_defer(interaction, thinking=False)
+
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         saved = await bot.module_manager.get_module_config(interaction.guild_id, 'interserver')
         view = InterServerConfigView(bot, interaction.guild_id, interaction.user.id, locale, current_config=saved)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_delete(self, interaction: discord.Interaction):
         """Supprime la configuration"""

--- a/modules/configs/logs_config.py
+++ b/modules/configs/logs_config.py
@@ -37,6 +37,7 @@ from utils.emojis import (
     BACK, DELETE, NOTE, SETTINGS, TOGGLE_OFF, TOGGLE_ON, log_emoji,
 )
 from utils.i18n import i18n, t
+from utils.interaction_response import deliver, safe_defer
 
 logger = logging.getLogger('moddy.modules.logs_config')
 
@@ -111,10 +112,7 @@ async def _refuse(interaction: discord.Interaction, error: str) -> None:
     locale = i18n.get_user_locale(interaction)
     view = create_error_message(
         t('modules.logs.config.errors.title', locale=locale), error)
-    if interaction.response.is_done():
-        await interaction.followup.send(view=view, ephemeral=True)
-    else:
-        await interaction.response.send_message(view=view, ephemeral=True)
+    await deliver(interaction, view=view, ephemeral=True)
 
 
 # --------------------------------------------------------------------------- #
@@ -277,8 +275,10 @@ class LogsConfigView(BaseView):
         values = interaction.data.get("values") or []
         if not values or values[0] not in registry.CATEGORIES:
             return
+        # Building a screen reads the stored config: acknowledge first.
+        await safe_defer(interaction, thinking=False)
         view = await LogsCategoryView.create(interaction, values[0], page=0)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_mass_channel(self, interaction: discord.Interaction):
         """Bind every category to a single channel in one click."""
@@ -303,8 +303,9 @@ class LogsConfigView(BaseView):
     async def on_options(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         view = await LogsOptionsView.create(interaction)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_clear(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
@@ -603,10 +604,11 @@ class LogsCategoryButton(ui.DynamicItem[ui.Button],
             return
 
         if self.action == "back":
+            await safe_defer(interaction, thinking=False)
             view = await LogsConfigView.create(
                 interaction.client, interaction.guild_id, interaction.user.id,
                 i18n.get_user_locale(interaction))
-            await interaction.response.edit_message(view=view)
+            await interaction.edit_original_response(view=view)
             return
 
         spec = registry.CATEGORIES[self.category_id]
@@ -615,8 +617,9 @@ class LogsCategoryButton(ui.DynamicItem[ui.Button],
         if self.action in ("prev", "next"):
             step = -1 if self.action == "prev" else 1
             page = (self.page + step) % page_count
+            await safe_defer(interaction, thinking=False)
             view = await LogsCategoryView.create(interaction, self.category_id, page)
-            await interaction.response.edit_message(view=view)
+            await interaction.edit_original_response(view=view)
             return
 
         await interaction.response.defer()
@@ -825,10 +828,11 @@ class LogsOptionsView(BaseView):
     async def on_back(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)
         view = await LogsConfigView.create(
             interaction.client, interaction.guild_id, interaction.user.id,
             i18n.get_user_locale(interaction))
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         return await check_guild_perms(interaction)

--- a/modules/configs/server_settings_config.py
+++ b/modules/configs/server_settings_config.py
@@ -37,6 +37,7 @@ from utils.guild_language import (
     set_language_setting,
 )
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger('moddy.modules.server_settings_config')
 
@@ -174,18 +175,15 @@ class ServerSettingsConfigView(BaseView):
         locale = i18n.get_user_locale(interaction)
         value = (interaction.data.get('values') or [AUTO])[0]
 
-        try:
-            stored = await set_language_setting(bot, interaction.guild_id, value)
-        except Exception as e:
-            logger.error(f"Could not save the language of guild {interaction.guild_id}: {e}",
-                         exc_info=True)
-            await interaction.response.send_message(
-                t('modules.config.save.error', locale=locale, error=str(e)), ephemeral=True)
-            return
+        # The write below is a round-trip: acknowledge before it. An unexpected
+        # failure is deliberately not caught — BaseView.on_error shows the user
+        # the error card and its code, which a bare "save failed" line cannot.
+        await safe_defer(interaction, thinking=False)
+        stored = await set_language_setting(bot, interaction.guild_id, value)
 
         view = ServerSettingsConfigView(bot, interaction.guild_id, interaction.user.id,
                                         locale, stored)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
         await interaction.followup.send(
             t('modules.config.save.success', locale=locale), ephemeral=True)
 

--- a/modules/configs/social_notifications_config.py
+++ b/modules/configs/social_notifications_config.py
@@ -47,6 +47,7 @@ from utils.emojis import (
     REQUIRED_FIELDS, PAUSE, PLAY, get_platform_emoji,
 )
 from utils.i18n import t, i18n
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger('moddy.modules.social_notifications_config')
 
@@ -148,13 +149,13 @@ async def _render_main(interaction: discord.Interaction) -> None:
     """(Re)build and show the main panel from a live interaction."""
     bot = interaction.client
     locale = i18n.get_user_locale(interaction)
+    # Acknowledge first: rebuilding the panel reads the DB, and an interaction
+    # left unacknowledged for 3s dies with Discord's own "did not respond".
+    await safe_defer(interaction, thinking=False)
     view = await SocialNotificationsConfigView.create(
         bot, interaction.guild_id, interaction.user.id, locale
     )
-    if interaction.response.is_done():
-        await interaction.edit_original_response(view=view)
-    else:
-        await interaction.response.edit_message(view=view)
+    await interaction.edit_original_response(view=view)
 
 
 # =========================================================================== #
@@ -436,13 +437,15 @@ class SocialNotificationsConfigView(BaseView):
             return
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
+        # The premium lookup is a round-trip: acknowledge before it.
+        await safe_defer(interaction, thinking=False)
         is_premium = False
         try:
             is_premium = await bot.db.is_guild_premium(interaction.guild_id)
         except Exception:
             pass
         add_view = AddSubscriptionView(bot, interaction.guild_id, locale, is_premium)
-        await interaction.response.edit_message(view=add_view)
+        await interaction.edit_original_response(view=add_view)
 
     async def on_manage_select(self, interaction: discord.Interaction):
         if not await _check_perms(interaction):
@@ -450,13 +453,14 @@ class SocialNotificationsConfigView(BaseView):
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         key = interaction.data['values'][0]
+        await safe_defer(interaction, thinking=False)  # a DB read follows
         subs = await bot.db.list_social_subscriptions(interaction.guild_id)
         sub = next((s for s in subs if _sub_key(s) == key), None)
         if not sub:
             await _render_main(interaction)
             return
         manage_view = ManageSubscriptionView(bot, interaction.guild_id, locale, sub)
-        await interaction.response.edit_message(view=manage_view)
+        await interaction.edit_original_response(view=manage_view)
 
     async def on_back(self, interaction: discord.Interaction):
         if not await _check_perms(interaction):
@@ -925,18 +929,20 @@ class ManageSubscriptionView(BaseView):
         if not await _check_perms(interaction):
             return
         values = interaction.data.get('values')
+        await safe_defer(interaction, thinking=False)  # the write below is a round-trip
         if values:
             await self._persist(channel_id=int(values[0]))
         self._build_view()
-        await interaction.response.edit_message(view=self)
+        await interaction.edit_original_response(view=self)
 
     async def on_role_select(self, interaction: discord.Interaction):
         if not await _check_perms(interaction):
             return
         role_ids = [int(r) for r in interaction.data.get('values', [])]
+        await safe_defer(interaction, thinking=False)  # the write below is a round-trip
         await self._persist(mention_role_ids=role_ids)
         self._build_view()
-        await interaction.response.edit_message(view=self)
+        await interaction.edit_original_response(view=self)
 
     async def on_edit_message(self, interaction: discord.Interaction):
         if not await _check_perms(interaction):
@@ -952,19 +958,21 @@ class ManageSubscriptionView(BaseView):
 
     async def _on_message_edited(self, interaction: discord.Interaction, message: str,
                                  color: Optional[int], show_avatar: bool, show_media: bool):
+        await safe_defer(interaction, thinking=False)  # the write below is a round-trip
         await self._persist(
             message=message, embed_color=color,
             show_avatar=show_avatar, show_media=show_media,
         )
         self._build_view()
-        await interaction.response.edit_message(view=self)
+        await interaction.edit_original_response(view=self)
 
     async def on_toggle(self, interaction: discord.Interaction):
         if not await _check_perms(interaction):
             return
+        await safe_defer(interaction, thinking=False)  # the write below is a round-trip
         await self._persist(enabled=not self.sub.get('enabled', True))
         self._build_view()
-        await interaction.response.edit_message(view=self)
+        await interaction.edit_original_response(view=self)
 
     async def on_remove(self, interaction: discord.Interaction):
         if not await _check_perms(interaction):

--- a/modules/configs/starboard_config.py
+++ b/modules/configs/starboard_config.py
@@ -9,6 +9,7 @@ from typing import Optional, Dict, Any
 import logging
 
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 from cogs.error_handler import BaseView, BaseModal
 from utils.emojis import STAR, REQUIRED_FIELDS, EDIT, BACK, SAVE, UNDONE, DELETE, is_standard_discord_emoji
 from modules.configs._common import check_guild_perms
@@ -313,6 +314,9 @@ class StarboardConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        # The stored config is read below: acknowledge before the round-trip.
+        await safe_defer(interaction, thinking=False)
+
         working_config = await self._fresh_working_config(interaction)
         if interaction.data['values']:
             working_config['channel_id'] = int(interaction.data['values'][0])
@@ -320,7 +324,7 @@ class StarboardConfigView(BaseView):
             working_config['channel_id'] = None
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_edit_reaction_count(self, interaction: discord.Interaction):
         """Edit reaction count"""
@@ -399,11 +403,13 @@ class StarboardConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        await safe_defer(interaction, thinking=False)
+
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         saved = await bot.module_manager.get_module_config(interaction.guild_id, 'starboard')
         view = StarboardConfigView(bot, interaction.guild_id, interaction.user.id, locale, current_config=saved)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_delete(self, interaction: discord.Interaction):
         """Delete configuration"""

--- a/modules/configs/tickets_category_config.py
+++ b/modules/configs/tickets_category_config.py
@@ -76,6 +76,7 @@ from utils.emojis import (
     TICKET_PERMISSIONS as PERM_EMOJI, SETTINGS, WARNING,
 )
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger('moddy.modules.tickets_category_config')
 
@@ -104,6 +105,7 @@ async def render_category(interaction: discord.Interaction, panel_id: str,
     """(Re)build and show one category's editor, falling back up the tree."""
     bot = interaction.client
     locale = i18n.get_user_locale(interaction)
+    await safe_defer(interaction, thinking=False)  # a config read follows
     config = await load_config(bot, interaction.guild_id)
     panel, category = locate_category(config, panel_id, category_id)
     if not category:
@@ -122,6 +124,7 @@ async def render_permissions(interaction: discord.Interaction, panel_id: str,
     """(Re)build and show the permissions screen of one category."""
     bot = interaction.client
     locale = i18n.get_user_locale(interaction)
+    await safe_defer(interaction, thinking=False)  # a config read follows
     config = await load_config(bot, interaction.guild_id)
     panel, category = locate_category(config, panel_id, category_id)
     if not category:

--- a/modules/configs/tickets_config.py
+++ b/modules/configs/tickets_config.py
@@ -54,6 +54,7 @@ from utils.emojis import (
     ADD, BACK, INFO, PREMIUM, TICKET, TICKET_PANEL, WARNING,
 )
 from utils.i18n import i18n, t
+from utils.interaction_response import deliver, safe_defer
 
 logger = logging.getLogger('moddy.modules.tickets_config')
 
@@ -116,14 +117,14 @@ async def report_save_error(interaction: discord.Interaction, error: Optional[st
     view = create_error_message(
         t('modules.tickets.errors.title', locale=locale),
         t('modules.config.save.error', locale=locale, error=error or ''))
-    if interaction.response.is_done():
-        await interaction.followup.send(view=view, ephemeral=True)
-    else:
-        await interaction.response.send_message(view=view, ephemeral=True)
+    await deliver(interaction, view=view, ephemeral=True)
 
 
 async def render_root(interaction: discord.Interaction) -> None:
     """(Re)build and show the panel list."""
+    # Every screen is rebuilt from the stored config: acknowledge before that
+    # read, or a cold DB burns the 3s window and the click looks dead.
+    await safe_defer(interaction, thinking=False)
     view = await TicketsConfigView.create(
         interaction.client, interaction.guild_id, interaction.user.id,
         i18n.get_user_locale(interaction))
@@ -136,6 +137,7 @@ async def render_panel(interaction: discord.Interaction, panel_id: str) -> None:
 
     bot = interaction.client
     locale = i18n.get_user_locale(interaction)
+    await safe_defer(interaction, thinking=False)
     config = await load_config(bot, interaction.guild_id)
     panel = find_panel(config, panel_id)
     if not panel:
@@ -440,10 +442,7 @@ class TicketsConfigView(BaseView):
                               url=PREMIUM_URL))
         view = create_error_message(
             t('modules.tickets.errors.title', locale=locale), description)
-        if interaction.response.is_done():
-            await interaction.followup.send(view=view, ephemeral=True)
-        else:
-            await interaction.response.send_message(view=view, ephemeral=True)
+        await deliver(interaction, view=view, ephemeral=True)
 
     async def on_manage(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):

--- a/modules/configs/voice_transcription_config.py
+++ b/modules/configs/voice_transcription_config.py
@@ -20,6 +20,7 @@ from utils.emojis import (
     BACK, DELETE, SAVE, TOGGLE_OFF, TOGGLE_ON, UNDONE, VOICE_CHAT,
 )
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger("moddy.modules.voice_transcription_config")
 
@@ -268,15 +269,20 @@ class VoiceTranscriptionConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        # The stored config is read below: acknowledge before the round-trip.
+        await safe_defer(interaction, thinking=False)
+
         working_config = await self._fresh_working_config(interaction)
         working_config["enabled"] = not bool(working_config.get("enabled"))
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_mode_select(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+
+        await safe_defer(interaction, thinking=False)
 
         values = interaction.data.get("values") or []
         mode = values[0] if values else MODE_BUTTON
@@ -284,18 +290,20 @@ class VoiceTranscriptionConfigView(BaseView):
         working_config["mode"] = mode if mode in MODES else MODE_BUTTON
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_channels_select(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
+
+        await safe_defer(interaction, thinking=False)
 
         values: List[str] = interaction.data.get("values") or []
         working_config = await self._fresh_working_config(interaction)
         working_config["channel_ids"] = [int(v) for v in values]
 
         view = await self._rebuild(interaction, working_config, has_changes=True)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     # --- action buttons ------------------------------------------------ #
 
@@ -344,13 +352,15 @@ class VoiceTranscriptionConfigView(BaseView):
         if not await check_guild_perms(interaction):
             return
 
+        await safe_defer(interaction, thinking=False)
+
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         saved = await bot.module_manager.get_module_config(interaction.guild_id, _MODULE_ID)
         view = VoiceTranscriptionConfigView(
             bot, interaction.guild_id, interaction.user.id, locale, current_config=saved,
         )
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def on_delete(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):

--- a/modules/configs/welcome_channel_config.py
+++ b/modules/configs/welcome_channel_config.py
@@ -45,6 +45,7 @@ from utils.emojis import (
     REQUIRED_FIELDS, PAUSE, PLAY,
 )
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger('moddy.modules.welcome_channel_config')
 
@@ -127,13 +128,13 @@ async def _render_main(interaction: discord.Interaction) -> None:
     """(Re)build and show the main panel from a live interaction."""
     bot = interaction.client
     locale = i18n.get_user_locale(interaction)
+    # Acknowledge first: rebuilding the panel reads the DB, and an interaction
+    # left unacknowledged for 3s dies with Discord's own "did not respond".
+    await safe_defer(interaction, thinking=False)
     view = await WelcomeChannelConfigView.create(
         bot, interaction.guild_id, interaction.user.id, locale
     )
-    if interaction.response.is_done():
-        await interaction.edit_original_response(view=view)
-    else:
-        await interaction.response.edit_message(view=view)
+    await interaction.edit_original_response(view=view)
 
 
 # =========================================================================== #
@@ -327,16 +328,18 @@ class WelcomeChannelConfigView(BaseView):
             return
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
+        # The entry list is read from the DB below: acknowledge first.
+        await safe_defer(interaction, thinking=False)
         messages = await _load_messages(bot, interaction.guild_id)
         if len(messages) >= MAX_WELCOME_MESSAGES:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t('modules.welcome_channel.errors.too_many', locale=locale,
                   max=MAX_WELCOME_MESSAGES),
                 ephemeral=True,
             )
             return
         add_view = AddWelcomeMessageView(bot, interaction.guild_id, locale)
-        await interaction.response.edit_message(view=add_view)
+        await interaction.edit_original_response(view=add_view)
 
     async def on_manage_select(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
@@ -344,13 +347,15 @@ class WelcomeChannelConfigView(BaseView):
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         entry_id = interaction.data['values'][0]
+        # The entry list is read from the DB below: acknowledge first.
+        await safe_defer(interaction, thinking=False)
         messages = await _load_messages(bot, interaction.guild_id)
         entry = next((m for m in messages if m['id'] == entry_id), None)
         if not entry:
             await _render_main(interaction)
             return
         manage_view = ManageWelcomeMessageView(bot, interaction.guild_id, locale, entry)
-        await interaction.response.edit_message(view=manage_view)
+        await interaction.edit_original_response(view=manage_view)
 
     async def on_back(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
@@ -684,6 +689,8 @@ class ManageWelcomeMessageView(BaseView):
         """
         bot = interaction.client
         entry_id = self.entry.get('id')
+        # A read plus a write: acknowledge before either can burn the 3s window.
+        await safe_defer(interaction, thinking=False)
         messages = await _load_messages(bot, interaction.guild_id)
         target = next((m for m in messages if m['id'] == entry_id), None)
         if not target:
@@ -703,13 +710,13 @@ class ManageWelcomeMessageView(BaseView):
             return
         success, error = result
         if not success:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t('modules.config.save.error', locale=locale, error=error or ''),
                 ephemeral=True,
             )
             return
         view = ManageWelcomeMessageView(interaction.client, interaction.guild_id, locale, self.entry)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     # -- callbacks -------------------------------------------------------- #
     async def on_channel_select(self, interaction: discord.Interaction):

--- a/modules/configs/welcome_dm_config.py
+++ b/modules/configs/welcome_dm_config.py
@@ -44,6 +44,7 @@ from utils.emojis import (
     WAVING_HAND, ADD, BACK, EDIT, DELETE, INFO, WARNING, PAUSE, PLAY,
 )
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger('moddy.modules.welcome_dm_config')
 
@@ -120,13 +121,13 @@ async def _render_main(interaction: discord.Interaction) -> None:
     """(Re)build and show the main panel from a live interaction."""
     bot = interaction.client
     locale = i18n.get_user_locale(interaction)
+    # Acknowledge first: rebuilding the panel reads the DB, and an interaction
+    # left unacknowledged for 3s dies with Discord's own "did not respond".
+    await safe_defer(interaction, thinking=False)
     view = await WelcomeDmConfigView.create(
         bot, interaction.guild_id, interaction.user.id, locale
     )
-    if interaction.response.is_done():
-        await interaction.edit_original_response(view=view)
-    else:
-        await interaction.response.edit_message(view=view)
+    await interaction.edit_original_response(view=view)
 
 
 # =========================================================================== #
@@ -373,6 +374,8 @@ class WelcomeDmConfigView(BaseView):
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
         entry_id = interaction.data['values'][0]
+        # The entry list is read from the DB below: acknowledge first.
+        await safe_defer(interaction, thinking=False)
         messages = await _load_messages(bot, interaction.guild_id)
         entry = next((m for m in messages if m['id'] == entry_id), None)
         if not entry:
@@ -380,7 +383,7 @@ class WelcomeDmConfigView(BaseView):
             return
         index = messages.index(entry) + 1
         manage_view = ManageWelcomeDmView(bot, interaction.guild_id, locale, entry, index)
-        await interaction.response.edit_message(view=manage_view)
+        await interaction.edit_original_response(view=manage_view)
 
     async def on_back(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
@@ -516,6 +519,8 @@ class ManageWelcomeDmView(BaseView):
         """
         bot = interaction.client
         entry_id = self.entry.get('id')
+        # A read plus a write: acknowledge before either can burn the 3s window.
+        await safe_defer(interaction, thinking=False)
         messages = await _load_messages(bot, interaction.guild_id)
         target = next((m for m in messages if m['id'] == entry_id), None)
         if not target:
@@ -537,14 +542,14 @@ class ManageWelcomeDmView(BaseView):
             return
         success, error = result
         if not success:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 t('modules.config.save.error', locale=locale, error=error or ''),
                 ephemeral=True,
             )
             return
         view = ManageWelcomeDmView(interaction.client, interaction.guild_id, locale,
                                    self.entry, self.index)
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     # -- callbacks -------------------------------------------------------- #
     async def on_edit_message(self, interaction: discord.Interaction):

--- a/modules/module_manager.py
+++ b/modules/module_manager.py
@@ -551,82 +551,81 @@ class ModuleManager:
         if blocked:
             return False, blocked
 
-        try:
-            # Crée une instance temporaire du module
-            module_class = self.registered_modules[module_id]
-            temp_instance = module_class(self.bot, guild_id)
+        # A genuinely unexpected failure (DB down, a broken module class) is not
+        # a validation error: it propagates so the central handler shows the user
+        # an error card with a code instead of a bare "Internal error" string.
 
-            # Vérifie que tous les champs obligatoires sont remplis
-            required_fields = temp_instance.get_required_fields()
-            missing_fields = []
+        # Crée une instance temporaire du module
+        module_class = self.registered_modules[module_id]
+        temp_instance = module_class(self.bot, guild_id)
 
-            for field in required_fields:
-                # Vérifie si le champ est présent et non vide
-                if field not in config_data or config_data[field] is None:
-                    missing_fields.append(field)
+        # Vérifie que tous les champs obligatoires sont remplis
+        required_fields = temp_instance.get_required_fields()
+        missing_fields = []
 
-            if missing_fields:
-                # Langue du serveur (/config → Paramètres du serveur)
-                from utils.guild_language import guild_locale
-                locale = await guild_locale(self.bot, guild_id)
+        for field in required_fields:
+            # Vérifie si le champ est présent et non vide
+            if field not in config_data or config_data[field] is None:
+                missing_fields.append(field)
 
-                # Construit le message d'erreur avec les labels traduits
-                from utils.i18n import t
-                field_labels = [temp_instance.get_field_label(field, locale) for field in missing_fields]
-                fields_str = "\n• ".join(field_labels)
+        if missing_fields:
+            # Langue du serveur (/config → Paramètres du serveur)
+            from utils.guild_language import guild_locale
+            locale = await guild_locale(self.bot, guild_id)
 
-                error_msg = t('modules.config.errors.required_fields', locale=locale, fields=fields_str)
-                return False, error_msg
+            # Construit le message d'erreur avec les labels traduits
+            from utils.i18n import t
+            field_labels = [temp_instance.get_field_label(field, locale) for field in missing_fields]
+            fields_str = "\n• ".join(field_labels)
 
-            # Valide la configuration (permissions, existence des ressources, etc.)
-            is_valid, error_msg = await temp_instance.validate_config(config_data)
+            error_msg = t('modules.config.errors.required_fields', locale=locale, fields=fields_str)
+            return False, error_msg
 
-            if not is_valid:
-                return False, error_msg
+        # Valide la configuration (permissions, existence des ressources, etc.)
+        is_valid, error_msg = await temp_instance.validate_config(config_data)
 
-            # S'assure que le serveur existe dans la DB
-            await self.bot.db.get_guild(guild_id)
+        if not is_valid:
+            return False, error_msg
 
-            # Sauvegarde dans la DB
-            await self.bot.db.update_guild_data(
-                guild_id,
-                f"modules.{module_id}",
-                config_data
-            )
+        # S'assure que le serveur existe dans la DB
+        await self.bot.db.get_guild(guild_id)
 
-            logger.info(f"Config saved to DB for module {module_id} in guild {guild_id}: {config_data}")
+        # Sauvegarde dans la DB
+        await self.bot.db.update_guild_data(
+            guild_id,
+            f"modules.{module_id}",
+            config_data
+        )
 
-            # Met à jour ou crée l'instance active
-            if guild_id not in self.active_modules:
-                self.active_modules[guild_id] = {}
+        logger.info(f"Config saved to DB for module {module_id} in guild {guild_id}: {config_data}")
 
-            # Crée ou met à jour l'instance
-            if module_id in self.active_modules[guild_id]:
-                # Met à jour l'instance existante
-                module_instance = self.active_modules[guild_id][module_id]
-                await module_instance.load_config(config_data)
-            else:
-                # Crée une nouvelle instance
-                module_instance = module_class(self.bot, guild_id)
-                await module_instance.load_config(config_data)
-                self.active_modules[guild_id][module_id] = module_instance
+        # Met à jour ou crée l'instance active
+        if guild_id not in self.active_modules:
+            self.active_modules[guild_id] = {}
 
-            # Active/désactive selon la validité de la config (enabled est déterminé dans load_config)
-            if module_instance.enabled:
-                await module_instance.enable()
-            else:
-                await module_instance.disable()
+        # Crée ou met à jour l'instance
+        if module_id in self.active_modules[guild_id]:
+            # Met à jour l'instance existante
+            module_instance = self.active_modules[guild_id][module_id]
+            await module_instance.load_config(config_data)
+        else:
+            # Crée une nouvelle instance
+            module_instance = module_class(self.bot, guild_id)
+            await module_instance.load_config(config_data)
+            self.active_modules[guild_id][module_id] = module_instance
 
-            logger.info(f"Configuration saved for module {module_id} in guild {guild_id} (enabled: {module_instance.enabled})")
+        # Active/désactive selon la validité de la config (enabled est déterminé dans load_config)
+        if module_instance.enabled:
+            await module_instance.enable()
+        else:
+            await module_instance.disable()
 
-            # A module that owns slash commands has just appeared in (or
-            # vanished from) this guild's command tree.
-            await self._sync_module_commands(guild_id, module_id)
-            return True, None
+        logger.info(f"Configuration saved for module {module_id} in guild {guild_id} (enabled: {module_instance.enabled})")
 
-        except Exception as e:
-            logger.error(f"[FAIL] Error saving module config: {e}", exc_info=True)
-            return False, f"Internal error: {str(e)}"
+        # A module that owns slash commands has just appeared in (or
+        # vanished from) this guild's command tree.
+        await self._sync_module_commands(guild_id, module_id)
+        return True, None
 
     async def delete_module_config(self, guild_id: int, module_id: str) -> bool:
         """
@@ -642,29 +641,28 @@ class ModuleManager:
         if not self.bot.db:
             return False
 
-        try:
-            # Désactive le module s'il est actif
-            if guild_id in self.active_modules and module_id in self.active_modules[guild_id]:
-                module_instance = self.active_modules[guild_id][module_id]
-                await module_instance.disable()
-                del self.active_modules[guild_id][module_id]
+        # An unexpected failure here is not an expected outcome: it must reach
+        # the central error handler (BaseView.on_error) so the user gets an
+        # error card with a code, not a bare "deletion failed" message.
 
-            # Supprime de la DB en mettant un objet vide
-            await self.bot.db.update_guild_data(
-                guild_id,
-                f"modules.{module_id}",
-                {}
-            )
+        # Désactive le module s'il est actif
+        if guild_id in self.active_modules and module_id in self.active_modules[guild_id]:
+            module_instance = self.active_modules[guild_id][module_id]
+            await module_instance.disable()
+            del self.active_modules[guild_id][module_id]
 
-            logger.info(f"Configuration deleted for module {module_id} in guild {guild_id}")
+        # Supprime de la DB en mettant un objet vide
+        await self.bot.db.update_guild_data(
+            guild_id,
+            f"modules.{module_id}",
+            {}
+        )
 
-            # Its commands must disappear from the guild along with it.
-            await self._sync_module_commands(guild_id, module_id)
-            return True
+        logger.info(f"Configuration deleted for module {module_id} in guild {guild_id}")
 
-        except Exception as e:
-            logger.error(f"[FAIL] Error deleting module config: {e}", exc_info=True)
-            return False
+        # Its commands must disappear from the guild along with it.
+        await self._sync_module_commands(guild_id, module_id)
+        return True
 
     async def get_module_config(self, guild_id: int, module_id: str) -> Optional[Dict[str, Any]]:
         """

--- a/modules/starboard.py
+++ b/modules/starboard.py
@@ -3,7 +3,6 @@ Module Starboard - Système de tableau d'honneur pour messages populaires
 """
 
 import re
-import asyncio
 import logging
 from typing import Dict, Any, Optional
 
@@ -68,10 +67,15 @@ def _extract_meta_content(html: str, props: tuple) -> Optional[str]:
     return None
 
 
-def _report_dynamic_item_error(interaction: discord.Interaction, error: Exception, source: str):
-    """Route a DynamicItem callback error to the central handler (fire-and-forget)."""
+async def _report_dynamic_item_error(interaction: discord.Interaction, error: Exception, source: str):
+    """Route a DynamicItem callback error to the central handler.
+
+    Awaited rather than fired off as a task: a task nobody holds a reference to
+    can be garbage-collected before it reports, and the user would be left with
+    Discord's own failure message instead of the error card and its code.
+    """
     from cogs.error_handler import report_component_error
-    asyncio.create_task(report_component_error(interaction, error, source))
+    await report_component_error(interaction, error, source)
 
 
 class _StarboardReactorsButton(
@@ -116,7 +120,7 @@ class _StarboardReactorsButton(
         try:
             await self._show_reactors(interaction)
         except Exception as e:
-            _report_dynamic_item_error(interaction, e, self.__class__.__name__)
+            await _report_dynamic_item_error(interaction, e, self.__class__.__name__)
 
     async def _show_reactors(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True, thinking=True)

--- a/services/appeal_service.py
+++ b/services/appeal_service.py
@@ -155,7 +155,15 @@ class AppealService:
                                           duration_hours=duration_hours)
             # refuse: nothing to change
         except Exception as e:
-            logger.error("appeal %s effect failed: %s", appeal_id, e, exc_info=True)
+            # The appeal is already recorded as decided, so the ruling stands —
+            # but its binding effect (unban, re-sanction) did not happen. That
+            # needs an error code and a Sentry trace, not just a log line.
+            from cogs.error_handler import report_error
+            await report_error(
+                self.bot, e, source=f"AppealService:effect:{decision}",
+                user=interaction.user, guild=guild, channel=interaction.channel,
+                error_type="Service Error",
+            )
 
         # Session 7: an appeal ruling is a strong human precedent — accept →
         # non_sanctionnable (proven false positive), refuse → sanctionnable
@@ -165,7 +173,9 @@ class AppealService:
             try:
                 await self._feed_precedent(appeal, accepted=(decision == "accept"))
             except Exception as e:  # noqa: BLE001 — precedents are best-effort
-                logger.debug("appeal %s precedent feed failed: %s", appeal_id, e)
+                # Best-effort, but a server quietly learning nothing from its
+                # own rulings is worth seeing in the logs.
+                logger.warning("appeal %s precedent feed failed: %s", appeal_id, e)
 
         # Timeline trace.
         await self._timeline(

--- a/services/appeal_service.py
+++ b/services/appeal_service.py
@@ -214,16 +214,22 @@ class AppealService:
             await self._ephemeral(interaction, "invite_failed", error=True)
             return
         from utils.components_v2 import create_info_message
-        try:
-            await interaction.response.send_message(
-                view=create_info_message(
-                    t("modules.automod_ai.appeal.invite.title", locale=locale),
-                    t("modules.automod_ai.appeal.invite.body", locale=locale, url=url, guild=guild.name),
-                ),
-                ephemeral=True,
-            )
-        except discord.HTTPException:
-            pass
+        from utils.interaction_response import deliver
+
+        # Acknowledgement-agnostic on purpose: the caller may have deferred
+        # (looking the appeal up and creating an invite is a REST round trip,
+        # easily past the 3-second window), and `response.send_message` would
+        # then raise `InteractionResponded` — which is not an `HTTPException`,
+        # so the reviewer would get nothing at all. `deliver` picks whichever
+        # transport is still valid.
+        await deliver(
+            interaction,
+            view=create_info_message(
+                t("modules.automod_ai.appeal.invite.title", locale=locale),
+                t("modules.automod_ai.appeal.invite.body", locale=locale, url=url, guild=guild.name),
+            ),
+            ephemeral=True,
+        )
 
     async def _make_invite(self, guild: discord.Guild) -> Optional[str]:
         from utils.invites import create_guild_invite

--- a/services/case_service.py
+++ b/services/case_service.py
@@ -130,7 +130,10 @@ class CaseService:
             from utils import global_sanctions
             global_sanctions.invalidate(self.bot, spec.subject_type.value, subject_id)
         except Exception as exc:  # never break a sanction on a cache miss
-            logger.debug("Global sanction cache invalidation failed: %s", exc)
+            # Warning, not debug: a stale global level keeps answering the old
+            # verdict until the TTL expires, and nothing else reports it.
+            logger.warning("Global sanction cache invalidation failed for %s %s: %s",
+                           spec.subject_type.value, subject_id, exc)
 
     async def record_sanction(
         self,
@@ -266,4 +269,11 @@ class CaseService:
                 reference=reference, revoked=revoked,
             )
         except Exception as exc:
-            logger.debug("Server-log mirror failed for a %s sanction: %s", action, exc)
+            # Nobody is waiting on the mirror, but a server silently losing its
+            # moderation logs is a bug, not a debug line: give it an error code.
+            from cogs.error_handler import report_error
+            await report_error(
+                self.bot, exc, source="CaseService:mirror_to_server_logs",
+                guild=self.bot.get_guild(int(scope_id)) if scope_id else None,
+                error_type="Service Error",
+            )

--- a/services/expiration_notifier.py
+++ b/services/expiration_notifier.py
@@ -57,7 +57,15 @@ class ExpirationNotifier:
                 if await self.handle(row):
                     sent += 1
             except Exception as exc:  # never let one row break the sweep
-                logger.error("Error handling expired sanction: %s", exc, exc_info=True)
+                # A sanction that never expires for real (no unban, no DM) is
+                # exactly the kind of failure that has to leave a trace: the
+                # sweep moves on, the central pipeline keeps the evidence.
+                from cogs.error_handler import report_error
+                await report_error(
+                    self.bot, exc,
+                    source=f"ExpirationNotifier:{row.get('action') or 'sanction'}",
+                    error_type="Service Error",
+                )
         return sent
 
     async def handle(self, row: Dict[str, Any]) -> bool:

--- a/services/global_sanction_service.py
+++ b/services/global_sanction_service.py
@@ -325,8 +325,15 @@ class GlobalSanctionService:
             try:
                 await self._execute(row)
             except Exception as exc:
-                logger.error("[Enforcement] Execution failed for group %s: %s",
-                             row.get("group_id"), exc, exc_info=True)
+                # A background sweep: nobody is waiting, but a group whose
+                # consequences never ran is invisible unless it is reported
+                # through the central pipeline (Sentry + internal log + code).
+                from cogs.error_handler import report_error
+                await report_error(
+                    self.bot, exc,
+                    source=f"GlobalSanctions:enforce:{row.get('group_id')}",
+                    error_type="Service Error",
+                )
         return len(due)
 
     async def _execute(self, row: Dict[str, Any]) -> None:
@@ -587,7 +594,9 @@ class GlobalSanctionService:
             sub = await get_subscription(self.bot, int(user_id))
             return bool(sub and sub.get("is_active"))
         except Exception as exc:
-            logger.debug("[GlobalSanction] Premium lookup failed for %s: %s", user_id, exc)
+            # Falling back to "not premium" only costs a warning line in the
+            # notice, but the lookup failing at all is worth seeing.
+            logger.warning("[GlobalSanction] Premium lookup failed for %s: %s", user_id, exc)
             return False
 
     async def _log_group_event(
@@ -604,7 +613,9 @@ class GlobalSanctionService:
                     content=content, payload={"kind": kind},
                 )
             except Exception as exc:
-                logger.debug("[GlobalSanction] Timeline event failed: %s", exc)
+                # The audit trail losing an entry silently is worse than noisy.
+                logger.warning("[GlobalSanction] Timeline event failed for case %s: %s",
+                               case.get("id"), exc)
 
     async def _publish(self, event_type: str, payload: Dict[str, Any]) -> None:
         """Publish a global-sanction event for the backend (fire-and-forget)."""

--- a/services/support_request_service.py
+++ b/services/support_request_service.py
@@ -118,7 +118,14 @@ class SupportRequestService:
                 locale=locale, subject=subject, body=body, details=details,
             )
         except Exception as exc:  # noqa: BLE001
-            logger.error("Failed to record support request: %s", exc, exc_info=True)
+            # The caller tells the user to use the support server instead, which
+            # is the right message — but the failure behind it still needs an
+            # error code, a Sentry capture and an internal log entry.
+            from cogs.error_handler import report_error
+            await report_error(
+                self.bot, exc, source=f"SupportRequests:open:{kind}",
+                user=user, guild=guild, error_type="Service Error",
+            )
             return None
 
         if request:

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -135,7 +135,14 @@ class TicketService:
         try:
             return await self.bot.module_manager.get_module_instance(guild_id, MODULE_ID)
         except Exception as e:
-            logger.error(f"[Tickets] Could not load module for guild {guild_id}: {e}")
+            # Callers read ``None`` as "tickets are not configured here", so a
+            # load failure would look to the server like the feature simply
+            # being off. Report it centrally instead of guessing.
+            from cogs.error_handler import report_error
+            await report_error(
+                self.bot, e, source="TicketService:get_module",
+                guild=self.bot.get_guild(guild_id), error_type="Service Error",
+            )
             return None
 
     async def get_ticket(self, channel_id: int) -> Optional[Dict[str, Any]]:

--- a/staff/commands/com/beta.py
+++ b/staff/commands/com/beta.py
@@ -56,6 +56,8 @@ class ComBetaCommand(StaffCommand):
     name = "beta"
     permission = "broadcast"
     description = "Send the beta-launch announcement to server owners."
+    # Answers with a Modal: Discord refuses one on a deferred interaction.
+    opens_modal = True
     options = [
         SlashOption("target", "string", "Who receives it.", required=True,
                     choices=["preview", "test", "owners"]),

--- a/staff/commands/com/beta.py
+++ b/staff/commands/com/beta.py
@@ -82,6 +82,13 @@ class ComBetaCommand(StaffCommand):
         recipient = (ctx.opt("recipient") or "").strip()
         exclude_guilds = (ctx.opt("exclude_guilds") or "").strip()
 
+        # ``opens_modal`` keeps the interaction fresh for the ``owners``
+        # confirmation modal — but every other branch answers with a panel
+        # after real work (a user fetch, a whole test DM), which would blow
+        # past the 3-second window. Those branches acknowledge first.
+        if target != "owners":
+            await ctx.defer()
+
         if target not in ("preview", "test", "owners"):
             await ctx.send(view=design.invalid_usage(
                 ctx.locale, "com.beta <preview|test|owners> [user_id]"))
@@ -331,7 +338,20 @@ async def _start(interaction: discord.Interaction, ctx,
             except discord.HTTPException:
                 pass
         except Exception as exc:  # noqa: BLE001 — a background task must not die silently
-            logger.error("Beta announcement failed: %s", exc, exc_info=True)
+            # Nothing above catches this and the sender is watching a progress
+            # panel that would otherwise freeze forever: report it centrally and
+            # replace the panel with the resulting error code.
+            from cogs.error_handler import ErrorView, report_error
+            error_code = await report_error(
+                ctx.bot, exc, source="Staff:com.beta", user=ctx.author,
+                guild=ctx.guild, channel=ctx.channel,
+                error_type="Staff Command Error",
+            )
+            if error_code:
+                try:
+                    await interaction.edit_original_response(view=ErrorView(error_code))
+                except discord.HTTPException:
+                    pass
 
     asyncio.create_task(_run())
 

--- a/staff/commands/com/send.py
+++ b/staff/commands/com/send.py
@@ -31,6 +31,7 @@ from staff.commands.com._send_modal import NotificationComposeModal
 from staff.framework.views import ConfirmView
 from utils import emojis
 from utils.i18n import t
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger("moddy.staff.com.send")
 
@@ -78,10 +79,18 @@ class ComSendCommand(StaffCommand):
                 ctx.locale, "com.send <user|guild|users|guilds> <id|segment> [dm_owner]"))
             return
 
-        audience, error = await _resolve_audience(ctx.bot, target, recipient, ctx.locale)
-        if error is not None:
-            await ctx.send(view=error)
-            return
+        # Resolving the audience costs a user fetch or a segment query. On the
+        # slash transport that has to wait: this command is ``opens_modal``, so
+        # the interaction is still unacknowledged and the composer must go out
+        # inside Discord's 3-second window. ``_handle_composed`` resolves it on
+        # the modal's own interaction instead. The message transport has no such
+        # window, and its prompt names the audience, so it resolves up front.
+        audience = None
+        if not ctx.is_slash:
+            audience, error = await _resolve_audience(ctx.bot, target, recipient, ctx.locale)
+            if error is not None:
+                await ctx.send(view=error)
+                return
 
         async def _composed(interaction: discord.Interaction, payload: Dict[str, Any]):
             await _handle_composed(
@@ -155,6 +164,9 @@ async def _resolve_audience(bot, target: str, recipient: str, locale: str
 
 
 def _audience_label(target: str, recipient: str, audience: Any) -> str:
+    """Name the audience for the prompt — ``audience`` may not be resolved yet."""
+    if audience is None:
+        return f"`{recipient}`"
     if target in ("user", "guild"):
         name = getattr(audience, "name", None) or getattr(audience, "display_name", recipient)
         return f"{name} (`{getattr(audience, 'id', recipient)}`)"
@@ -180,14 +192,29 @@ def _build_content(payload: Dict[str, Any]) -> NotificationContent:
 async def _handle_composed(interaction: discord.Interaction, ctx, *, target: str,
                            recipient: str, audience: Any, dm_owner: bool,
                            payload: Dict[str, Any]) -> None:
-    """Single targets go out immediately; group targets are confirmed first."""
+    """Single targets go out immediately; group targets are confirmed first.
+
+    ``audience`` is ``None`` when the command opened the composer before
+    resolving it (the slash path): this interaction is fresh, so the lookup
+    happens here, behind a defer.
+    """
     locale = ctx.locale
+    # One defer for every branch: the audience lookup and the sends that follow
+    # all outlast the window, and a deferred interaction still answers through
+    # `followup` — the confirmation prompt included.
+    await safe_defer(interaction, ephemeral=True, thinking=True)
+
+    if audience is None:
+        audience, error = await _resolve_audience(ctx.bot, target, recipient, locale)
+        if error is not None:
+            await interaction.followup.send(view=error, ephemeral=True)
+            return
+
     content = _build_content(payload)
     source = NotificationSource.service(
         "moddy", author=ContentAuthor.STAFF, actor_id=interaction.user.id)
 
     if target == "user":
-        await interaction.response.defer(ephemeral=True, thinking=True)
         result = await ctx.bot.notifications.send_dm(
             audience, content=content, source=source, locale=locale)
         await interaction.followup.send(view=_single_result(
@@ -195,7 +222,6 @@ async def _handle_composed(interaction: discord.Interaction, ctx, *, target: str
         return
 
     if target == "guild":
-        await interaction.response.defer(ephemeral=True, thinking=True)
         results = await ctx.bot.notifications.notify_guild(
             audience, content=content, source=source, dm_owner=dm_owner)
         delivered = [r for r in results if r.delivered]
@@ -229,7 +255,7 @@ async def _handle_composed(interaction: discord.Interaction, ctx, *, target: str
             i, ctx, target=target, recipient=recipient, audience=audience,
             content=content, source=source, dm_owner=dm_owner, locale=locale),
     )
-    await interaction.response.send_message(view=confirm, ephemeral=True)
+    await interaction.followup.send(view=confirm, ephemeral=True)
 
 
 def _single_result(result, *, name: str, locale: str) -> BaseView:
@@ -279,7 +305,20 @@ async def _start_broadcast(interaction: discord.Interaction, ctx, *, target: str
             except discord.HTTPException:
                 pass
         except Exception as exc:  # noqa: BLE001 — a background task must not die silently
-            logger.error("Broadcast failed: %s", exc, exc_info=True)
+            # Same reasoning as the progress edits above: the sender is watching
+            # a panel that would otherwise never finish, so the failure gets an
+            # error code they can quote instead of a silent log line.
+            from cogs.error_handler import ErrorView, report_error
+            error_code = await report_error(
+                ctx.bot, exc, source="Staff:com.send", user=ctx.author,
+                guild=ctx.guild, channel=ctx.channel,
+                error_type="Staff Command Error",
+            )
+            if error_code:
+                try:
+                    await interaction.edit_original_response(view=ErrorView(error_code))
+                except discord.HTTPException:
+                    pass
 
     asyncio.create_task(_run())
     return _progress_panel({"total": 0, "sent": 0, "failed": 0},

--- a/staff/commands/com/send.py
+++ b/staff/commands/com/send.py
@@ -200,8 +200,8 @@ async def _handle_composed(interaction: discord.Interaction, ctx, *, target: str
     """
     locale = ctx.locale
     # One defer for every branch: the audience lookup and the sends that follow
-    # all outlast the window, and a deferred interaction still answers through
-    # `followup` — the confirmation prompt included.
+    # all outlast the 3-second window, and a deferred interaction still answers
+    # — through `followup`, or by editing the placeholder it just put up.
     await safe_defer(interaction, ephemeral=True, thinking=True)
 
     if audience is None:
@@ -255,7 +255,9 @@ async def _handle_composed(interaction: discord.Interaction, ctx, *, target: str
             i, ctx, target=target, recipient=recipient, audience=audience,
             content=content, source=source, dm_owner=dm_owner, locale=locale),
     )
-    await interaction.followup.send(view=confirm, ephemeral=True)
+    # Edit, not followup: the defer above already put a placeholder in front of
+    # the sender, and the confirmation belongs in it rather than beside it.
+    await interaction.edit_original_response(view=confirm)
 
 
 def _single_result(result, *, name: str, locale: str) -> BaseView:

--- a/staff/commands/com/send.py
+++ b/staff/commands/com/send.py
@@ -48,6 +48,8 @@ class ComSendCommand(StaffCommand):
     name = "send"
     permission = "broadcast"
     description = "Send a Moddy notification to a user, a server, or a group of them."
+    # Answers with a Modal: Discord refuses one on a deferred interaction.
+    opens_modal = True
     options = [
         SlashOption("target", "string", "Who receives it.", required=True,
                     choices=["user", "guild", "users", "guilds"]),

--- a/staff/commands/dev/error.py
+++ b/staff/commands/dev/error.py
@@ -1,10 +1,13 @@
 """`/dev error` — look up a logged error by its code (cache + database)."""
 
+import logging
 from datetime import datetime
 
 from staff.framework import StaffCommand, SlashOption, staff_command, design, CommandType
 from utils import emojis
 from utils.i18n import t
+
+logger = logging.getLogger("moddy.staff.dev.error")
 
 
 @staff_command
@@ -36,7 +39,10 @@ class ErrorCommand(StaffCommand):
         if bot.db:
             try:
                 db_error = await bot.db.get_error(code)
-            except Exception:
+            except Exception as exc:
+                # Falling through to the cache is right, but "not found" must
+                # not be the only trace of a database that refused to answer.
+                logger.warning("Error lookup failed for %s: %s", code, exc)
                 db_error = None
 
         if not cached and not db_error:

--- a/staff/commands/dev/jsk.py
+++ b/staff/commands/dev/jsk.py
@@ -101,6 +101,8 @@ class JskCommand(StaffCommand):
     aliases = ("jsk",)
     description = "Evaluate Python code in the bot runtime."
     sensitive = True
+    # Answers with a Modal: Discord refuses one on a deferred interaction.
+    opens_modal = True
 
     async def execute(self, ctx):
         # Message command with inline code -> run directly.

--- a/staff/commands/manage/redirect/add.py
+++ b/staff/commands/manage/redirect/add.py
@@ -14,6 +14,8 @@ class RedirectAddCommand(StaffCommand):
     name = "add"
     permission = "redirect_manage"
     description = "Create a redirect link."
+    # Answers with a Modal: Discord refuses one on a deferred interaction.
+    opens_modal = True
 
     async def execute(self, ctx):
         await ctx.open_modal(

--- a/staff/commands/manage/redirect/edit.py
+++ b/staff/commands/manage/redirect/edit.py
@@ -14,6 +14,8 @@ class RedirectEditCommand(StaffCommand):
     name = "edit"
     permission = "redirect_manage"
     description = "Edit a redirect link."
+    # Answers with a Modal: Discord refuses one on a deferred interaction.
+    opens_modal = True
     options = [
         SlashOption("id", "integer", "Redirect id.", required=True),
     ]

--- a/staff/commands/mod/case/edit.py
+++ b/staff/commands/mod/case/edit.py
@@ -17,6 +17,8 @@ class CaseEditCommand(StaffCommand):
     name = "edit"
     permission = "case_edit"
     description = "Edit the reason of a moderation case."
+    # Answers with a Modal: Discord refuses one on a deferred interaction.
+    opens_modal = True
     options = [
         SlashOption("reference", "string", "The public case reference.", required=True),
     ]

--- a/staff/commands/mod/case/note.py
+++ b/staff/commands/mod/case/note.py
@@ -17,6 +17,8 @@ class CaseNoteCommand(StaffCommand):
     name = "note"
     permission = "case_note"
     description = "Add a comment or internal note to a case timeline."
+    # Answers with a Modal: Discord refuses one on a deferred interaction.
+    opens_modal = True
     options = [
         SlashOption("reference", "string", "The public case reference.", required=True),
         SlashOption(

--- a/staff/commands/mod/global_sanction/apply.py
+++ b/staff/commands/mod/global_sanction/apply.py
@@ -24,6 +24,8 @@ class GlobalApplyCommand(StaffCommand):
     name = "apply"
     permission = "global_sanction"
     description = "Apply a global sanction to a user and/or servers (one group)."
+    # Answers with a Modal: Discord refuses one on a deferred interaction.
+    opens_modal = True
     options = [
         SlashOption("user", "user", "The sanctioned user.", required=False),
         SlashOption("guilds", "string",

--- a/staff/commands/mod/global_sanction/halt.py
+++ b/staff/commands/mod/global_sanction/halt.py
@@ -25,6 +25,8 @@ class GlobalHaltCommand(StaffCommand):
     name = "halt"
     permission = "global_enforcement"
     description = "Stop the enforcement countdown of a group (appeal received)."
+    # Answers with a Modal: Discord refuses one on a deferred interaction.
+    opens_modal = True
     options = [
         SlashOption("target", "string",
                     "Group id, or any case reference inside it.", required=True),

--- a/staff/commands/mod/global_sanction/resume.py
+++ b/staff/commands/mod/global_sanction/resume.py
@@ -27,6 +27,8 @@ class GlobalResumeCommand(StaffCommand):
     name = "resume"
     permission = "global_enforcement"
     description = "Restart the enforcement countdown of a group (appeal refused)."
+    # Answers with a Modal: Discord refuses one on a deferred interaction.
+    opens_modal = True
     options = [
         SlashOption("target", "string",
                     "Group id, or any case reference inside it.", required=True),

--- a/staff/commands/mod/interserver_delete.py
+++ b/staff/commands/mod/interserver_delete.py
@@ -89,6 +89,11 @@ async def _purge(bot, data) -> int:
         if channel:
             original = await channel.fetch_message(data["original_message_id"])
             await original.delete()
-    except Exception:
-        pass
+    except discord.NotFound:
+        pass  # already gone — that is the desired end state
+    except Exception as exc:
+        # The relayed copies are already deleted; leaving the original behind
+        # silently is what made this look like a successful purge.
+        logger.warning("Error deleting the original message %s: %s",
+                       data.get("original_message_id"), exc)
     return deleted

--- a/staff/commands/team/subscription.py
+++ b/staff/commands/team/subscription.py
@@ -15,8 +15,6 @@ from staff.framework import badges
 from utils import emojis
 from utils.i18n import t
 
-logger = logging.getLogger("moddy.staff.team.subscription")
-
 
 @staff_command
 class SubscriptionCommand(StaffCommand):
@@ -54,8 +52,16 @@ class SubscriptionCommand(StaffCommand):
             sub = await get_subscription(bot, user_id)
             servers = await bot.db.get_subscription_servers(user_id) if bot.db else []
         except Exception as exc:
-            logger.error("subscription fetch error for %s: %s", user_id, exc, exc_info=True)
-            await ctx.send(view=design.error(
+            # Any failure here is unexpected (Redis, backend, DB): give it an
+            # error code so the reader can quote it, and keep the specific
+            # wording only as the fallback when no code could be generated.
+            from cogs.error_handler import ErrorView, report_error
+            error_code = await report_error(
+                bot, exc, source="Staff:t.subscription", user=ctx.author,
+                guild=ctx.guild, channel=ctx.channel,
+                error_type="Staff Command Error",
+            )
+            await ctx.send(view=ErrorView(error_code) if error_code else design.error(
                 t("staff.common.error.title", locale=locale),
                 t("staff.team.subscription.fetch_fail", locale=locale),
             ))

--- a/staff/communication_commands.py
+++ b/staff/communication_commands.py
@@ -16,6 +16,7 @@ from utils.components_v2 import create_error_message, create_info_message
 from utils.emojis import EMOJIS
 from utils.staff_logger import staff_logger
 from staff.base import StaffCommandsCog
+from cogs.error_handler import ErrorView, report_error
 
 logger = logging.getLogger('moddy.communication_commands')
 
@@ -58,15 +59,40 @@ class CommunicationCommands(StaffCommandsCog):
             await self.reply_with_tracking(message, view)
             return
 
-        # Route to appropriate command
-        if command_name == "help":
-            await self.handle_help_command(message, args)
-        else:
-            view = create_error_message(
-                "Unknown Command",
-                f"Communication command `{command_name}` not found.\n\nCommunication commands are in development."
+        # `com.send` and `com.beta` live in the new framework, which answers
+        # them from its own router. Without this check the migrated commands
+        # would also get an "unknown command" reply from here.
+        router = self.bot.get_cog("StaffCommandsRouter")
+        if router is not None and router.is_migrated(command_type.value, command_name):
+            return
+
+        # A message listener has no global error handler behind it: an
+        # unexpected failure here would vanish into discord.py's dispatch log
+        # and leave the author with no answer at all. Route it through the same
+        # central pipeline every other command uses, and show the error code.
+        try:
+            if command_name == "help":
+                await self.handle_help_command(message, args)
+            else:
+                view = create_error_message(
+                    "Unknown Command",
+                    f"Communication command `{command_name}` not found.\n\nCommunication commands are in development."
+                )
+                await self.reply_with_tracking(message, view)
+        except Exception as exc:
+            error_code = await report_error(
+                self.bot, exc, source=f"Staff:com.{command_name}",
+                user=message.author, guild=message.guild, channel=message.channel,
+                error_type="Staff Command Error",
             )
-            await self.reply_with_tracking(message, view)
+            view = ErrorView(error_code) if error_code else create_error_message(
+                "Error", "An unexpected error occurred."
+            )
+            try:
+                await self.reply_with_tracking(message, view)
+            except discord.HTTPException as send_error:
+                logger.error("CRITICAL: could not show the error card for com.%s: %s",
+                             command_name, send_error)
 
     async def handle_help_command(self, message: discord.Message, args: str):
         """

--- a/staff/framework/cog.py
+++ b/staff/framework/cog.py
@@ -13,6 +13,7 @@ Responsibilities:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import discord
@@ -163,15 +164,28 @@ class StaffCommandsRouter(StaffCommandsCog):
 
     # --- shared invocation -------------------------------------------------
 
+    async def _audit(self, command, ctx: StaffContext) -> None:
+        """Write the staff audit entry, off the command's critical path."""
+        try:
+            await staff_logger.log_command(
+                command.command_type.value, command.name, ctx.author,
+                args=command.log_args(ctx), target_server=ctx.guild,
+            )
+        except Exception as exc:  # logging must never break a command
+            # Warning, not debug: a silent audit gap is exactly what an
+            # investigation later needs to know about.
+            logger.warning("Staff audit log failed for %s.%s (user=%s): %s",
+                           command.command_type.value, command.name,
+                           getattr(ctx.author, "id", None), exc)
+
     async def _invoke(self, command, ctx: StaffContext):
+        # The audit entry goes out through a Discord webhook. Awaiting it here
+        # would spend part of the 3-second window that a modal command still
+        # needs (the router deliberately leaves those interactions
+        # unacknowledged), and no command depends on its result — so it runs
+        # beside the command instead of in front of it.
         if staff_logger:
-            try:
-                await staff_logger.log_command(
-                    command.command_type.value, command.name, ctx.author,
-                    args=command.log_args(ctx), target_server=ctx.guild,
-                )
-            except Exception as exc:  # pragma: no cover - logging must never break commands
-                logger.debug("staff log failed for %s.%s: %s", command.command_type.value, command.name, exc)
+            asyncio.create_task(self._audit(command, ctx))
 
         try:
             await command.execute(ctx)

--- a/staff/framework/cog.py
+++ b/staff/framework/cog.py
@@ -39,6 +39,10 @@ class StaffCommandsRouter(StaffCommandsCog):
         self.message_index = {}
         self.subgroup_index = {}
         self.groups = []
+        # Strong references to the fire-and-forget audit tasks. asyncio only
+        # holds a weak one, so without this the event loop may garbage-collect
+        # an audit write mid-flight and the entry silently never lands.
+        self._audit_tasks: set = set()
         # Types fully owned by the new framework. Message commands of these
         # types are handled here; legacy cogs keep handling the rest.
         self.owned_types = set()
@@ -190,7 +194,9 @@ class StaffCommandsRouter(StaffCommandsCog):
         # unacknowledged), and no command depends on its result — so it runs
         # beside the command instead of in front of it.
         if staff_logger:
-            asyncio.create_task(self._audit(command, ctx))
+            task = asyncio.create_task(self._audit(command, ctx))
+            self._audit_tasks.add(task)
+            task.add_done_callback(self._audit_tasks.discard)
 
         try:
             await command.execute(ctx)

--- a/staff/framework/cog.py
+++ b/staff/framework/cog.py
@@ -135,7 +135,12 @@ class StaffCommandsRouter(StaffCommandsCog):
 
         try:
             options = command.parse_message(raw_args)
-        except Exception:
+        except Exception as exc:
+            # Empty options make the command answer with its usage panel, which
+            # is the right thing for a malformed argument — but a parser that
+            # raises on a valid one would otherwise never be noticed.
+            logger.warning("parse_message failed for %s.%s (%r): %s",
+                           command.command_type.value, command.name, raw_args, exc)
             options = {}
         ctx = StaffContext.from_message(self.bot, command, message, options, raw_args, cog=self)
         await self._invoke(command, ctx)

--- a/staff/framework/cog.py
+++ b/staff/framework/cog.py
@@ -24,6 +24,8 @@ from staff.framework.context import StaffContext
 from utils.staff_permissions import staff_permissions, CommandType
 from utils.staff_logger import staff_logger
 from utils.i18n import t
+from utils.interaction_response import deliver, safe_defer
+from cogs.error_handler import report_error, ErrorView
 
 logger = logging.getLogger("moddy.staff.router")
 
@@ -140,12 +142,22 @@ class StaffCommandsRouter(StaffCommandsCog):
     # --- slash transport ---------------------------------------------------
 
     async def _run_slash(self, command, interaction: discord.Interaction, options: dict, incognito: bool):
-        allowed, reason = await self._has_permission(command, interaction.user.id)
         ctx = StaffContext.from_interaction(self.bot, command, interaction, options, incognito, cog=self)
+
+        # Acknowledge FIRST, before the permission lookup and the audit write.
+        # Both hit the database, and either one can outlast the 3-second
+        # window Discord gives an interaction — after which every call on it
+        # fails with 10062 and the user only ever sees "the application did
+        # not respond". Commands that answer with a Modal are the exception:
+        # Discord refuses a modal on an acknowledged interaction, so they are
+        # left fresh and must stay fast.
+        if not command.opens_modal:
+            await safe_defer(interaction, ephemeral=incognito, thinking=True)
+
+        allowed, reason = await self._has_permission(command, interaction.user.id)
         if not allowed:
-            await interaction.response.send_message(
-                view=design.permission_denied(ctx.locale, reason), ephemeral=True
-            )
+            await deliver(interaction, view=design.permission_denied(ctx.locale, reason),
+                          ephemeral=True)
             return
         await self._invoke(command, ctx)
 
@@ -164,19 +176,37 @@ class StaffCommandsRouter(StaffCommandsCog):
         try:
             await command.execute(ctx)
         except Exception as exc:
-            logger.error("Error in staff command %s.%s: %s",
-                         command.command_type.value, command.name, exc, exc_info=True)
-            # For a not-yet-answered slash, let the global handler produce the
-            # standard error view (and capture to Sentry).
+            # For a not-yet-answered slash, let the global app-command handler
+            # produce the standard error view (and capture to Sentry).
             if ctx.is_slash and not ctx.interaction.response.is_done():
                 raise
+            # Otherwise the interaction is already acknowledged (the router
+            # defers up front) or this is a message command, so no global
+            # handler will ever see this exception. Run the same central
+            # pipeline by hand and show the user the resulting error code —
+            # a bare "an error occurred" with nothing to trace is not an
+            # acceptable answer.
+            error_code = await report_error(
+                self.bot, exc,
+                source=f"Staff:{command.command_type.value}.{command.name}",
+                user=ctx.author, guild=ctx.guild, channel=ctx.channel,
+                error_type="Staff Command Error",
+            )
             try:
-                await ctx.send(view=design.error(
-                    t("staff.common.error.title", locale=ctx.locale),
-                    t("staff.common.error.description", locale=ctx.locale),
-                ))
-            except Exception:
-                pass
+                if error_code:
+                    view = ErrorView(error_code)
+                else:
+                    view = design.error(
+                        t("staff.common.error.title", locale=ctx.locale),
+                        t("staff.common.error.description", locale=ctx.locale),
+                    )
+                if ctx.is_slash:
+                    await deliver(ctx.interaction, view=view, ephemeral=ctx.incognito)
+                else:
+                    await ctx.send(view=view)
+            except Exception as send_error:
+                logger.error("CRITICAL: could not show the error card for %s.%s: %s",
+                             command.command_type.value, command.name, send_error)
 
 
 async def setup(bot):

--- a/staff/framework/command.py
+++ b/staff/framework/command.py
@@ -80,6 +80,14 @@ class StaffCommand:
     permission: Optional[str] = None
     #: Redact arguments in the staff audit log (for ``sql`` / ``jsk``).
     sensitive: bool = False
+    #: Set to ``True`` when the command answers a slash invocation by opening
+    #: a Modal. Discord only accepts a modal on a *fresh* interaction, so the
+    #: router must not acknowledge it early for these commands. Every other
+    #: command is deferred by the router before any awaited work, which is
+    #: what keeps a slow permission lookup or audit write from burning the
+    #: 3-second window and turning the reply into "the application did not
+    #: respond" (10062).
+    opens_modal: bool = False
 
     def __init__(self, bot):
         self.bot = bot

--- a/staff/framework/context.py
+++ b/staff/framework/context.py
@@ -15,6 +15,7 @@ locale and an ``incognito`` flag, plus transport-agnostic helpers:
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable, Dict, Optional
 
 import discord
@@ -22,7 +23,10 @@ from discord import ui
 
 from utils.i18n import t
 from utils import emojis
+from utils.interaction_response import deliver, safe_defer
 from cogs.error_handler import BaseView
+
+logger = logging.getLogger("moddy.staff.context")
 
 
 def resolve_message_locale(bot, user_id: int, guild: Optional[discord.Guild]) -> str:
@@ -117,27 +121,57 @@ class StaffContext:
 
     async def send(self, view: Optional[ui.LayoutView] = None,
                    content: Optional[str] = None) -> Optional[discord.Message]:
-        """Send the first/follow-up response and return the message."""
+        """Send the first/follow-up response and return the message.
+
+        Returns the sent message when the transport hands one back, so callers
+        can keep editing it. A failure on the reply path never propagates: the
+        answer falls back to :func:`deliver`, which walks every remaining
+        transport (up to a plain channel message) rather than turning a
+        finished command into a second, traceless error.
+        """
         if self.is_slash:
-            if self.interaction.response.is_done():
-                return await self.interaction.followup.send(
-                    content=content, view=view, ephemeral=self.incognito, wait=True
+            try:
+                if self.interaction.response.is_done():
+                    return await self.interaction.followup.send(
+                        content=content, view=view, ephemeral=self.incognito, wait=True
+                    )
+                await self.interaction.response.send_message(
+                    content=content, view=view, ephemeral=self.incognito
                 )
-            await self.interaction.response.send_message(
-                content=content, view=view, ephemeral=self.incognito
-            )
+            except discord.HTTPException:
+                # Dead token, consumed response, expired followup… `deliver`
+                # knows every way out; there is simply no message to return.
+                await deliver(self.interaction, view=view, content=content,
+                              ephemeral=self.incognito)
+                return None
+            # Sent, but fetching the handle can still fail — the user has the
+            # answer either way, so this only costs the caller the edit handle.
             try:
                 return await self.interaction.original_response()
             except discord.HTTPException:
                 return None
         # message transport
-        if self.cog is not None and hasattr(self.cog, "reply_with_tracking"):
-            return await self.cog.reply_with_tracking(self.message, view=view, content=content)
-        return await self.message.reply(content=content, view=view, mention_author=False)
+        try:
+            if self.cog is not None and hasattr(self.cog, "reply_with_tracking"):
+                return await self.cog.reply_with_tracking(self.message, view=view, content=content)
+            return await self.message.reply(content=content, view=view, mention_author=False)
+        except discord.HTTPException as exc:
+            # The original message may be gone (deleted mid-command); answering
+            # in the channel is better than losing the reply entirely.
+            logger.warning("Staff reply failed, falling back to the channel: %s", exc)
+            try:
+                return await self.channel.send(content=content, view=view)
+            except discord.HTTPException:
+                return None
 
     async def defer(self, thinking: bool = True):
-        if self.is_slash and not self.interaction.response.is_done():
-            await self.interaction.response.defer(ephemeral=self.incognito, thinking=thinking)
+        """Acknowledge the interaction (no-op when the router already did).
+
+        Never raises: an interaction whose window has already closed is
+        reported by :func:`safe_defer` and handled by :meth:`send`.
+        """
+        if self.is_slash:
+            await safe_defer(self.interaction, ephemeral=self.incognito, thinking=thinking)
 
     async def open_modal(self, modal_factory: Callable[[], discord.ui.Modal], *,
                          label: str, emoji: Optional[str] = None,
@@ -149,8 +183,15 @@ class StaffContext:
         same prompt can be reopened after a failed submit.
         """
         if self.is_slash and not self.interaction.response.is_done():
-            await self.interaction.response.send_modal(modal_factory())
-            return None
+            try:
+                await self.interaction.response.send_modal(modal_factory())
+                return None
+            except discord.HTTPException as exc:
+                # The 3-second window closed, or something else acknowledged
+                # the interaction first. The button below reopens the same
+                # modal on a fresh interaction rather than dropping the command.
+                logger.warning("Could not open the modal for %s, falling back to a button: %s",
+                               getattr(self.command, "name", "?"), exc)
 
         view = _ModalButtonView(
             bot=self.bot,

--- a/staff/support_commands.py
+++ b/staff/support_commands.py
@@ -21,6 +21,7 @@ from utils.emojis import (
 )
 from utils.staff_logger import staff_logger
 from staff.base import StaffCommandsCog
+from cogs.error_handler import ErrorView, report_error
 
 logger = logging.getLogger('moddy.support_commands')
 
@@ -58,16 +59,39 @@ class SupportCommands(StaffCommandsCog):
             await self.reply_with_tracking(message, view)
             return
 
-        if command_name == "help":
-            await self.handle_help_command(message, args)
-        elif command_name == "subscription":
-            await self.handle_subscription_command(message, args)
-        else:
-            view = create_error_message(
-                "Unknown Command",
-                f"Support command `{command_name}` not found.\n\nUse `sup.help` to see available commands."
-            )
+        # A message listener has no global error handler behind it: an
+        # unexpected failure here would vanish into discord.py's dispatch log
+        # and leave the author with no answer at all. Route it through the same
+        # central pipeline every other command uses, and show the error code.
+        try:
+            if command_name == "help":
+                await self.handle_help_command(message, args)
+            elif command_name == "subscription":
+                await self.handle_subscription_command(message, args)
+            else:
+                view = create_error_message(
+                    "Unknown Command",
+                    f"Support command `{command_name}` not found.\n\nUse `sup.help` to see available commands."
+                )
+                await self.reply_with_tracking(message, view)
+        except Exception as exc:
+            await self._report(exc, message, command_name)
+
+    async def _report(self, exc: Exception, message: discord.Message, command_name: str):
+        """Central error pipeline for this legacy cog (no framework behind it)."""
+        error_code = await report_error(
+            self.bot, exc, source=f"Staff:sup.{command_name}",
+            user=message.author, guild=message.guild, channel=message.channel,
+            error_type="Staff Command Error",
+        )
+        view = ErrorView(error_code) if error_code else create_error_message(
+            "Error", "An unexpected error occurred."
+        )
+        try:
             await self.reply_with_tracking(message, view)
+        except discord.HTTPException as send_error:
+            logger.error("CRITICAL: could not show the error card for sup.%s: %s",
+                         command_name, send_error)
 
     async def handle_help_command(self, message: discord.Message, args: str):
         """
@@ -144,7 +168,10 @@ class SupportCommands(StaffCommandsCog):
             return
 
         if staff_logger:
-            await staff_logger.log_command("sup", "subscription", message.author, target_user_id=user_id)
+            # `log_command` takes `args`/`target_user`, never a `target_user_id`:
+            # the old call raised a TypeError before the command even ran.
+            await staff_logger.log_command("sup", "subscription", message.author,
+                                           args=f"user={user_id}")
 
         try:
             try:
@@ -188,14 +215,14 @@ class SupportCommands(StaffCommandsCog):
             view.add_item(container)
             await self.reply_with_tracking(message, view)
 
-        except Exception as e:
-            logger.error(f"Unexpected error in sup.subscription: {e}", exc_info=True)
-            view = create_error_message("Error", "An unexpected error occurred.")
-            await self.reply_with_tracking(message, view)
+        except Exception as exc:
+            # An error code, not a bare "an unexpected error occurred": without
+            # one neither the user nor the team can trace what happened.
+            await self._report(exc, message, "subscription")
             if staff_logger:
                 await staff_logger.log_command(
                     "sup", "subscription", message.author,
-                    target_user_id=user_id, success=False, error=str(e)
+                    args=f"user={user_id}", success=False, error_message=str(exc),
                 )
 
 

--- a/tests/test_interaction_response.py
+++ b/tests/test_interaction_response.py
@@ -1,0 +1,357 @@
+"""Interaction delivery guarantees — `utils/interaction_response.py`.
+
+The contract these tests defend is a single sentence: **an unexpected error
+always reaches the user as Moddy's own card, never as Discord's "the
+application did not respond"**. That failure mode is what this module exists
+to make impossible, so the interesting cases here are all failure cases —
+a dead interaction token (10062), a refused followup, a channel that will
+not accept a message.
+
+Everything is pure Python against stubs; no gateway, no database, no bot.
+
+    pytest tests/test_interaction_response.py -q
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import discord
+import pytest
+
+from utils.interaction_response import (
+    deliver,
+    deliver_out_of_band,
+    is_already_acknowledged,
+    is_expired_interaction,
+    safe_defer,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Stubs
+# --------------------------------------------------------------------------- #
+
+def _http_error(code: int) -> discord.HTTPException:
+    """A `discord.HTTPException` carrying a Discord error code."""
+    response = SimpleNamespace(status=404, reason="Not Found")
+    return discord.HTTPException(response, {"code": code, "message": "boom"})
+
+
+#: The one that used to end the story: the 3-second window elapsed, so every
+#: call on this interaction token fails and nothing can be delivered through it.
+UNKNOWN_INTERACTION = 10062
+ALREADY_ACKNOWLEDGED = 40060
+
+
+class FakeResponse:
+    def __init__(self, *, done=False, defer_error=None, send_error=None):
+        self._done = done
+        self.defer_error = defer_error
+        self.send_error = send_error
+        self.defer_calls = []
+        self.send_calls = []
+
+    def is_done(self):
+        return self._done
+
+    async def defer(self, *, ephemeral=True, thinking=True):
+        self.defer_calls.append({"ephemeral": ephemeral, "thinking": thinking})
+        if self.defer_error:
+            raise self.defer_error
+        self._done = True
+
+    async def send_message(self, *, content=None, view=None, ephemeral=True):
+        self.send_calls.append({"content": content, "view": view, "ephemeral": ephemeral})
+        if self.send_error:
+            raise self.send_error
+        self._done = True
+
+
+class FakeFollowup:
+    def __init__(self, error=None):
+        self.error = error
+        self.calls = []
+
+    async def send(self, *, content=None, view=None, ephemeral=True, wait=False):
+        self.calls.append({"content": content, "view": view, "ephemeral": ephemeral})
+        if self.error:
+            raise self.error
+
+
+class FakeChannel:
+    def __init__(self, error=None):
+        self.error = error
+        self.calls = []
+        self.name = "general"
+
+    async def send(self, *, content=None, view=None, allowed_mentions=None):
+        self.calls.append({"content": content, "view": view})
+        if self.error:
+            raise self.error
+
+
+class FakeInteraction:
+    def __init__(self, *, response=None, followup=None, channel=None,
+                 edit_error=None, itype=None):
+        self.response = response or FakeResponse()
+        self.followup = followup or FakeFollowup()
+        self.channel = channel if channel is not None else FakeChannel()
+        self.user = SimpleNamespace(id=42, mention="<@42>")
+        self.guild_id = 7
+        self.command = SimpleNamespace(qualified_name="stripe trial")
+        self.type = itype or discord.InteractionType.application_command
+        self.edit_error = edit_error
+        self.edit_calls = []
+
+    async def edit_original_response(self, *, content=None, view=None):
+        self.edit_calls.append({"content": content, "view": view})
+        if self.edit_error:
+            raise self.edit_error
+
+
+# --------------------------------------------------------------------------- #
+# Error classification
+# --------------------------------------------------------------------------- #
+
+def test_expired_interaction_is_recognised():
+    assert is_expired_interaction(_http_error(UNKNOWN_INTERACTION))
+    assert not is_expired_interaction(_http_error(ALREADY_ACKNOWLEDGED))
+    assert not is_expired_interaction(ValueError("not an HTTP error"))
+
+
+def test_already_acknowledged_is_recognised():
+    assert is_already_acknowledged(_http_error(ALREADY_ACKNOWLEDGED))
+    assert not is_already_acknowledged(_http_error(UNKNOWN_INTERACTION))
+
+
+# --------------------------------------------------------------------------- #
+# safe_defer
+# --------------------------------------------------------------------------- #
+
+def test_safe_defer_acknowledges():
+    interaction = FakeInteraction()
+    assert asyncio.run(safe_defer(interaction)) is True
+    assert interaction.response.defer_calls == [{"ephemeral": True, "thinking": True}]
+
+
+def test_safe_defer_is_a_noop_when_already_done():
+    interaction = FakeInteraction(response=FakeResponse(done=True))
+    assert asyncio.run(safe_defer(interaction)) is True
+    assert interaction.response.defer_calls == []
+
+
+def test_safe_defer_reports_a_dead_token_instead_of_raising():
+    """The exact `/manage stripe trial` failure: 10062 raised by defer itself."""
+    interaction = FakeInteraction(
+        response=FakeResponse(defer_error=_http_error(UNKNOWN_INTERACTION)))
+    assert asyncio.run(safe_defer(interaction)) is False
+
+
+def test_safe_defer_treats_a_double_acknowledgement_as_success():
+    interaction = FakeInteraction(
+        response=FakeResponse(defer_error=_http_error(ALREADY_ACKNOWLEDGED)))
+    assert asyncio.run(safe_defer(interaction)) is True
+
+
+def test_safe_defer_never_raises_on_an_unexpected_failure():
+    interaction = FakeInteraction(response=FakeResponse(defer_error=RuntimeError("nope")))
+    assert asyncio.run(safe_defer(interaction)) is False
+
+
+def test_thinking_defaults_to_the_interaction_type():
+    """A slash command needs the placeholder; a component re-rendering in
+    place must not get one, or it leaves a stray "thinking…" beside the panel."""
+    slash = FakeInteraction(itype=discord.InteractionType.application_command)
+    asyncio.run(safe_defer(slash))
+    assert slash.response.defer_calls[0]["thinking"] is True
+
+    component = FakeInteraction(itype=discord.InteractionType.component)
+    asyncio.run(safe_defer(component))
+    assert component.response.defer_calls[0]["thinking"] is False
+
+
+def test_explicit_thinking_wins_over_the_default():
+    component = FakeInteraction(itype=discord.InteractionType.component)
+    asyncio.run(safe_defer(component, thinking=True))
+    assert component.response.defer_calls[0]["thinking"] is True
+
+
+# --------------------------------------------------------------------------- #
+# deliver — transport cascade
+# --------------------------------------------------------------------------- #
+
+def test_unacknowledged_interaction_answers_directly():
+    interaction = FakeInteraction()
+    assert asyncio.run(deliver(interaction, content="hi")) is True
+    assert len(interaction.response.send_calls) == 1
+    assert interaction.followup.calls == []
+
+
+def test_acknowledged_interaction_goes_through_followup():
+    interaction = FakeInteraction(response=FakeResponse(done=True))
+    assert asyncio.run(deliver(interaction, content="hi")) is True
+    assert len(interaction.followup.calls) == 1
+
+
+def test_a_refused_followup_falls_back_to_editing():
+    interaction = FakeInteraction(
+        response=FakeResponse(done=True),
+        followup=FakeFollowup(error=_http_error(50027)),  # invalid webhook token
+    )
+    assert asyncio.run(deliver(interaction, content="hi")) is True
+    assert len(interaction.edit_calls) == 1
+
+
+def test_a_dead_token_still_reaches_the_user_in_channel():
+    """The whole point: no interaction transport can work, so post in-channel
+    rather than leave the user on Discord's own failure message."""
+    dead = _http_error(UNKNOWN_INTERACTION)
+    channel = FakeChannel()
+    interaction = FakeInteraction(
+        response=FakeResponse(done=True, send_error=dead),
+        followup=FakeFollowup(error=dead),
+        edit_error=dead,
+        channel=channel,
+    )
+    assert asyncio.run(deliver(interaction, content="boom")) is True
+    assert len(channel.calls) == 1
+    # The invoker is mentioned so the card is not mistaken for a stray message.
+    assert "<@42>" in channel.calls[0]["content"]
+
+
+def test_a_dead_token_short_circuits_the_other_transports():
+    """Once 10062 comes back, retrying the same token is pointless."""
+    dead = _http_error(UNKNOWN_INTERACTION)
+    interaction = FakeInteraction(
+        response=FakeResponse(done=True),
+        followup=FakeFollowup(error=dead),
+        edit_error=dead,
+    )
+    asyncio.run(deliver(interaction, content="boom"))
+    assert interaction.edit_calls == []
+    assert interaction.response.send_calls == []
+
+
+def test_channel_fallback_can_be_refused():
+    dead = _http_error(UNKNOWN_INTERACTION)
+    interaction = FakeInteraction(
+        response=FakeResponse(done=True, send_error=dead),
+        followup=FakeFollowup(error=dead),
+        edit_error=dead,
+    )
+    assert asyncio.run(deliver(interaction, content="boom",
+                               allow_channel_fallback=False)) is False
+
+
+def test_deliver_never_raises_when_every_transport_fails():
+    """A second exception on the error path would silence the first."""
+    dead = _http_error(UNKNOWN_INTERACTION)
+    interaction = FakeInteraction(
+        response=FakeResponse(done=True, send_error=dead),
+        followup=FakeFollowup(error=dead),
+        edit_error=dead,
+        channel=FakeChannel(error=discord.Forbidden(
+            SimpleNamespace(status=403, reason="Forbidden"), "no")),
+    )
+    assert asyncio.run(deliver(interaction, content="boom")) is False
+
+
+def test_deliver_survives_a_non_http_failure():
+    """A transport blowing up in an unforeseen way is just another dead
+    transport — the cascade moves on instead of propagating."""
+    interaction = FakeInteraction(response=FakeResponse(send_error=RuntimeError("nope")))
+    assert asyncio.run(deliver(interaction, content="boom")) is True
+    assert len(interaction.followup.calls) == 1
+
+
+def test_out_of_band_delivery_without_a_channel():
+    """Nothing left to try — the caller learns it, rather than believing the
+    user was reached."""
+    interaction = FakeInteraction()
+    interaction.channel = None
+    assert asyncio.run(deliver_out_of_band(interaction, content="boom")) is False
+
+
+# --------------------------------------------------------------------------- #
+# The incognito preference: the lookup that used to sit in front of the window
+# --------------------------------------------------------------------------- #
+
+class FakeDB:
+    def __init__(self, value=None, error=None, delay=0.0):
+        self.value = value
+        self.error = error
+        self.delay = delay
+        self.calls = 0
+
+    async def get_attribute(self, entity, entity_id, key):
+        self.calls += 1
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if self.error:
+            raise self.error
+        return self.value
+
+
+def _bot(db):
+    return SimpleNamespace(db=db)
+
+
+@pytest.fixture(autouse=True)
+def _clear_incognito_cache():
+    from utils import incognito
+    incognito._cache.clear()
+    yield
+    incognito._cache.clear()
+
+
+def test_incognito_preference_is_cached():
+    """The read used to happen on every command, in front of the 3s window."""
+    from utils.incognito import resolve_incognito
+    db = FakeDB(value=False)
+    assert asyncio.run(resolve_incognito(_bot(db), 1)) is False
+    assert asyncio.run(resolve_incognito(_bot(db), 1)) is False
+    assert db.calls == 1
+
+
+def test_incognito_falls_back_to_private_without_a_preference():
+    from utils.incognito import resolve_incognito
+    assert asyncio.run(resolve_incognito(_bot(FakeDB(value=None)), 1)) is True
+
+
+def test_incognito_default_is_honoured():
+    from utils.incognito import resolve_incognito
+    assert asyncio.run(resolve_incognito(_bot(FakeDB(value=None)), 1, default=False)) is False
+
+
+def test_a_slow_lookup_cannot_eat_the_window():
+    """A hung database degrades the visibility of one reply, never the reply."""
+    from utils import incognito
+    db = FakeDB(value=False, delay=5.0)
+    original = incognito._LOOKUP_TIMEOUT
+    incognito._LOOKUP_TIMEOUT = 0.01
+    try:
+        assert asyncio.run(incognito.resolve_incognito(_bot(db), 1)) is True
+    finally:
+        incognito._LOOKUP_TIMEOUT = original
+    # A timeout is not cached: the next command gets a fresh attempt.
+    assert 1 not in incognito._cache
+
+
+def test_a_failing_lookup_never_raises():
+    from utils.incognito import resolve_incognito
+    db = FakeDB(error=RuntimeError("database is down"))
+    assert asyncio.run(resolve_incognito(_bot(db), 1)) is True
+
+
+def test_no_database_means_the_default():
+    from utils.incognito import resolve_incognito
+    assert asyncio.run(resolve_incognito(SimpleNamespace(db=None), 1)) is True
+
+
+def test_invalidation_forces_a_fresh_read():
+    from utils.incognito import invalidate_incognito, resolve_incognito
+    db = FakeDB(value=False)
+    asyncio.run(resolve_incognito(_bot(db), 1))
+    invalidate_incognito(1)
+    asyncio.run(resolve_incognito(_bot(db), 1))
+    assert db.calls == 2

--- a/utils/appeal_views.py
+++ b/utils/appeal_views.py
@@ -687,6 +687,10 @@ class AppealInviteButton(
 
     @_guarded
     async def callback(self, interaction: discord.Interaction):
+        # The appeal read and the invite creation are two round trips, one of
+        # them a REST call, so acknowledge before either. `appeal_service.invite`
+        # answers through `deliver`, which works on both sides of a defer.
+        await safe_defer(interaction, ephemeral=True)
         locale = i18n.get_user_locale(interaction)
         bot = interaction.client
         appeal = await bot.db.get_appeal(self.appeal_id)

--- a/utils/appeal_views.py
+++ b/utils/appeal_views.py
@@ -41,6 +41,7 @@ from utils.emojis import (
     get_sanction_dm_emoji, get_sanction_accent,
 )
 from utils.automod_render import is_long, make_text_file
+from utils.interaction_response import deliver, safe_defer
 
 logger = logging.getLogger("moddy.appeal_views")
 
@@ -567,8 +568,7 @@ class AppealNewButton(
         existing = await bot.db.get_active_for_sanction(self.sanction_id)
         if existing:
             from utils.components_v2 import create_warning_message
-            await interaction.response.send_message(
-                view=create_warning_message(
+            await deliver(interaction, view=create_warning_message(
                     t("modules.automod_ai.appeal.error.title", locale=locale),
                     t("modules.automod_ai.appeal.error.already", locale=locale),
                 ),
@@ -589,15 +589,15 @@ async def _guard_review(interaction: discord.Interaction, appeal: Optional[dict]
     """Shared gate for reviewer actions: still pending + may review (+ not own)."""
     from utils.components_v2 import create_warning_message, create_error_message
     if not appeal or appeal["status"] != "pending":
-        await interaction.response.send_message(
-            view=create_warning_message(
+        # `deliver` so a guard still reaches the reviewer once the callback
+        # has acknowledged the interaction up front.
+        await deliver(interaction, view=create_warning_message(
                 t("modules.automod_ai.appeal.error.title", locale=locale),
                 t("modules.automod_ai.appeal.error.handled", locale=locale)),
             ephemeral=True)
         return False
     if not await _can_review(interaction, appeal):
-        await interaction.response.send_message(
-            view=create_error_message(
+        await deliver(interaction, view=create_error_message(
                 t("modules.automod_ai.appeal.error.title", locale=locale),
                 t("modules.automod_ai.appeal.error.no_perms", locale=locale)),
             ephemeral=True)
@@ -610,15 +610,13 @@ async def _require_claimer(interaction: discord.Interaction, appeal: dict, local
     from utils.components_v2 import create_warning_message
     claimed_by = appeal.get("claimed_by_id")
     if not claimed_by:
-        await interaction.response.send_message(
-            view=create_warning_message(
+        await deliver(interaction, view=create_warning_message(
                 t("modules.automod_ai.appeal.error.title", locale=locale),
                 t("modules.automod_ai.appeal.error.claim_first", locale=locale)),
             ephemeral=True)
         return False
     if str(claimed_by) != str(interaction.user.id):
-        await interaction.response.send_message(
-            view=create_warning_message(
+        await deliver(interaction, view=create_warning_message(
                 t("modules.automod_ai.appeal.error.title", locale=locale),
                 t("modules.automod_ai.appeal.error.not_claimer", locale=locale)),
             ephemeral=True)
@@ -652,6 +650,11 @@ class AppealClaimButton(
 
     @_guarded
     async def callback(self, interaction: discord.Interaction):
+        # Appeal read + reviewer-permission lookup + the claim write, all
+        # before anything is rendered: acknowledge first. Every response path
+        # downstream (`_ephemeral`, `_rerender_pending_panel`) already handles
+        # an acknowledged interaction.
+        await safe_defer(interaction, ephemeral=True, thinking=False)
         locale = i18n.get_user_locale(interaction)
         bot = interaction.client
         appeal = await bot.db.get_appeal(self.appeal_id)
@@ -691,8 +694,7 @@ class AppealInviteButton(
             return
         if not await _can_review(interaction, appeal):
             from utils.components_v2 import create_error_message
-            await interaction.response.send_message(
-                view=create_error_message(
+            await deliver(interaction, view=create_error_message(
                     t("modules.automod_ai.appeal.error.title", locale=locale),
                     t("modules.automod_ai.appeal.error.no_perms", locale=locale)),
                 ephemeral=True)
@@ -727,6 +729,10 @@ class AppealDecisionButton(
 
     @_guarded
     async def callback(self, interaction: discord.Interaction):
+        # The appeal read and the two guards are database round-trips, and the
+        # binding effects behind a refusal far exceed 3s — acknowledge before
+        # any of it rather than after the guards.
+        await safe_defer(interaction, ephemeral=True, thinking=False)
         locale = i18n.get_user_locale(interaction)
         bot = interaction.client
         appeal = await bot.db.get_appeal(self.appeal_id)
@@ -736,11 +742,9 @@ class AppealDecisionButton(
             return
         if self.decision == "accept":
             # Ask whether to fully cancel or modify the case.
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 view=build_accept_choice_view(self.appeal_id, locale), ephemeral=True)
             return
-        # decline → refuse (binding effects can exceed 3s → ack first)
-        await interaction.response.defer(ephemeral=True)
         await bot.appeals.decide(
             interaction=interaction, appeal_id=self.appeal_id,
             decision="refuse", by_id=interaction.user.id)

--- a/utils/automod_shadow_views.py
+++ b/utils/automod_shadow_views.py
@@ -28,6 +28,7 @@ from discord import ui
 
 from cogs.error_handler import BaseView
 from utils.i18n import t, i18n
+from utils.interaction_response import deliver, safe_defer
 from utils.emojis import SHIELD, SEARCH, DONE, UNDONE, WARNING, get_sanction_accent
 from utils.automod_render import bareme_breakdown, sanction_name
 
@@ -184,6 +185,10 @@ class ShadowAnnotateButton(
 
     @_guarded
     async def callback(self, interaction: discord.Interaction):
+        # The annotation write and the precedent feed both land before the card
+        # is re-rendered — acknowledge first so a slow write cannot cost the
+        # 3s window.
+        await safe_defer(interaction, thinking=False)
         locale = i18n.get_user_locale(interaction)
         bot = interaction.client
 
@@ -191,8 +196,7 @@ class ShadowAnnotateButton(
         perms = getattr(interaction.user, "guild_permissions", None)
         if perms is None or not perms.manage_messages:
             from utils.components_v2 import create_error_message
-            await interaction.response.send_message(
-                view=create_error_message(
+            await deliver(interaction, view=create_error_message(
                     t("modules.automod_ai.shadow.error.title", locale=locale),
                     t("modules.automod_ai.shadow.error.no_perms", locale=locale)),
                 ephemeral=True)
@@ -203,8 +207,7 @@ class ShadowAnnotateButton(
             self.candidate_id, verdict_humain, annotated_by=interaction.user.id)
         if not row:
             from utils.components_v2 import create_error_message
-            await interaction.response.send_message(
-                view=create_error_message(
+            await deliver(interaction, view=create_error_message(
                     t("modules.automod_ai.shadow.error.title", locale=locale),
                     t("modules.automod_ai.shadow.error.gone", locale=locale)),
                 ephemeral=True)
@@ -216,7 +219,7 @@ class ShadowAnnotateButton(
         await self._feed_precedent(bot, row)
 
         # Re-render the card in place (buttons → the recorded ruling).
-        await interaction.response.edit_message(view=render_shadow_card(row))
+        await interaction.edit_original_response(view=render_shadow_card(row))
 
     @staticmethod
     async def _feed_precedent(bot, row: Dict[str, Any]) -> None:

--- a/utils/beta_announcement.py
+++ b/utils/beta_announcement.py
@@ -38,6 +38,7 @@ from cogs.error_handler import BaseView
 from notifications.models import NotificationContent
 from utils.emojis import MODDY_SQUARE_MIN, TRANSLATE
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 from utils.support_request_views import ConfigHelpButton, shorten
 
 logger = logging.getLogger("moddy.beta_announcement")
@@ -142,6 +143,9 @@ class BetaTranslateButton(
 
     async def callback(self, interaction: discord.Interaction):
         try:
+            # The stored notification and its attribution line are two
+            # database reads before the card can be re-rendered.
+            await safe_defer(interaction, thinking=False)
             locale = i18n.get_user_locale(interaction)
             service = getattr(interaction.client, "notifications", None)
             record = await service.get(self.notification_id) if service else None
@@ -155,7 +159,7 @@ class BetaTranslateButton(
             if service is not None:
                 service.append_attribution(
                     view, await service.attribution_line(record, locale))
-            await interaction.response.edit_message(view=view)
+            await interaction.edit_original_response(view=view)
         except Exception as exc:  # noqa: BLE001 — dynamic items have no BaseView
             from cogs.error_handler import report_component_error
             await report_component_error(interaction, exc, self.__class__.__name__)

--- a/utils/cases_views.py
+++ b/utils/cases_views.py
@@ -38,6 +38,7 @@ from cogs.error_handler import BaseView, BaseModal
 from config import COLORS
 from utils import emojis
 from utils.i18n import t
+from utils.interaction_response import deliver, safe_defer
 from utils.moderation_cases import (
     Case,
     CaseType,
@@ -328,9 +329,13 @@ class CasesBrowserView(BaseView):
         )
 
     async def _rehydrate_and_list(self, interaction: discord.Interaction):
+        # `_reload` runs two to three queries; acknowledging afterwards means a
+        # cold database costs the 3s window and the click dies as Discord's
+        # own "did not respond".
+        await safe_defer(interaction, thinking=False)
         view = self._make_live_from_interaction(interaction, self.mode)
         await view._reload()
-        await interaction.response.edit_message(view=view)
+        await interaction.edit_original_response(view=view)
 
     async def _rehydrate_and_detail(self, interaction: discord.Interaction, case_id: str):
         view = self._make_live_from_interaction(interaction, self.mode)
@@ -396,20 +401,27 @@ class CasesBrowserView(BaseView):
 
     async def refresh(self, interaction: Optional[discord.Interaction] = None):
         """Reload data, rebuild, and (if given) edit the live message."""
+        if interaction is not None:
+            # Every page turn and filter change lands here, always behind a
+            # query — acknowledge first, edit after.
+            await safe_defer(interaction, thinking=False)
         await self._reload()
         if interaction is not None:
-            await interaction.response.edit_message(view=self)
+            await interaction.edit_original_response(view=self)
 
     async def show_detail(self, interaction: discord.Interaction, case_id: str):
         """Load a case folder and switch to the detail screen."""
+        # Reached from buttons *and* from modal submits that already wrote to
+        # the database — acknowledge before the folder read either way.
+        await safe_defer(interaction, thinking=False)
         data = await self.bot.db.get_case_by_id(_uuid.UUID(case_id))
         if not data:
-            await interaction.response.send_message(
-                t("commands.cases.error", locale=self.locale), ephemeral=True)
+            await deliver(interaction, content=t(
+                "commands.cases.error", locale=self.locale), ephemeral=True)
             return
         self.detail = Case.from_db(data["case"], data["sanctions"], data["events"])
         self._build_detail()
-        await interaction.response.edit_message(view=self)
+        await interaction.edit_original_response(view=self)
 
     async def open_reference(self, reference: str) -> bool:
         """Render the detail screen for a case given by its public reference.
@@ -860,8 +872,8 @@ class CasesBrowserView(BaseView):
         if self.viewer_id is None:
             return True
         if interaction.user.id != self.viewer_id:
-            await interaction.response.send_message(
-                t("commands.cases.not_yours", locale=self.locale), ephemeral=True)
+            await deliver(interaction, content=t(
+                "commands.cases.not_yours", locale=self.locale), ephemeral=True)
             return False
         return True
 
@@ -930,7 +942,7 @@ class CasesBrowserView(BaseView):
         member = interaction.user
         if isinstance(member, discord.Member) and can_view_server_cases(member):
             return True
-        await interaction.response.send_message(view=_perm_error(self.locale), ephemeral=True)
+        await deliver(interaction, view=_perm_error(self.locale), ephemeral=True)
         return False
 
     async def _on_comment(self, interaction: discord.Interaction):
@@ -972,8 +984,8 @@ class CasesBrowserView(BaseView):
             if _can_issue_action(interaction.user, a)
         ]
         if not allowed:
-            await interaction.response.send_message(
-                t("commands.cases.browser.no_permitted_actions", locale=self.locale),
+            await deliver(interaction, content=t(
+                "commands.cases.browser.no_permitted_actions", locale=self.locale),
                 ephemeral=True)
             return
         await interaction.response.send_modal(
@@ -987,15 +999,15 @@ class CasesBrowserView(BaseView):
             return
         active = [s for s in self.detail.sanctions if s.status == SanctionStatus.ACTIVE]
         if not active:
-            await interaction.response.send_message(
-                t("commands.cases.browser.no_active_sanctions", locale=self.locale),
+            await deliver(interaction, content=t(
+                "commands.cases.browser.no_active_sanctions", locale=self.locale),
                 ephemeral=True)
             return
         # Only sanctions whose kind this member may lift.
         permitted = [s for s in active if _can_issue_action(interaction.user, s.action)]
         if not permitted:
-            await interaction.response.send_message(
-                t("commands.cases.browser.no_permitted_actions", locale=self.locale),
+            await deliver(interaction, content=t(
+                "commands.cases.browser.no_permitted_actions", locale=self.locale),
                 ephemeral=True)
             return
         await interaction.response.send_modal(
@@ -1008,6 +1020,8 @@ class CasesBrowserView(BaseView):
             await self._rehydrate_and_list(interaction)
             return
         case = self.detail
+        # Write then re-read: acknowledge before either.
+        await safe_defer(interaction, thinking=False)
         new_status = "closed" if case.is_open else "open"
         await self.bot.db.set_status_manual(
             _uuid.UUID(case.id), new_status, "discord_user", interaction.user.id,
@@ -1327,17 +1341,21 @@ class CaseAddEvidenceModalV2(BaseModal):
 
     async def on_submit(self, interaction: discord.Interaction):
         loc = self.browser.locale
+        # `fetch_channel` + `fetch_message` are REST round-trips: acknowledge
+        # the submit before them, not after.
+        await safe_defer(interaction, thinking=False)
+
         raw = (self.link.component.value or "").strip()
         match = _MESSAGE_LINK_RE.match(raw)
         if not match:
-            await interaction.response.send_message(
-                t("commands.cases.browser.evidence_link_invalid", locale=loc), ephemeral=True)
+            await deliver(interaction, content=t(
+                "commands.cases.browser.evidence_link_invalid", locale=loc), ephemeral=True)
             return
 
         link_guild_id = match.group("guild_id")
         if self.case.scope_id and link_guild_id != str(self.case.scope_id):
-            await interaction.response.send_message(
-                t("commands.cases.browser.evidence_wrong_server", locale=loc), ephemeral=True)
+            await deliver(interaction, content=t(
+                "commands.cases.browser.evidence_wrong_server", locale=loc), ephemeral=True)
             return
 
         bot = self.browser.bot
@@ -1360,8 +1378,8 @@ class CaseAddEvidenceModalV2(BaseModal):
                     message = None
 
         if message is None:
-            await interaction.response.send_message(
-                t("commands.cases.browser.evidence_message_not_found", locale=loc), ephemeral=True)
+            await deliver(interaction, content=t(
+                "commands.cases.browser.evidence_message_not_found", locale=loc), ephemeral=True)
             return
 
         payload = {
@@ -1444,7 +1462,7 @@ class CaseAddSanctionModalV2(BaseModal):
         action = SanctionAction(self.action_label.component.values[0])
 
         if not isinstance(interaction.user, discord.Member) or not _can_issue_action(interaction.user, action):
-            await interaction.response.send_message(view=_perm_error(self.browser.locale), ephemeral=True)
+            await deliver(interaction, view=_perm_error(self.browser.locale), ephemeral=True)
             return
 
         expires_at = None
@@ -1452,8 +1470,8 @@ class CaseAddSanctionModalV2(BaseModal):
             try:
                 expires_at = _parse_duration_hours(self.duration.component.value)
             except ValueError:
-                await interaction.response.send_message(
-                    t("commands.cases.browser.invalid_duration", locale=self.browser.locale),
+                await deliver(interaction, content=t(
+                    "commands.cases.browser.invalid_duration", locale=self.browser.locale),
                     ephemeral=True)
                 return
 
@@ -1499,7 +1517,7 @@ class CaseRevokeModalV2(BaseModal):
             not isinstance(interaction.user, discord.Member)
             or not _can_issue_action(interaction.user, target.action)
         ):
-            await interaction.response.send_message(view=_perm_error(self.browser.locale), ephemeral=True)
+            await deliver(interaction, view=_perm_error(self.browser.locale), ephemeral=True)
             return
         await self.browser.bot.db.revoke_sanction(
             sanction_id, "discord_user", interaction.user.id)

--- a/utils/global_sanction_views.py
+++ b/utils/global_sanction_views.py
@@ -32,6 +32,7 @@ from utils import emojis
 from utils import global_sanctions as gs
 from utils.global_sanctions import GlobalLevel
 from utils.i18n import t
+from utils.interaction_response import deliver
 
 logger = logging.getLogger('moddy.global_sanction_views')
 
@@ -796,7 +797,10 @@ class GlobalSanctionHaltButton(
         from utils.i18n import i18n
         locale = i18n.get_user_locale(interaction)
         if not await _may_manage(interaction):
-            await interaction.response.send_message(view=_error_panel(
+            # Cannot defer here (the happy path opens a modal), so deliver the
+            # refusal through every transport: the two permission lookups
+            # above may already have cost the acknowledgement window.
+            await deliver(interaction, view=_error_panel(
                 t("global_sanctions.staff.denied_title", locale=locale),
                 t("global_sanctions.staff.denied", locale=locale),
             ), ephemeral=True)
@@ -832,7 +836,7 @@ class GlobalSanctionResumeButton(
         from utils.i18n import i18n
         locale = i18n.get_user_locale(interaction)
         if not await _may_manage(interaction):
-            await interaction.response.send_message(view=_error_panel(
+            await deliver(interaction, view=_error_panel(
                 t("global_sanctions.staff.denied_title", locale=locale),
                 t("global_sanctions.staff.denied", locale=locale),
             ), ephemeral=True)

--- a/utils/incognito.py
+++ b/utils/incognito.py
@@ -3,11 +3,76 @@ Incognito system for Moddy's slash commands
 Allows users to control the visibility of their responses
 """
 
+import asyncio
+import logging
+import time
+
 import discord
 from discord import app_commands
 from typing import Optional
 import functools
 import types
+
+logger = logging.getLogger("moddy.incognito")
+
+# The visibility preference is read before the command body runs, which means
+# it sits in front of the interaction's 3-second acknowledgement window on
+# every single command that carries the option. A cold or contended database
+# there does not degrade the reply — it kills the interaction outright and the
+# user gets Discord's "the application did not respond".
+#
+# So the read is cached and time-boxed. The preference changes rarely (it is
+# set from the dashboard, never by the bot itself), a stale value for a few
+# minutes only means one reply has the wrong visibility, and either failure is
+# incomparably cheaper than a dead interaction.
+_CACHE_TTL = 300.0
+#: Bound the cache so a busy shard cannot grow it without limit.
+_CACHE_MAX = 10_000
+#: Hard ceiling on the lookup. Well under the window, leaving the command room.
+_LOOKUP_TIMEOUT = 1.0
+
+_cache: "dict[int, tuple[float, Optional[bool]]]" = {}
+
+
+def invalidate_incognito(user_id: int) -> None:
+    """Drop a user's cached visibility preference (call after changing it)."""
+    _cache.pop(user_id, None)
+
+
+async def resolve_incognito(bot, user_id: int, default: bool = True) -> bool:
+    """Resolve a user's response visibility, cached and time-boxed.
+
+    Never raises and never blocks for long: on a miss, a timeout or any
+    failure it falls back to ``default``. Private is the safe default — an
+    answer that should have been public is a nuisance, one that should have
+    been private is a leak.
+    """
+    now = time.monotonic()
+    cached = _cache.get(user_id)
+    if cached is not None and now - cached[0] < _CACHE_TTL:
+        return default if cached[1] is None else bool(cached[1])
+
+    db = getattr(bot, "db", None)
+    if not db:
+        return default
+
+    try:
+        pref = await asyncio.wait_for(
+            db.get_attribute("user", user_id, "DEFAULT_INCOGNITO"),
+            timeout=_LOOKUP_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        # Do not cache a timeout: the next command should try again.
+        logger.warning("Incognito preference lookup timed out for user %s", user_id)
+        return default
+    except Exception as exc:
+        logger.warning("Incognito preference lookup failed for user %s: %s", user_id, exc)
+        return default
+
+    if len(_cache) >= _CACHE_MAX:
+        _cache.clear()
+    _cache[user_id] = (now, pref)
+    return default if pref is None else bool(pref)
 
 
 def add_incognito_option(default_value: bool = True):
@@ -25,25 +90,9 @@ def add_incognito_option(default_value: bool = True):
             # IMPORTANT: If incognito is not specified explicitly in the command
             # we check the user's preference
             if incognito is None:
-                # First, check the user attribute for the default preference
-                if hasattr(self, 'bot') and self.bot.db:
-                    try:
-                        # Get the DEFAULT_INCOGNITO preference
-                        user_pref = await self.bot.db.get_attribute('user', interaction.user.id, 'DEFAULT_INCOGNITO')
-
-                        # If the user has a defined preference
-                        if user_pref is not None:
-                            # If DEFAULT_INCOGNITO is False, we want messages to be public by default
-                            incognito = user_pref
-                        else:
-                            # No preference defined, use the default value
-                            incognito = default_value
-                    except Exception as e:
-                        # In case of an error, use the default value
-                        import logging
-                        logger = logging.getLogger('moddy')
-                        logger.error(f"Error getting incognito preference: {e}")
-                        incognito = default_value
+                if hasattr(self, 'bot'):
+                    incognito = await resolve_incognito(
+                        self.bot, interaction.user.id, default_value)
                 else:
                     incognito = default_value
 
@@ -92,4 +141,5 @@ def get_incognito_setting(interaction: discord.Interaction) -> bool:
 
 
 # Export of the main functions
-__all__ = ['add_incognito_option', 'get_incognito_setting']
+__all__ = ['add_incognito_option', 'get_incognito_setting',
+           'resolve_incognito', 'invalidate_incognito']

--- a/utils/interaction_response.py
+++ b/utils/interaction_response.py
@@ -1,0 +1,187 @@
+"""Interaction delivery guarantees.
+
+Discord gives an interaction a 3-second window to receive its *first*
+response, then 15 minutes for follow-ups. Miss the first window and every
+call on that interaction fails with ``10062 Unknown interaction`` — and the
+user is left staring at Discord's own "The application did not respond".
+
+That outcome is never acceptable: an unexpected error must always reach the
+user as Moddy's own error card carrying an error code. This module is the
+single place that knows how to make that true.
+
+Two public helpers:
+
+- :func:`safe_defer` — acknowledge an interaction as early as possible and
+  never explode when the window has already closed.
+- :func:`deliver` — put a view in front of the user no matter the state of
+  the interaction, walking down a cascade of transports until one works
+  (followup → edit → initial response → channel message).
+
+Both are total: they never raise. Callers on an error path can rely on that.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import discord
+
+logger = logging.getLogger("moddy.interactions")
+
+#: Discord error codes meaning "this interaction token is no longer usable".
+#: 10062 — unknown interaction (the 3s acknowledgement window elapsed).
+#: 40060 — interaction has already been acknowledged.
+_EXPIRED_CODES = {10062}
+_ALREADY_ACKED_CODES = {40060}
+
+
+def is_expired_interaction(error: BaseException) -> bool:
+    """True if ``error`` means the interaction token is dead (10062)."""
+    return isinstance(error, discord.HTTPException) and error.code in _EXPIRED_CODES
+
+
+def is_already_acknowledged(error: BaseException) -> bool:
+    """True if ``error`` means the interaction was already acknowledged (40060)."""
+    return isinstance(error, discord.HTTPException) and error.code in _ALREADY_ACKED_CODES
+
+
+async def safe_defer(
+    interaction: discord.Interaction,
+    *,
+    ephemeral: bool = True,
+    thinking: bool = True,
+) -> bool:
+    """Defer ``interaction`` without ever raising.
+
+    Returns ``True`` when the interaction is acknowledged (either by this
+    call or by an earlier one), ``False`` when the token is already dead.
+
+    Call this as the *first* awaited statement of any handler that may take
+    more than a moment — a permission lookup, an audit-log write and an API
+    call are each enough to burn the 3-second budget on a cold connection.
+    """
+    if interaction.response.is_done():
+        return True
+    try:
+        await interaction.response.defer(ephemeral=ephemeral, thinking=thinking)
+        return True
+    except discord.HTTPException as exc:
+        if is_already_acknowledged(exc):
+            return True
+        if is_expired_interaction(exc):
+            logger.warning(
+                "Interaction expired before it could be deferred (command=%s user=%s) — "
+                "falling back to channel delivery",
+                getattr(interaction.command, "qualified_name", None),
+                getattr(interaction.user, "id", None),
+            )
+            return False
+        logger.warning("Failed to defer interaction: %s", exc)
+        return False
+    except Exception as exc:  # pragma: no cover - defensive, defer must never raise
+        logger.warning("Unexpected failure deferring interaction: %s", exc)
+        return False
+
+
+async def deliver(
+    interaction: discord.Interaction,
+    *,
+    view: Optional[discord.ui.LayoutView] = None,
+    content: Optional[str] = None,
+    ephemeral: bool = True,
+    allow_channel_fallback: bool = True,
+) -> bool:
+    """Get ``view``/``content`` in front of the user, whatever it takes.
+
+    The cascade, stopping at the first transport that succeeds:
+
+    1. ``followup.send`` — the interaction is acknowledged and alive.
+    2. ``edit_original_response`` — acknowledged, but the followup was
+       refused (a deferred-and-consumed response, typically).
+    3. ``response.send_message`` — not acknowledged yet.
+    4. a plain channel message mentioning the user — the token is dead, so
+       this is the only way the user ever learns what happened.
+
+    Returns ``True`` if any transport delivered. Never raises: this runs on
+    the error path, where a second exception would silence the first.
+    """
+    ordered = (
+        (_via_followup, _via_edit, _via_initial)
+        if interaction.response.is_done()
+        else (_via_initial, _via_followup, _via_edit)
+    )
+
+    for transport in ordered:
+        try:
+            await transport(interaction, view=view, content=content, ephemeral=ephemeral)
+            return True
+        except discord.HTTPException as exc:
+            if is_expired_interaction(exc):
+                break  # token is dead — no interaction transport can work
+            continue
+        except Exception:  # pragma: no cover - defensive
+            continue
+
+    if not allow_channel_fallback:
+        logger.error(
+            "Could not deliver interaction response (user=%s) and channel fallback is disabled",
+            getattr(interaction.user, "id", None),
+        )
+        return False
+
+    return await deliver_out_of_band(interaction, view=view, content=content)
+
+
+async def deliver_out_of_band(
+    interaction: discord.Interaction,
+    *,
+    view: Optional[discord.ui.LayoutView] = None,
+    content: Optional[str] = None,
+) -> bool:
+    """Deliver outside the interaction, as a plain channel message.
+
+    Used when the interaction token is unusable. The message pings the
+    invoker so the card is not mistaken for a reply to someone else.
+
+    Deliberately does not fall back to a DM: every DM Moddy sends goes
+    through ``bot.notifications`` (see docs/NOTIFICATIONS.md), and an error
+    card is not a notification.
+    """
+    user = getattr(interaction, "user", None)
+    mention = user.mention if user else ""
+    channel = getattr(interaction, "channel", None)
+
+    if channel is not None and hasattr(channel, "send"):
+        try:
+            await channel.send(
+                content=f"{mention} {content}".strip() if content else (mention or None),
+                view=view,
+                allowed_mentions=discord.AllowedMentions(users=True),
+            )
+            return True
+        except Exception as exc:
+            logger.debug("Channel fallback failed: %s", exc)
+
+    logger.error(
+        "CRITICAL: no transport could reach the user (user=%s guild=%s) — "
+        "they will see Discord's own failure message",
+        getattr(user, "id", None),
+        getattr(interaction, "guild_id", None),
+    )
+    return False
+
+
+# --- transports ------------------------------------------------------------
+
+
+async def _via_followup(interaction, *, view, content, ephemeral):
+    await interaction.followup.send(content=content, view=view, ephemeral=ephemeral)
+
+
+async def _via_edit(interaction, *, view, content, ephemeral):
+    await interaction.edit_original_response(content=content, view=view)
+
+
+async def _via_initial(interaction, *, view, content, ephemeral):
+    await interaction.response.send_message(content=content, view=view, ephemeral=ephemeral)

--- a/utils/interaction_response.py
+++ b/utils/interaction_response.py
@@ -50,7 +50,7 @@ async def safe_defer(
     interaction: discord.Interaction,
     *,
     ephemeral: bool = True,
-    thinking: bool = True,
+    thinking: Optional[bool] = None,
 ) -> bool:
     """Defer ``interaction`` without ever raising.
 
@@ -60,9 +60,19 @@ async def safe_defer(
     Call this as the *first* awaited statement of any handler that may take
     more than a moment — a permission lookup, an audit-log write and an API
     call are each enough to burn the 3-second budget on a cold connection.
+
+    ``thinking`` defaults to what the interaction type actually wants. A
+    slash command has no message yet, so it needs the "thinking…" placeholder
+    or the user sees nothing. A component callback re-rendering its own panel
+    in place must NOT get one — ``thinking=False`` there means "acknowledge
+    silently, the message is about to be edited". Passing the wrong one
+    leaves a stray placeholder next to the panel, so let this decide unless
+    you have a reason not to.
     """
     if interaction.response.is_done():
         return True
+    if thinking is None:
+        thinking = interaction.type is discord.InteractionType.application_command
     try:
         await interaction.response.defer(ephemeral=ephemeral, thinking=thinking)
         return True

--- a/utils/notification_views.py
+++ b/utils/notification_views.py
@@ -37,6 +37,7 @@ from utils.emojis import (
     SNOWFLAKE, TIME, UNDONE, USER,
 )
 from utils.i18n import i18n, t
+from utils.interaction_response import deliver, safe_defer
 
 logger = logging.getLogger("moddy.notification_views")
 
@@ -245,7 +246,9 @@ async def _load_review(interaction: discord.Interaction, report_id: str, locale:
     notifications = getattr(interaction.client, "notifications", None)
     report = await notifications.get_report(report_id) if notifications else None
     if not report:
-        await interaction.response.send_message(view=create_error_message(
+        # `deliver` so the caller is free to have deferred first: this runs
+        # both before and after acknowledgement.
+        await deliver(interaction, view=create_error_message(
             t("notifications.errors.unknown.title", locale=locale),
             t("notifications.errors.unknown_report.description", locale=locale,
               uuid=report_id),
@@ -261,14 +264,14 @@ async def _guard_reviewer(interaction: discord.Interaction, report: Dict[str, An
     from utils.staff_permissions import has_staff_node
 
     if not await has_staff_node(interaction.client, interaction.user.id, "notif_review"):
-        await interaction.response.send_message(view=create_error_message(
+        await deliver(interaction, view=create_error_message(
             t("notifications.review.no_permission.title", locale=locale),
             t("notifications.review.no_permission.description", locale=locale),
         ), ephemeral=True)
         return False
 
     if interaction.user.id == report.get("reporter_id"):
-        await interaction.response.send_message(view=create_error_message(
+        await deliver(interaction, view=create_error_message(
             t("notifications.review.own_report.title", locale=locale),
             t("notifications.review.own_report.description", locale=locale),
         ), ephemeral=True)
@@ -301,6 +304,9 @@ class NotifReviewClaimButton(
 
     @_guarded
     async def callback(self, interaction: discord.Interaction):
+        # Three round-trips (report, staff node, claim) before anything is
+        # shown: acknowledge first or the 3s window closes on a cold DB.
+        await safe_defer(interaction, ephemeral=True, thinking=False)
         locale = i18n.get_user_locale(interaction)
         report, _record = await _load_review(interaction, self.report_id, locale)
         if not report or not await _guard_reviewer(interaction, report, locale):
@@ -330,6 +336,9 @@ class NotifReviewPreviewButton(
 
     @_guarded
     async def callback(self, interaction: discord.Interaction):
+        # Two database reads plus a staff-node lookup before the preview can
+        # be rendered — acknowledge up front.
+        await safe_defer(interaction, ephemeral=True)
         locale = i18n.get_user_locale(interaction)
         report, record = await _load_review(interaction, self.report_id, locale)
         if not report or not record:
@@ -341,7 +350,7 @@ class NotifReviewPreviewButton(
         # the exact wording that reached the recipient, attribution row left
         # off (its buttons belong to the recipient, not to the reviewer).
         content = NotificationContent.from_dict(record.get("content") or {})
-        await interaction.response.send_message(
+        await interaction.followup.send(
             view=build_content_view(content, record.get("variables") or {},
                                     locale=record.get("locale") or locale),
             ephemeral=True,
@@ -380,7 +389,7 @@ class NotifReviewDecisionButton(
         if not report or not await _guard_reviewer(interaction, report, locale):
             return
         if report.get("status") in (ReportStatus.ACCEPTED.value, ReportStatus.REFUSED.value):
-            await interaction.response.send_message(view=create_error_message(
+            await deliver(interaction, view=create_error_message(
                 t("notifications.review.already_decided.title", locale=locale),
                 t("notifications.review.already_decided.description", locale=locale),
             ), ephemeral=True)

--- a/utils/support_request_views.py
+++ b/utils/support_request_views.py
@@ -42,6 +42,7 @@ from utils.emojis import (
     BUG, BUILD, DONE, GROUPS, HAND, NOTE, REPLY, SUPPORT, TIME, USER,
 )
 from utils.i18n import i18n, t
+from utils.interaction_response import deliver, safe_defer
 
 logger = logging.getLogger("moddy.support_request_views")
 
@@ -231,7 +232,8 @@ async def _load_request(interaction: discord.Interaction, request_id: str, local
     service = getattr(interaction.client, "support_requests", None)
     request = await service.get(request_id) if service else None
     if not request:
-        await interaction.response.send_message(view=create_error_message(
+        # `deliver` so this works whether or not the caller deferred first.
+        await deliver(interaction, view=create_error_message(
             t("support.errors.unknown.title", locale=locale),
             t("support.errors.unknown.description", locale=locale, reference=request_id),
         ), ephemeral=True)
@@ -245,7 +247,7 @@ async def _guard_staff(interaction: discord.Interaction, locale: str) -> bool:
 
     if await has_staff_node(interaction.client, interaction.user.id, "support_request"):
         return True
-    await interaction.response.send_message(view=create_error_message(
+    await deliver(interaction, view=create_error_message(
         t("support.errors.no_permission.title", locale=locale),
         t("support.errors.no_permission.description", locale=locale),
     ), ephemeral=True)
@@ -275,11 +277,14 @@ class SupportClaimButton(
 
     @_guarded
     async def callback(self, interaction: discord.Interaction):
+        # The request read and the staff-node lookup both hit the database
+        # before anything is shown: acknowledge first, or a cold query costs
+        # the 3s window and the click dies as "did not respond".
+        await safe_defer(interaction, ephemeral=True, thinking=False)
         locale = i18n.get_user_locale(interaction)
         request = await _load_request(interaction, self.request_id, locale)
         if not request or not await _guard_staff(interaction, locale):
             return
-        await interaction.response.defer()
         claimed = await interaction.client.support_requests.claim(
             self.request_id, interaction.user)
         if claimed is None:
@@ -341,11 +346,12 @@ class SupportResolveButton(
 
     @_guarded
     async def callback(self, interaction: discord.Interaction):
+        # Same reasoning as the claim button: acknowledge before the reads.
+        await safe_defer(interaction, ephemeral=True, thinking=False)
         locale = i18n.get_user_locale(interaction)
         request = await _load_request(interaction, self.request_id, locale)
         if not request or not await _guard_staff(interaction, locale):
             return
-        await interaction.response.defer()
         resolved = await interaction.client.support_requests.resolve(
             self.request_id, interaction.user)
         if resolved is None:
@@ -426,13 +432,13 @@ class SupportUserReplyButton(
         if not request:
             return
         if request["user_id"] != interaction.user.id:
-            await interaction.response.send_message(view=create_error_message(
+            await deliver(interaction, view=create_error_message(
                 t("support.errors.not_yours.title", locale=locale),
                 t("support.errors.not_yours.description", locale=locale),
             ), ephemeral=True)
             return
         if request.get("status") == STATUS_RESOLVED:
-            await interaction.response.send_message(view=create_error_message(
+            await deliver(interaction, view=create_error_message(
                 t("support.errors.closed.title", locale=locale),
                 t("support.errors.closed.description", locale=locale),
             ), ephemeral=True)
@@ -516,7 +522,7 @@ class ConfigHelpButton(
         if service is not None and await service.is_rate_limited(
             interaction.user.id, KIND_CONFIG_HELP
         ):
-            await interaction.response.send_message(view=create_error_message(
+            await deliver(interaction, view=create_error_message(
                 t("support.errors.rate_limited.title", locale=locale),
                 t("support.errors.rate_limited.description", locale=locale),
             ), ephemeral=True)

--- a/utils/ticket_views.py
+++ b/utils/ticket_views.py
@@ -1258,7 +1258,9 @@ async def run_staff_thread(interaction: discord.Interaction, service) -> None:
     from services.ticket_service import TicketError
 
     locale = i18n.get_user_locale(interaction)
-    await interaction.response.defer(ephemeral=True, thinking=True)
+    # Idempotent: the caller may already have acknowledged before its own
+    # database lookups, which is what keeps those off the 3s window.
+    await safe_defer(interaction, ephemeral=True, thinking=True)
     try:
         thread = await service.open_staff_thread(interaction.channel, interaction.user)
     except TicketError as e:
@@ -1283,7 +1285,9 @@ async def run_claim(interaction: discord.Interaction, service, *,
     from services.ticket_service import TicketError
 
     locale = i18n.get_user_locale(interaction)
-    await interaction.response.defer(ephemeral=True, thinking=True)
+    # Idempotent: the caller may already have acknowledged before its own
+    # database lookups, which is what keeps those off the 3s window.
+    await safe_defer(interaction, ephemeral=True, thinking=True)
     try:
         if force is None:
             _, claimed = await service.toggle_claim(interaction.channel,

--- a/utils/ticket_views.py
+++ b/utils/ticket_views.py
@@ -76,6 +76,7 @@ from utils.emojis import (
     TICKET_STAFF_THREAD, UNDONE,
 )
 from utils.i18n import i18n, t
+from utils.interaction_response import deliver, safe_defer
 
 logger = logging.getLogger('moddy.tickets.views')
 
@@ -139,19 +140,15 @@ async def send_error(interaction: discord.Interaction, description: str,
     locale = locale or i18n.get_user_locale(interaction)
     view = create_error_message(
         t('modules.tickets.errors.title', locale=locale), description)
-    if interaction.response.is_done():
-        await interaction.followup.send(view=view, ephemeral=True)
-    else:
-        await interaction.response.send_message(view=view, ephemeral=True)
+    # `deliver` knows the whole transport cascade, including a channel message
+    # when the interaction token has already expired.
+    await deliver(interaction, view=view, ephemeral=True)
 
 
 async def send_success(interaction: discord.Interaction, title: str,
                        description: str) -> None:
     view = create_success_message(title, description)
-    if interaction.response.is_done():
-        await interaction.followup.send(view=view, ephemeral=True)
-    else:
-        await interaction.response.send_message(view=view, ephemeral=True)
+    await deliver(interaction, view=view, ephemeral=True)
 
 
 async def handle_ticket_error(interaction: discord.Interaction, error) -> None:
@@ -282,6 +279,10 @@ async def _open_from_panel(interaction: discord.Interaction, panel_id: str,
     """Shared body of both panel controls: open a ticket, or say why not."""
     from services.ticket_service import TicketError
 
+    # The module read below is a database round-trip and opening a channel is
+    # several more — acknowledge before any of it.
+    await safe_defer(interaction, ephemeral=True, thinking=True)
+
     locale = i18n.get_user_locale(interaction)
     bot = interaction.client
     service = getattr(bot, 'tickets', None)
@@ -303,7 +304,6 @@ async def _open_from_panel(interaction: discord.Interaction, panel_id: str,
                          t('modules.tickets.errors.category_gone', locale=locale), locale)
         return
 
-    await interaction.response.defer(ephemeral=True, thinking=True)
     try:
         channel = await service.open_ticket(interaction.user, panel, category)
     except TicketError as e:
@@ -494,11 +494,12 @@ class TicketControlView(BaseView):
 
     async def _do_close(self, interaction: discord.Interaction, reason: Optional[str]):
         from services.ticket_service import TicketError
+        # `_resolve` reads the ticket row: acknowledge before it, not after.
+        await safe_defer(interaction, ephemeral=True, thinking=True)
         resolved = await _resolve(interaction)
         if not resolved:
             return
         service, ticket, panel, category = resolved
-        await interaction.response.defer(ephemeral=True, thinking=True)
         try:
             await service.close_ticket(interaction.channel, interaction.user, reason)
         except TicketError as e:
@@ -510,6 +511,9 @@ class TicketControlView(BaseView):
                            t('modules.tickets.close.done_description', locale=locale))
 
     async def on_claim(self, interaction: discord.Interaction):
+        # `_resolve` reads the ticket row before `run_claim` gets its chance
+        # to defer — acknowledge here instead.
+        await safe_defer(interaction, ephemeral=True, thinking=True)
         resolved = await _resolve(interaction)
         if not resolved:
             return
@@ -523,11 +527,11 @@ class TicketControlView(BaseView):
     async def _do_close_request(self, interaction: discord.Interaction,
                                 reason: Optional[str]):
         from services.ticket_service import TicketError
+        await safe_defer(interaction, ephemeral=True, thinking=True)
         resolved = await _resolve(interaction)
         if not resolved:
             return
         service, ticket, panel, category = resolved
-        await interaction.response.defer(ephemeral=True, thinking=True)
         try:
             await service.request_close(interaction.channel, interaction.user, reason)
         except TicketError as e:
@@ -540,6 +544,9 @@ class TicketControlView(BaseView):
             t('modules.tickets.close_request.sent_description', locale=locale))
 
     async def on_escalate(self, interaction: discord.Interaction):
+        # `_resolve` precedes every branch of `start_escalation` — acknowledge
+        # here so none of them races the 3s window.
+        await safe_defer(interaction, ephemeral=True, thinking=True)
         resolved = await _resolve(interaction)
         if not resolved:
             return
@@ -547,6 +554,9 @@ class TicketControlView(BaseView):
         await start_escalation(interaction, service, ticket, category)
 
     async def on_staff_thread(self, interaction: discord.Interaction):
+        # Same as the claim button: the resolve happens before the defer that
+        # `run_staff_thread` would have done.
+        await safe_defer(interaction, ephemeral=True, thinking=True)
         resolved = await _resolve(interaction)
         if not resolved:
             return
@@ -632,11 +642,11 @@ class TicketClosedView(BaseView):
 
     async def on_reopen(self, interaction: discord.Interaction):
         from services.ticket_service import TicketError
+        await safe_defer(interaction, ephemeral=True, thinking=True)
         resolved = await _resolve(interaction)
         if not resolved:
             return
         service = resolved[0]
-        await interaction.response.defer(ephemeral=True, thinking=True)
         try:
             await service.reopen_ticket(interaction.channel, interaction.user)
         except TicketError as e:
@@ -649,6 +659,9 @@ class TicketClosedView(BaseView):
 
     async def on_delete(self, interaction: discord.Interaction):
         from services.ticket_service import TicketError
+        # The channel is about to disappear: acknowledge before the reads so
+        # the actor still gets the "deleting…" card.
+        await safe_defer(interaction, ephemeral=True, thinking=True)
         resolved = await _resolve(interaction)
         if not resolved:
             return
@@ -659,8 +672,7 @@ class TicketClosedView(BaseView):
                 interaction,
                 t('modules.tickets.errors.missing_permission', locale=locale), locale)
             return
-        await interaction.response.send_message(
-            view=create_success_message(
+        await deliver(interaction, view=create_success_message(
                 t('modules.tickets.delete.pending_title', locale=locale),
                 t('modules.tickets.delete.pending_description', locale=locale)),
             ephemeral=True)
@@ -733,11 +745,11 @@ class TicketCloseRequestView(BaseView):
 
     async def on_accept(self, interaction: discord.Interaction):
         from services.ticket_service import TicketError
+        await safe_defer(interaction, ephemeral=True, thinking=True)
         resolved = await _resolve(interaction)
         if not resolved:
             return
         service = resolved[0]
-        await interaction.response.defer(ephemeral=True, thinking=True)
         try:
             await service.close_ticket(interaction.channel, interaction.user, None)
         except TicketError as e:
@@ -750,6 +762,8 @@ class TicketCloseRequestView(BaseView):
 
     async def on_refuse(self, interaction: discord.Interaction):
         from services.ticket_service import TicketError
+        # Two writes before the card is rewritten — acknowledge first.
+        await safe_defer(interaction, thinking=False)
         resolved = await _resolve(interaction)
         if not resolved:
             return
@@ -760,7 +774,7 @@ class TicketCloseRequestView(BaseView):
             await handle_ticket_error(interaction, e)
             return
         locale = i18n.get_user_locale(interaction)
-        await interaction.response.edit_message(
+        await interaction.edit_original_response(
             view=_close_request_resolved(interaction.user, locale))
 
     @classmethod
@@ -837,11 +851,11 @@ class TicketEscalationView(BaseView):
 
     async def on_cancel(self, interaction: discord.Interaction):
         from services.ticket_service import TicketError
+        await safe_defer(interaction, ephemeral=True, thinking=True)
         resolved = await _resolve(interaction)
         if not resolved:
             return
         service = resolved[0]
-        await interaction.response.defer(ephemeral=True, thinking=True)
         try:
             await service.deescalate(interaction.channel, interaction.user)
         except TicketError as e:
@@ -887,11 +901,12 @@ async def start_escalation(interaction: discord.Interaction, service,
 
     manual = list(ticket.get('participants', [])) + list(ticket.get('participant_roles', []))
     if manual:
-        await interaction.response.send_message(
-            view=TicketEscalateConfirmView(ticket, reason, locale), ephemeral=True)
+        await deliver(interaction,
+                      view=TicketEscalateConfirmView(ticket, reason, locale),
+                      ephemeral=True)
         return
 
-    await interaction.response.defer(ephemeral=True, thinking=True)
+    await safe_defer(interaction, ephemeral=True, thinking=True)
     try:
         await service.escalate(interaction.channel, interaction.user, reason=reason)
     except TicketError as e:
@@ -970,12 +985,12 @@ class TicketEscalateConfirmView(BaseView):
     async def _escalate(self, interaction: discord.Interaction, *,
                         keep: bool, mute: bool):
         from services.ticket_service import TicketError
+        await safe_defer(interaction, thinking=False)
         resolved = await _resolve(interaction)
         if not resolved:
             return
         service = resolved[0]
         locale = i18n.get_user_locale(interaction)
-        await interaction.response.defer()
         try:
             await service.escalate(interaction.channel, interaction.user,
                                    reason=self.reason, keep_participants=keep,
@@ -1145,6 +1160,8 @@ def _merge_participants(current: List[int], selected: List[int],
 async def _apply_participants(interaction: discord.Interaction, mode: str,
                               users: List[int], roles: List[int]) -> None:
     """Add, remove or replace the ticket's manual participants."""
+    # `_resolve`, the write and the permission sync are all round-trips.
+    await safe_defer(interaction, ephemeral=True, thinking=True)
     resolved = await _resolve(interaction)
     if not resolved:
         return
@@ -1166,7 +1183,6 @@ async def _apply_participants(interaction: discord.Interaction, mode: str,
     # list stops "remove the owner" from being one submit.
     users = [uid for uid in users if uid != ticket['owner_id']]
 
-    await interaction.response.defer(ephemeral=True, thinking=True)
     await interaction.client.db.set_participants(
         interaction.channel.id, users=users, roles=roles)
     ticket = await service.get_ticket(interaction.channel.id) or ticket

--- a/utils/transcription_views.py
+++ b/utils/transcription_views.py
@@ -33,6 +33,7 @@ from config import COLORS
 from utils.automod_render import make_text_file
 from utils.emojis import DOWNLOAD, ROBOT_WORKING, TIME, VOICE_CHAT
 from utils.i18n import i18n, t
+from utils.interaction_response import safe_defer
 
 logger = logging.getLogger("moddy.transcription_views")
 
@@ -272,11 +273,14 @@ class TranscribeButton(
         from services.transcription_service import ErrorCode, TranscriptionError
 
         bot = interaction.client
+        # The server-language lookup is the first await of the callback and can
+        # reach the database — acknowledge before it, then edit.
+        await safe_defer(interaction, thinking=False)
         public_locale = await card_locale(interaction)
 
         # Swap the button for the loading state straight away: the model call
         # takes seconds, and a button that looks idle invites a second click.
-        await interaction.response.edit_message(view=render_loading_card(public_locale))
+        await interaction.edit_original_response(view=render_loading_card(public_locale))
 
         message = await self._fetch_message(bot)
         if message is None:


### PR DESCRIPTION
## Summary

Consolidate and harden interaction response delivery across the error handler and staff framework. Introduces a new `utils/interaction_response.py` module that guarantees error messages reach users even when the interaction token expires (Discord error 10062), eliminating the "application did not respond" failure case.

## Key Changes

- **New module `utils/interaction_response.py`**: Provides two public helpers:
  - `safe_defer()` — acknowledge interactions early without raising, returns `False` if token is already dead
  - `deliver()` — cascade through multiple transports (followup → edit → initial response → channel message) to guarantee delivery, never raises
  - Helper functions to detect expired interactions (10062) and already-acknowledged interactions (40060)

- **Refactored `cogs/error_handler.py`**:
  - Replace all manual `interaction.response.is_done()` checks and try-except blocks with calls to `deliver()`
  - Extract common error reporting logic into new `report_error()` function (transport-agnostic half of error pipeline)
  - Simplify `report_component_error()` to use `report_error()` and `deliver()`
  - Removes ~80 lines of repetitive error-handling boilerplate across 4 error paths

- **Updated `staff/framework/cog.py`**:
  - Call `safe_defer()` early in `_run_slash()` before permission lookups and database writes (which can exceed the 3-second interaction window)
  - Use `deliver()` for permission-denied responses
  - Refactor `_invoke()` error handling to call `report_error()` for acknowledged/message-command errors, then `deliver()` the result
  - Add `opens_modal` flag to `StaffCommand` to skip early deferral for commands that answer with Modals (Discord refuses modals on deferred interactions)

- **Updated staff command classes** (`beta.py`, `send.py`, `jsk.py`, `redirect/add.py`, `redirect/edit.py`, `case/edit.py`, `case/note.py`, `global_sanction/*.py`):
  - Set `opens_modal = True` for commands that answer with Modals

## Implementation Details

- `deliver()` intelligently orders transports based on `interaction.response.is_done()` state to minimize failures
- Both `safe_defer()` and `deliver()` are total functions: they never raise, making them safe to call on error paths
- Channel fallback (out-of-band delivery) mentions the user so the error card is not mistaken for a reply to someone else
- Maintains backward compatibility: all existing error paths now use the same robust delivery mechanism
- Reduces cognitive load: callers no longer need to understand Discord's interaction state machine

https://claude.ai/code/session_014LacW97fCD7sCkQTGmuo3J