### PR TITLE
Log Discord's own answer whenever the role binding fails

### DIFF
--- a/docs/LINKED_ROLES.md
+++ b/docs/LINKED_ROLES.md
@@ -177,6 +177,25 @@ the inner ones a **AND**. Ours is one requirement:
 
 Only the first two mean the administrator has nothing left to do.
 
+#### Every refusal is logged verbatim
+
+The route is undocumented, so **Discord's own answer is the only thing that will
+ever explain a failure** — and the only thing that will say the route has
+changed. Every failing path logs, at `error` level on `moddy.moddy_team_role`:
+the HTTP status, Discord's error code, the raw response body, the role and guild
+ids, and the payload that was sent. Never a bare "forbidden".
+
+```
+Binding the role connection failed on role 8 in guild 7 — HTTP 403
+(Discord code 50013): Missing Permissions | sent: [[{"connection_type":…}]]
+```
+
+A 404/405 additionally logs that the route is no longer available to Moddy —
+that is the line to grep for the day `/team role` starts falling back for
+everyone. `tests/test_linked_roles.py` asserts the body reaches the logs, since
+a swallowed answer is exactly the kind of thing nobody notices until it
+matters.
+
 ---
 
 ## `/team role` — creating it

--- a/docs/sessions/2026-09-01_auto-link-moddy-team-role.md
+++ b/docs/sessions/2026-09-01_auto-link-moddy-team-role.md
@@ -20,7 +20,7 @@ Discord's **official** API has nothing — no field on the role payload, and
 |---|---|
 | `utils/moddy_team_role.py` | `link_team_role()`, `resolve_metadata_key()`, `build_requirement()`, `merge_configuration()`, `configuration_contains()`, `LinkResult` |
 | `staff/commands/team/team_role.py` | binds after creating; three state wordings; the failure reason on the card |
-| `tests/test_linked_roles.py` | +15 tests (payload, merge, every failure mode, the `premium` trap) |
+| `tests/test_linked_roles.py` | +16 tests (payload, merge, every failure mode, the `premium` trap) |
 | `locales/*.json` (×5) | `linked_auto`, `auto_{no_metadata,unsupported,forbidden,failed}`; `howto` reworded |
 | `docs/LINKED_ROLES.md` | "Why the linking step is manual" → "How the binding is done" |
 
@@ -49,6 +49,15 @@ Discord's **official** API has nothing — no field on the role payload, and
   `GUILD_ROLE_UPDATE` gateway event, which has not arrived when the card is
   built. A "just linked" wording distinguishes Moddy's own binding from one an
   admin did last week.
+
+### Logging (added after review)
+
+A refusal used to log `"Discord refused the role connection binding (forbidden)"`
+and nothing else. On an undocumented route that is worthless: the body is the
+only thing that can say *why*, or that the route itself has changed. Every
+failing path now logs, at `error`, the status, Discord's error code, the raw
+body, the role/guild ids and the payload sent — with a test asserting it, so a
+future refactor cannot quietly swallow it again.
 
 ## Known issues / follow-ups
 

--- a/tests/test_linked_roles.py
+++ b/tests/test_linked_roles.py
@@ -287,6 +287,29 @@ class TestRoleBinding:
         assert run(link_team_role(bot, make_role())) == LinkResult.NO_METADATA
         assert http.written is None
 
+    def test_discord_s_own_answer_reaches_the_logs(self, caplog):
+        """The route is undocumented: its body is the only thing that will ever
+        explain a refusal, so it must never be swallowed."""
+        import logging
+
+        import discord
+
+        response = SimpleNamespace(status=403, reason="Forbidden")
+        error = discord.Forbidden(response, {
+            "code": 50013, "message": "Missing Permissions",
+        })
+        http = FakeHTTP(on_write=error)
+        with caplog.at_level(logging.ERROR, logger="moddy.moddy_team_role"):
+            run(link_team_role(make_linking_bot(http, application_id=next(_app_ids)),
+                               make_role(guild_id=7, role_id=8)))
+
+        logged = "\n".join(r.getMessage() for r in caplog.records)
+        assert "403" in logged
+        assert "50013" in logged                 # Discord's own error code
+        assert "Missing Permissions" in logged   # the body, verbatim
+        assert "role 8" in logged and "guild 7" in logged
+        assert "connection_metadata_field" in logged  # what we actually sent
+
     def test_no_application_id_is_not_a_crash(self):
         bot = SimpleNamespace(application_id=None, http=FakeHTTP())
         assert run(link_team_role(bot, make_role())) == LinkResult.FAILED

--- a/utils/moddy_team_role.py
+++ b/utils/moddy_team_role.py
@@ -37,6 +37,7 @@ the bot knew about it (or by hand).
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Optional
 
@@ -145,8 +146,12 @@ def is_linked(role: discord.Role) -> bool:
 
     ``guild_connections`` is the flag Discord sets on a role as soon as it has
     at least one *Links* requirement — including requirements that have nothing
-    to do with Moddy. It answers "an admin has been through the Links screen",
-    which is exactly the step `/team role` cannot do for them.
+    to do with Moddy. It answers "this role has a requirement on it", which is
+    what `/team role` reports before deciding whether to bind it itself.
+
+    It is deliberately *not* used to confirm a binding Moddy just made: tags
+    only refresh on the ``GUILD_ROLE_UPDATE`` gateway event, so they are still
+    stale one millisecond after the ``PUT``.
     """
     tags = role.tags
     return bool(tags and tags.is_guild_connection())
@@ -205,6 +210,29 @@ class LinkResult:
 
     #: The two outcomes that mean the admin has nothing left to do.
     DONE = (LINKED_NOW, ALREADY_LINKED)
+
+
+def _log_discord_refusal(what: str, role: discord.Role, exc: discord.HTTPException,
+                         *, payload=None) -> None:
+    """Log **what Discord actually answered**, not our interpretation of it.
+
+    The route this module depends on is undocumented: the day it changes, the
+    only thing that will say so is the body Discord sent back. A log line
+    reading "forbidden" would be worthless — the status, Discord's own error
+    code and the raw text are the whole point, so they are always logged, at
+    ``error`` level, whatever the failure.
+
+    The payload is logged too when there is one: an argument Discord rejects is
+    invisible otherwise.
+    """
+    logger.error(
+        "%s failed on role %s in guild %s — HTTP %s (Discord code %s): %s%s",
+        what, role.id, role.guild.id,
+        getattr(exc, "status", "?"),
+        getattr(exc, "code", "?"),
+        getattr(exc, "text", None) or str(exc),
+        f" | sent: {json.dumps(payload, separators=(',', ':'))}" if payload is not None else "",
+    )
 
 
 def build_requirement(application_id: int, metadata_key: str) -> dict:
@@ -284,7 +312,9 @@ async def resolve_metadata_key(bot) -> Optional[str]:
     try:
         records = await bot.http.request(route)
     except discord.HTTPException as e:
-        logger.warning("Could not read Moddy's role-connection metadata: %s", e)
+        logger.error("Could not read Moddy's role-connection metadata — HTTP %s "
+                     "(Discord code %s): %s", getattr(e, "status", "?"),
+                     getattr(e, "code", "?"), getattr(e, "text", None) or e)
         return None
 
     key = next((r.get("key") for r in (records or [])
@@ -334,32 +364,40 @@ async def link_team_role(bot, role: discord.Role) -> str:
 
     try:
         current = await bot.http.request(read)
-    except discord.NotFound:
+    except discord.NotFound as e:
         # No configuration yet is a legitimate answer on a fresh role; only a
-        # missing *route* is fatal, and the PUT below tells us which it is.
+        # missing *route* is fatal, and the PUT below tells us which it is. Log
+        # it anyway: it is also what a withdrawn route looks like from here.
+        logger.info("No role connection configuration on role %s in guild %s "
+                    "(HTTP 404: %s)", role.id, role.guild.id,
+                    getattr(e, "text", None) or e)
         current = []
-    except discord.Forbidden:
+    except discord.Forbidden as e:
+        _log_discord_refusal("Reading the role connection configuration", role, e)
         return LinkResult.FORBIDDEN
     except discord.HTTPException as e:
-        logger.warning("Could not read the role connection configuration of %s: %s", role.id, e)
+        _log_discord_refusal("Reading the role connection configuration", role, e)
         current = []
 
     if configuration_contains(current, requirement):
         return LinkResult.ALREADY_LINKED
 
+    payload = merge_configuration(current, requirement)
     try:
-        await bot.http.request(write, json=merge_configuration(current, requirement))
-    except discord.Forbidden:
-        logger.info("Discord refused the role connection binding of %s (forbidden)", role.id)
+        await bot.http.request(write, json=payload)
+    except discord.Forbidden as e:
+        _log_discord_refusal("Binding the role connection", role, e, payload=payload)
         return LinkResult.FORBIDDEN
     except discord.HTTPException as e:
+        _log_discord_refusal("Binding the role connection", role, e, payload=payload)
         # 404/405 is the shape a withdrawn route takes: say so plainly rather
         # than reporting a permission problem the admin cannot act on.
         if e.status in (404, 405):
-            logger.warning("The role connection route is not available to Moddy "
-                           "(HTTP %s) — falling back on the manual instructions", e.status)
+            logger.error("The role connection route is not available to Moddy "
+                         "(HTTP %s) — falling back on the manual instructions. "
+                         "If this is permanent, `/team role` must go back to "
+                         "printing the manual steps only.", e.status)
             return LinkResult.UNSUPPORTED
-        logger.warning("Could not bind the role connection of %s: %s", role.id, e)
         return LinkResult.FAILED
 
     logger.info("Moddy Team role %s bound to the linked-role requirement in guild %s",


### PR DESCRIPTION
Follow-up to #376, which shipped the automatic binding of the Moddy Team role.

## The problem

A refusal logged this, and nothing more:

```
Discord refused the role connection binding of 8 (forbidden)
```

The route the binding rides on (`PUT /guilds/{id}/roles/{id}/connections/configuration`) is undocumented. Discord's own answer is therefore the only thing that can ever say *why* a call failed — or that the route has changed shape. Throwing the body away kept the half that carries no information.

## What changed

A single `_log_discord_refusal()` helper now logs, at `error` level on `moddy.moddy_team_role`: the HTTP status, Discord's error code, the raw response body, the role and guild ids, and **the payload that was sent**.

```
Binding the role connection failed on role 8 in guild 7 — HTTP 403
(Discord code 50013): Missing Permissions | sent: [[{"connection_type":"application",…}]]
```

The payload matters as much as the answer: an argument Discord rejects is invisible otherwise.

Applied to every failing path, not just the `PUT`:

- reading the metadata schema (`GET /applications/{id}/role-connections/metadata`);
- reading the existing configuration, both `Forbidden` and `HTTPException`;
- the `404` on that read, which was entirely silent — a legitimate answer on a fresh role, but also exactly what a withdrawn route looks like from here (logged at `info`);
- the `404/405` on the write keeps its dedicated line saying the route is no longer open to Moddy.

## Tests

`test_discord_s_own_answer_reaches_the_logs` raises a real `discord.Forbidden` carrying `code 50013` / `"Missing Permissions"` and asserts all five elements reach the logs, so a later refactor cannot quietly swallow the response again. 49 tests pass in `tests/test_linked_roles.py`.

## Also

`is_linked()`'s docstring still claimed the binding was the step `/team role` "cannot do" — corrected, with a note on why it is not used to confirm a binding Moddy just made (tags only refresh on `GUILD_ROLE_UPDATE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXBN4xGkad54Xa5pdgwb1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXBN4xGkad54Xa5pdgwb1b)_