### PR TITLE
Railway cost: memory optimization pass (tier 0 + tier 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,8 @@ moddy/
 │   ├── appeal_views.py        #   Automod appeal UI (DM buttons + reviewer panels, persistent)
 │   ├── expiration_views.py    #   Sanction-expiration DM (unban/unmute/unwarn + invite)
 │   ├── invites.py             #   Shared guild invite creation (appeals, expirations)
+│   ├── members.py             #   Member lookup without the startup chunk
+│   │                          #   (get_or_fetch_member / fetch_all_members)
 │   ├── moderation_cases.py    #   Cases domain model + enums + reference gen
 │   ├── global_sanctions.py    #   Global (Moddy-team) sanction levels: warn/limited/suspended
 │   ├── global_sanction_views.py #  Global sanction UI (notice DMs, staff panels, Modals V2)
@@ -502,7 +504,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/REDIS_COMMUNICATION.md](docs/REDIS_COMMUNICATION.md) | **Redis inter-service communication** — Pub/Sub vs Streams vs plain keys, current channel/stream inventory, checklist for wiring up a new Redis-based service |
 | [docs/SOCIAL_NOTIFICATIONS.md](docs/SOCIAL_NOTIFICATIONS.md) | Social Notifications module + `moddy-feeds` Redis contract (what the backend must mirror) |
 | [docs/SUBSCRIPTION_SCHEMA.md](docs/SUBSCRIPTION_SCHEMA.md) | Subscription DB schema, Redis cache contract, Pub/Sub events (incl. `notify_invoice` — Stripe invoice DMs) |
-| [docs/RAILWAY.md](docs/RAILWAY.md) | Environment variables, deployment, troubleshooting |
+| [docs/RAILWAY.md](docs/RAILWAY.md) | Environment variables, deployment, troubleshooting, **memory footprint & Railway cost** |
 
 ### Other
 | Document | When to Read |

--- a/automod/constants.py
+++ b/automod/constants.py
@@ -264,6 +264,13 @@ PRECEDENT_MAX_PER_GUILD: int = 500
 # In-process TTL of a guild's precedent set (service-side cache; bounds DB load
 # to one query per guild per window while keeping matching in-process).
 PRECEDENT_CACHE_TTL_SECONDS: float = 300.0
+# Hard cap on how many guilds may hold a precedent set in memory at once. The
+# TTL alone bounds the cache to "guilds active in the last 5 minutes", which is
+# unbounded by design: at PRECEDENT_MAX_PER_GUILD 1536-dim float32 vectors, that
+# is ~3 MB per guild, so a busy window could pin hundreds of megabytes. The
+# least-recently-loaded guild is evicted past this; it only costs that guild one
+# extra DB query on its next message.
+PRECEDENT_CACHE_MAX_GUILDS: int = 50
 # Bounded cache of the primary message embedding captured during scoring, so the
 # precedent query reuses the funnel's embedding instead of paying a second call.
 PRECEDENT_QUERY_VECTOR_CACHE: int = 256

--- a/automod/engine.py
+++ b/automod/engine.py
@@ -93,9 +93,15 @@ class AutomodEngine:
         # counter lives in Redis so it is shared across shards / restarts).
         self._budget_calls = 0          # real nano calls counted this process
         self._budget_dropped = 0        # nano-bound messages dropped over budget
-        self._budget_degraded: Set[Tuple[int, str]] = set()   # (guild, day) degraded
-        self._budget_notified: Set[Tuple[int, str]] = set()   # (guild, day) card sent
-        self._budget_notice_pending: Set[int] = set()          # guilds the module owes a card
+        # Both sets are scoped to a single UTC day and only ever read for the
+        # current one, so they hold guild ids and are cleared when the day rolls
+        # over. Keyed by (guild, day) they instead grew by one tuple per active
+        # guild per day for the life of the process, and nothing ever read the
+        # old days back.
+        self._budget_day: str = self._utc_day()
+        self._budget_degraded: Set[int] = set()       # guilds degraded today
+        self._budget_notified: Set[int] = set()       # guilds already sent a card today
+        self._budget_notice_pending: Set[int] = set()  # guilds the module owes a card
 
     # -- Gateway-backed primitives -----------------------------------------
 
@@ -159,7 +165,7 @@ class AutomodEngine:
             "nano_calls": self._budget_calls,
             "dropped": self._budget_dropped,
             "degraded_guilds": sorted(
-                {g for (g, d) in self._budget_degraded if d == day}),
+                self._budget_degraded if day == self._budget_day else ()),
         }
 
     async def ensure_ready(self) -> bool:
@@ -749,11 +755,20 @@ class AutomodEngine:
                 return True
         return False
 
-    def _mark_degraded(self, guild_id: int) -> None:
+    def _roll_budget_day(self) -> str:
+        """Reset today's guild sets when the UTC day has changed."""
         day = self._utc_day()
-        self._budget_degraded.add((guild_id, day))
-        if (guild_id, day) not in self._budget_notified:
-            self._budget_notified.add((guild_id, day))
+        if day != self._budget_day:
+            self._budget_day = day
+            self._budget_degraded.clear()
+            self._budget_notified.clear()
+        return day
+
+    def _mark_degraded(self, guild_id: int) -> None:
+        self._roll_budget_day()
+        self._budget_degraded.add(guild_id)
+        if guild_id not in self._budget_notified:
+            self._budget_notified.add(guild_id)
             self._budget_notice_pending.add(guild_id)
 
     def pop_budget_notice(self, guild_id: int) -> bool:

--- a/bot.py
+++ b/bot.py
@@ -6,6 +6,7 @@ Handles all core logic and events
 import discord
 from discord.ext import commands, tasks
 import asyncio
+import gc
 import logging
 from datetime import datetime, timezone
 from typing import Dict, Optional, Set
@@ -18,6 +19,7 @@ import aiohttp
 import math
 
 from config import (
+    CHUNK_GUILDS_AT_STARTUP,
     DEBUG,
     DEFAULT_PREFIX,
     DATABASE_URL,
@@ -106,10 +108,14 @@ class ModdyBot(ModdyFrameworkBot):
             # content cache behind the AI-suggested sanction reason) and the
             # non-raw on_reaction_add feeding the automod relationship graph
             # (REACTION_WAIT_SECONDS = 20). All of those act on messages seconds
-            # to minutes old, so 10000 was far past the useful window while
+            # to minutes old, so even 5000 was far past the useful window while
             # costing ~1.5-3 KB per resident Message.
-            max_messages=5000,
+            max_messages=1000,
             member_cache_flags=member_cache_flags,
+            # Off by default: see config.CHUNK_GUILDS_AT_STARTUP. Lookups go
+            # through utils.members.get_or_fetch_member and the few code paths
+            # needing a full list call utils.members.ensure_chunked.
+            chunk_guilds_at_startup=CHUNK_GUILDS_AT_STARTUP,
             http_timeout=http_timeout  # Apply custom timeout
         )
 
@@ -198,9 +204,6 @@ class ModdyBot(ModdyFrameworkBot):
         # does not change which modules own commands must not spend one.
         self._guild_module_commands: Dict[int, frozenset] = {}
 
-        # Serveur HTTP interne pour /status
-        self.internal_api_server = None
-        self.internal_api_thread = None
 
         # Configure global error handler
         self.setup_error_handler()
@@ -263,36 +266,20 @@ class ModdyBot(ModdyFrameworkBot):
             logger.error(f"[FAIL] Error fetching version: {e}")
             self.version = "Unknown"
 
-    def start_internal_api_server(self):
+    def wire_internal_api(self):
         """
-        Démarre le serveur HTTP interne dans un thread séparé.
-        Expose GET /health et GET /status (appelé par le backend pour les métriques).
+        Hand this bot instance to the internal API so GET /status can report on it.
+
+        The uvicorn server itself is started once by `main.start_api_server()`, on
+        the bot's own event loop. This used to spawn a *second* uvicorn on the same
+        port from a daemon thread with its own event loop; only one of the two could
+        ever bind, and the loser died silently while still costing a thread, an
+        extra loop and a duplicate FastAPI app.
         """
-        import threading
-        import uvicorn
-        from internal_api.server import app, set_bot
+        from internal_api.server import set_bot
 
         set_bot(self)
-
-        port = int(os.getenv("PORT", 3000))
-
-        def run_server():
-            logger.info(f"Starting internal API server on port {port}")
-            uvicorn.run(
-                app,
-                host="::",  # IPv4 + IPv6 dual-stack
-                port=port,
-                log_level="warning",
-                access_log=False,
-            )
-
-        self.internal_api_thread = threading.Thread(
-            target=run_server,
-            daemon=True,
-            name="InternalAPIServer"
-        )
-        self.internal_api_thread.start()
-        logger.info(f"Internal API server started on port {port}")
+        logger.info("Internal API wired to the bot instance")
 
     async def _setup_redis(self):
         """Initialize Redis connection and start background listeners."""
@@ -798,9 +785,14 @@ class ModdyBot(ModdyFrameworkBot):
             try:
                 last_id = await self.redis.get(LAST_ID_KEY) or "0"
                 while True:
+                    # A blocking XREAD returns as soon as an entry lands, so a
+                    # longer block does not add latency -- it only stops the
+                    # client re-issuing the command every 5s around the clock.
+                    # Four such loops across the services were burning nearly as
+                    # much Redis CPU as the bot itself.
                     messages = await self.redis.xread(
                         {TASK_STREAM: last_id},
-                        block=5000,
+                        block=30000,
                         count=10,
                     )
                     if not messages:
@@ -1043,9 +1035,8 @@ class ModdyBot(ModdyFrameworkBot):
         self.module_manager.discover_modules()
         logger.info("Module manager ready")
 
-        # Start internal API server
-        logger.info("Starting internal API server...")
-        self.start_internal_api_server()
+        # Hand the bot instance to the internal API (server started in main.py)
+        self.wire_internal_api()
 
         # Set start time for /status uptime metric
         import time as _time
@@ -1116,6 +1107,14 @@ class ModdyBot(ModdyFrameworkBot):
             # In production, sync commands properly
             await self.sync_commands()
             logger.info("Commands synced")
+
+        # Everything loaded above (cogs, modules, staff commands, persistent views,
+        # translations) lives for the whole process. Moving it out of the
+        # generational GC's reach stops every collection from re-walking tens of
+        # thousands of permanent objects, and keeps their pages shareable instead of
+        # being dirtied by refcount writes during each sweep.
+        gc.freeze()
+        logger.info("GC: startup objects frozen into the permanent generation")
 
     async def sync_commands(self):
         """

--- a/cogs/altguard.py
+++ b/cogs/altguard.py
@@ -35,6 +35,7 @@ from services.altguard_client import (
 from utils.altguard_views import format_member_name
 from utils.components_v2 import create_error_message, create_success_message
 from utils.i18n import i18n, t
+from utils.members import fetch_all_members
 
 logger = logging.getLogger('moddy.cogs.altguard')
 
@@ -255,17 +256,21 @@ class AltGuard(commands.Cog):
         if module is None:
             return False
 
-        # A partially-filled cache would mark real members as `left`, so a
-        # guild whose members are not all cached is skipped this round
-        # rather than reconciled against a lie.
-        if guild.member_count and len(guild.members) < guild.member_count:
+        # A partially-filled cache would mark real members as `left`, so the list
+        # is pulled in full over the gateway rather than reconciled against a
+        # lie. Guilds are not chunked at startup any more (see
+        # config.CHUNK_GUILDS_AT_STARTUP), and only guilds that actually run the
+        # gate reach this point -- so this is the one place that pays for a full
+        # member list, once an hour, without keeping it resident.
+        members = await fetch_all_members(guild, cache=False)
+        if members is None:
             logger.debug(
-                f"[AltGuard] Skipping resync for guild {guild.id}: member cache "
-                f"incomplete ({len(guild.members)}/{guild.member_count})"
+                f"[AltGuard] Skipping resync for guild {guild.id}: "
+                f"member list unavailable"
             )
             return False
 
-        member_ids = [m.id for m in guild.members if not m.bot]
+        member_ids = [m.id for m in members if not m.bot]
         try:
             reconciled = await client.resync_membership(guild.id, member_ids)
             logger.info(

--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -32,12 +32,12 @@ if SENTRY_DSN:
         # Add data like request headers and IP for users
         # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
         send_default_pii=False,
-        # Set traces_sample_rate to 1.0 to capture 100% of transactions for performance monitoring.
-        # Adjust this value in production.
-        traces_sample_rate=0.1,  # 10% of transactions
-        # Set profiles_sample_rate to 1.0 to profile 100% of sampled transactions.
-        # Adjust this value in production.
-        profiles_sample_rate=0.1,  # 10% of sampled transactions
+        # What we actually use Sentry for is error tracking, which is unaffected by
+        # these two. Tracing keeps a span buffer per transaction, and the profiler
+        # runs a dedicated sampling thread (and therefore its own glibc malloc
+        # arena) -- both are pure memory cost here. Overridable per environment.
+        traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.01")),
+        profiles_sample_rate=float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.0")),
         # Auto-enabled integrations import their target library at init time
         # (e.g. the OpenAI integration imports `openai`, which imports its
         # vendored aiohttp transport). A version mismatch in that import

--- a/cogs/moderation_commands.py
+++ b/cogs/moderation_commands.py
@@ -24,6 +24,7 @@ from config import COLORS
 from notifications.models import NotificationContent, NotificationSource
 from utils import emojis
 from utils.i18n import t, get_locale
+from utils.members import get_or_fetch_member
 
 logger = logging.getLogger("moddy.moderation_commands")
 
@@ -1134,7 +1135,7 @@ class ModerationCommands(commands.Cog):
         subject_id = int(case_row["subject_id"])
         issuer_id = payload.get("issuer_id")
         expires_at = _parse_iso(payload.get("expires_at"))
-        member = guild.get_member(subject_id)
+        member = await get_or_fetch_member(guild, subject_id)
 
         mod_name = "Moddy"
         try:

--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -18,6 +18,7 @@ from cogs.error_handler import BaseView
 
 from utils.i18n import i18n, t
 from utils.components_v2 import create_error_message
+from utils.members import get_or_fetch_member
 from cogs.error_handler import BaseModal
 
 logger = logging.getLogger('moddy.reminder')
@@ -891,7 +892,7 @@ class Reminder(commands.Cog):
                 guild = self.bot.get_guild(guild_id)
                 if guild:
                     # Check if user is still in the guild
-                    member = guild.get_member(user_id)
+                    member = await get_or_fetch_member(guild, user_id)
                     if member:
                         channel = guild.get_channel(channel_id)
                         if channel and channel.permissions_for(guild.me).send_messages:

--- a/cogs/tickets.py
+++ b/cogs/tickets.py
@@ -34,6 +34,7 @@ from modules.tickets import (
 from services.ticket_service import TicketError
 from utils.components_v2 import create_success_message
 from utils.i18n import i18n, t
+from utils.members import get_or_fetch_member
 from utils.ticket_views import (
     TicketRenameModal,
     handle_ticket_error,
@@ -475,7 +476,7 @@ class Tickets(commands.Cog):
             if not ticket or ticket.get('staff_thread_id') != thread.id:
                 return
 
-            guild_member = thread.guild.get_member(member.id)
+            guild_member = await get_or_fetch_member(thread.guild, member.id)
             if guild_member is None:
                 guild_member = await thread.guild.fetch_member(member.id)
 

--- a/config.py
+++ b/config.py
@@ -73,6 +73,27 @@ DB_POOL_MIN_SIZE: int = int(os.environ.get("DB_POOL_MIN_SIZE", "1"))
 DB_POOL_MAX_SIZE: int = int(os.environ.get("DB_POOL_MAX_SIZE", "8"))
 
 # =============================================================================
+# CACHE DISCORD
+# =============================================================================
+
+# Whether to request every guild's full member list at startup.
+#
+# discord.py defaults this to True as soon as the `members` intent is on, which
+# materialises one resident Member object (~1-2 KB) for every member of every
+# guild -- by far the largest single memory cost of the process, and Railway
+# bills RAM by the GB-minute.
+#
+# Almost nothing here needs a complete member list: the three places that
+# iterate `guild.members` chunk on demand instead (see
+# `utils/members.py::fetch_all_members`), and lookups go through
+# `utils/members.py::get_or_fetch_member`, which falls back to a REST fetch on a
+# cache miss. Set CHUNK_GUILDS_AT_STARTUP=true to restore the old behaviour
+# without a code change if a regression shows up in production.
+CHUNK_GUILDS_AT_STARTUP: bool = os.environ.get(
+    "CHUNK_GUILDS_AT_STARTUP", "False"
+).lower() in ("true", "1", "yes", "on")
+
+# =============================================================================
 # REDIS
 # =============================================================================
 

--- a/docs/RAILWAY.md
+++ b/docs/RAILWAY.md
@@ -92,6 +92,62 @@ python -c "import secrets; print(secrets.token_urlsafe(32))"
 **Description :** Port sur lequel le bot expose `/health` et `/status`
 **Note :** Le backend appelle `GET <BOT_URL>/status` pour les métriques du bot
 
+## Empreinte mémoire et coût Railway
+
+Railway facture la RAM à la GB-minute, et c'est de loin le premier poste de
+coût du projet (≈93 % de la facture, contre ≈4 % pour le CPU). Ces variables
+existent uniquement pour piloter cette empreinte.
+
+### MALLOC_ARENA_MAX
+**Valeur recommandée :** `2`
+**Description :** glibc alloue une arène mémoire (jusqu'à 64 Mo) **par thread**
+et ne la rend jamais à l'OS. Le process fait tourner uvicorn, le bot et
+plusieurs threads de bibliothèques, ce qui fait stagner le RSS bien au-dessus
+de la mémoire réellement vivante. La brider à 2 arènes réduit typiquement le
+RSS de 20 à 40 % sans aucun changement de code. À définir sur **tous** les
+services Python du projet, pas seulement sur le bot.
+
+### CHUNK_GUILDS_AT_STARTUP
+**Valeur :** `False` (défaut) / `True` pour restaurer l'ancien comportement
+**Description :** quand elle vaut `True`, discord.py télécharge la liste
+complète des membres de **tous** les serveurs au démarrage et garde un objet
+`Member` résident (~1 à 2 Ko) pour chacun — le plus gros poste mémoire du
+process.
+
+Avec la valeur par défaut (`False`), le cache ne contient que les membres que
+Moddy a réellement vus (`MemberCacheFlags(joined=True)` : arrivées, messages,
+interactions). Les recherches passent par `utils/members.py` :
+
+- `get_or_fetch_member(guild, user_id)` — cache, puis un fetch REST sur défaut
+  de cache. À utiliser partout où un `None` casserait une fonctionnalité
+  (permissions de ticket, application d'une sanction, gate AltGuard…).
+- `fetch_all_members(guild, cache=False)` — la liste complète à la demande, sans
+  la laisser résidente. Réservée aux rares endroits qui en ont vraiment besoin
+  (resync AltGuard, statistiques staff).
+
+**Régression connue et assumée :** tout ce qui balaie *tous* les serveurs pour
+savoir où un utilisateur est membre (`/mutualserver`, le compte de serveurs
+partagés de `/team user`, le fan-out `on_user_update` des logs serveur) ne voit
+plus que les serveurs où la personne est en cache. Y appliquer un fetch coûterait
+une requête REST **par serveur**, ce qui est pire que la sous-estimation. Passer
+`CHUNK_GUILDS_AT_STARTUP=true` restaure l'exactitude, au prix de la mémoire.
+
+### SENTRY_TRACES_SAMPLE_RATE / SENTRY_PROFILES_SAMPLE_RATE
+**Valeurs par défaut :** `0.01` / `0.0`
+**Description :** le suivi d'erreurs (le seul usage réel de Sentry ici) n'est pas
+concerné. Le tracing garde un tampon de spans par transaction et le profileur
+lance un thread d'échantillonnage dédié (donc une arène malloc de plus). Les
+remonter n'a d'intérêt que pour une investigation ponctuelle.
+
+### Journalisation
+Le logger racine suit `DEBUG` : `INFO` en production, `DEBUG` uniquement si
+`DEBUG=True`. Le laisser en `DEBUG` fait formater et allouer par toutes les
+bibliothèques des enregistrements que personne ne lit.
+
+Sur Railway (détecté via `RAILWAY_ENVIRONMENT`), **aucun fichier de log n'est
+écrit** : stdout est déjà collecté et le disque du conteneur est éphémère.
+Ailleurs, un `RotatingFileHandler` plafonne `logs/moddy.log` à 5 Mo × 3.
+
 ## Variables optionnelles
 
 ### DEBUG
@@ -200,6 +256,9 @@ et les notifications
 - [ ] `HM_URL` (optionnel, désactive le heartbeat si absent)
 - [ ] `HM_INGEST_TOKEN` (optionnel, désactive le heartbeat si absent, identique sur tous les services)
 - [ ] `BETTERSTACK_HEARTBEAT_URL` (optionnel, désactive le ping Better Stack si absent)
+- [ ] `MALLOC_ARENA_MAX` → `2` (fortement recommandé — voir « Empreinte mémoire »)
+- [ ] `CHUNK_GUILDS_AT_STARTUP` (optionnel, défaut `False` — `True` restaure l'ancien cache complet)
+- [ ] `SENTRY_TRACES_SAMPLE_RATE` / `SENTRY_PROFILES_SAMPLE_RATE` (optionnels, défauts `0.01` / `0.0`)
 
 ## Dépannage
 

--- a/docs/sessions/2026-09-02_railway-cost-memory-optimization.md
+++ b/docs/sessions/2026-09-02_railway-cost-memory-optimization.md
@@ -1,0 +1,141 @@
+# 2026-09-02 — Railway cost: memory optimization pass (tier 0 + tier 1)
+
+## Why
+
+The Railway bill was **$6.14** over the billed window, of which **93% is RAM**
+($5.70) against $0.25 CPU, $0.12 volumes and $0.08 egress. Optimizing anything
+other than memory is wasted effort.
+
+The per-service breakdown also reframed the target: the bot is only **24.7%** of
+the bill. The four separate Postgres instances together are **27.5%**, the
+backend 22.7%, moddy-feeds 10.2%, AltGuard 7.6%.
+
+This session covers what is fixable **inside this repo**. The infrastructure
+work (consolidating the four Postgres instances, the redundant Health service)
+is documented in the plan but is a dashboard operation, not a code change.
+
+## What was done
+
+### Tier 0 — no behaviour change
+
+- **Removed the duplicate uvicorn server.** `bot.start_internal_api_server()`
+  spawned a *second* uvicorn for the same `internal_api.server:app` on the same
+  port, in a daemon thread with its own event loop, while `main.start_api_server()`
+  already served it on the bot's loop. Only one could ever bind; the loser died
+  silently while still costing a thread, a loop and a duplicate FastAPI app.
+  Replaced by `ModdyBot.wire_internal_api()`, which keeps the one thing the
+  thread actually did that mattered: `set_bot(self)` — `main.py` imported
+  `set_bot` but never called it, so removing the thread outright would have left
+  `/status` reporting on a `None` bot.
+- **Logging.** Root logger and handlers now follow `DEBUG` (INFO in production
+  instead of DEBUG everywhere), and no log file is written on Railway
+  (`RAILWAY_ENVIRONMENT`), where stdout is already collected. Elsewhere a
+  `RotatingFileHandler` (5 MB × 3) replaces the un-rotated per-day
+  `logging.FileHandler`, which grew forever with no cleanup path.
+- **Sentry.** `traces_sample_rate` 0.1 → 0.01, `profiles_sample_rate` 0.1 → 0.0,
+  both env-overridable. The profiler ran a dedicated sampling thread; error
+  tracking, the actual use case, is unaffected.
+- **i18n loaded once.** The singleton is built at import time and `bot.setup_hook`
+  called `load_translations()` again, re-parsing ~1.1 MB of JSON into a dict that
+  was simply overwritten. `load_translations()` is now idempotent;
+  `reload_translations()` passes `force=True`.
+- **`gc.freeze()`** at the end of `setup_hook`, once cogs, modules, staff
+  commands, persistent views and translations are all resident and permanent.
+
+### Tier 1 — behaviour change, gated and compensated
+
+- **`chunk_guilds_at_startup=False`** (new `config.CHUNK_GUILDS_AT_STARTUP`,
+  default False, `CHUNK_GUILDS_AT_STARTUP=true` restores the old behaviour in one
+  redeploy). This is the single largest memory item: with the `members` intent on,
+  discord.py otherwise downloads every guild's full member list at startup and
+  keeps a resident `Member` (~1–2 KB) for each.
+- **New `utils/members.py`**: `get_or_fetch_member()` (cache, then one REST
+  fetch) and `fetch_all_members(guild, cache=False)` (full list on demand,
+  without leaving it resident).
+- **Converted the call sites where a `None` breaks a feature**, all verified to
+  be in async functions: ticket permissions, appeal apply/reverse, backend
+  sanction add/revoke, interserver relay, team link sessions, staff thread guard,
+  AltGuard staff target resolution, reminder delivery, poll-vote logs.
+  `modules/altguard.py` already had its own fetch fallback and was left alone.
+- **`modules/automod_ai.py::_observe_target_reaction`** was the sharpest edge: it
+  read a plain cache miss as `target_gone = True`, which would have fed a false
+  signal into the target-reaction classifier and therefore into a sanction
+  decision. Now resolved authoritatively.
+- **`services/ticket_service.build_overwrites` stayed synchronous.** It has 4
+  production callers and 12 test callers; making it async would have churned all
+  of them. Instead it takes an optional pre-resolved `members` map (falling back
+  to `guild.get_member`), and the four async callers build it first via the new
+  `resolve_ticket_members()`. An uncached ticket owner would otherwise have been
+  left out of the overwrites — locked out of their own ticket.
+- **`max_messages`** 5000 → 1000. Every consumer acts on messages seconds to
+  minutes old (the file's own comment says so).
+- **Redis blocking reads** `block=5000` → `30000` in the task stream and both
+  feeds loops. A blocking `XREAD` returns as soon as an entry lands, so latency
+  is unchanged; the client just stops re-issuing the command every 5s around the
+  clock. Redis was burning 152 vCPU-min, nearly as much as the bot itself.
+- **Bounded three caches that could only grow:**
+  - `automod/engine.py`: `_budget_degraded` / `_budget_notified` were keyed
+    `(guild, UTC day)` and grew by one tuple per active guild per day forever,
+    while only the current day was ever read. Now guild-id sets cleared on day
+    rollover.
+  - `gateway/quota.py`: `_limit_cache` checked its TTL on read only, so expired
+    entries stayed resident — one per distinct user/guild ever served. Now an
+    `OrderedDict` pruned of expired entries and capped at 2048 on the write path.
+  - `services/precedent_service.py`: the TTL bounded the cache in *time* but not
+    in *size*. Added `PRECEDENT_CACHE_MAX_GUILDS = 50` with LRU eviction — at
+    500 vectors per guild that is ~3 MB each, so a busy window could otherwise
+    pin hundreds of megabytes.
+
+## Decisions and why
+
+- **The Health heartbeat interval was left at 20s.** It was going to move to 60s
+  for egress, until the file's own docstring turned out to state the monitor's
+  TTL is 60s (three missed heartbeats). A 60s interval would have broken the dead
+  man's switch. Egress is 1.3% of the bill — not worth any risk.
+- **float32 vectors and the precedent TTL sweep were already implemented.** The
+  plan listed both; only the missing global size cap was added.
+- **Mutual-server scans were deliberately NOT converted.** `cogs/logs.py`
+  (`on_user_update` fan-out), `staff/commands/team/mutualserver.py` and
+  `staff/commands/team/user.py` iterate `bot.guilds` calling `get_member` on each.
+  Fetching there would mean one REST call **per guild per lookup**. They now
+  under-report to "guilds where the user is cached" — see Known issues.
+
+## Files modified
+
+`bot.py`, `main.py`, `config.py`, `utils/i18n.py`, `utils/tech_logger.py`,
+`utils/members.py` (new), `cogs/error_handler.py`, `cogs/altguard.py`,
+`cogs/tickets.py`, `cogs/reminder.py`, `cogs/moderation_commands.py`,
+`modules/automod_ai.py`, `modules/interserver.py`, `services/ticket_service.py`,
+`services/appeal_service.py`, `services/team_link_session.py`,
+`services/precedent_service.py`, `services/feeds_client.py`,
+`serverlogs/listeners/polls.py`, `staff/commands/team/server.py`,
+`staff/commands/mod/altguard/_shared.py`, `automod/engine.py`,
+`automod/constants.py`, `gateway/quota.py`, `docs/RAILWAY.md`, `CLAUDE.md`.
+
+## Known issues / follow-ups
+
+- **Accepted regression from disabling the chunk:** anything scanning every guild
+  to find where a user is a member now under-reports — `/mutualserver`, the shared
+  server count in `/team user`, and the `on_user_update` fan-out in server logs
+  (username/avatar changes will only be logged in guilds where the member is
+  cached). `CHUNK_GUILDS_AT_STARTUP=true` restores accuracy at the old memory
+  cost. Worth watching in production before deciding.
+- **`MALLOC_ARENA_MAX=2` is not set by this commit** — it is a Railway env var,
+  and probably the single best effort/reward item left. Documented in
+  `docs/RAILWAY.md`.
+- **Not touched, and where the money actually is:** consolidating the four
+  Postgres instances into one (~27.5% of the bill), the Health service that
+  duplicates Better Stack, and the Backend / moddy-feeds services (33% combined),
+  none of which live in this repo.
+- **No memory instrumentation exists.** Every figure above is an estimate. A
+  `/dev memory` staff command exposing `tracemalloc` and the size of the main
+  caches would turn the next pass into measurement rather than guesswork
+  (`psutil` is already a dependency).
+
+## Verification
+
+- `python3 -m pytest -q` → **1546 passed**.
+- Every `.py` in the repo compiles (`compile()`, which catches `await` outside an
+  async function where `ast.parse` does not).
+- Every touched module imports cleanly, and `i18n` was confirmed to load its five
+  locales exactly once.

--- a/gateway/quota.py
+++ b/gateway/quota.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -11,6 +12,8 @@ from .errors import QuotaExceededError
 logger = logging.getLogger("moddy.gateway.quota")
 
 _LIMIT_CACHE_TTL = 60.0  # seconds
+# Hard cap on distinct (scope, key, type) limits kept in memory.
+_LIMIT_CACHE_MAX_ENTRIES = 2048
 _QUOTA_KEY_TTL = 172800  # 48h in seconds
 
 
@@ -21,8 +24,11 @@ class QuotaManager:
     def __init__(self, redis, pool):
         self._redis = redis
         self._pool = pool
-        # (scope, key, type) -> (limit, cached_at)
-        self._limit_cache: dict[tuple, tuple[int, float]] = {}
+        # (scope, key, type) -> (limit, cached_at). The TTL was only checked on
+        # read, so an expired entry stayed resident forever: one key per distinct
+        # user/guild the gateway ever served. Insertion-ordered and capped, with
+        # expired entries dropped on write (see _prune_limit_cache).
+        self._limit_cache: "OrderedDict[tuple, tuple[int, float]]" = OrderedDict()
         self._cache_lock = asyncio.Lock()
 
     def _date_str(self) -> str:
@@ -62,8 +68,25 @@ class QuotaManager:
 
         async with self._cache_lock:
             self._limit_cache[cache_key] = (limit, time.monotonic())
+            self._limit_cache.move_to_end(cache_key)
+            self._prune_limit_cache()
 
         return limit
+
+    def _prune_limit_cache(self) -> None:
+        """Drop expired entries, then the oldest ones past the size cap.
+
+        Called under `_cache_lock` from the write path only: the read path is hot
+        and must stay a plain dict lookup. Re-resolving an evicted limit costs one
+        query, which is what the cache miss would have cost anyway.
+        """
+        now = time.monotonic()
+        expired = [k for k, (_, at) in self._limit_cache.items()
+                   if now - at >= _LIMIT_CACHE_TTL]
+        for k in expired:
+            del self._limit_cache[k]
+        while len(self._limit_cache) > _LIMIT_CACHE_MAX_ENTRIES:
+            self._limit_cache.popitem(last=False)
 
     async def _get_count(self, target: QuotaTarget) -> int:
         """Current daily usage from Redis."""

--- a/main.py
+++ b/main.py
@@ -283,27 +283,40 @@ def setup_logging():
     log_format = '%(asctime)s [%(levelname)-8s] %(name)-25s | %(message)s'
     date_format = '%Y-%m-%d %H:%M:%S'
 
+    # DEBUG is opt-in. Leaving the root logger at DEBUG means every library on the
+    # stack formats and allocates log records that are then thrown away, which is
+    # pure memory churn in a container where nobody reads them.
+    debug_enabled = os.getenv("DEBUG", "").strip().lower() in ("1", "true", "yes", "on")
+    level = logging.DEBUG if debug_enabled else logging.INFO
+
     # Console handler
     console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setLevel(logging.INFO)
+    console_handler.setLevel(level)
     console_handler.setFormatter(CompactExceptionFormatter(log_format, date_format))
-
-    # File handler
-    log_dir = Path(__file__).parent / 'logs'
-    log_dir.mkdir(exist_ok=True)
-
-    file_handler = logging.FileHandler(
-        log_dir / f'moddy_{time.strftime("%Y%m%d")}.log',
-        encoding='utf-8'
-    )
-    file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(CompactExceptionFormatter(log_format, date_format))
 
     # Root logger configuration
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.DEBUG)
+    root_logger.setLevel(level)
     root_logger.addHandler(console_handler)
-    root_logger.addHandler(file_handler)
+
+    # File handler. On Railway stdout is already collected and the container disk is
+    # ephemeral, so writing a second copy only grows a file nobody reads. Everywhere
+    # else the file is capped and rotated instead of growing forever.
+    if not os.getenv("RAILWAY_ENVIRONMENT"):
+        from logging.handlers import RotatingFileHandler
+
+        log_dir = Path(__file__).parent / 'logs'
+        log_dir.mkdir(exist_ok=True)
+
+        file_handler = RotatingFileHandler(
+            log_dir / 'moddy.log',
+            maxBytes=5_000_000,
+            backupCount=2,
+            encoding='utf-8',
+        )
+        file_handler.setLevel(level)
+        file_handler.setFormatter(CompactExceptionFormatter(log_format, date_format))
+        root_logger.addHandler(file_handler)
 
     # Reduces noise from certain modules
     logging.getLogger('discord').setLevel(logging.WARNING)

--- a/modules/automod_ai.py
+++ b/modules/automod_ai.py
@@ -61,6 +61,7 @@ from automod import bareme as ab
 from automod import relations as ar
 from utils import global_sanctions
 from utils.i18n import t
+from utils.members import get_or_fetch_member
 from utils.moderation_cases import IssuerType, SanctionAction, EventType, AuthorType
 
 logger = logging.getLogger("moddy.modules.automod_ai")
@@ -620,8 +621,12 @@ class AutomodModule(ModuleBase):
 
         target_gone = False
         guild = message.guild
-        if guild is not None and guild.get_member(int(target_id)) is None:
-            target_gone = True
+        if guild is not None:
+            # Must be an authoritative answer: guilds are not chunked at startup
+            # (config.CHUNK_GUILDS_AT_STARTUP), so a plain cache miss would be
+            # read as "the target left", feeding a false signal into the
+            # target-reaction classifier and therefore into a sanction.
+            target_gone = await get_or_fetch_member(guild, int(target_id)) is None
 
         engine = get_engine(self.bot)
         aggressive = sum(1 for r in replies if engine.blocklist.match(r) is not None)

--- a/modules/interserver.py
+++ b/modules/interserver.py
@@ -14,6 +14,7 @@ import asyncio
 
 from modules.module_manager import ModuleBase
 from utils.emojis import GROUPS, UNDONE, DONE, VERIFIED, LOADING as LOADING_EMOJI, REPLY as REPLY_EMOJI
+from utils.members import get_or_fetch_member
 
 logger = logging.getLogger('moddy.modules.interserver')
 
@@ -261,7 +262,7 @@ class InterServerModule(ModuleBase):
                 if not is_moddy_team:
                     try:
                         # Vérifie si l'auteur est membre du serveur cible
-                        target_member = channel.guild.get_member(message.author.id)
+                        target_member = await get_or_fetch_member(channel.guild, message.author.id)
 
                         if target_member:
                             # Vérifie si le membre est en timeout

--- a/serverlogs/listeners/polls.py
+++ b/serverlogs/listeners/polls.py
@@ -6,8 +6,9 @@ Discord happily sends message events for messages that never carried a poll,
 and a message can also lose its poll after the fact.
 
 Votes arrive as raw payloads (``on_raw_poll_vote_add``/``_remove``), so the
-voter is resolved from the guild cache when possible and falls back to a bare
-id line when the member is not cached.
+voter is resolved from the guild cache and, on a miss, fetched over REST --
+guilds are not chunked at startup, and a vote log with no voter in it says
+nothing. A bare id line is still the fallback when even the fetch fails.
 """
 
 from __future__ import annotations
@@ -19,6 +20,7 @@ import discord
 from serverlogs.renderer import (
     escape, fmt_channel, fmt_number, fmt_time, fmt_user,
 )
+from utils.members import get_or_fetch_member
 
 #: Answers listed inline before the block would overflow into a file.
 MAX_LISTED_ANSWERS = 10
@@ -68,7 +70,9 @@ async def on_poll_vote(service, guild: discord.Guild,
                        added: bool) -> None:
     """One member adding or removing one vote on one answer."""
     channel = guild.get_channel_or_thread(payload.channel_id)
-    member = guild.get_member(payload.user_id)
+    # Fetch on a miss: without the voter the whole log line says nothing. Only
+    # costs a request for someone who has not been seen in the guild yet.
+    member = await get_or_fetch_member(guild, payload.user_id)
     event = "poll_votes_add" if added else "poll_votes_remove"
 
     entry = await service.open(guild, event, channel=channel, subject=member,

--- a/services/appeal_service.py
+++ b/services/appeal_service.py
@@ -28,6 +28,7 @@ import discord
 import config
 from utils.i18n import t
 from utils.moderation_cases import IssuerType, SanctionAction, EventType, AuthorType
+from utils.members import get_or_fetch_member
 
 logger = logging.getLogger("moddy.appeal_service")
 
@@ -387,7 +388,7 @@ class AppealService:
             if action == "ban":
                 await guild.unban(discord.Object(id=subject_id), reason="[Automod] appel accepté")
             elif action == "mute":
-                member = guild.get_member(subject_id)
+                member = await get_or_fetch_member(guild, subject_id)
                 if member is not None:
                     await member.timeout(None, reason="[Automod] appel accepté")
         except (discord.Forbidden, discord.HTTPException, discord.NotFound) as e:
@@ -400,7 +401,7 @@ class AppealService:
             return
         from datetime import timedelta
         me = guild.me
-        member = guild.get_member(subject_id)
+        member = await get_or_fetch_member(guild, subject_id)
         mute_for = (min(timedelta(hours=int(duration_hours)), timedelta(days=28))
                     if duration_hours and duration_hours > 0 else _TRANSFORM_MUTE_DURATION)
         try:

--- a/services/feeds_client.py
+++ b/services/feeds_client.py
@@ -143,7 +143,7 @@ class FeedsClient:
         last_id = "$"  # only replies produced after we start listening
         while True:
             try:
-                messages = await self.redis.xread({REPLIES_STREAM: last_id}, block=5000, count=20)
+                messages = await self.redis.xread({REPLIES_STREAM: last_id}, block=30000, count=20)
                 if not messages:
                     continue
                 for _stream, entries in messages:
@@ -188,7 +188,7 @@ class FeedsClient:
                     self._consumer_name,
                     {QUEUE_STREAM: ">"},
                     count=50,
-                    block=5000,
+                    block=30000,
                 )
                 for _stream, messages in resp or []:
                     for msg_id, fields in messages:

--- a/services/precedent_service.py
+++ b/services/precedent_service.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections import OrderedDict
 from typing import Awaitable, Callable, List, Optional
 
 from automod import constants as ac
@@ -38,7 +39,12 @@ class PrecedentService:
         # holds up to PRECEDENT_MAX_PER_GUILD embedding vectors per guild, so
         # letting stale entries linger is the single largest memory leak-shaped
         # cost in the bot even though nothing here actually leaks.
-        self._cache: dict[int, tuple[float, List[ap.Precedent]]] = {}
+        #
+        # An OrderedDict in insertion order, capped at PRECEDENT_CACHE_MAX_GUILDS:
+        # the TTL bounds the cache in *time* but not in *size*, so a busy window
+        # across many guilds could otherwise pin hundreds of megabytes of vectors
+        # at once. Past the cap the least-recently-loaded guild is dropped.
+        self._cache: "OrderedDict[int, tuple[float, List[ap.Precedent]]]" = OrderedDict()
 
     # -- Recording (from a human ruling) -----------------------------------
 
@@ -108,10 +114,23 @@ class PrecedentService:
         for gid in stale:
             del self._cache[gid]
 
+    def _evict_overflow(self) -> None:
+        """Drop least-recently-loaded guilds past PRECEDENT_CACHE_MAX_GUILDS.
+
+        Complements the TTL sweep: that one bounds how *long* a guild stays
+        cached, this one bounds how *many* do at once. Evicting costs the guild a
+        single extra query the next time it is seen.
+        """
+        while len(self._cache) > ac.PRECEDENT_CACHE_MAX_GUILDS:
+            self._cache.popitem(last=False)
+
     async def _guild_precedents(self, guild_id: int) -> List[ap.Precedent]:
         now = time.time()
         entry = self._cache.get(guild_id)
         if entry is not None and entry[0] > now:
+            # Refresh recency so a guild that keeps being read is not the one
+            # evicted when the cache overflows.
+            self._cache.move_to_end(guild_id)
             return entry[1]
         self._evict_expired(now)
         pres: List[ap.Precedent] = []
@@ -137,6 +156,8 @@ class PrecedentService:
                 source=r.get("source") or "",
             ))
         self._cache[guild_id] = (now + ac.PRECEDENT_CACHE_TTL_SECONDS, pres)
+        self._cache.move_to_end(guild_id)
+        self._evict_overflow()
         return pres
 
     def make_provider(

--- a/services/team_link_session.py
+++ b/services/team_link_session.py
@@ -56,6 +56,7 @@ from typing import Dict, Iterable, List, Optional, Sequence, Set
 import discord
 
 from utils.moddy_team_role import is_linked
+from utils.members import get_or_fetch_member
 
 logger = logging.getLogger("moddy.team_link_session")
 
@@ -349,7 +350,7 @@ async def _undo(session: LinkSession, entry: discord.AuditLogEntry) -> None:
                 await role.edit(permissions=before, reason=reason)
 
         elif action is discord.AuditLogAction.member_role_update:
-            member = guild.get_member(getattr(entry.target, "id", 0))
+            member = await get_or_fetch_member(guild, getattr(entry.target, "id", 0))
             if member:
                 # discord.py puts the roles *added* in `after` and the roles
                 # *removed* in `before`; undoing is exactly swapping them back.
@@ -553,7 +554,7 @@ async def recover_sessions(bot) -> None:
         # what one interrupted before this file handled two roles stored. Both
         # are read, or that staffer never gets their roles back.
         team_ids = id_set(stored.get("team_role_ids")) or id_set(stored.get("team_role_id"))
-        member = guild.get_member(int(stored.get("staff_id") or 0))
+        member = await get_or_fetch_member(guild, int(stored.get("staff_id") or 0))
         if member:
             await _give_roles_back(bot, guild, member,
                                    stored.get("saved_role_ids") or [], team_ids)

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -60,6 +60,7 @@ from modules.tickets import (
     ticket_status_dot,
 )
 from utils.i18n import t
+from utils.members import get_or_fetch_member
 
 logger = logging.getLogger('moddy.services.tickets')
 
@@ -213,8 +214,28 @@ class TicketService:
     # ------------------------------------------------------------------ #
     # Channel permissions
     # ------------------------------------------------------------------ #
+    async def resolve_ticket_members(
+        self, guild: discord.Guild, ticket: Dict[str, Any]
+    ) -> Dict[int, discord.Member]:
+        """Resolve everyone who needs a personal overwrite on a ticket channel.
+
+        One REST fetch per person missing from the cache, only for the handful
+        of people actually on a ticket. Feed the result to `build_overwrites`.
+        """
+        wanted = {ticket.get('owner_id'), ticket.get('claimed_by'),
+                  *ticket.get('participants', [])}
+        resolved: Dict[int, discord.Member] = {}
+        for uid in wanted:
+            if not uid:
+                continue
+            member = await get_or_fetch_member(guild, int(uid))
+            if member is not None:
+                resolved[int(uid)] = member
+        return resolved
+
     def build_overwrites(self, guild: discord.Guild, category: Dict[str, Any],
-                         ticket: Dict[str, Any]
+                         ticket: Dict[str, Any],
+                         members: Optional[Dict[int, discord.Member]] = None,
                          ) -> Dict[Union[discord.Role, discord.Member],
                                    discord.PermissionOverwrite]:
         """The full overwrite map for a ticket channel, from scratch.
@@ -234,6 +255,19 @@ class TicketService:
           side, so a closed ticket disappears from the opener's channel list
           without losing anything: reopening restores it exactly.
         """
+        # Guilds are no longer chunked at startup (config.CHUNK_GUILDS_AT_STARTUP),
+        # so an opener who has not spoken recently may not be in the member cache
+        # -- and a missing overwrite locks them out of their own ticket. Callers
+        # resolve the people involved beforehand with `resolve_ticket_members()`
+        # and pass them in; `guild.get_member` stays the fallback so this method
+        # remains synchronous and usable on its own.
+        def _lookup(uid: int) -> Optional[discord.Member]:
+            if members is not None:
+                found = members.get(uid)
+                if found is not None:
+                    return found
+            return guild.get_member(uid)
+
         escalated = bool(ticket.get('escalated'))
         closed = ticket.get('status') == 'closed'
         muted = escalated and bool(ticket.get('escalation_mute'))
@@ -282,7 +316,7 @@ class TicketService:
             # drop them, or to keep them read-only).
             member_ids = [ticket['owner_id'], *ticket.get('participants', [])]
             for user_id in member_ids:
-                member = guild.get_member(user_id)
+                member = _lookup(user_id)
                 if member and member not in overwrites:
                     overwrites[member] = (_MEMBER_MUTED_OVERWRITE if muted
                                           else _MEMBER_OVERWRITE)
@@ -290,7 +324,7 @@ class TicketService:
         # The claimer, last: a member overwrite outranks the role one they were
         # just muted through, which is the whole point of claiming.
         if locked and claimer_id:
-            claimer = guild.get_member(claimer_id)
+            claimer = _lookup(claimer_id)
             if claimer:
                 overwrites[claimer] = _STAFF_OVERWRITE
 
@@ -362,9 +396,10 @@ class TicketService:
                                category: Dict[str, Any],
                                ticket: Dict[str, Any]) -> bool:
         """Push the rebuilt overwrite map onto the channel."""
+        members = await self.resolve_ticket_members(channel.guild, ticket)
         try:
             await channel.edit(
-                overwrites=self.build_overwrites(channel.guild, category, ticket),
+                overwrites=self.build_overwrites(channel.guild, category, ticket, members),
                 reason="Moddy tickets: permission sync",
             )
             return True
@@ -413,13 +448,14 @@ class TicketService:
         number = await self.bot.db.next_ticket_number(guild.id)
         draft = {'owner_id': member.id, 'status': 'open', 'escalated': False,
                  'participants': [], 'participant_roles': [], 'claimed_by': None}
+        members = await self.resolve_ticket_members(guild, draft)
         try:
             channel = await guild.create_text_channel(
                 name=apply_status_prefix(
                     render_channel_name(category, member=member, number=number),
                     ticket_status_dot(category, draft)),
                 category=parent,
-                overwrites=self.build_overwrites(guild, category, draft),
+                overwrites=self.build_overwrites(guild, category, draft, members),
                 topic=t('modules.tickets.channel.topic', locale=locale,
                         number=number, category=category['name'],
                         user=str(member), user_id=member.id)[:1024],
@@ -570,10 +606,11 @@ class TicketService:
         draft = {'owner_id': actor.id, 'status': 'open', 'escalated': False,
                  'participants': [], 'participant_roles': [], 'claimed_by': None}
 
+        members = await self.resolve_ticket_members(guild, draft)
         try:
             channel = await guild.create_text_channel(
                 name=render_channel_name(category, member=actor, number=number),
-                overwrites=self.build_overwrites(guild, category, draft),
+                overwrites=self.build_overwrites(guild, category, draft, members),
                 topic=t('staff.team.ticket.topic', locale=locale, number=number,
                         user=str(actor), user_id=actor.id)[:1024],
                 reason=f"Moddy staff ticket opened by {actor} ({actor.id})",
@@ -1104,6 +1141,7 @@ class TicketService:
         await self.bot.db.set_ticket_category(channel.id, target_panel['id'], target['id'])
         ticket = await self.get_ticket(channel.id) or ticket
 
+        members = await self.resolve_ticket_members(channel.guild, ticket)
         try:
             await channel.edit(
                 category=parent,
@@ -1112,7 +1150,7 @@ class TicketService:
                 # showing the previous category's convention.
                 name=apply_status_prefix(channel.name,
                                          ticket_status_dot(target, ticket)),
-                overwrites=self.build_overwrites(channel.guild, target, ticket),
+                overwrites=self.build_overwrites(channel.guild, target, ticket, members),
                 reason=f"Moddy ticket moved by {actor} ({actor.id})",
             )
         except discord.Forbidden:

--- a/staff/commands/mod/altguard/_shared.py
+++ b/staff/commands/mod/altguard/_shared.py
@@ -6,6 +6,7 @@ from typing import Optional, Tuple
 
 from staff.framework import design, parse_guild_id, parse_user_id
 from utils.i18n import t
+from utils.members import get_or_fetch_member
 
 GROUP = "altguard"
 GROUP_DESCRIPTION = "AltGuard verification (anti multi-account)"
@@ -39,7 +40,7 @@ async def resolve_target(ctx, *, user_option: str = "user",
             t("staff.mod.altguard.no_guild", locale=ctx.locale, id=f"`{guild_id}`"),
         )
 
-    member = guild.get_member(user_id)
+    member = await get_or_fetch_member(guild, user_id)
     if member is None:
         try:
             member = await guild.fetch_member(user_id)

--- a/staff/commands/team/server.py
+++ b/staff/commands/team/server.py
@@ -7,6 +7,7 @@ information plus Moddy database attributes.
 from staff.framework import StaffCommand, SlashOption, staff_command, design, CommandType, parse_guild_id
 from utils import emojis
 from utils.i18n import t
+from utils.members import fetch_all_members
 
 
 @staff_command
@@ -35,8 +36,16 @@ class ServerCommand(StaffCommand):
             ))
             return
 
-        humans = sum(1 for m in guild.members if not m.bot)
-        bots = guild.member_count - humans if guild.member_count else 0
+        # Guilds are not chunked at startup (config.CHUNK_GUILDS_AT_STARTUP), so
+        # the split is pulled on demand here rather than counted off a partial
+        # cache, which would silently under-report. `None` when the pull fails.
+        members = await fetch_all_members(guild, cache=False)
+        if members is None:
+            humans_str = bots_str = "?"
+        else:
+            humans = sum(1 for m in members if not m.bot)
+            bots = (guild.member_count - humans) if guild.member_count else (len(members) - humans)
+            humans_str, bots_str = f"{humans:,}", f"{bots:,}"
         owner = f"<@{guild.owner_id}> (`{guild.owner_id}`)"
 
         fields = [{
@@ -51,8 +60,8 @@ class ServerCommand(StaffCommand):
             "name": f"{emojis.USER} {t('staff.team.server.members', locale=locale)}",
             "value": (
                 f"**{t('staff.team.server.total', locale=locale)}:** `{guild.member_count:,}`\n"
-                f"**{t('staff.team.server.humans', locale=locale)}:** `{humans:,}`\n"
-                f"**{t('staff.team.server.bots', locale=locale)}:** `{bots:,}`"
+                f"**{t('staff.team.server.humans', locale=locale)}:** `{humans_str}`\n"
+                f"**{t('staff.team.server.bots', locale=locale)}:** `{bots_str}`"
             ),
         }, {
             "name": f"{emojis.COMMANDS} {t('staff.team.server.channels', locale=locale)}",

--- a/utils/i18n.py
+++ b/utils/i18n.py
@@ -69,6 +69,7 @@ class I18n:
     _translations: Dict[str, Dict[str, Any]] = {}
     _default_locale = Locale.EN_US
     _supported_locales = set()
+    _loaded = False
 
     def __new__(cls):
         if cls._instance is None:
@@ -81,8 +82,18 @@ class I18n:
             self._initialized = True
             self.load_translations()
 
-    def load_translations(self):
-        """Charge toutes les traductions depuis les fichiers JSON"""
+    def load_translations(self, force: bool = False):
+        """Charge toutes les traductions depuis les fichiers JSON.
+
+        Idempotent: the singleton is built at import time (and `utils.i18n` is
+        imported by most of the codebase), so a second call would re-parse ~1.1 MB
+        of JSON and double the peak allocation for a dict that is simply
+        overwritten with the same content. Use `force=True` (or
+        `reload_translations()`) to genuinely re-read the files.
+        """
+        if self.__class__._loaded and not force:
+            return
+
         translations_dir = Path(__file__).parent.parent / 'locales'
 
         if not translations_dir.exists():
@@ -104,12 +115,15 @@ class I18n:
 
         if not self._translations:
             logger.warning("⚠️ Aucune traduction chargée, utilisation des valeurs par défaut")
+        else:
+            self.__class__._loaded = True
 
     def reload_translations(self):
         """Recharge toutes les traductions (utile pour le développement)"""
         self._translations.clear()
         self._supported_locales.clear()
-        self.load_translations()
+        self.__class__._loaded = False
+        self.load_translations(force=True)
         logger.info("🔄 Traductions rechargées")
 
     def get_user_locale(self, interaction: discord.Interaction) -> str:

--- a/utils/members.py
+++ b/utils/members.py
@@ -1,0 +1,94 @@
+"""
+Member lookup helpers that work with or without the startup member chunk.
+
+`config.CHUNK_GUILDS_AT_STARTUP` defaults to False, so `guild.get_member()` is
+no longer guaranteed to hit: the cache only holds members Moddy has actually
+seen (joins, messages, interactions -- `MemberCacheFlags(joined=True)`). These
+helpers cover the two patterns the codebase needs:
+
+- `get_or_fetch_member()` for a single lookup: cache first, one REST call on a
+  miss.
+- `fetch_all_members()` for the rare code path that genuinely needs the whole
+  member list (stats, AltGuard resync): pulls it on demand over the gateway,
+  without leaving it resident unless the caller asks.
+
+Both are safe to call when chunking is enabled -- they simply hit the cache.
+"""
+
+import logging
+from typing import Optional
+
+import discord
+
+logger = logging.getLogger('moddy.members')
+
+
+async def get_or_fetch_member(
+    guild: Optional[discord.Guild],
+    user_id: Optional[int],
+) -> Optional[discord.Member]:
+    """Return a guild member, falling back to a REST fetch on a cache miss.
+
+    Returns None when the guild or id is missing, when the user is not a member,
+    or when Discord refuses the lookup. Callers already handle None because
+    `guild.get_member()` could always return it.
+
+    A successful fetch populates the member cache, so repeated lookups for the
+    same person cost one request, not one per call.
+    """
+    if guild is None or user_id is None:
+        return None
+
+    member = guild.get_member(user_id)
+    if member is not None:
+        return member
+
+    try:
+        return await guild.fetch_member(user_id)
+    except discord.NotFound:
+        # Not a member (left, never joined, or a bare user id).
+        return None
+    except discord.HTTPException as e:
+        logger.warning(
+            f"fetch_member failed for {user_id} in guild {guild.id}: {e}"
+        )
+        return None
+
+
+async def fetch_all_members(
+    guild: Optional[discord.Guild],
+    *,
+    cache: bool = False,
+) -> Optional[list]:
+    """Return a guild's complete member list, chunking over the gateway if needed.
+
+    Returns None when the list could not be completed -- the caller must then
+    treat `guild.members` as a partial sample rather than report a wrong total.
+
+    `cache` defaults to False: callers that only need to count or enumerate once
+    (stats, an hourly reconciliation) should not leave every member resident in
+    memory afterwards. Pass cache=True only if repeated lookups follow.
+    """
+    if guild is None:
+        return None
+
+    if guild.chunked:
+        return list(guild.members)
+
+    try:
+        members = await guild.chunk(cache=cache)
+    except (discord.ClientException, discord.HTTPException) as e:
+        logger.warning(f"Could not chunk guild {guild.id}: {e}")
+        return None
+    except Exception as e:  # gateway timeouts surface as plain TimeoutError
+        logger.warning(f"Could not chunk guild {guild.id}: {e}")
+        return None
+
+    if members is not None:
+        return list(members)
+
+    # Some paths populate the cache instead of returning the list.
+    if guild.chunked:
+        return list(guild.members)
+
+    return None

--- a/utils/tech_logger.py
+++ b/utils/tech_logger.py
@@ -36,6 +36,7 @@ from utils.emojis import (
     DONE, UNDONE, ADD, LOGOUT, MODDY, BUG, MODDYTEAM_BADGE, SETTINGS, COMMANDS,
     SAVE, MANAGE_USER, BLACKLIST, TIME, PAUSE, CODE, MODDY_SQUARE,
 )
+from utils.members import fetch_all_members
 
 logger = logging.getLogger("moddy.tech_logger")
 
@@ -190,8 +191,12 @@ class TechLogger:
 
     async def log_guild_join(self, guild: discord.Guild):
         try:
-            humans = sum(1 for m in guild.members if not m.bot) if guild.members else None
-            bots = sum(1 for m in guild.members if m.bot) if guild.members else None
+            # Guilds are not chunked at startup (config.CHUNK_GUILDS_AT_STARTUP).
+            # This fires once, on join, so the list is pulled on demand and not
+            # kept resident; None when it cannot be completed.
+            all_members = await fetch_all_members(guild, cache=False)
+            humans = sum(1 for m in all_members if not m.bot) if all_members else None
+            bots = sum(1 for m in all_members if m.bot) if all_members else None
             members = guild.member_count or 0
             owner = f"`{guild.owner}`" if guild.owner else "unknown"
 


### PR DESCRIPTION
## Summary

This PR implements a comprehensive memory optimization pass targeting Railway's RAM billing (93% of the $6.14 bill). The changes are split into two tiers: tier 0 (no behavior change) and tier 1 (behavior change, gated and compensated).

## Key Changes

### Tier 0 — No Behavior Change

- **Removed duplicate uvicorn server**: `bot.start_internal_api_server()` spawned a second uvicorn instance on the same port in a daemon thread. Replaced with `ModdyBot.wire_internal_api()` which only calls `set_bot(self)` on the single server instance started by `main.py`.

- **Logging improvements**:
  - Root logger now follows `DEBUG` flag (INFO in production, DEBUG only when `DEBUG=True`)
  - No log file written on Railway (stdout already collected); elsewhere uses `RotatingFileHandler` (5 MB × 3) instead of unbounded daily files
  - Reduces memory churn from formatting log records that are never read

- **Sentry sampling reduced**:
  - `traces_sample_rate`: 0.1 → 0.01
  - `profiles_sample_rate`: 0.1 → 0.0
  - Error tracking (actual use case) unaffected; profiler thread eliminated

- **i18n loaded once**: Singleton built at import time; `load_translations()` now idempotent, `reload_translations()` passes `force=True`. Prevents re-parsing ~1.1 MB of JSON on every `setup_hook`.

- **`gc.freeze()`** called at end of `setup_hook` once all permanent objects are resident.

### Tier 1 — Behavior Change, Gated and Compensated

- **`chunk_guilds_at_startup=False`** (new `config.CHUNK_GUILDS_AT_STARTUP`, default False): Disables downloading every guild's full member list at startup. Single largest memory item (~1–2 KB per member × all members). Restorable via `CHUNK_GUILDS_AT_STARTUP=true`.

- **New `utils/members.py`**:
  - `get_or_fetch_member(guild, user_id)`: Cache first, one REST fetch on miss
  - `fetch_all_members(guild, cache=False)`: Full list on demand without keeping it resident

- **Converted call sites** where `None` breaks a feature (all in async functions): ticket permissions, appeal apply/reverse, backend sanction add/revoke, interserver relay, team link sessions, staff thread guard, AltGuard staff target resolution, reminder delivery, poll-vote logs.

- **`modules/automod_ai.py::_observe_target_reaction`**: Now resolves target authoritatively instead of treating cache miss as `target_gone=True`, preventing false signals to the sanction classifier.

- **`services/ticket_service.build_overwrites`** stays synchronous: Takes optional pre-resolved `members` map; async callers build it via new `resolve_ticket_members()`. Prevents uncached ticket owners from being locked out.

- **`max_messages`**: 5000 → 1000 (consumers act on messages seconds to minutes old).

- **Redis blocking reads**: `block=5000` → `30000` in task stream and feeds loops. Latency unchanged; stops re-issuing commands every 5s around the clock. Redis was burning 152 vCPU-min.

- **Bounded three unbounded caches**:
  - `automod/engine.py`: `_budget_degraded`/`_budget_notified` now guild-id sets cleared on day rollover (was growing forever)
  - `gateway/quota.py`: `_limit_cache` now `OrderedDict` pruned of expired entries and capped at 2048
  - `services/precedent_service.py`: Added `PRECEDENT_CACHE_MAX_GUILDS=50` with LRU eviction

## Known Issues / Follow-ups

- **Accepted regression**: Anything scanning every guild to find where a user is a member now under-reports (`/

https://claude.ai/code/session_01QGXExMci1rwbw7j4YNtSUF