### PR TITLE
Add OpenAI rate limiting for embeddings and chat models

### DIFF
--- a/docs/API_GATEWAY.md
+++ b/docs/API_GATEWAY.md
@@ -204,6 +204,15 @@ Rules live in `gateway/config.py` and mirror the provider console:
 | | `rpd` | 2 000 requests | 1 day | `GROQ_WHISPER_RPD` |
 | | `ash` | 7 200 audio seconds | 1 hour | `GROQ_WHISPER_AUDIO_SECONDS_PER_HOUR` |
 | | `asd` | 28 800 audio seconds | 1 day | `GROQ_WHISPER_AUDIO_SECONDS_PER_DAY` |
+| openai / `text-embedding-3-small` | `rpm` | 3 000 requests | 1 min | `OPENAI_EMBED_RPM` |
+| openai / `gpt-4.1-nano` | `rpm` | 500 requests | 1 min | `OPENAI_NANO_RPM` |
+| openai / `gpt-4.1-mini` | `rpm` | 500 requests | 1 min | `OPENAI_MINI_RPM` |
+
+The OpenAI values mirror our org's Tier 1 limits (platform.openai.com → Limits
+→ Rate limits). Only RPM is enforced (not TPM) — estimating tokens ahead of
+the call would need a tokenizer, and RPM alone stops the bot from bursting
+past what the account tier allows. Raise them (env vars above) when the
+account tier changes.
 
 How it works:
 - Fixed windows in Redis (`ratelimit:{provider}:{model}:{rule}:{window}`), shared across shards.
@@ -320,6 +329,9 @@ except (APIUnavailableError, GatewayError):
 | `GROQ_WHISPER_RPD` | `2000` | Whisper requests per day |
 | `GROQ_WHISPER_AUDIO_SECONDS_PER_HOUR` | `7200` | Whisper audio seconds per hour |
 | `GROQ_WHISPER_AUDIO_SECONDS_PER_DAY` | `28800` | Whisper audio seconds per day |
+| `OPENAI_EMBED_RPM` | `3000` | `text-embedding-3-small` requests per minute (provider account) |
+| `OPENAI_NANO_RPM` | `500` | `gpt-4.1-nano` requests per minute |
+| `OPENAI_MINI_RPM` | `500` | `gpt-4.1-mini` requests per minute |
 | `GATEWAY_MAX_RETRIES` | `3` | Max retry attempts |
 | `GATEWAY_RETRY_BASE_DELAY` | `0.5` | Retry base delay (seconds) |
 | `GATEWAY_CB_FAILURE_THRESHOLD` | `5` | Circuit breaker failure count |

--- a/gateway/adapters/openai.py
+++ b/gateway/adapters/openai.py
@@ -103,6 +103,11 @@ class OpenAIAdapter(BaseAdapter):
                 retry_after = float(resp.headers.get("Retry-After", 0)) or None
             except (ValueError, TypeError):
                 pass
+            try:
+                body = await resp.text()
+            except Exception:
+                body = ""
+            logger.warning("OpenAI 429 on %s: %s", resp.url, body[:500])
             raise RateLimitError("openai", retry_after)
         if resp.status >= 400:
             try:

--- a/gateway/clients/ai.py
+++ b/gateway/clients/ai.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from ..spec import CallSpec, QuotaPlan
 from ..executor import GatewayExecutor
+from ..ratelimit import UNIT_REQUESTS
 
 
 class AIClient:
@@ -41,6 +42,7 @@ class AIClient:
             call_type=call_type,
             correlation_id=correlation_id or str(uuid.uuid4()),
             metadata=metadata or {},
+            rate_cost={UNIT_REQUESTS: 1},
         )
         return await self._executor.execute(spec)
 
@@ -79,5 +81,6 @@ class AIClient:
             call_type=call_type,
             correlation_id=correlation_id or str(uuid.uuid4()),
             metadata=metadata or {},
+            rate_cost={UNIT_REQUESTS: 1},
         )
         return await self._executor.execute(spec)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -41,10 +41,30 @@ def _whisper_turbo_rules() -> List[RateRule]:
     ]
 
 
+def _openai_rpm_rules(env_name: str, default_rpm: int) -> List[RateRule]:
+    """Request-per-minute cap mirroring the OpenAI console (*Limits* page).
+
+    Only RPM is enforced here (not TPM): estimating tokens before the call
+    would need a tokenizer, and RPM alone is enough to stop the bot from
+    bursting past what the account tier allows.
+    """
+    return [RateRule("rpm", UNIT_REQUESTS, MINUTE, _int_env(env_name, default_rpm))]
+
+
 def _default_model_rate_limits() -> Dict[Tuple[str, str], List[RateRule]]:
-    """(provider, model) → the rules enforced for it. Add new models here."""
+    """(provider, model) → the rules enforced for it. Add new models here.
+
+    OpenAI values mirror the org's Tier 1 limits (platform.openai.com →
+    Limits → Rate limits) as of 2026-09-02. Raise them here (or via the env
+    vars) the day the account tier changes.
+    """
     return {
         ("groq", "whisper-large-v3-turbo"): _whisper_turbo_rules(),
+        ("openai", "text-embedding-3-small"): _openai_rpm_rules(
+            "OPENAI_EMBED_RPM", 3_000
+        ),
+        ("openai", "gpt-4.1-nano"): _openai_rpm_rules("OPENAI_NANO_RPM", 500),
+        ("openai", "gpt-4.1-mini"): _openai_rpm_rules("OPENAI_MINI_RPM", 500),
     }
 
 


### PR DESCRIPTION
## Summary
Implements request-per-minute (RPM) rate limiting for OpenAI models (`text-embedding-3-small`, `gpt-4.1-nano`, `gpt-4.1-mini`) to align with the organization's Tier 1 account limits. Also adds improved error logging for OpenAI 429 responses.

## Key Changes

- **Rate limit configuration** (`gateway/config.py`):
  - Added `_openai_rpm_rules()` helper to generate RPM-only rate rules (TPM not enforced to avoid needing a tokenizer)
  - Registered three OpenAI models with their Tier 1 limits:
    - `text-embedding-3-small`: 3,000 RPM
    - `gpt-4.1-nano`: 500 RPM
    - `gpt-4.1-mini`: 500 RPM
  - All limits configurable via environment variables (`OPENAI_EMBED_RPM`, `OPENAI_NANO_RPM`, `OPENAI_MINI_RPM`)

- **Rate cost tracking** (`gateway/clients/ai.py`):
  - Added `rate_cost={UNIT_REQUESTS: 1}` to both `embed()` and `chat()` methods to ensure each request counts toward rate limits

- **Error logging** (`gateway/adapters/openai.py`):
  - Enhanced 429 (rate limit) error handling to log the response body (first 500 chars) for debugging

- **Documentation** (`docs/API_GATEWAY.md`):
  - Added OpenAI models to the rate limits table with their defaults and env var names
  - Documented the RPM-only enforcement rationale and upgrade path when account tier changes

## Implementation Notes
- Values mirror platform.openai.com → Limits → Rate limits as of 2026-09-02
- Only RPM is enforced (not TPM) to avoid the complexity of pre-call token estimation
- Environment variables allow runtime adjustment without code changes

https://claude.ai/code/session_01WYrgpu3xZHxrbg1AhYStaY