### PR TITLE
Add Bump Reminder module — detect successful bumps and schedule reminders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ moddy/
     ├── test_transcription.py  #   Voice transcription helpers, guard rails, cards
     ├── test_notifications.py  #   Notifications: hashing, attribution, report rules, i18n
     ├── test_support_requests.py #  Support requests: cards, buttons, beta card, welcome DM
-    ├── test_bump_reminder.py  #   Bump detection (7 real payloads), config, cards, i18n
+    ├── test_bump_reminder.py  #   Bump detection (real payloads + refusals), config, cards, i18n
     ├── test_logs.py           #   Server logs: registry, routing, rendering, delivery
     ├── test_logs_i18n.py      #   Server logs: i18n completeness on the 5 locales
     ├── test_heartbeat.py      #   Health Monitor heartbeat: payload, lifecycle, status decisions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ moddy/
 │   ├── brocoli_chat.py        #   Brocoli in a channel (dev-guild gated, SSE → Components V2)
 │   ├── emoji.py               #   Emoji management
 │   ├── reminder.py            #   /reminder command
+│   ├── bump_reminder.py       #   Bump Reminder listener + 30s sweeper loop
 │   ├── saved_messages.py      #   Message bookmarking
 │   ├── translate.py           #   /translate (DeepL)
 │   ├── text_tools.py          #   /fix, /rephrase, /summarize (OpenAI, Modal V2 + context menus)
@@ -77,6 +78,7 @@ moddy/
 │   ├── adaptive_slowmode.py   #   Adaptive slowmode (EWMA + hysteresis)
 │   ├── interserver.py         #   Inter-server message relay
 │   ├── social_notifications.py #  Social notifications (via moddy-feeds service)
+│   ├── bump_reminder.py       #   Bump reminders (Disboard, DiscordL, French.gg…)
 │   ├── altguard.py            #   AltGuard anti multi-account verification gate
 │   ├── tickets.py             #   Tickets (panels, categories, permissions, claim)
 │   ├── automod_ai.py          #   Automod AI (applies decisions, cases+evidence, scalable features)
@@ -88,6 +90,7 @@ moddy/
 │       ├── adaptive_slowmode_config.py
 │       ├── altguard_config.py             # AltGuard gate (channel, roles, logs)
 │       ├── social_notifications_config.py
+│       ├── bump_reminder_config.py        # Bump reminders list + Modal V2
 │       ├── automod_ai_config.py
 │       ├── automod_ai_precedents_view.py  # Learned-precedents browser (S7)
 │       ├── welcome_channel_config.py      # Welcome messages list + add/manage (Modal V2)
@@ -114,6 +117,10 @@ moddy/
 │   ├── models.py              #   Uniform payload + source + service registry + hashing
 │   ├── render.py              #   Payload → Components V2 + `sent by` attribution line
 │   └── service.py             #   NotificationService (bot.notifications)
+│
+├── bumpreminder/              # Bump detection core (pure; no Discord, no DB)
+│   ├── registry.py            #   The 7 supported directories + their markers
+│   └── detect.py              #   Success/failure funnel, next-bump time, intervals
 │
 ├── automod/                   # Automod AI DETECTION pipeline (decides only; no side effects)
 │   ├── engine.py              #   Shared per-bot orchestrator (funnel entry)
@@ -174,6 +181,7 @@ moddy/
 │       ├── notifications.py   #   Notifications, deliveries, abuse reports
 │       ├── support_requests.py #  Bug reports / config-help requests + their exchange
 │       ├── social.py          #   Social notifications subscriptions
+│       ├── bump.py            #   Pending bump reminders (bump_reminders)
 │       └── _utils.py
 │
 ├── utils/                     # Utility modules
@@ -201,6 +209,7 @@ moddy/
 │   ├── beta_announcement.py   #   Beta-launch campaign card (temporary — see docs)
 │   ├── ticket_views.py        #   Ticket panel, ticket message, cards, claim, participants modal
 │   ├── transcription_views.py #   Voice transcription cards + persistent Transcribe button
+│   ├── bump_views.py          #   Bump thank-you + reminder cards, opt-in button
 │   ├── appeal_views.py        #   Automod appeal UI (DM buttons + reviewer panels, persistent)
 │   ├── expiration_views.py    #   Sanction-expiration DM (unban/unmute/unwarn + invite)
 │   ├── invites.py             #   Shared guild invite creation (appeals, expirations)
@@ -289,6 +298,7 @@ moddy/
     ├── test_transcription.py  #   Voice transcription helpers, guard rails, cards
     ├── test_notifications.py  #   Notifications: hashing, attribution, report rules, i18n
     ├── test_support_requests.py #  Support requests: cards, buttons, beta card, welcome DM
+    ├── test_bump_reminder.py  #   Bump detection (7 real payloads), config, cards, i18n
     ├── test_logs.py           #   Server logs: registry, routing, rendering, delivery
     ├── test_logs_i18n.py      #   Server logs: i18n completeness on the 5 locales
     ├── test_heartbeat.py      #   Health Monitor heartbeat: payload, lifecycle, status decisions
@@ -475,6 +485,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/SERVER_LANGUAGE.md](docs/SERVER_LANGUAGE.md) | **Server language** — the single setting every module reads; what follows the server vs. the user |
 | [docs/WELCOME_MESSAGES.md](docs/WELCOME_MESSAGES.md) | Welcome messages module (`welcome_channel`) — config schema, placeholders, backend/dashboard contract |
 | [docs/WELCOME_DM.md](docs/WELCOME_DM.md) | Welcome DM module (`welcome_dm`) — config schema, placeholders, backend/dashboard contract |
+| [docs/BUMP_REMINDER.md](docs/BUMP_REMINDER.md) | **Bump Reminder** — detecting a *successful* bump on 7 directories, the reminder, ping modes, quotas |
 | [docs/TICKETS.md](docs/TICKETS.md) | **Tickets** — panels, categories, per-role permissions, the claim system, escalation, module-gated `/ticket` commands |
 | [docs/ALTGUARD.md](docs/ALTGUARD.md) | **AltGuard** — anti multi-account verification gate, consent, service contract, staff commands |
 | [docs/ALTGUARD_INTEGRATION.md](docs/ALTGUARD_INTEGRATION.md) | AltGuard ↔ bot exact wire contract — payload types, error codes, debugging |

--- a/bumpreminder/__init__.py
+++ b/bumpreminder/__init__.py
@@ -1,0 +1,53 @@
+"""Bump reminder — the pure detection core.
+
+A *bump* is a slash command offered by Discord server directories (DISBOARD,
+DiscordL, French.gg…) that pushes a server back to the top of a listing. It is
+rate limited: one bump every one to four hours depending on the directory. The
+window is easy to miss, which is the whole reason this module exists.
+
+Everything in this package is **pure Python decision code**: it reads a message
+and answers "did a bump just succeed, and when is the next one due?". It never
+sends anything, never touches the database, and never imports anything from the
+bot. That is what lets the whole detection surface be tested from the raw
+message payloads captured from each directory.
+
+The Discord-facing halves live elsewhere:
+
+- ``modules/bump_reminder.py`` — the per-guild module and its config schema
+- ``cogs/bump_reminder.py``    — the listener and the 30s sweeper loop
+- ``utils/bump_views.py``      — the thank-you and reminder cards
+
+See docs/BUMP_REMINDER.md.
+"""
+
+from bumpreminder.registry import (
+    BUMP_BOTS,
+    BumpBot,
+    bot_by_app_id,
+    bot_by_key,
+    is_bump_bot,
+)
+from bumpreminder.detect import (
+    BumpHit,
+    MAX_INTERVAL,
+    MIN_INTERVAL,
+    detect,
+    evaluate,
+    format_interval,
+    parse_interval,
+)
+
+__all__ = [
+    "BUMP_BOTS",
+    "BumpBot",
+    "BumpHit",
+    "MAX_INTERVAL",
+    "MIN_INTERVAL",
+    "bot_by_app_id",
+    "bot_by_key",
+    "detect",
+    "evaluate",
+    "format_interval",
+    "is_bump_bot",
+    "parse_interval",
+]

--- a/bumpreminder/detect.py
+++ b/bumpreminder/detect.py
@@ -324,11 +324,14 @@ def evaluate(message: Any, spec: BumpBot, interval: int, *,
 
     text, media, custom_ids = _harvest(message)
 
-    # The shared blocklist exists to recognise a *visible* refusal. A directory
-    # that refuses privately can never send one, so applying it there could only
-    # ever cost a real bump — some translation of the success message tripping
-    # on a word it has no business owning. Its own markers still veto.
-    if not spec.refusal_is_ephemeral and _matches(_FAILURE_TEXT, text):
+    # The shared blocklist recognises a *visible* refusal in the languages these
+    # directories answer in. It is skipped only for a directory that answers in
+    # languages we cannot list AND refuses privately — there it could only ever
+    # cost a real bump, on some translation tripping over a word it does not
+    # own. Everywhere else it stays, including where refusals are private: if
+    # that assumption is ever wrong, this is what catches it.
+    if not (spec.answers_in_any_language and spec.refusal_is_ephemeral) \
+            and _matches(_FAILURE_TEXT, text):
         return None
     if _matches(spec.failure_text, text):
         return None

--- a/bumpreminder/detect.py
+++ b/bumpreminder/detect.py
@@ -1,0 +1,401 @@
+"""Did a bump just succeed, and when is the next one due?
+
+The whole problem is that a directory answers ``/bump`` from the same bot, with
+the same command, whether the bump went through or the server is still on
+cooldown. Watching for the command would therefore arm reminders off failures,
+and a reminder that fires an hour early is worse than none — the channel gets
+pinged, somebody runs the command, and the directory says no.
+
+So detection is a funnel, cheapest test first:
+
+1. the author is one of the seven known directories (a dict lookup — this is
+   what runs on every message the bot sees, and what rejects all of them)
+2. the command name matches, *when Discord sends one*
+3. no cooldown wording anywhere in the message
+4. at least one of that directory's success markers
+
+Steps 3 and 4 are deliberately in that order: a failure marker vetoes, it never
+competes with a success marker. A message saying both is a message we do not
+understand, and staying quiet is the safe way to be wrong.
+
+Nothing here touches Discord, the database or the network — which is what lets
+``tests/test_bump_reminder.py`` replay the real captured payload of every
+directory against the real code.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, List, Optional, Sequence, Set, Tuple
+
+from bumpreminder.registry import BumpBot, bot_by_app_id
+
+__all__ = [
+    "BumpHit",
+    "MIN_INTERVAL",
+    "MAX_INTERVAL",
+    "detect",
+    "evaluate",
+    "format_interval",
+    "parse_interval",
+]
+
+
+# A server may shorten or lengthen the wait (some directories sell a faster
+# cooldown), so the interval is configurable — but not to the point of turning
+# the module into a spammer or into a reminder nobody will ever see.
+MIN_INTERVAL = 5 * 60
+MAX_INTERVAL = 24 * 3600
+
+# A "next bump" time a directory states itself is only believed inside this
+# window. It rejects DiscordL's footer stamp, which is the *current* time and
+# would otherwise schedule a reminder three seconds out.
+_MIN_LEAD = timedelta(minutes=5)
+_MAX_LEAD = timedelta(hours=24)
+
+
+# Cooldown wording, in the languages these directories actually answer in.
+# Applied to text only — never to URLs, where a filename like ``bump-wait.png``
+# would poison an otherwise good match. Every one of these was checked against
+# the seven captured success payloads: none of them fires on a real bump.
+_FAILURE_TEXT = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\bwait\b",
+        r"\battend(?:re|ez|s)\b",
+        r"\bpatiente[rz]?\b",
+        r"\balready\b",
+        r"\bd[ée]j[àa]\b",
+        r"\bcool ?down\b",
+        r"\bslow down\b",
+        r"\besper[ae]\b",
+        r"\bwarte[nt]?\b",
+        r"\baguard[ae]\b",
+        r"\btry again\b",
+        r"\br[ée]essay",
+        r"\bnot? enough\b",
+        r"\berror\b",
+        r"\berreur\b",
+        r"\b[ée]chec\b",
+        r"\bfailed\b",
+    )
+)
+
+# The harvested text is lowercased, so the style suffix must match either
+# case — ``<t:123:R>`` arrives here as ``<t:123:r>``.
+_TIMESTAMP_RE = re.compile(r"<t:(\d{1,15})(?::[tdfr])?>", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class BumpHit:
+    """A bump that went through."""
+
+    bot: BumpBot
+    bumper_id: Optional[int]
+    """Who ran the command. ``None`` when Discord sent no interaction data."""
+
+    due_at: datetime
+    """When the next bump becomes possible, always timezone-aware UTC."""
+
+    stated_by_bot: bool
+    """``True`` when the directory announced ``due_at`` itself.
+
+    A stated time beats the configured interval, because the directory is the
+    authority on its own cooldown — and because a server that mis-set the
+    interval then still gets a correct reminder.
+    """
+
+
+# --------------------------------------------------------------------------- #
+# Reading a message
+# --------------------------------------------------------------------------- #
+def _walk_components(components: Sequence[Any], text: List[str],
+                     media: List[str], custom_ids: List[str]) -> None:
+    """Collect every scrap of text, media URL and custom_id, at any depth.
+
+    Components V2 nests: a Container holds Sections and MediaGalleries, a
+    Section holds an accessory. Four of the seven directories answer this way,
+    and three of those put their only usable marker inside a nested node — so
+    walking the whole tree is not thoroughness, it is the feature.
+    """
+    for component in components or ():
+        content = getattr(component, "content", None)
+        if isinstance(content, str) and content:
+            text.append(content)
+
+        label = getattr(component, "label", None)
+        if isinstance(label, str) and label:
+            text.append(label)
+
+        custom_id = getattr(component, "custom_id", None)
+        if isinstance(custom_id, str) and custom_id:
+            custom_ids.append(custom_id)
+
+        for attribute in ("url", "proxy_url"):
+            value = getattr(component, attribute, None)
+            if isinstance(value, str) and value:
+                media.append(value)
+
+        # A MediaGallery holds items, each wrapping its own media object.
+        for item in getattr(component, "items", None) or ():
+            item_media = getattr(item, "media", None) or item
+            for attribute in ("url", "proxy_url"):
+                value = getattr(item_media, attribute, None)
+                if isinstance(value, str) and value:
+                    media.append(value)
+
+        for attribute in ("media", "accessory", "thumbnail"):
+            nested = getattr(component, attribute, None)
+            if nested is not None and not isinstance(nested, (str, bytes)):
+                value = getattr(nested, "url", None)
+                if isinstance(value, str) and value:
+                    media.append(value)
+
+        children = getattr(component, "children", None) or getattr(component, "components", None)
+        if children:
+            _walk_components(children, text, media, custom_ids)
+
+
+def _harvest(message: Any) -> Tuple[str, str, Set[str]]:
+    """Flatten a message into ``(text, media_urls, custom_ids)``, lowercased.
+
+    Text and URLs come back as two single blobs rather than lists: every caller
+    only ever asks "does this appear anywhere", and one ``in`` over one string
+    beats a loop over a dozen.
+    """
+    text: List[str] = []
+    media: List[str] = []
+    custom_ids: List[str] = []
+
+    if getattr(message, "content", None):
+        text.append(message.content)
+
+    for embed in getattr(message, "embeds", None) or ():
+        for value in (getattr(embed, "title", None), getattr(embed, "description", None)):
+            if value:
+                text.append(str(value))
+        author = getattr(embed, "author", None)
+        if author is not None and getattr(author, "name", None):
+            text.append(str(author.name))
+        footer = getattr(embed, "footer", None)
+        if footer is not None and getattr(footer, "text", None):
+            text.append(str(footer.text))
+        for embed_field in getattr(embed, "fields", None) or ():
+            for value in (getattr(embed_field, "name", None), getattr(embed_field, "value", None)):
+                if value:
+                    text.append(str(value))
+        for attribute in ("image", "thumbnail"):
+            asset = getattr(embed, attribute, None)
+            if asset is not None and getattr(asset, "url", None):
+                media.append(str(asset.url))
+
+    _walk_components(getattr(message, "components", None) or (), text, media, custom_ids)
+
+    for attachment in getattr(message, "attachments", None) or ():
+        for attribute in ("url", "proxy_url", "filename"):
+            value = getattr(attachment, attribute, None)
+            if value:
+                media.append(str(value))
+
+    return (
+        "\n".join(text).lower(),
+        "\n".join(media).lower(),
+        {custom_id.lower() for custom_id in custom_ids},
+    )
+
+
+def _command_name(message: Any) -> Optional[str]:
+    """The slash command that produced this message, if Discord said so.
+
+    ``interaction`` is deprecated in favour of ``interaction_metadata``, but it
+    is the only one of the two carrying the command *name* — and Discord still
+    populates it. So we read the name from the deprecated field and take the
+    user from whichever is present.
+    """
+    interaction = getattr(message, "interaction", None)
+    name = getattr(interaction, "name", None)
+    return name.lower() if isinstance(name, str) else None
+
+
+def _bumper_id(message: Any, custom_ids: Set[str], spec: BumpBot) -> Optional[int]:
+    """Who ran the command.
+
+    Prefers ``interaction_metadata`` (current), falls back to ``interaction``
+    (deprecated), and finally to a marker custom_id that embeds the id —
+    French.gg suffixes its reminder button with the bumper's user id.
+    """
+    for attribute in ("interaction_metadata", "interaction"):
+        source = getattr(message, attribute, None)
+        user = getattr(source, "user", None)
+        user_id = getattr(user, "id", None)
+        if isinstance(user_id, int):
+            return user_id
+
+    for marker in spec.success_custom_id:
+        for custom_id in custom_ids:
+            if custom_id.startswith(marker):
+                suffix = custom_id[len(marker):]
+                if suffix.isdigit():
+                    return int(suffix)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Next-bump time
+# --------------------------------------------------------------------------- #
+def _fresh(candidate: Optional[datetime], now: datetime) -> Optional[datetime]:
+    """Keep a stated time only if it plausibly is the *next* bump.
+
+    A directory that stamps its message with "now" (DiscordL's footer) or with
+    a date far out is not telling us about the cooldown, so we fall back to the
+    configured interval rather than trust it.
+    """
+    if candidate is None:
+        return None
+    if candidate.tzinfo is None:
+        candidate = candidate.replace(tzinfo=timezone.utc)
+    lead = candidate - now
+    return candidate if _MIN_LEAD < lead <= _MAX_LEAD else None
+
+
+def _stated_due(message: Any, spec: BumpBot, text: str, now: datetime) -> Optional[datetime]:
+    if spec.next_due == "embed_timestamp":
+        for embed in getattr(message, "embeds", None) or ():
+            stamp = _fresh(getattr(embed, "timestamp", None), now)
+            if stamp is not None:
+                return stamp
+        return None
+
+    if spec.next_due == "relative":
+        candidates = []
+        for raw in _TIMESTAMP_RE.findall(text):
+            try:
+                stamp = datetime.fromtimestamp(int(raw), tz=timezone.utc)
+            except (ValueError, OverflowError, OSError):
+                continue
+            stamp = _fresh(stamp, now)
+            if stamp is not None:
+                candidates.append(stamp)
+        return min(candidates) if candidates else None
+
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# The funnel
+# --------------------------------------------------------------------------- #
+def _matches(patterns, haystack: str) -> bool:
+    return any(pattern.search(haystack) for pattern in patterns)
+
+
+def detect(message: Any, interval: int, *, now: Optional[datetime] = None) -> Optional[BumpHit]:
+    """Return the bump this message reports, or ``None``.
+
+    ``interval`` is the server's configured cooldown in seconds, used unless the
+    directory states its own next-bump time. ``now`` is injectable so the tests
+    can replay payloads captured months ago.
+    """
+    author = getattr(message, "author", None)
+    if author is None or not getattr(author, "bot", False):
+        return None
+
+    spec = bot_by_app_id(author.id)
+    if spec is None:
+        return None
+
+    return evaluate(message, spec, interval, now=now)
+
+
+def evaluate(message: Any, spec: BumpBot, interval: int, *,
+             now: Optional[datetime] = None) -> Optional[BumpHit]:
+    """:func:`detect` with the directory already decided.
+
+    Split out so the tests can push every directory's payload through every
+    *other* directory's markers — the check that actually proves two listings
+    can never be confused for one another.
+    """
+    # A command name, when Discord sends one, must be a command that can bump.
+    # It is never sufficient on its own — a cooldown reply carries it too.
+    command = _command_name(message)
+    if command is not None and command not in spec.command_names:
+        return None
+
+    text, media, custom_ids = _harvest(message)
+
+    # The shared blocklist exists to recognise a *visible* refusal. A directory
+    # that refuses privately can never send one, so applying it there could only
+    # ever cost a real bump — some translation of the success message tripping
+    # on a word it has no business owning. Its own markers still veto.
+    if not spec.refusal_is_ephemeral and _matches(_FAILURE_TEXT, text):
+        return None
+    if _matches(spec.failure_text, text):
+        return None
+    if any(marker in media for marker in spec.failure_media):
+        return None
+
+    # "Visible means it worked" is only safe for a message we know is a bump
+    # reply. Without the command name it could be anything the directory posts,
+    # so that shortcut is withheld and the markers have to earn it.
+    succeeded = (
+        (spec.refusal_is_ephemeral and command is not None)
+        or _matches(spec.success_text, text)
+        or any(marker in media for marker in spec.success_media)
+        or any(
+            custom_id.startswith(marker)
+            for marker in spec.success_custom_id
+            for custom_id in custom_ids
+        )
+    )
+    if not succeeded:
+        return None
+
+    now = now or datetime.now(timezone.utc)
+    stated = _stated_due(message, spec, text, now)
+    return BumpHit(
+        bot=spec,
+        bumper_id=_bumper_id(message, custom_ids, spec),
+        due_at=stated or (now + timedelta(seconds=interval)),
+        stated_by_bot=stated is not None,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Intervals, as a human types them
+# --------------------------------------------------------------------------- #
+_INTERVAL_RE = re.compile(
+    r"^(?:(?P<hours>\d{1,3})\s*h\s*(?P<hmins>\d{1,2})?|(?P<mins>\d{1,5})\s*(?:m(?:in(?:ute)?s?)?)?)$",
+    re.IGNORECASE,
+)
+
+
+def parse_interval(raw: str) -> Optional[int]:
+    """Read ``2h``, ``2h30``, ``90m`` or a bare ``120`` (minutes) into seconds.
+
+    Returns ``None`` for anything unreadable **or** out of range, so a caller
+    has one thing to check. The bounds are part of the contract, not a detail:
+    an interval of zero would turn the reminder into a loop.
+    """
+    if not raw:
+        return None
+    match = _INTERVAL_RE.match(raw.strip().replace(",", ".").replace(" ", ""))
+    if not match:
+        return None
+
+    if match.group("hours") is not None:
+        seconds = int(match.group("hours")) * 3600 + int(match.group("hmins") or 0) * 60
+    else:
+        seconds = int(match.group("mins")) * 60
+
+    return seconds if MIN_INTERVAL <= seconds <= MAX_INTERVAL else None
+
+
+def format_interval(seconds: int) -> str:
+    """Render seconds the way :func:`parse_interval` reads them back."""
+    hours, minutes = divmod(max(0, int(seconds)) // 60, 60)
+    if hours and minutes:
+        return f"{hours}h{minutes:02d}"
+    if hours:
+        return f"{hours}h"
+    return f"{minutes}m"

--- a/bumpreminder/registry.py
+++ b/bumpreminder/registry.py
@@ -174,6 +174,14 @@ BUMP_BOTS: Tuple[BumpBot, ...] = (
             r"faster\s+than",
             r"plus\s+rapide\s+que",
         ),
+        # Its refusal carries no cooldown word at all ("You are so hot! 2 hours
+        # 19 minutes until the next like") — the shared blocklist does not fire,
+        # so this marker is the only thing rejecting it. "until the": the
+        # success footer is *also* "Next Like".
+        failure_text=_rx(
+            r"until\s+the\s+next\s+like",
+            r"avant\s+le\s+prochain\s+like",
+        ),
         next_due="embed_timestamp",
     ),
     # --------------------------------------------------------------- D-INVITES
@@ -245,6 +253,14 @@ BUMP_BOTS: Tuple[BumpBot, ...] = (
             r"beemp\s+(?:done|effectu|r[ée]ussi|realizado)",
             r"beemp[^.\n]{0,40}success",
             r"beemp[^.\n]{0,40}succ[èe]s",
+        ),
+        # Kept per-directory on purpose. "You can bump again at X" is a refusal
+        # here, but it is semantically what a *success* says about the next
+        # window elsewhere (DiscordTop: "Prochain boost disponible <t:…>"), so
+        # promoting it to the shared blocklist would kill real bumps.
+        failure_text=_rx(
+            r"can\s+bump\s+again",
+            r"peux\s+bump\s+[àa]\s+nouveau",
         ),
     ),
     # -------------------------------------------------------------- DiscordTop

--- a/bumpreminder/registry.py
+++ b/bumpreminder/registry.py
@@ -164,8 +164,13 @@ BUMP_BOTS: Tuple[BumpBot, ...] = (
     ),
     # --------------------------------------------------------------- D-INVITES
     # The hard one: a successful bump is a bare image with a "view the server"
-    # button and not one word of text. The asset filename is the only signal
-    # there is — see the note in docs/BUMP_REMINDER.md.
+    # button and not one word of text, so the asset filename is the only signal
+    # a success carries — see the note in docs/BUMP_REMINDER.md.
+    #
+    # Its refusal, by contrast, is explicit: `bump-error.png` plus "Tu pourras
+    # bump à nouveau <t:…>". Both markers below are taken from a captured
+    # refusal, not guessed — `/bump.png` and `bump-error.png` are distinct
+    # enough that the success marker cannot match a failure.
     BumpBot(
         key="dinvites",
         app_id=678211574183362571,
@@ -175,7 +180,11 @@ BUMP_BOTS: Tuple[BumpBot, ...] = (
         command_names=frozenset({"bump"}),
         default_interval=2 * HOUR,
         success_media=("/bump.png", "/bump.gif", "/bump.jpg", "/bump.webp"),
-        failure_media=("/cooldown.", "/error.", "/wait.", "/already."),
+        failure_text=_rx(
+            r"pourras\s+bump",
+            r"able\s+to\s+bump\s+again",
+        ),
+        failure_media=("bump-error",),
     ),
     # ---------------------------------------------------------------- DiscordL
     # Components V2. Its banner URL carries the bump path, and its footer

--- a/bumpreminder/registry.py
+++ b/bumpreminder/registry.py
@@ -72,6 +72,19 @@ class BumpBot:
     failure_text: Tuple[Pattern, ...] = ()
     failure_media: Tuple[str, ...] = ()
 
+    answers_in_any_language: bool = False
+    """The directory replies in the reader's language, from a set we cannot list.
+
+    Only DISBOARD does, being the one global listing here. The shared cooldown
+    blocklist is skipped for such a directory: that blocklist recognises a
+    *visible* refusal, so where refusals are private it can only ever cost a
+    real bump — some translation tripping over a word it does not own.
+
+    A single-language directory keeps the blocklist even when its refusals are
+    private, as a cheap net under that assumption: if it ever does post a
+    visible refusal, the blocklist still catches it.
+    """
+
     refusal_is_ephemeral: bool = False
     """The directory refuses a bump *privately*, so anything visible is a success.
 
@@ -140,6 +153,7 @@ BUMP_BOTS: Tuple[BumpBot, ...] = (
         success_media=("bot-command-image-bump",),
         failure_media=("bot-command-image-notification",),
         refusal_is_ephemeral=True,
+        answers_in_any_language=True,
     ),
     # ----------------------------------------------------------- DSMonitoring
     # Calls a bump a "like". Its embed timestamp is the *next* like, four hours
@@ -201,13 +215,22 @@ BUMP_BOTS: Tuple[BumpBot, ...] = (
         # "a été bump **par**" — the trailing preposition is what keeps this
         # apart from French.gg's "a été bump**é**", which is otherwise the
         # same sentence in the same language.
+        #
+        # "Résultat du Bump sur DiscordL" is deliberately NOT here: it is the
+        # message *header*, printed on the refusal too. It sat in this list
+        # until a captured refusal showed it firing there — harmless only
+        # because "attendre" tripped the shared blocklist first, which is to
+        # say harmless by luck.
         success_text=_rx(
-            r"r[ée]sultat\s+du\s+bump",
             r"a\s+[ée]t[ée]\s+bump\s+par",
             r"has\s+been\s+bumped\s+by",
             r"fue\s+bumpeado\s+por",
         ),
         success_media=("/v2/bump/",),
+        failure_text=_rx(
+            r"avant\s+de\s+pouvoir\s+bump",
+            r"before\s+you\s+can\s+bump",
+        ),
     ),
     # ------------------------------------------------------------------- Beemp
     BumpBot(
@@ -226,7 +249,12 @@ BUMP_BOTS: Tuple[BumpBot, ...] = (
     ),
     # -------------------------------------------------------------- DiscordTop
     # Calls it a "boost" — hence the separate command name. Names its asset
-    # after the outcome and states the next boost as a relative timestamp.
+    # after the outcome (`boost-success.png` / `boost-error.png`, both observed)
+    # and states the next boost as a relative timestamp.
+    #
+    # "propulsé" is deliberately NOT a success marker: the refusal reads "Ce
+    # serveur vient **déjà** d'être propulsé", so the word appears on both. The
+    # verb is not the signal — "Boost envoyé" versus "Boost impossible" is.
     BumpBot(
         key="dtop",
         app_id=1071460654839517184,
@@ -237,18 +265,23 @@ BUMP_BOTS: Tuple[BumpBot, ...] = (
         default_interval=1 * HOUR,
         success_text=_rx(
             r"boost\s+(?:envoy[ée]|sent|enviado|gesendet)",
-            r"propuls[ée]",
-            r"pushed\s+to\s+the\s+front",
         ),
         success_media=("boost-success",),
-        failure_media=("boost-error", "boost-cooldown", "boost-failed"),
+        failure_text=_rx(
+            r"boost\s+(?:impossible|unavailable)",
+            r"booster\s+[àa]\s+nouveau",
+        ),
+        failure_media=("boost-error",),
         next_due="relative",
     ),
     # -------------------------------------------------------------- French.gg
-    # Offers its own "remind me in 2h" button, and only on a success — so the
-    # button's custom_id is the strongest marker available here. Its suffix is
-    # the bumper's user id, which the detector uses when Discord omits the
-    # interaction metadata.
+    # Refuses privately, like DISBOARD (see ``refusal_is_ephemeral``), which is
+    # what makes its "remind me in 2h" button safe to trust: the button would
+    # arguably make *more* sense on a cooldown than on a success, so without
+    # that guarantee it would have been the wrong marker to lean on.
+    #
+    # The button's custom_id is suffixed with the bumper's user id, which the
+    # detector falls back on when Discord omits the interaction metadata.
     BumpBot(
         key="frenchgg",
         app_id=1313443824483307531,
@@ -263,6 +296,7 @@ BUMP_BOTS: Tuple[BumpBot, ...] = (
             r"a\s+[ée]t[ée]\s+bump[ée]",
         ),
         success_custom_id=("buttons-custom-reminder-",),
+        refusal_is_ephemeral=True,
     ),
 )
 

--- a/bumpreminder/registry.py
+++ b/bumpreminder/registry.py
@@ -1,0 +1,280 @@
+"""The directories Moddy knows how to watch.
+
+One :class:`BumpBot` per directory. The tuple order is the order every menu
+shows them in, biggest audience first, so the directory most servers actually
+use is the first thing offered.
+
+Adding a directory is meant to be a one-entry change here plus a fixture in
+``tests/test_bump_reminder.py`` — nothing else in the module knows the list.
+
+**On the markers.** A directory answers ``/bump`` with the *same* command, from
+the *same* application, whether the bump went through or the server is still on
+cooldown. Matching the command alone would therefore schedule reminders off
+failed bumps. So each entry carries what a **success** looks like, and the
+detector additionally refuses anything carrying cooldown wording (that shared
+blocklist lives in :mod:`bumpreminder.detect`).
+
+Markers come in three flavours because the directories are not built alike:
+
+``success_text``
+    Regexes over every scrap of text in the message. Written multilingual —
+    these bots answer in the reader's language, not the server's.
+``success_media``
+    Substrings of an image URL. Several directories name their assets after the
+    outcome (``boost-success.png``), which is a stronger signal than any
+    sentence and survives every translation.
+``success_custom_id``
+    Substrings of a button's ``custom_id``. French.gg only offers its own
+    "remind me" button on a successful bump, which makes that button the tell.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Pattern, Tuple
+
+__all__ = ["BumpBot", "BUMP_BOTS", "bot_by_app_id", "bot_by_key", "is_bump_bot"]
+
+
+HOUR = 3600
+
+
+@dataclass(frozen=True)
+class BumpBot:
+    """One server directory and how to recognise its successful bump."""
+
+    key: str
+    """Stable identifier stored in config and in the database. Never renamed."""
+
+    app_id: int
+    """The bot's application id — also its message author id."""
+
+    name: str
+    """Display name, shown as-is (a brand, so never translated)."""
+
+    emoji: str
+    """Custom emoji for menus and cards."""
+
+    command: str
+    """The clickable command mention put in the reminder card."""
+
+    command_names: frozenset
+    """Command names that can produce a bump. Checked when Discord sends it."""
+
+    default_interval: int
+    """The directory's advertised cooldown, in seconds. Servers may override it."""
+
+    success_text: Tuple[Pattern, ...] = ()
+    success_media: Tuple[str, ...] = ()
+    success_custom_id: Tuple[str, ...] = ()
+
+    failure_text: Tuple[Pattern, ...] = ()
+    failure_media: Tuple[str, ...] = ()
+
+    refusal_is_ephemeral: bool = False
+    """The directory refuses a bump *privately*, so anything visible is a success.
+
+    DISBOARD answers a cooldown with an ephemeral message, which the gateway
+    never delivers to a bot. Every ``/bump`` reply Moddy can actually see from
+    it therefore went through — which makes the detection language-proof
+    instead of hostage to a list of translated phrases.
+
+    The shortcut applies only to a message Discord tagged with a command name
+    from :attr:`command_names` — without that, the reply could be anything the
+    directory posts, so the ordinary markers have to carry it instead.
+
+    Setting this on another directory needs the same evidence: a *visible*
+    refusal would otherwise be read as a success and arm a reminder an hour
+    early. The per-directory failure markers below still veto, as cheap
+    insurance against the day a directory changes its mind.
+    """
+
+    next_due: str = ""
+    """Where the message states the next bump time, when it does at all.
+
+    ``"embed_timestamp"`` reads the embed's ``timestamp`` field, ``"relative"``
+    picks the earliest future ``<t:…>`` out of the text. Empty means the
+    directory says nothing and the configured interval is authoritative.
+    """
+
+    @property
+    def command_hint(self) -> str:
+        """``/bump`` — the plain name, for places a command mention cannot render.
+
+        Select descriptions and modal labels are plain text: a ``</bump:id>``
+        mention would show up there as its raw source.
+        """
+        name = self.command.split(":", 1)[0].lstrip("<")
+        return name or "/bump"
+
+
+def _rx(*patterns: str) -> Tuple[Pattern, ...]:
+    return tuple(re.compile(p, re.IGNORECASE) for p in patterns)
+
+
+# --------------------------------------------------------------------------- #
+# The directories, largest audience first
+# --------------------------------------------------------------------------- #
+BUMP_BOTS: Tuple[BumpBot, ...] = (
+    # ---------------------------------------------------------------- DISBOARD
+    # The reference listing, and the only one here that is global rather than
+    # French-speaking — so it answers in a dozen languages Moddy has no phrase
+    # list for. It also refuses privately (see ``refusal_is_ephemeral``), which
+    # settles the problem outright: whatever language a visible reply is in, it
+    # is a success. The markers below stay as a second, cheaper path and as the
+    # thing the cross-directory test exercises.
+    BumpBot(
+        key="disboard",
+        app_id=302050872383242240,
+        name="DISBOARD",
+        emoji="<:disboard:1545025221612802101>",
+        command="</bump:947088344167366698>",
+        command_names=frozenset({"bump"}),
+        default_interval=2 * HOUR,
+        success_text=_rx(
+            r"bump\s*(?:effectu|done|hecho|erledigt|feito|conclu|fatto|selesai)",
+            r"表示順をアップ",
+            r"bumpeado",
+        ),
+        success_media=("bot-command-image-bump",),
+        failure_media=("bot-command-image-notification",),
+        refusal_is_ephemeral=True,
+    ),
+    # ----------------------------------------------------------- DSMonitoring
+    # Calls a bump a "like". Its embed timestamp is the *next* like, four hours
+    # out — authoritative, so we prefer it over the configured interval.
+    BumpBot(
+        key="dsmonitoring",
+        app_id=575776004233232386,
+        name="DSMonitoring",
+        emoji="<:DSMonitoring:1545027259323256842>",
+        command="</bump:1343606491386609716>",
+        command_names=frozenset({"bump", "like"}),
+        default_interval=4 * HOUR,
+        success_text=_rx(
+            r"successfully\s+liked",
+            r"liked\s+the\s+server",
+            r"aim[ée]\s+le\s+serveur",
+            r"(?:vous\s+avez\s+)?lik[ée]\s+le\s+serveur",
+            r"faster\s+than",
+            r"plus\s+rapide\s+que",
+        ),
+        next_due="embed_timestamp",
+    ),
+    # --------------------------------------------------------------- D-INVITES
+    # The hard one: a successful bump is a bare image with a "view the server"
+    # button and not one word of text. The asset filename is the only signal
+    # there is — see the note in docs/BUMP_REMINDER.md.
+    BumpBot(
+        key="dinvites",
+        app_id=678211574183362571,
+        name="D-INVITES",
+        emoji="<:dinvites:1545025725948624956>",
+        command="</bump:1099048758228037742>",
+        command_names=frozenset({"bump"}),
+        default_interval=2 * HOUR,
+        success_media=("/bump.png", "/bump.gif", "/bump.jpg", "/bump.webp"),
+        failure_media=("/cooldown.", "/error.", "/wait.", "/already."),
+    ),
+    # ---------------------------------------------------------------- DiscordL
+    # Components V2. Its banner URL carries the bump path, and its footer
+    # carries a ``<t:…>`` that is *now* rather than the next bump — which is
+    # exactly what the freshness window in the detector is there to reject.
+    BumpBot(
+        key="dl",
+        app_id=528557940811104258,
+        name="DiscordL",
+        emoji="<:DiscordDL:1545024517066465370>",
+        command="</bump:1011963835634159667>",
+        command_names=frozenset({"bump"}),
+        default_interval=1 * HOUR,
+        # "a été bump **par**" — the trailing preposition is what keeps this
+        # apart from French.gg's "a été bump**é**", which is otherwise the
+        # same sentence in the same language.
+        success_text=_rx(
+            r"r[ée]sultat\s+du\s+bump",
+            r"a\s+[ée]t[ée]\s+bump\s+par",
+            r"has\s+been\s+bumped\s+by",
+            r"fue\s+bumpeado\s+por",
+        ),
+        success_media=("/v2/bump/",),
+    ),
+    # ------------------------------------------------------------------- Beemp
+    BumpBot(
+        key="beemp",
+        app_id=1293636927337136269,
+        name="Beemp",
+        emoji="<:beemp:1545026898520969216>",
+        command="</bump:1470530261170257972>",
+        command_names=frozenset({"bump", "beemp"}),
+        default_interval=1 * HOUR,
+        success_text=_rx(
+            r"beemp\s+(?:done|effectu|r[ée]ussi|realizado)",
+            r"beemp[^.\n]{0,40}success",
+            r"beemp[^.\n]{0,40}succ[èe]s",
+        ),
+    ),
+    # -------------------------------------------------------------- DiscordTop
+    # Calls it a "boost" — hence the separate command name. Names its asset
+    # after the outcome and states the next boost as a relative timestamp.
+    BumpBot(
+        key="dtop",
+        app_id=1071460654839517184,
+        name="DiscordTop",
+        emoji="<:DTOP:1545026416331198515>",
+        command="</boost:1364194690290683965>",
+        command_names=frozenset({"boost", "bump"}),
+        default_interval=1 * HOUR,
+        success_text=_rx(
+            r"boost\s+(?:envoy[ée]|sent|enviado|gesendet)",
+            r"propuls[ée]",
+            r"pushed\s+to\s+the\s+front",
+        ),
+        success_media=("boost-success",),
+        failure_media=("boost-error", "boost-cooldown", "boost-failed"),
+        next_due="relative",
+    ),
+    # -------------------------------------------------------------- French.gg
+    # Offers its own "remind me in 2h" button, and only on a success — so the
+    # button's custom_id is the strongest marker available here. Its suffix is
+    # the bumper's user id, which the detector uses when Discord omits the
+    # interaction metadata.
+    BumpBot(
+        key="frenchgg",
+        app_id=1313443824483307531,
+        name="French.gg",
+        emoji="<:frenchgg:1545026009235988490>",
+        command="</bump:1319697709363494946>",
+        command_names=frozenset({"bump"}),
+        default_interval=2 * HOUR,
+        success_text=_rx(
+            r"nouveau\s+bump",
+            r"new\s+bump",
+            r"a\s+[ée]t[ée]\s+bump[ée]",
+        ),
+        success_custom_id=("buttons-custom-reminder-",),
+    ),
+)
+
+
+_BY_APP_ID: Dict[int, BumpBot] = {spec.app_id: spec for spec in BUMP_BOTS}
+_BY_KEY: Dict[str, BumpBot] = {spec.key: spec for spec in BUMP_BOTS}
+
+
+def bot_by_app_id(app_id: int) -> Optional[BumpBot]:
+    """The directory a message author belongs to, or ``None``.
+
+    This is the hot path: it runs for every message the bot sees, so it must
+    stay a single dict lookup over seven entries.
+    """
+    return _BY_APP_ID.get(app_id)
+
+
+def bot_by_key(key: str) -> Optional[BumpBot]:
+    """The directory a stored config entry refers to, or ``None`` if retired."""
+    return _BY_KEY.get(key)
+
+
+def is_bump_bot(app_id: int) -> bool:
+    return app_id in _BY_APP_ID

--- a/cogs/bump_reminder.py
+++ b/cogs/bump_reminder.py
@@ -1,0 +1,280 @@
+"""
+Bump Reminder — the Discord wiring.
+
+Two halves, both of which have to live outside the module: a `modules/*.py` is
+instantiated *per guild* and so cannot own a listener or a loop.
+
+**The listener.** It is deliberately its own, and not a block inside
+``cogs/module_events.py``: that cog drops bot-authored messages before any
+module sees them (``if message.author.bot: return``), which is exactly the class
+of message this feature reads. Relaxing that shared guard would change what four
+other modules receive, so this cog watches on its own instead — the same
+arrangement ``cogs/logs.py`` already uses.
+
+The listener runs on **every message the bot can see**, so its first test is a
+dict lookup over the seven known directories. Everything else — the guild's
+module, the channel, the detection itself — sits behind that.
+
+**The sweeper.** One query every thirty seconds, against a partial index, no
+matter how many servers Moddy is in. Reminders live as rows, never as timers, so
+the bot holds nothing in memory and a restart costs nothing: whatever came due
+while it was down is simply due now, and goes out with a note saying it is late.
+
+See docs/BUMP_REMINDER.md.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import discord
+from discord.ext import commands, tasks
+
+from bumpreminder import bot_by_app_id, bot_by_key
+from notifications.models import NotificationContent, NotificationSource
+from utils.bump_views import (
+    LATE_AFTER,
+    NO_MENTIONS,
+    build_reminder_card,
+    build_thanks_card,
+    reminder_mentions,
+)
+from utils.emojis import ROCKET_LAUNCH
+from utils.i18n import t
+
+logger = logging.getLogger('moddy.cogs.bump_reminder')
+
+MODULE_ID = "bump_reminder"
+
+# How many due reminders one pass may take. Well above what any realistic
+# thirty-second window produces; it exists so a backlog after a long outage
+# drains over several passes instead of one enormous burst of API calls.
+SWEEP_BATCH = 50
+
+
+def _thanks_content(spec, guild_name: str) -> NotificationContent:
+    """Uniform payload behind a thank-you card.
+
+    Placeholders stay unresolved: every server bumping the same directory shares
+    one stored body, and each notification stays reproducible from its variables.
+    """
+    return NotificationContent(
+        title=guild_name,
+        body="{user} bumped {server} on {directory}. Next bump {timestamp}.",
+        icon=ROCKET_LAUNCH,
+        template_id=f"bump_reminder.thanks.{spec.key}",
+    )
+
+
+def _reminder_content(spec, guild_name: str) -> NotificationContent:
+    return NotificationContent(
+        title=guild_name,
+        body="{server} can be bumped on {directory} again.",
+        icon=ROCKET_LAUNCH,
+        template_id=f"bump_reminder.reminder.{spec.key}",
+    )
+
+
+class BumpReminder(commands.Cog):
+    """Watches for successful bumps and posts the reminders they earn."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.sweep_bump_reminders.start()
+
+    def cog_unload(self):
+        self.sweep_bump_reminders.cancel()
+
+    # --------------------------------------------------------------- listener
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        # The hot path. Everything below the first two lines runs only for a
+        # message posted by one of the seven directories.
+        author = message.author
+        if not author.bot or message.guild is None:
+            return
+
+        spec = bot_by_app_id(author.id)
+        if spec is None or not self.bot.module_manager:
+            return
+
+        try:
+            module = await self.bot.module_manager.get_module_instance(
+                message.guild.id, MODULE_ID)
+            if not module or not module.enabled:
+                return
+
+            found = await module.on_message(message, spec)
+            if found is None:
+                return
+
+            await self._on_bump(message, module, found['hit'], found['entry'])
+        except Exception as e:
+            logger.error(
+                f"Error handling bump message in guild {message.guild.id}: {e}",
+                exc_info=True)
+
+    async def _on_bump(self, message: discord.Message, module,
+                       hit, entry: Dict[str, Any]) -> None:
+        """Thank the bumper and arm the reminder."""
+        guild = message.guild
+        from utils.guild_language import guild_locale
+        locale = await guild_locale(self.bot, guild)
+
+        view = build_thanks_card(
+            hit.bot, hit.bumper_id, hit.due_at,
+            locale=locale, ping_mode=entry['ping_mode'],
+        )
+
+        # The thank-you is a courtesy; the reminder is the promise. So a failed
+        # card is logged and stepped over — the row still gets armed below.
+        result = await self.bot.notifications.send_channel(
+            message.channel,
+            content=_thanks_content(hit.bot, guild.name),
+            source=NotificationSource.service_guild(MODULE_ID, guild.id),
+            guild_id=guild.id,
+            variables={
+                "user": f"<@{hit.bumper_id}>" if hit.bumper_id else "—",
+                "server": guild.name,
+                "directory": hit.bot.name,
+                "timestamp": f"<t:{int(hit.due_at.timestamp())}:R>",
+            },
+            view=view,
+            allowed_mentions=NO_MENTIONS,
+            locale=locale,
+            attribution=False,
+        )
+        if not result.delivered:
+            logger.warning(
+                f"Bump thanks not posted in guild {guild.id} channel "
+                f"{message.channel.id}: {result.error}")
+
+        sent = result.message
+        await self.bot.db.record_bump(
+            guild.id, hit.bot.key,
+            channel_id=entry['channel_id'],
+            due_at=hit.due_at,
+            bumper_id=hit.bumper_id,
+            thanks_channel_id=message.channel.id,
+            thanks_message_id=getattr(sent, "id", None),
+        )
+        logger.info(
+            f"Bump recorded: guild {guild.id}, {hit.bot.key}, "
+            f"by {hit.bumper_id}, due {hit.due_at.isoformat()}"
+            f"{' (stated by the directory)' if hit.stated_by_bot else ''}"
+        )
+
+    # ---------------------------------------------------------------- sweeper
+    @tasks.loop(seconds=30)
+    async def sweep_bump_reminders(self):
+        if not self.bot.db or not self.bot.db.pool:
+            return
+        try:
+            for state in await self.bot.db.claim_due_bumps(SWEEP_BATCH):
+                try:
+                    await self._fire(state)
+                except Exception as e:
+                    logger.error(
+                        f"Error firing bump reminder for guild {state['guild_id']}: {e}",
+                        exc_info=True)
+        except Exception as e:
+            logger.error(f"Error sweeping bump reminders: {e}", exc_info=True)
+
+    @sweep_bump_reminders.before_loop
+    async def before_sweep(self):
+        # Nothing to replay by hand: a reminder missed while the bot was down is
+        # simply a row whose due_at is in the past, which the first pass claims.
+        await self.bot.wait_until_ready()
+
+    async def _fire(self, state: Dict[str, Any]) -> None:
+        """Post one directory's reminder into every channel that asked for it."""
+        guild = self.bot.get_guild(state['guild_id'])
+        spec = bot_by_key(state['bot_key'])
+        if guild is None or spec is None:
+            return
+
+        module = await self.bot.module_manager.get_module_instance(guild.id, MODULE_ID)
+        if not module or not module.enabled:
+            return
+
+        # Re-read the config rather than trust the row: the reminder may have
+        # been deleted, paused or re-pointed during the hours it was pending.
+        entries = module.entries_for_bot(spec.key)
+        if not entries:
+            return
+
+        from utils.guild_language import guild_locale
+        locale = await guild_locale(self.bot, guild)
+
+        now = datetime.now(timezone.utc)
+        late_by = int((now - state['due_at']).total_seconds())
+        bumped_at = state.get('bumped_at')
+        elapsed = int((state['due_at'] - bumped_at).total_seconds()) if bumped_at else None
+
+        bumper = None
+        if state.get('bumper_id'):
+            bumper = guild.get_member(state['bumper_id'])
+
+        for entry in entries:
+            await self._post(guild, spec, entry, state, locale,
+                             bumper=bumper, elapsed=elapsed, late_by=late_by)
+
+    async def _post(self, guild: discord.Guild, spec, entry: Dict[str, Any],
+                    state: Dict[str, Any], locale: str, *,
+                    bumper: Optional[discord.Member],
+                    elapsed: Optional[int], late_by: int) -> None:
+        channel = guild.get_channel(entry['channel_id'])
+        if not isinstance(channel, discord.TextChannel):
+            logger.warning(
+                f"Bump reminder channel {entry['channel_id']} gone (guild {guild.id})")
+            return
+
+        perms = channel.permissions_for(guild.me)
+        if not perms.view_channel or not perms.send_messages:
+            logger.warning(
+                f"Cannot post bump reminder in guild {guild.id} channel {channel.id} "
+                "— missing permissions")
+            return
+
+        # Three ways the last bumper gets mentioned, and only these three.
+        ping_mode = entry['ping_mode']
+        mention_bumper = bool(bumper) and (
+            ping_mode == "auto" or (ping_mode == "button" and state.get('opt_in'))
+        )
+
+        roles, allowed = reminder_mentions(
+            guild, entry['role_ids'], bumper, mention_bumper)
+
+        view = build_reminder_card(
+            spec, locale=locale,
+            role_ids=[role.id for role in roles],
+            bumper_id=state.get('bumper_id'),
+            mention_bumper=mention_bumper,
+            elapsed=elapsed,
+            late_by=late_by,
+        )
+
+        result = await self.bot.notifications.send_channel(
+            channel,
+            content=_reminder_content(spec, guild.name),
+            source=NotificationSource.service_guild(MODULE_ID, guild.id),
+            guild_id=guild.id,
+            variables={"server": guild.name, "directory": spec.name},
+            view=view,
+            allowed_mentions=allowed,
+            locale=locale,
+            attribution=False,
+        )
+        if result.delivered:
+            logger.info(
+                f"Bump reminder sent: guild {guild.id}, {spec.key}, channel {channel.id}"
+                f"{f' (late by {late_by}s)' if late_by >= LATE_AFTER else ''}"
+            )
+        else:
+            logger.warning(
+                f"Bump reminder not posted in guild {guild.id} channel "
+                f"{channel.id}: {result.error}")
+
+
+async def setup(bot):
+    await bot.add_cog(BumpReminder(bot))

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -281,6 +281,14 @@ class ConfigMainView(BaseView):
                 user_id,
                 locale
             )
+        elif module_id == 'bump_reminder':
+            from modules.configs.bump_reminder_config import BumpReminderConfigView
+            config_view = await BumpReminderConfigView.create(
+                bot,
+                guild_id,
+                user_id,
+                locale
+            )
         elif module_id == 'adaptive_slowmode':
             from modules.configs.adaptive_slowmode_config import AdaptiveSlowmodeConfigView
             config_view = AdaptiveSlowmodeConfigView(

--- a/db/base.py
+++ b/db/base.py
@@ -37,6 +37,7 @@ from db.repositories.altguard import AltGuardRepository
 from db.repositories.tickets import TicketsRepository
 from db.repositories.notifications import NotificationRepository
 from db.repositories.support_requests import SupportRequestRepository
+from db.repositories.bump import BumpReminderRepository
 
 logger = logging.getLogger('moddy.database')
 
@@ -75,6 +76,7 @@ class ModdyDatabase(
     TicketsRepository,
     NotificationRepository,
     SupportRequestRepository,
+    BumpReminderRepository,
 ):
     """Gestionnaire principal de la base de données"""
 
@@ -707,6 +709,31 @@ class ModdyDatabase(
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_enforcements_subject "
                 "ON case_enforcements (subject_type, subject_id)")
+
+            # bump_reminders — one row per (guild, directory), never more.
+            # The module's *config* lives in guilds.data.modules.bump_reminder;
+            # this is the live half: what is pending right now. A second bump
+            # before the reminder fires upserts the same row, which is how the
+            # countdown restarts without ever stacking two reminders. The
+            # partial index is the sweeper's query, verbatim.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS bump_reminders (
+                    guild_id          BIGINT      NOT NULL,
+                    bot_key           TEXT        NOT NULL,
+                    channel_id        BIGINT      NOT NULL,
+                    due_at            TIMESTAMPTZ NOT NULL,
+                    sent              BOOLEAN     NOT NULL DEFAULT FALSE,
+                    bumper_id         BIGINT,
+                    opt_in            BOOLEAN     NOT NULL DEFAULT FALSE,
+                    thanks_channel_id BIGINT,
+                    thanks_message_id BIGINT,
+                    bumped_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    PRIMARY KEY (guild_id, bot_key)
+                )
+            """)
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_bump_reminders_due "
+                "ON bump_reminders (due_at) WHERE sent = FALSE")
 
             # automod_eval_candidates — the annotation corpus that feeds the
             # offline golden set (automod/eval). A row is created for every

--- a/db/repositories/bump.py
+++ b/db/repositories/bump.py
@@ -1,0 +1,144 @@
+"""Live state of the bump reminders — one row per (guild, directory).
+
+The *configuration* of the Bump Reminder module lives in
+``guilds.data.modules.bump_reminder`` like every other module. This table holds
+the opposite half: what is actually pending right now. Which server bumped
+where, who ran the command, and when the next reminder is owed.
+
+Two properties are the point of the shape:
+
+**One row per directory, forever.** The key is ``(guild_id, bot_key)`` and not
+the config entry, because a cooldown belongs to the *server*: bumping DISBOARD
+once locks the whole server for two hours no matter which channel the command
+ran in. A premium server pointing three channels at DISBOARD therefore still
+owns one row, and the sweeper fans that one row out to its three channels. So a
+server running ``/bump`` twenty times a day owns at most seven rows — nothing
+accumulates, nothing needs a cleanup job. And a second bump before the reminder
+fired is an upsert that pushes ``due_at`` back and clears ``sent``, which is
+precisely the "restart the countdown" behaviour the module promises, obtained
+for free rather than coded.
+
+**Nothing lives in memory.** A pending reminder is a row with ``sent = FALSE``
+and a ``due_at`` in the future. No timer, no task, no cache — so a restart costs
+nothing and loses nothing: the sweeper's next pass picks up whatever came due
+while the bot was down.
+
+See docs/BUMP_REMINDER.md.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger('moddy.database')
+
+
+def _row_to_dict(row) -> Dict[str, Any]:
+    return {
+        "guild_id": row["guild_id"],
+        "bot_key": row["bot_key"],
+        "channel_id": row["channel_id"],
+        "due_at": row["due_at"],
+        "sent": row["sent"],
+        "bumper_id": row["bumper_id"],
+        "opt_in": row["opt_in"],
+        "thanks_channel_id": row["thanks_channel_id"],
+        "thanks_message_id": row["thanks_message_id"],
+        "bumped_at": row["bumped_at"],
+    }
+
+
+class BumpReminderRepository:
+    """Pending bump reminders (``bump_reminders``)."""
+
+    async def record_bump(self, guild_id: int, bot_key: str, *, channel_id: int,
+                          due_at: datetime, bumper_id: Optional[int],
+                          thanks_channel_id: Optional[int] = None,
+                          thanks_message_id: Optional[int] = None) -> None:
+        """Arm (or re-arm) the reminder for one directory in one guild.
+
+        Deliberately an upsert: somebody bumping again before the previous
+        reminder fired must push the countdown back, not stack a second one.
+        ``opt_in`` resets with it — a "ping me next time" armed for the previous
+        bump has been honoured or superseded, and carrying it over would ping
+        somebody for a bump that is no longer theirs.
+        """
+        async with self.pool.acquire() as conn:
+            await conn.execute("""
+                INSERT INTO bump_reminders (
+                    guild_id, bot_key, channel_id, due_at, sent, bumper_id,
+                    opt_in, thanks_channel_id, thanks_message_id, bumped_at
+                ) VALUES ($1, $2, $3, $4, FALSE, $5, FALSE, $6, $7, now())
+                ON CONFLICT (guild_id, bot_key) DO UPDATE SET
+                    channel_id        = EXCLUDED.channel_id,
+                    due_at            = EXCLUDED.due_at,
+                    sent              = FALSE,
+                    bumper_id         = EXCLUDED.bumper_id,
+                    opt_in            = FALSE,
+                    thanks_channel_id = EXCLUDED.thanks_channel_id,
+                    thanks_message_id = EXCLUDED.thanks_message_id,
+                    bumped_at         = now()
+            """, guild_id, bot_key, channel_id, due_at, bumper_id,
+                 thanks_channel_id, thanks_message_id)
+
+    async def claim_due_bumps(self, limit: int = 50) -> List[Dict[str, Any]]:
+        """Take the reminders that have come due, marking them in the same breath.
+
+        The rows flip to ``sent`` inside the statement that returns them, so a
+        second sweeper — or this one restarting mid-pass — can never post the
+        same reminder twice. ``SKIP LOCKED`` means a row another worker is
+        already holding is passed over rather than waited on.
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch("""
+                UPDATE bump_reminders SET sent = TRUE
+                WHERE (guild_id, bot_key) IN (
+                    SELECT guild_id, bot_key FROM bump_reminders
+                    WHERE sent = FALSE AND due_at <= now()
+                    ORDER BY due_at
+                    LIMIT $1
+                    FOR UPDATE SKIP LOCKED
+                )
+                RETURNING *
+            """, limit)
+        return [_row_to_dict(row) for row in rows]
+
+    async def get_guild_bump_states(self, guild_id: int) -> Dict[str, Dict[str, Any]]:
+        """Every pending/last state of a guild, keyed by directory.
+
+        One query feeds the whole config panel, which is what lets it show a
+        live "next reminder <t:…:R>" per entry instead of a dead form.
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT * FROM bump_reminders WHERE guild_id = $1", guild_id)
+        return {row["bot_key"]: _row_to_dict(row) for row in rows}
+
+    async def set_bump_opt_in(self, guild_id: int, bot_key: str,
+                              user_id: int, opt_in: bool) -> bool:
+        """Arm or disarm the "mention me next time" flag from the thank-you card.
+
+        Scoped to ``bumper_id`` in the statement itself: if another bump landed
+        between the card being posted and the button being clicked, the click
+        belongs to a bump that is over and quietly does nothing.
+        """
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                UPDATE bump_reminders SET opt_in = $4
+                WHERE guild_id = $1 AND bot_key = $2 AND bumper_id = $3
+                RETURNING opt_in
+            """, guild_id, bot_key, user_id, opt_in)
+        return row is not None
+
+    async def drop_bump_reminder(self, guild_id: int, bot_key: str) -> None:
+        """Forget one directory — the reminder was deleted from the config."""
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM bump_reminders WHERE guild_id = $1 AND bot_key = $2",
+                guild_id, bot_key)
+
+    async def drop_guild_bump_reminders(self, guild_id: int) -> None:
+        """Forget a whole guild — the module was disabled or reset."""
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM bump_reminders WHERE guild_id = $1", guild_id)

--- a/docs/BUMP_REMINDER.md
+++ b/docs/BUMP_REMINDER.md
@@ -153,6 +153,22 @@ The lesson generalises: **the signal is what differs between the two messages**,
 never what the directory says about bumping in general. "Boost envoyé" versus
 "Boost impossible" is a signal. "propulsé" is vocabulary.
 
+### And a refusal need not sound like one
+
+DSMonitoring answers a cooldown with *"You are so hot! 2 hours 19 minutes until
+the next like."* Beemp with *"You can bump again `<t:…>`"*. Neither contains a
+single word of the shared cooldown blocklist — no "wait", no "already". Both were
+rejected only because no success marker happened to fire.
+
+So each carries an explicit failure marker taken from its captured refusal. And
+Beemp's stays **per-directory on purpose**: "you can bump again at X" is a
+refusal there, but it is semantically what a *success* says about the next window
+elsewhere — DiscordTop's success reads "Prochain boost disponible `<t:…>`".
+Promoting it to the shared blocklist would kill real bumps.
+
+Captured refusals now exist for all five directories that have a visible one.
+DISBOARD and French.gg refuse ephemerally, so there is nothing to capture.
+
 ### D-INVITES is the fragile one
 
 Its successful bump is a bare image with a "view the server" button and **not one

--- a/docs/BUMP_REMINDER.md
+++ b/docs/BUMP_REMINDER.md
@@ -132,9 +132,19 @@ Setting this flag on another directory needs the same evidence.
 ### D-INVITES is the fragile one
 
 Its successful bump is a bare image with a "view the server" button and **not one
-word of text**. The asset filename (`bump.png`) is the only signal there is. If
-D-INVITES renames that file, detection for it stops — and it is the one detector
-here that would.
+word of text**. The asset filename (`bump.png`) is the only signal a success
+carries. If D-INVITES renames that file, detection for it stops — and it is the
+one detector here that would.
+
+Its *refusal*, by contrast, is explicit: `bump-error.png` plus "Tu pourras bump à
+nouveau `<t:…>`". Both are captured in `tests/data/bump_refusals.json` rather
+than guessed — which matters, because the guesses were wrong. The markers were
+`cooldown.png` and `error.png` until a real refusal showed the file is called
+`bump-error.png`. The refusal was rejected before the fix, but only because no
+success marker happened to fire; nothing vetoed it. That is the weakest reason a
+detector can be right, and
+`TestCapturedRefusals::test_a_captured_refusal_is_vetoed_not_merely_unmatched`
+now forbids it.
 
 ### Stated next-bump times, and the freshness window
 
@@ -432,7 +442,13 @@ Directory names are brands and are never translated.
    directory nobody captured a reply for.
 2. Add one `BumpBot` entry to `BUMP_BOTS`, positioned by audience size.
 3. Add its emoji to `utils/emojis.py` and [docs/EMOJIS.md](EMOJIS.md) if it is new.
-4. Run `pytest tests/test_bump_reminder.py`. The cross-directory test will tell
+4. Capture a **refusal** too, into `tests/data/bump_refusals.json`. This is the
+   step that is easy to skip and should not be: a guessed failure marker only
+   tests the guess, and the danger is a *success* marker that also appears on
+   the refusal — a button, a banner path — which turns every failed bump into a
+   reminder. Directories whose success rests on an image URL or a button id are
+   the exposed ones.
+5. Run `pytest tests/test_bump_reminder.py`. The cross-directory test will tell
    you if a marker is too generic — that is its job, and the reason DiscordL's
    marker is `a été bump **par**` rather than the `a été bump` it started as,
    which also matched French.gg.

--- a/docs/BUMP_REMINDER.md
+++ b/docs/BUMP_REMINDER.md
@@ -1,0 +1,440 @@
+# Bump Reminder — never miss a bump window
+
+Server directories (DISBOARD, DiscordL, French.gg…) let a server climb back to
+the top of their listing with a `/bump` command, reusable every one to four
+hours. The window is trivial to miss, and a missed window is visibility lost.
+
+This module watches the channel a server points it at, recognises that a bump
+actually **went through**, thanks whoever ran it, and calls the channel back the
+moment the command becomes available again.
+
+## Table of contents
+
+- [The hard part is not the timer](#the-hard-part-is-not-the-timer)
+- [Supported directories](#supported-directories)
+- [Detection](#detection)
+- [Files](#files)
+- [Limits (free / premium)](#limits-free--premium)
+- [Configuration schema](#configuration-schema)
+- [The `bump_reminders` table](#the-bump_reminders-table)
+- [The two cards](#the-two-cards)
+- [Pings](#pings)
+- [The sweeper](#the-sweeper)
+- [Cost](#cost)
+- [Persistence](#persistence)
+- [i18n](#i18n)
+- [Adding a directory](#adding-a-directory)
+
+---
+
+## The hard part is not the timer
+
+Scheduling a message two hours out is a row in a table. The difficulty is
+knowing whether to schedule it at all.
+
+A directory answers `/bump` **from the same bot, with the same command**, whether
+the bump went through or the server is still on cooldown. Watching for the
+command would therefore arm reminders off failures — and a reminder that fires
+an hour early is worse than none: it pings a channel, somebody runs the command,
+and the directory says no.
+
+So the module detects *"the bump is through"*, never *"the command was run"*.
+When the two cannot be told apart, it stays quiet. That asymmetry is deliberate:
+a missed reminder costs one bump window, a false one costs the channel's trust
+in every reminder after it.
+
+---
+
+## Supported directories
+
+Ordered as every menu shows them, largest audience first.
+
+| # | `key` | Directory | Command | Cooldown | What a success looks like |
+|---|---|---|---|---|---|
+| 1 | `disboard` | DISBOARD | `/bump` | 2 h | Anything visible (refuses privately) |
+| 2 | `dsmonitoring` | DSMonitoring | `/bump` | 4 h | "successfully liked" wording; embed timestamp = next like |
+| 3 | `dinvites` | D-INVITES | `/bump` | 2 h | An image named `bump.png` — and nothing else |
+| 4 | `dl` | DiscordL | `/bump` | 1 h | Banner URL under `/v2/bump/`, or "a été bump par" |
+| 5 | `beemp` | Beemp | `/bump` | 1 h | "Beemp done successfully" wording |
+| 6 | `dtop` | DiscordTop | `/boost` | 1 h | Asset named `boost-success`; states its next boost |
+| 7 | `frenchgg` | French.gg | `/bump` | 2 h | Its own "remind me" button, offered only on success |
+
+The order is an editorial judgement, not a measured ranking: DISBOARD is
+verifiably the largest (700k+ listed servers, and the only global one here); the
+rest are ordered by the bot account's age and general reputation, because no
+comparable published guild counts exist for them. Reordering is a one-line move
+in `BUMP_BOTS` — nothing derives meaning from the position.
+
+---
+
+## Detection
+
+`bumpreminder/` is pure Python: no Discord calls, no database, no network. That
+is what lets `tests/test_bump_reminder.py` replay the **real captured reply** of
+all seven directories (`tests/data/bump_payloads.json`) through the real code.
+
+The funnel, cheapest test first:
+
+1. **The author is a known directory.** One dict lookup over seven entries. This
+   runs for every message the bot can see, and rejects essentially all of them.
+2. **The command matches** — `interaction.name` against that directory's
+   `command_names`, *when Discord sends it*. Necessary, never sufficient: a
+   cooldown reply carries the same name.
+3. **Harvest.** Everything textual, every media URL and every button `custom_id`,
+   walked recursively — Components V2 nests, and three directories hide their
+   only usable marker inside a nested node.
+4. **Failure vetoes.** A shared multilingual cooldown blocklist (`wait`,
+   `attendre`, `already`, `déjà`, `cooldown`, `espera`, `warte`…) plus the
+   directory's own failure markers.
+5. **Success.** At least one of that directory's markers.
+6. **Due time.** The directory's own stated next-bump time when it publishes one,
+   otherwise `now + interval`.
+
+Steps 4 and 5 are in that order on purpose: **a failure marker vetoes, it never
+competes**. A message carrying both is a message we do not understand.
+
+### Three kinds of marker
+
+Directories are not built alike, so neither are the markers:
+
+- **`success_text`** — regexes over the harvested text, written multilingual
+  because these bots answer in the *reader's* language.
+- **`success_media`** — a substring of an image URL. Several directories name
+  their assets after the outcome (`boost-success.png`), which beats any sentence
+  and survives every translation.
+- **`success_custom_id`** — a button's id. French.gg only offers its own
+  "remind me" button on a success, which makes that button the tell. Its suffix
+  is the bumper's user id, which the detector falls back on when Discord omits
+  the interaction metadata.
+
+### DISBOARD refuses privately
+
+DISBOARD answers a cooldown with an **ephemeral** message, which the gateway
+never delivers to a bot. Every `/bump` reply Moddy can actually *see* from it
+therefore went through.
+
+That is modelled as `refusal_is_ephemeral`, and it makes DISBOARD detection
+language-proof — Japanese, Korean, Russian, Turkish all work, with no phrase
+list to maintain. Two guard rails keep the shortcut honest:
+
+- it applies **only** to a message Discord tagged with `/bump`. Without a command
+  name the reply could be anything the directory posts, so the ordinary markers
+  have to carry it instead;
+- the directory's own failure markers still veto, as insurance against the day
+  DISBOARD changes its mind.
+
+The shared text blocklist is *skipped* for it, though: that blocklist exists to
+recognise a visible refusal, which cannot happen here — so applying it could only
+ever cost a real bump, on some translation tripping over a word it does not own.
+
+Setting this flag on another directory needs the same evidence.
+
+### D-INVITES is the fragile one
+
+Its successful bump is a bare image with a "view the server" button and **not one
+word of text**. The asset filename (`bump.png`) is the only signal there is. If
+D-INVITES renames that file, detection for it stops — and it is the one detector
+here that would.
+
+### Stated next-bump times, and the freshness window
+
+DiscordTop prints `Prochain boost disponible <t:…:R>`; DSMonitoring stamps its
+embed with the next like. Both are the authority on their own cooldown, so they
+outrank the configured interval — which also means a server that mis-set the
+interval still gets a correct reminder.
+
+A stated time is only believed if it lands **between 5 minutes and 24 hours out**.
+That window is not decoration: DiscordL's footer carries a `<t:…>` that is the
+*current* time, and believing it would schedule a reminder three seconds out.
+
+---
+
+## Files
+
+| File | Role |
+|---|---|
+| `bumpreminder/registry.py` | The seven directories and their markers |
+| `bumpreminder/detect.py` | The funnel, the due-time reader, the interval parser |
+| `modules/bump_reminder.py` | `ModuleBase`: config schema, validation, routing |
+| `cogs/bump_reminder.py` | The listener and the 30-second sweeper |
+| `utils/bump_views.py` | Both cards, the opt-in button, the persistence marker |
+| `modules/configs/bump_reminder_config.py` | The `/config` panel and its modal |
+| `db/repositories/bump.py` | `bump_reminders` — the live half |
+| `tests/data/bump_payloads.json` | The seven captured replies |
+
+---
+
+## Limits (free / premium)
+
+Reminders are capped **per directory**, not as a global total, so a free server
+can still cover every listing it bumps on:
+
+| | Per directory | In total |
+|---|---|---|
+| Free | 1 | 7 |
+| Premium | 3 | 21 |
+
+One is all a normal server needs: a bump puts the *whole server* on that
+directory's cooldown, so a second entry for the same listing only makes sense to
+call a **second channel** back — a large-server need, hence premium.
+
+Premium is `utils.subscription.is_guild_premium(bot, guild_id)`. There is no
+PREMIUM guild attribute (see [docs/PREMIUM.md](PREMIUM.md)).
+
+Two reminders for the same directory **in the same channel** are refused at any
+tier: both would post the same card, every time.
+
+---
+
+## Configuration schema
+
+`guilds.data.modules.bump_reminder`:
+
+```json
+{
+  "version": 1,
+  "reminders": [
+    {
+      "id": "br_a1b2c3d4",
+      "bot": "disboard",
+      "channel_id": 123456789012345678,
+      "role_ids": [234567890123456789],
+      "ping_mode": "button",
+      "interval": 7200,
+      "enabled": true,
+      "created_by": 345678901234567890,
+      "created_at": "2026-09-03T10:00:00+00:00"
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `bot` | A `key` from `BUMP_BOTS`. An entry naming a retired directory is dropped on read rather than raised — a delisted directory must not brick the panel. |
+| `channel_id` | Both where Moddy watches for the bump **and** where it answers. |
+| `role_ids` | Up to 5. Optional. |
+| `ping_mode` | `auto` / `button` / `never` — how the last bumper is mentioned. |
+| `interval` | Seconds, 300 – 86 400. Overridden by a time the directory states itself. |
+| `enabled` | Paused entries watch nothing. |
+
+`enabled` on the **module** is computed, never stored: it is true as soon as one
+entry is enabled and has a channel.
+
+### Detection is channel-scoped, arming is server-scoped
+
+A bump is only *read* in the channel the entry points at — the reminder belongs
+to a channel the server chose, and answering in one it never picked would be
+Moddy talking out of turn.
+
+But once read, it arms **every** entry for that directory in the guild, because
+the cooldown belongs to the server, not the channel. That is what makes a
+premium server's three DISBOARD entries useful rather than three quarters dead.
+
+---
+
+## The `bump_reminders` table
+
+```sql
+CREATE TABLE bump_reminders (
+    guild_id          BIGINT      NOT NULL,
+    bot_key           TEXT        NOT NULL,
+    channel_id        BIGINT      NOT NULL,
+    due_at            TIMESTAMPTZ NOT NULL,
+    sent              BOOLEAN     NOT NULL DEFAULT FALSE,
+    bumper_id         BIGINT,
+    opt_in            BOOLEAN     NOT NULL DEFAULT FALSE,
+    thanks_channel_id BIGINT,
+    thanks_message_id BIGINT,
+    bumped_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (guild_id, bot_key)
+);
+CREATE INDEX idx_bump_reminders_due
+    ON bump_reminders (due_at) WHERE sent = FALSE;
+```
+
+**Repository:** `db/repositories/bump.py` — `BumpReminderRepository`
+
+Keyed on the *directory*, not the config entry, for the reason above. A server
+therefore owns at most seven rows however often it bumps: nothing accumulates,
+and there is no cleanup job to forget to run.
+
+**A second bump before the reminder fires is an upsert** that pushes `due_at`
+back, clears `sent`, and records the new bumper. That is the whole "restart the
+countdown" behaviour, obtained from the schema rather than coded. `opt_in`
+resets with it: a "ping me" armed for the previous bump has been honoured or
+superseded, and carrying it over would ping somebody for a bump that is no
+longer theirs.
+
+`claim_due_bumps` flips the rows to `sent` **inside the statement that returns
+them** (`FOR UPDATE SKIP LOCKED`), so a second sweeper — or this one restarting
+mid-pass — can never post the same reminder twice.
+
+---
+
+## The two cards
+
+The whole design of the feature is in the difference between them.
+
+### The thank-you, immediately
+
+```
+### <:rocket_launch:…> Merci @juthing !
+Le serveur vient de remonter sur <:disboard:…> **DISBOARD**.
+Prochain bump possible dans 2 heures.
+
+[ ⏰ Me rappeler ]        ← only when ping_mode is "button"
+```
+
+It renders the bumper's mention but **does not notify them**: they typed the
+command one second ago and are looking straight at the channel. Buzzing somebody
+for their own action is noise, so it goes out with `AllowedMentions.none()`.
+
+### The reminder, when the window opens
+
+```
+@Bumpeurs @juthing                      ← TextDisplay at the view's top level
+┌──────────────────────────────────
+│ ### <:rocket_launch:…> C'est reparti
+│ Le serveur peut de nouveau être bumpé sur <:disboard:…> **DISBOARD**.
+│ </bump:947088344167366698>
+│ -# Dernier bump par @juthing, il y a 2h.
+└──────────────────────────────────
+```
+
+The command is a real command mention, so it is one click away.
+
+---
+
+## Pings
+
+Discord rejects any message carrying both a `content` field and the
+`IS_COMPONENTS_V2` flag that discord.py sets for every `LayoutView` — so the
+mentions cannot ride in `content` (see
+[docs/TICKETS.md § Pings](TICKETS.md#pings) for where that bites elsewhere).
+
+They ride in a **`TextDisplay` added to the view itself**, above and outside the
+container. It is an ordinary V2 component, it renders outside the card's frame,
+and it genuinely notifies. Here the mention *is* the message, so unlike a ticket
+card it belongs in the message rather than in a self-deleting ghost ping nobody
+can scroll back to.
+
+**What actually notifies is decided by `allowed_mentions`, never by what the card
+draws.** `reminder_mentions()` builds it from the *resolved* role and member
+objects — never `roles=True` — so:
+
+- a role deleted since the config was written simply drops out;
+- a bumper who left the guild drops out, and the roles still go through;
+- the `-# Dernier bump par @juthing` credit line renders a mention **whatever the
+  ping mode**, and stays silent unless the mode put them in `allowed_mentions`.
+  The credit survives; the unwanted ping cannot happen.
+
+### The three ping modes
+
+| Mode | The last bumper is mentioned |
+|---|---|
+| `auto` | By every reminder. |
+| `button` *(default)* | Only if they asked, via the button on the thank-you. |
+| `never` | Not at all — only the chosen roles. |
+
+The button is a `DynamicItem` carrying the bumper's id, so authorisation is
+re-read from the click and a card left in a channel for a month is exactly as
+safe as a fresh one. It **toggles**: somebody who armed it by reflex and changed
+their mind clicks again. A reminder nobody asked for is the thing this module
+exists to avoid, and that includes its own ping.
+
+Clicking it after a newer bump has replaced that one says so, and changes
+nothing — the write is scoped to `bumper_id` in the statement itself.
+
+---
+
+## The sweeper
+
+A `modules/*.py` is instantiated *per guild*, so it can own neither a listener
+nor a loop. `cogs/bump_reminder.py` owns both.
+
+**The listener is its own**, not a block in `cogs/module_events.py`: that cog
+drops bot-authored messages before any module sees them, which is exactly the
+class of message this feature reads. Relaxing the shared guard would change what
+four other modules receive. (`cogs/logs.py` already watches separately for the
+same reason.)
+
+**The loop runs every 30 seconds.** Restart recovery needs no special case: a
+reminder missed while the bot was down is simply a row whose `due_at` is in the
+past, which the first pass claims. A reminder more than five minutes late says so
+on the card rather than pretending to be on time.
+
+Before posting, the sweeper **re-reads the config** rather than trusting the row:
+during the hours a reminder was pending it may have been deleted, paused or
+re-pointed. Deleting a reminder (or moving it to another directory) drops the
+orphaned row too, so a reminder deleted at 3pm cannot still fire at 4.
+
+If the channel is gone or the permissions were withdrawn, the pass logs and moves
+on. Nothing retries, nothing crashes.
+
+---
+
+## Cost
+
+Railway bills RAM, so the shape was chosen for it:
+
+- **Zero timers.** A pending reminder is a row, not a task. Nothing is held.
+- **≤ 7 rows per guild**, bounded for life.
+- **One indexed query per 30 seconds**, whatever the number of servers — the
+  partial index `WHERE sent = FALSE` is that query, verbatim.
+- **The listener's first test is a dict lookup** over seven ints. Everything
+  else — the guild's module, the channel, the detection — sits behind it, so a
+  message from an unrelated bot costs one hash.
+- The registry is module-level and frozen: one copy, shared by every guild.
+
+---
+
+## Persistence
+
+Every view is persistent (see [docs/PERSISTENT_VIEWS.md](PERSISTENT_VIEWS.md)),
+registered in `utils/persistent_views.py` under group 10b:
+
+| Class | Auth |
+|---|---|
+| `BumpReminderConfigView` | Manage Server, re-checked on every click |
+| `ManageBumpReminderView` | Manage Server, re-checked on every click |
+| `BumpReminderPersistence` | Marker view registering `BumpOptInButton` |
+
+`BumpOptInButton` template:
+`moddy:bump:optin:(?P<bot>[a-z]{1,16}):(?P<user>\d{1,20})`
+
+`\d{1,20}` rather than `\d{17,20}`: the bare shell the persistence tests build
+uses zeros and has to match its own template.
+
+The modal is deliberately excluded — modals are never persistent.
+
+---
+
+## i18n
+
+Everything posted into a channel speaks the **server** language
+(`guild_locale(bot, guild)`). Everything one person reads privately — the config
+panel, an ephemeral error, the "you'll be mentioned" confirmation — speaks
+theirs (`i18n.get_user_locale`). See [docs/SERVER_LANGUAGE.md](SERVER_LANGUAGE.md).
+
+Keys live under `modules.bump_reminder.*` in all five locale files.
+`tests/test_bump_reminder.py::TestTranslations` asserts key parity in both
+directions and that every key the source actually calls resolves.
+
+Directory names are brands and are never translated.
+
+---
+
+## Adding a directory
+
+1. Capture a **real** successful reply and add it to
+   `tests/data/bump_payloads.json` under the new key. The tests refuse a
+   directory nobody captured a reply for.
+2. Add one `BumpBot` entry to `BUMP_BOTS`, positioned by audience size.
+3. Add its emoji to `utils/emojis.py` and [docs/EMOJIS.md](EMOJIS.md) if it is new.
+4. Run `pytest tests/test_bump_reminder.py`. The cross-directory test will tell
+   you if a marker is too generic — that is its job, and the reason DiscordL's
+   marker is `a été bump **par**` rather than the `a été bump` it started as,
+   which also matched French.gg.
+
+Nothing else knows the list. No i18n key, no config migration, no schema change.

--- a/docs/BUMP_REMINDER.md
+++ b/docs/BUMP_REMINDER.md
@@ -57,7 +57,7 @@ Ordered as every menu shows them, largest audience first.
 | 4 | `dl` | DiscordL | `/bump` | 1 h | Banner URL under `/v2/bump/`, or "a été bump par" |
 | 5 | `beemp` | Beemp | `/bump` | 1 h | "Beemp done successfully" wording |
 | 6 | `dtop` | DiscordTop | `/boost` | 1 h | Asset named `boost-success`; states its next boost |
-| 7 | `frenchgg` | French.gg | `/bump` | 2 h | Its own "remind me" button, offered only on success |
+| 7 | `frenchgg` | French.gg | `/bump` | 2 h | Anything visible (refuses privately); its own "remind me" button |
 
 The order is an editorial judgement, not a measured ranking: DISBOARD is
 verifiably the largest (700k+ listed servers, and the only global one here); the
@@ -107,27 +107,51 @@ Directories are not built alike, so neither are the markers:
   is the bumper's user id, which the detector falls back on when Discord omits
   the interaction metadata.
 
-### DISBOARD refuses privately
+### Two directories refuse privately
 
-DISBOARD answers a cooldown with an **ephemeral** message, which the gateway
-never delivers to a bot. Every `/bump` reply Moddy can actually *see* from it
-therefore went through.
+DISBOARD and French.gg answer a cooldown with an **ephemeral** message, which
+the gateway never delivers to a bot. Every `/bump` reply Moddy can actually
+*see* from them therefore went through.
 
-That is modelled as `refusal_is_ephemeral`, and it makes DISBOARD detection
+That is modelled as `refusal_is_ephemeral`. For DISBOARD it makes detection
 language-proof — Japanese, Korean, Russian, Turkish all work, with no phrase
-list to maintain. Two guard rails keep the shortcut honest:
+list to maintain. For French.gg it is what makes its "remind me in 2h" button
+safe to lean on: that button would arguably make *more* sense on a cooldown than
+on a success, so without the guarantee it would have been the wrong marker.
+
+Two guard rails keep the shortcut honest:
 
 - it applies **only** to a message Discord tagged with `/bump`. Without a command
   name the reply could be anything the directory posts, so the ordinary markers
   have to carry it instead;
 - the directory's own failure markers still veto, as insurance against the day
-  DISBOARD changes its mind.
+  it changes its mind.
 
-The shared text blocklist is *skipped* for it, though: that blocklist exists to
-recognise a visible refusal, which cannot happen here — so applying it could only
-ever cost a real bump, on some translation tripping over a word it does not own.
+The shared text blocklist is a **separate** decision, carried by
+`answers_in_any_language` and skipped only for DISBOARD. Private refusals alone
+are not reason enough to drop it: the flag is an assumption about someone else's
+product, and the blocklist is the net under that assumption. Only a directory
+that *also* answers in languages we cannot enumerate has anything to lose by
+keeping it — and French.gg, being a French listing, does not. Setting either flag
+on another directory needs the same evidence.
 
-Setting this flag on another directory needs the same evidence.
+### A success marker must never appear on a refusal
+
+This is the failure mode that actually bites, and it bit twice.
+
+`Résultat du Bump sur DiscordL` looked like a success marker. It is DiscordL's
+message **header**, printed on the refusal too. `propulsé` looked like one for
+DiscordTop. Its refusal reads "Ce serveur vient **déjà** d'être propulsé".
+
+Both were harmless — but only because some veto happened to fire first
+("attendre", "déjà"). Reword either refusal and the detector starts arming
+reminders off failed bumps. `TestCapturedRefusals` now forbids it outright:
+no success marker of a directory may match that directory's own captured
+refusal. It fails against both original markers, naming them.
+
+The lesson generalises: **the signal is what differs between the two messages**,
+never what the directory says about bumping in general. "Boost envoyé" versus
+"Boost impossible" is a signal. "propulsé" is vocabulary.
 
 ### D-INVITES is the fragile one
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -740,6 +740,48 @@ demandeur), dans l'ordre.
 
 See → [SUPPORT_REQUESTS.md](SUPPORT_REQUESTS.md).
 
+### 19. Table `bump_reminders`
+
+L'état vivant du module Bump Reminder : ce qui est en attente **maintenant**. La
+*configuration* du module, elle, vit dans `guilds.data.modules.bump_reminder`
+comme celle de tous les autres modules.
+
+La clé est `(guild_id, bot_key)` et non l'entrée de configuration, parce qu'un
+cooldown appartient au **serveur** : bumper DISBOARD une fois verrouille tout le
+serveur pendant deux heures, quel que soit le salon d'où la commande est partie.
+Un serveur premium qui pointe trois salons vers DISBOARD ne possède donc qu'une
+ligne, que le balayeur diffuse ensuite vers ses trois salons. Un serveur détient
+au plus 7 lignes, à vie : rien ne s'accumule, aucun job de nettoyage à écrire.
+
+Un second bump avant l'échéance est un `ON CONFLICT DO UPDATE` qui repousse
+`due_at`, remet `sent` à FALSE et enregistre le nouveau bumpeur — c'est tout le
+comportement « on redémarre le compte à rebours », obtenu du schéma plutôt que
+codé.
+
+**Columns:**
+- `guild_id` (BIGINT) + `bot_key` (TEXT) — PRIMARY KEY ; `bot_key` est une clé
+  de `bumpreminder.registry.BUMP_BOTS` (`disboard`, `dl`, `dtop`…)
+- `channel_id` (BIGINT) — le salon surveillé au moment du bump
+- `due_at` (TIMESTAMPTZ) — quand la commande redevient disponible
+- `sent` (BOOLEAN) — le rappel est parti (ou a été réclamé par le balayeur)
+- `bumper_id` (BIGINT) — qui a lancé la commande, si Discord l'a dit
+- `opt_in` (BOOLEAN) — cette personne a demandé à être mentionnée (bouton
+  « Me rappeler » du message de remerciement)
+- `thanks_channel_id` / `thanks_message_id` (BIGINT) — la carte de remerciement
+- `bumped_at` (TIMESTAMPTZ)
+
+**Index:**
+- `idx_bump_reminders_due` on `(due_at) WHERE sent = FALSE` — c'est la requête
+  du balayeur, mot pour mot
+
+**Repository:** `db/repositories/bump.py` — `BumpReminderRepository`
+
+`claim_due_bumps` bascule les lignes à `sent` **dans l'instruction qui les
+renvoie** (`FOR UPDATE SKIP LOCKED`) : ni double envoi, ni perte sur un
+redémarrage en plein balayage.
+
+See → [BUMP_REMINDER.md](BUMP_REMINDER.md).
+
 ---
 
 ## Système d'attributs et de données

--- a/docs/EMOJIS.md
+++ b/docs/EMOJIS.md
@@ -143,6 +143,7 @@
 <:ticket:1541216667420594257>
 <:threads:1541216661699436675>
 <:claim:1541239118888181770>
+<:rocket_launch:1545028494298447873>
 
 
 ## Server logs icon set — `utils/emojis.py::LOG_EMOJIS`

--- a/docs/sessions/2026-09-03_bump-reminder-module.md
+++ b/docs/sessions/2026-09-03_bump-reminder-module.md
@@ -84,6 +84,19 @@ bot-authored messages before any module sees them, which is exactly what this
 feature reads. Relaxing the shared guard would change what four other modules
 receive.
 
+## Correction after the first push
+
+Jules supplied a real D-INVITES refusal. It showed the failure markers were
+wrong: invented as `cooldown.png` / `error.png`, the file is actually
+`bump-error.png`, and the message reads "Tu pourras bump à nouveau `<t:…>`".
+
+The refusal *was* already rejected — but only because no success marker happened
+to fire, which is the weakest reason a detector can be right: the day a
+directory adds a banner or a phrase to its refusal, the rejection silently
+becomes an acceptance. `tests/data/bump_refusals.json` now holds captured
+refusals, and `TestCapturedRefusals` asserts each one trips an **explicit** veto.
+That test fails against the old guessed markers, which is how it earns its place.
+
 ## Bugs caught during the work
 
 - `_by_channel` keyed on the channel alone would have silently dropped a second
@@ -108,7 +121,11 @@ receive.
   DISBOARD is verifiably largest; the rest are ordered by bot account age and
   reputation because no comparable published guild counts exist. Reordering is a
   one-line move in `BUMP_BOTS`.
-- Failure payloads in the tests are *synthetic* (plausible cooldown replies in
-  FR and EN). Real captured refusals would be stronger — worth adding whenever
-  one is seen in the wild.
+- **Captured refusals exist only for D-INVITES so far.** The rest of
+  `TestFailure` replays hand-written cooldown replies, which only ever test the
+  guess. The exposed directories are the ones whose *success* marker could
+  plausibly also appear on a refusal: French.gg (its "remind me" button — which
+  makes more sense on a cooldown than on a success), DiscordL (a banner under
+  `/v2/bump/`), and DiscordTop (whose failure markers `boost-error`,
+  `boost-cooldown`, `boost-failed` are still invented). Requested from Jules.
 - The module ships no slash command, so `locales/commands/` is untouched.

--- a/docs/sessions/2026-09-03_bump-reminder-module.md
+++ b/docs/sessions/2026-09-03_bump-reminder-module.md
@@ -1,0 +1,114 @@
+# 2026-09-03 — Bump Reminder module
+
+New server module: detect a **successful** bump on seven server directories,
+thank whoever ran it, and call the channel back when the command is available
+again.
+
+## What was done
+
+A complete module, from the detection core to the `/config` panel:
+
+- `bumpreminder/` — a new pure-Python package (no Discord, no DB) holding the
+  registry of the seven directories and the detection funnel.
+- `bump_reminders` table + `BumpReminderRepository`.
+- `modules/bump_reminder.py` — `ModuleBase`, config schema, validation, routing.
+- `cogs/bump_reminder.py` — a dedicated `on_message` listener and a 30s sweeper.
+- `utils/bump_views.py` — both cards and the persistent opt-in button.
+- `modules/configs/bump_reminder_config.py` — the panel and its Modal V2.
+- `modules.bump_reminder.*` in all five locales (68 keys each).
+- `tests/test_bump_reminder.py` (141 tests) + `tests/data/bump_payloads.json`.
+- `docs/BUMP_REMINDER.md`, plus DATABASE / EMOJIS / CLAUDE.md updates.
+
+Full suite: **1683 passed**.
+
+## Decisions, and why
+
+**Detect "the bump is through", never "the command was run".** A directory
+answers `/bump` from the same bot with the same command whether it succeeded or
+the server is on cooldown. A reminder armed off a failure fires an hour early,
+pings the channel, and the directory then refuses — worse than no reminder. So
+a failure marker *vetoes*, it never competes with a success marker, and a message
+carrying both is treated as not understood.
+
+**Markers come in three kinds** because the directories are not built alike:
+text regexes (multilingual — these bots answer in the reader's language), media
+URL substrings (several name their assets after the outcome, which beats any
+sentence and survives every translation), and button custom_ids (French.gg only
+offers its "remind me" button on a success).
+
+**DISBOARD refuses privately** (Jules), so anything visible from it went through
+— modelled as `refusal_is_ephemeral`, which makes it language-proof instead of
+hostage to a phrase list. Two guard rails: the shortcut needs Discord to have
+tagged the message with `/bump` (otherwise it could be anything DISBOARD posts),
+and its own failure markers still veto.
+
+**A stated next-bump time beats the configured interval**, but only inside a
+5min–24h freshness window. DiscordTop and DSMonitoring publish theirs and are the
+authority on their own cooldown; DiscordL's footer stamp is the *current* time
+and would otherwise schedule a reminder three seconds out.
+
+**Detection is channel-scoped, arming is server-scoped.** A bump is only read in
+the channel the entry points at (Jules's call), but once read it arms every entry
+for that directory in the guild — the cooldown belongs to the server, not the
+channel. That is what makes a premium server's three DISBOARD entries useful
+rather than three quarters dead, and it is why `bump_reminders` is keyed on
+`(guild_id, bot_key)` rather than on the config entry.
+
+**Quotas are per directory** (1 free / 3 premium), not a global total, so a free
+server can still cover every listing it bumps on. Premium via
+`utils.subscription.is_guild_premium` — there is no PREMIUM guild attribute.
+
+**The reminder's mentions ride in a top-level `TextDisplay`**, above and outside
+the container (Jules's placement). `content=` is illegal alongside a
+`LayoutView`, and a self-deleting ghost ping cannot be scrolled back to. Here the
+mention *is* the message.
+
+**The "last bumped by" credit line keeps its mention even when the bumper ping is
+off** (Jules caught this): what notifies is `allowed_mentions`, which lists
+resolved objects only — so the credit survives and the unwanted ping cannot
+happen. The thank-you card goes out with `AllowedMentions.none()`: buzzing
+somebody one second after they typed the command is noise.
+
+**Adding is a select, not a button.** The delay field must open pre-filled with
+the directory's own cooldown, and a Discord modal is static — it cannot react to
+a choice made inside itself. Picking the directory on the panel means the modal
+opens fully filled in, for the same number of clicks.
+
+**Zero timers.** A pending reminder is a row; restart recovery is
+`due_at <= now()` with no special case, and `claim_due_bumps` flips rows to
+`sent` inside the statement that returns them, so nothing double-posts. ≤7 rows
+per guild, one indexed query per 30s regardless of scale.
+
+**A dedicated listener, not a `module_events.py` block**: that cog drops
+bot-authored messages before any module sees them, which is exactly what this
+feature reads. Relaxing the shared guard would change what four other modules
+receive.
+
+## Bugs caught during the work
+
+- `_by_channel` keyed on the channel alone would have silently dropped a second
+  directory sharing one `#bump` channel — the most common setup. Now `(channel,
+  bot)`, with duplicate `(bot, channel)` pairs refused at validation.
+- The `<t:…>` regex was case-sensitive while the harvested text is lowercased, so
+  DiscordTop's stated time was never read. Caught by the payload replay.
+- DiscordL and French.gg shared the marker `a été bump`. Caught by the
+  cross-directory test; DiscordL now requires `a été bump **par**`.
+- The German module description was 111 characters — Discord caps a
+  SelectOption description at 100 and `/config` would have truncated it mid-word.
+  Now tested for all five locales.
+- Two `except discord.Forbidden` blocks in the cog were dead: the notification
+  service swallows it and returns a failed `DeliveryResult`.
+
+## Known limits / follow-ups
+
+- **D-INVITES is the fragile detector.** Its successful bump is a bare image with
+  no text at all; the asset filename (`bump.png`) is the only signal. If they
+  rename it, detection stops. Documented in `docs/BUMP_REMINDER.md`.
+- **The directory ordering is an editorial judgement**, not a measured ranking.
+  DISBOARD is verifiably largest; the rest are ordered by bot account age and
+  reputation because no comparable published guild counts exist. Reordering is a
+  one-line move in `BUMP_BOTS`.
+- Failure payloads in the tests are *synthetic* (plausible cooldown replies in
+  FR and EN). Real captured refusals would be stronger — worth adding whenever
+  one is seen in the wild.
+- The module ships no slash command, so `locales/commands/` is untouched.

--- a/docs/sessions/2026-09-03_bump-reminder-module.md
+++ b/docs/sessions/2026-09-03_bump-reminder-module.md
@@ -107,6 +107,19 @@ impossible to reintroduce: a captured refusal must trip an **explicit** veto,
 and **no success marker may match a directory's own refusal**. Both fail against
 the original markers, naming them.
 
+The last two refusals taught the opposite lesson to the first three. I predicted
+DSMonitoring would say "already liked" and collide with its success marker
+`liked the server`. It does not — it says *"You are so hot! 2 hours 19 minutes
+until the next like."* Beemp says *"You can bump again `<t:…>`"*. **Neither
+contains a single word of the shared cooldown blocklist.** No success marker
+fired either, so both were rejected — by omission, again. Each now carries an
+explicit marker from its captured refusal.
+
+Beemp's stays per-directory deliberately: "you can bump again at X" is a refusal
+there, but it is what a *success* says about the next window elsewhere
+(DiscordTop: "Prochain boost disponible <t:…>"). Promoting it to the shared
+blocklist would kill real bumps.
+
 The generalisable lesson, now in the docs: the signal is what *differs* between
 the two messages, never what the directory says about bumping in general.
 "Boost envoyé" versus "Boost impossible" is a signal; "propulsé" is vocabulary.
@@ -155,10 +168,8 @@ That test fails against the old guessed markers, which is how it earns its place
   DISBOARD is verifiably largest; the rest are ordered by bot account age and
   reputation because no comparable published guild counts exist. Reordering is a
   one-line move in `BUMP_BOTS`.
-- **Captured refusals exist for D-INVITES, DiscordL and DiscordTop.** DISBOARD
-  and French.gg refuse ephemerally, so there is nothing to capture. Still
-  synthetic, and worth replacing whenever a real one is seen: **Beemp** and
-  **DSMonitoring**. Both rest on text markers covered by the shared blocklist,
-  so the exposure is lower than it was for the three above — but "lower" is what
-  I said about DiscordL before its refusal turned up a live marker collision.
+- **Captured refusals now exist for all five directories that have a visible
+  one** (D-INVITES, DiscordL, DiscordTop, DSMonitoring, Beemp). DISBOARD and
+  French.gg refuse ephemerally, so there is nothing to capture. No directory is
+  still detected on guessed failure markers.
 - The module ships no slash command, so `locales/commands/` is untouched.

--- a/docs/sessions/2026-09-03_bump-reminder-module.md
+++ b/docs/sessions/2026-09-03_bump-reminder-module.md
@@ -84,7 +84,41 @@ bot-authored messages before any module sees them, which is exactly what this
 feature reads. Relaxing the shared guard would change what four other modules
 receive.
 
-## Correction after the first push
+## Corrections after the first push
+
+Jules supplied real refusals for D-INVITES, DiscordL and DiscordTop, and the
+information that DISBOARD *and* French.gg refuse ephemerally. Three real bugs
+came out of it, all of the same shape: **a marker that is present on both the
+success and the refusal**.
+
+| Directory | The bad marker | Why it looked right |
+|---|---|---|
+| D-INVITES | failure `cooldown.png` / `error.png` | Invented. The file is `bump-error.png`. |
+| DiscordL | success `Résultat du Bump` | It is the message *header*, printed on both. |
+| DiscordTop | success `propulsé` | The refusal reads "vient **déjà** d'être propulsé". |
+
+None of the three was *observable*: every refusal was still rejected, because
+some other veto happened to fire first — `bump-error` missing a success marker,
+"attendre", "déjay". That is the worst kind of correct: reword any of those
+refusals and the detector silently starts arming reminders off failed bumps.
+
+`TestCapturedRefusals` now holds two assertions that make this class of bug
+impossible to reintroduce: a captured refusal must trip an **explicit** veto,
+and **no success marker may match a directory's own refusal**. Both fail against
+the original markers, naming them.
+
+The generalisable lesson, now in the docs: the signal is what *differs* between
+the two messages, never what the directory says about bumping in general.
+"Boost envoyé" versus "Boost impossible" is a signal; "propulsé" is vocabulary.
+
+Separately, `refusal_is_ephemeral` was doing two jobs and has been split.
+Granting the "visible means success" shortcut is one fact; dropping the shared
+cooldown blocklist is another, now `answers_in_any_language` and true only for
+DISBOARD. Private refusals alone are an assumption about someone else's product,
+and the blocklist is the net under it — French.gg, being a French listing, keeps
+it for free.
+
+## Superseded note (kept for the record)
 
 Jules supplied a real D-INVITES refusal. It showed the failure markers were
 wrong: invented as `cooldown.png` / `error.png`, the file is actually
@@ -121,11 +155,10 @@ That test fails against the old guessed markers, which is how it earns its place
   DISBOARD is verifiably largest; the rest are ordered by bot account age and
   reputation because no comparable published guild counts exist. Reordering is a
   one-line move in `BUMP_BOTS`.
-- **Captured refusals exist only for D-INVITES so far.** The rest of
-  `TestFailure` replays hand-written cooldown replies, which only ever test the
-  guess. The exposed directories are the ones whose *success* marker could
-  plausibly also appear on a refusal: French.gg (its "remind me" button — which
-  makes more sense on a cooldown than on a success), DiscordL (a banner under
-  `/v2/bump/`), and DiscordTop (whose failure markers `boost-error`,
-  `boost-cooldown`, `boost-failed` are still invented). Requested from Jules.
+- **Captured refusals exist for D-INVITES, DiscordL and DiscordTop.** DISBOARD
+  and French.gg refuse ephemerally, so there is nothing to capture. Still
+  synthetic, and worth replacing whenever a real one is seen: **Beemp** and
+  **DSMonitoring**. Both rest on text markers covered by the shared blocklist,
+  so the exposure is lower than it was for the three above — but "lower" is what
+  I said about DiscordL before its refusal turned up a live marker collision.
 - The module ships no slash command, so `locales/commands/` is untouched.

--- a/locales/de.json
+++ b/locales/de.json
@@ -1482,6 +1482,94 @@
         "internal_error": "<:error:1519790252594827264> Etwas ist schiefgelaufen. Bitte versuche es erneut."
       }
     },
+    "bump_reminder": {
+      "name": "Bump-Erinnerung",
+      "description": "Bedankt sich bei allen, die den Server bumpen, und meldet sich, sobald er wieder dran ist",
+      "config": {
+        "title": "Bump-Erinnerung",
+        "description": "Ein verpasstes Bump-Fenster ist verlorene Sichtbarkeit. Moddy erkennt einen **erfolgreichen** Bump im Kanal deiner Wahl, bedankt sich bei der Person und meldet sich im Kanal, sobald der Befehl wieder verfügbar ist.",
+        "limit": "{max} Erinnerung(en) pro Verzeichnis.",
+        "add_placeholder": "Erinnerung für ein Verzeichnis hinzufügen",
+        "manage_placeholder": "Bestehende Erinnerung verwalten",
+        "all_configured": "Du hast dein Kontingent bei jedem unterstützten Verzeichnis erreicht.",
+        "list": {
+          "title": "Eingerichtete Erinnerungen",
+          "count": "{count} Erinnerung(en)",
+          "empty": "Noch keine Erinnerung. Wähle unten ein Verzeichnis, um zu beginnen.",
+          "every": "Alle {interval}",
+          "paused": "Pausiert"
+        },
+        "state": {
+          "waiting": "Wartet auf den ersten Bump.",
+          "scheduled": "Nächste Erinnerung {timestamp}.",
+          "ready": "Der Server kann sofort gebumpt werden."
+        }
+      },
+      "modal": {
+        "title": "Bump-Erinnerung",
+        "bot_label": "Verzeichnis",
+        "bot_description": "Die Liste, deren Befehl Moddy beobachten soll.",
+        "bot_option": "{command} · alle {interval}",
+        "channel_label": "Kanal",
+        "channel_description": "Hier achtet Moddy auf den Bump und postet die Erinnerung.",
+        "roles_label": "Zu erwähnende Rollen",
+        "roles_description": "Optional. Leer lassen, um niemanden zu erwähnen.",
+        "ping_label": "Die letzte Person erwähnen, die gebumpt hat",
+        "ping_description": "Was Moddy mit der Person macht, die den Befehl ausgeführt hat.",
+        "interval_label": "Wartezeit bis zur Erinnerung",
+        "interval_description": "Zum Beispiel 2h, 2h30 oder 90m. Zwischen 5 Minuten und 24 Stunden."
+      },
+      "ping": {
+        "auto": "Immer",
+        "auto_description": "Sie wird bei jeder Erinnerung erwähnt.",
+        "button": "Auf Wunsch",
+        "button_description": "Ein Button auf dem Dank lässt sie darum bitten.",
+        "never": "Nie",
+        "never_description": "Nur die gewählten Rollen werden erwähnt."
+      },
+      "card": {
+        "thanks_title": "Danke {user}!",
+        "thanks_title_anonymous": "Danke!",
+        "thanks_body": "Der Server ist gerade auf {emoji} **{name}** wieder nach oben gerutscht.\nNächster Bump möglich {timestamp}.",
+        "optin": "Erinnere mich",
+        "optin_armed": "Du wirst erwähnt",
+        "optin_expired": "Ein neuerer Bump hat diesen bereits ersetzt.",
+        "reminder_title": "Zeit für den nächsten Bump",
+        "reminder_body": "Der Server kann auf {emoji} **{name}** wieder gebumpt werden.\n{command}",
+        "reminder_last": "Letzter Bump von {user}, vor {duration}.",
+        "reminder_late": "Erinnerung verspätet gesendet: Moddy war nicht erreichbar."
+      },
+      "manage": {
+        "subtitle": "Alle {interval} · {command}",
+        "channel": "**Kanal:** {channel}",
+        "roles": "**Erwähnte Rollen:** {roles}",
+        "no_roles": "keine",
+        "ping": "**Letzte Person, die gebumpt hat:** {mode}",
+        "paused_notice": "Diese Erinnerung ist pausiert: Moddy ignoriert Bumps dieses Verzeichnisses.",
+        "edit": "Bearbeiten",
+        "pause": "Pausieren",
+        "resume": "Fortsetzen",
+        "remove": "Löschen",
+        "removed": "Erinnerung gelöscht.",
+        "saved": "Erinnerung gespeichert."
+      },
+      "add": {
+        "success": "Erinnerung erstellt. Moddy beobachtet diesen Kanal ab sofort."
+      },
+      "errors": {
+        "guild_not_found": "Server nicht gefunden.",
+        "unknown_bot": "Dieses Verzeichnis wird nicht mehr unterstützt.",
+        "quota": "Du hast dein Kontingent von {max} Erinnerung(en) für {name} erreicht. Mit Premium kannst du mehr einrichten.",
+        "duplicate_id": "Zwei Erinnerungen haben dieselbe Kennung.",
+        "duplicate_target": "In {channel} gibt es bereits eine {name}-Erinnerung: beide würden dieselbe Nachricht posten.",
+        "channel_required": "Wähle einen Kanal.",
+        "channel_not_found": "Diesen Kanal gibt es nicht mehr.",
+        "channel_type": "Der Kanal muss ein Textkanal sein.",
+        "no_send_permission": "Moddy kann in {channel} nicht posten.",
+        "too_many_roles": "Höchstens {max} Rollen.",
+        "invalid_interval": "Ungültige Wartezeit. Nutze zum Beispiel `2h`, `2h30` oder `90m`, zwischen 5 Minuten und 24 Stunden."
+      }
+    },
     "automod_ai": {
       "description": "Automatische Moderation problematischer Nachrichten (KI)",
       "config": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1482,6 +1482,94 @@
         "internal_error": "<:error:1519790252594827264> Something went wrong. Please try again."
       }
     },
+    "bump_reminder": {
+      "name": "Bump Reminder",
+      "description": "Thanks whoever bumps the server and calls the channel back the moment it can be bumped again",
+      "config": {
+        "title": "Bump Reminder",
+        "description": "A missed bump window is visibility lost. Moddy recognises a **successful** bump in the channel you point it at, thanks whoever ran it, and calls the channel back the moment the command is available again.",
+        "limit": "{max} reminder(s) per directory.",
+        "add_placeholder": "Add a reminder for a directory",
+        "manage_placeholder": "Manage an existing reminder",
+        "all_configured": "You have reached your quota on every supported directory.",
+        "list": {
+          "title": "Configured reminders",
+          "count": "{count} reminder(s)",
+          "empty": "No reminder yet. Pick a directory below to get started.",
+          "every": "Every {interval}",
+          "paused": "Paused"
+        },
+        "state": {
+          "waiting": "Waiting for a first bump.",
+          "scheduled": "Next reminder {timestamp}.",
+          "ready": "The server can be bumped right now."
+        }
+      },
+      "modal": {
+        "title": "Bump reminder",
+        "bot_label": "Directory",
+        "bot_description": "The listing whose command Moddy should watch.",
+        "bot_option": "{command} · every {interval}",
+        "channel_label": "Channel",
+        "channel_description": "Moddy watches for the bump here, and posts the reminder here.",
+        "roles_label": "Roles to mention",
+        "roles_description": "Optional. Leave empty to mention nobody.",
+        "ping_label": "Mention the last person who bumped",
+        "ping_description": "What Moddy does about whoever ran the command.",
+        "interval_label": "Delay before the reminder",
+        "interval_description": "For example 2h, 2h30 or 90m. Between 5 minutes and 24 hours."
+      },
+      "ping": {
+        "auto": "Always",
+        "auto_description": "They are mentioned by every reminder.",
+        "button": "On request",
+        "button_description": "A button on the thank-you lets them ask for it.",
+        "never": "Never",
+        "never_description": "Only the chosen roles are mentioned."
+      },
+      "card": {
+        "thanks_title": "Thanks {user}!",
+        "thanks_title_anonymous": "Thanks!",
+        "thanks_body": "The server just climbed back up on {emoji} **{name}**.\nNext bump possible {timestamp}.",
+        "optin": "Remind me",
+        "optin_armed": "You will be mentioned",
+        "optin_expired": "A more recent bump has already replaced this one.",
+        "reminder_title": "Time to bump again",
+        "reminder_body": "The server can be bumped on {emoji} **{name}** again.\n{command}",
+        "reminder_last": "Last bumped by {user}, {duration} ago.",
+        "reminder_late": "Reminder sent late: Moddy was unavailable."
+      },
+      "manage": {
+        "subtitle": "Every {interval} · {command}",
+        "channel": "**Channel:** {channel}",
+        "roles": "**Mentioned roles:** {roles}",
+        "no_roles": "none",
+        "ping": "**Last person who bumped:** {mode}",
+        "paused_notice": "This reminder is paused: Moddy ignores bumps from this directory.",
+        "edit": "Edit",
+        "pause": "Pause",
+        "resume": "Resume",
+        "remove": "Delete",
+        "removed": "Reminder deleted.",
+        "saved": "Reminder saved."
+      },
+      "add": {
+        "success": "Reminder created. Moddy is now watching that channel."
+      },
+      "errors": {
+        "guild_not_found": "Server not found.",
+        "unknown_bot": "This directory is no longer supported.",
+        "quota": "You have reached your quota of {max} reminder(s) for {name}. Go premium to configure more.",
+        "duplicate_id": "Two reminders share the same identifier.",
+        "duplicate_target": "A {name} reminder already exists in {channel}: both would post the same message.",
+        "channel_required": "Pick a channel.",
+        "channel_not_found": "That channel no longer exists.",
+        "channel_type": "The channel must be a text channel.",
+        "no_send_permission": "Moddy cannot post in {channel}.",
+        "too_many_roles": "{max} roles at most.",
+        "invalid_interval": "Invalid delay. Use for example `2h`, `2h30` or `90m`, between 5 minutes and 24 hours."
+      }
+    },
     "automod_ai": {
       "description": "Automatic moderation of problematic messages (AI)",
       "config": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1482,6 +1482,94 @@
         "internal_error": "<:error:1519790252594827264> Algo salió mal. Inténtalo de nuevo."
       }
     },
+    "bump_reminder": {
+      "name": "Recordatorio de bump",
+      "description": "Agradece a quien hace bump y avisa al canal cuando se puede volver a hacer",
+      "config": {
+        "title": "Recordatorio de bump",
+        "description": "Una ventana de bump perdida es visibilidad perdida. Moddy reconoce un bump **exitoso** en el canal que elijas, agradece a quien lo hizo y avisa al canal en cuanto el comando vuelve a estar disponible.",
+        "limit": "{max} recordatorio(s) por directorio.",
+        "add_placeholder": "Añadir un recordatorio para un directorio",
+        "manage_placeholder": "Gestionar un recordatorio existente",
+        "all_configured": "Has alcanzado tu cuota en todos los directorios compatibles.",
+        "list": {
+          "title": "Recordatorios configurados",
+          "count": "{count} recordatorio(s)",
+          "empty": "Todavía no hay recordatorios. Elige un directorio abajo para empezar.",
+          "every": "Cada {interval}",
+          "paused": "En pausa"
+        },
+        "state": {
+          "waiting": "Esperando un primer bump.",
+          "scheduled": "Próximo recordatorio {timestamp}.",
+          "ready": "El servidor puede recibir bump ahora mismo."
+        }
+      },
+      "modal": {
+        "title": "Recordatorio de bump",
+        "bot_label": "Directorio",
+        "bot_description": "El listado cuyo comando debe vigilar Moddy.",
+        "bot_option": "{command} · cada {interval}",
+        "channel_label": "Canal",
+        "channel_description": "Moddy vigila el bump aquí y publica aquí el recordatorio.",
+        "roles_label": "Roles a mencionar",
+        "roles_description": "Opcional. Déjalo vacío para no mencionar a nadie.",
+        "ping_label": "Mencionar a la última persona que hizo bump",
+        "ping_description": "Qué hace Moddy con quien ejecutó el comando.",
+        "interval_label": "Retraso antes del recordatorio",
+        "interval_description": "Por ejemplo 2h, 2h30 o 90m. Entre 5 minutos y 24 horas."
+      },
+      "ping": {
+        "auto": "Siempre",
+        "auto_description": "Se le menciona en cada recordatorio.",
+        "button": "A petición",
+        "button_description": "Un botón en el agradecimiento le permite pedirlo.",
+        "never": "Nunca",
+        "never_description": "Solo se menciona a los roles elegidos."
+      },
+      "card": {
+        "thanks_title": "¡Gracias {user}!",
+        "thanks_title_anonymous": "¡Gracias!",
+        "thanks_body": "El servidor acaba de subir en {emoji} **{name}**.\nPróximo bump posible {timestamp}.",
+        "optin": "Recuérdamelo",
+        "optin_armed": "Se te mencionará",
+        "optin_expired": "Un bump más reciente ya ha reemplazado a este.",
+        "reminder_title": "Toca hacer bump",
+        "reminder_body": "El servidor puede recibir bump de nuevo en {emoji} **{name}**.\n{command}",
+        "reminder_last": "Último bump por {user}, hace {duration}.",
+        "reminder_late": "Recordatorio enviado con retraso: Moddy no estaba disponible."
+      },
+      "manage": {
+        "subtitle": "Cada {interval} · {command}",
+        "channel": "**Canal:** {channel}",
+        "roles": "**Roles mencionados:** {roles}",
+        "no_roles": "ninguno",
+        "ping": "**Última persona que hizo bump:** {mode}",
+        "paused_notice": "Este recordatorio está en pausa: Moddy ignora los bumps de este directorio.",
+        "edit": "Editar",
+        "pause": "Pausar",
+        "resume": "Reanudar",
+        "remove": "Eliminar",
+        "removed": "Recordatorio eliminado.",
+        "saved": "Recordatorio guardado."
+      },
+      "add": {
+        "success": "Recordatorio creado. Moddy ya vigila ese canal."
+      },
+      "errors": {
+        "guild_not_found": "Servidor no encontrado.",
+        "unknown_bot": "Este directorio ya no es compatible.",
+        "quota": "Has alcanzado tu cuota de {max} recordatorio(s) para {name}. Hazte premium para configurar más.",
+        "duplicate_id": "Dos recordatorios comparten el mismo identificador.",
+        "duplicate_target": "Ya existe un recordatorio de {name} en {channel}: ambos publicarían el mismo mensaje.",
+        "channel_required": "Elige un canal.",
+        "channel_not_found": "Ese canal ya no existe.",
+        "channel_type": "El canal debe ser un canal de texto.",
+        "no_send_permission": "Moddy no puede publicar en {channel}.",
+        "too_many_roles": "{max} roles como máximo.",
+        "invalid_interval": "Retraso no válido. Usa por ejemplo `2h`, `2h30` o `90m`, entre 5 minutos y 24 horas."
+      }
+    },
     "automod_ai": {
       "description": "Moderación automática de mensajes problemáticos (IA)",
       "config": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1481,6 +1481,94 @@
         "internal_error": "<:error:1519790252594827264> Une erreur est survenue. Réessayez."
       }
     },
+    "bump_reminder": {
+      "name": "Rappel de bump",
+      "description": "Remercie qui bumpe le serveur et relance le salon dès que la commande redevient disponible",
+      "config": {
+        "title": "Rappel de bump",
+        "description": "Une fenêtre de bump ratée, c'est de la visibilité perdue. Moddy reconnaît un bump **réussi** dans le salon que vous désignez, remercie la personne, et rappelle le salon dès que la commande redevient disponible.",
+        "limit": "{max} rappel(s) par site de référencement.",
+        "add_placeholder": "Ajouter un rappel pour un site",
+        "manage_placeholder": "Gérer un rappel existant",
+        "all_configured": "Vous avez atteint votre quota sur chaque site pris en charge.",
+        "list": {
+          "title": "Rappels configurés",
+          "count": "{count} rappel(s)",
+          "empty": "Aucun rappel pour l'instant. Choisissez un site ci-dessous pour commencer.",
+          "every": "Toutes les {interval}",
+          "paused": "En pause"
+        },
+        "state": {
+          "waiting": "En attente d'un premier bump.",
+          "scheduled": "Prochain rappel {timestamp}.",
+          "ready": "Le serveur peut être bumpé dès maintenant."
+        }
+      },
+      "modal": {
+        "title": "Rappel de bump",
+        "bot_label": "Site de référencement",
+        "bot_description": "Le site dont Moddy doit surveiller la commande.",
+        "bot_option": "{command} · toutes les {interval}",
+        "channel_label": "Salon",
+        "channel_description": "Moddy y guette le bump et y poste le rappel.",
+        "roles_label": "Rôles à mentionner",
+        "roles_description": "Facultatif. Laissez vide pour ne mentionner personne.",
+        "ping_label": "Mentionner la dernière personne à avoir bumpé",
+        "ping_description": "Ce que Moddy fait de la personne qui a lancé la commande.",
+        "interval_label": "Délai avant le rappel",
+        "interval_description": "Par exemple 2h, 2h30 ou 90m. Entre 5 minutes et 24 heures."
+      },
+      "ping": {
+        "auto": "Toujours",
+        "auto_description": "Elle est mentionnée à chaque rappel.",
+        "button": "Sur demande",
+        "button_description": "Un bouton sur le remerciement lui permet de le demander.",
+        "never": "Jamais",
+        "never_description": "Seuls les rôles choisis sont mentionnés."
+      },
+      "card": {
+        "thanks_title": "Merci {user} !",
+        "thanks_title_anonymous": "Merci !",
+        "thanks_body": "Le serveur vient de remonter sur {emoji} **{name}**.\nProchain bump possible {timestamp}.",
+        "optin": "Me rappeler",
+        "optin_armed": "Tu seras mentionné",
+        "optin_expired": "Ce bump a déjà été remplacé par un plus récent.",
+        "reminder_title": "C'est reparti",
+        "reminder_body": "Le serveur peut de nouveau être bumpé sur {emoji} **{name}**.\n{command}",
+        "reminder_last": "Dernier bump par {user}, il y a {duration}.",
+        "reminder_late": "Rappel envoyé en retard : Moddy était indisponible."
+      },
+      "manage": {
+        "subtitle": "Toutes les {interval} · {command}",
+        "channel": "**Salon :** {channel}",
+        "roles": "**Rôles mentionnés :** {roles}",
+        "no_roles": "aucun",
+        "ping": "**Dernière personne à avoir bumpé :** {mode}",
+        "paused_notice": "Ce rappel est en pause : Moddy ignore les bumps de ce site.",
+        "edit": "Modifier",
+        "pause": "Mettre en pause",
+        "resume": "Reprendre",
+        "remove": "Supprimer",
+        "removed": "Rappel supprimé.",
+        "saved": "Rappel enregistré."
+      },
+      "add": {
+        "success": "Rappel créé. Moddy surveille désormais ce salon."
+      },
+      "errors": {
+        "guild_not_found": "Serveur introuvable.",
+        "unknown_bot": "Ce site de référencement n'est plus pris en charge.",
+        "quota": "Vous avez atteint votre quota de {max} rappel(s) pour {name}. Passez au premium pour en configurer davantage.",
+        "duplicate_id": "Deux rappels portent le même identifiant.",
+        "duplicate_target": "Un rappel {name} existe déjà dans {channel} : les deux posteraient le même message.",
+        "channel_required": "Choisissez un salon.",
+        "channel_not_found": "Ce salon n'existe plus.",
+        "channel_type": "Le salon doit être un salon textuel.",
+        "no_send_permission": "Moddy ne peut pas écrire dans {channel}.",
+        "too_many_roles": "{max} rôles au maximum.",
+        "invalid_interval": "Délai invalide. Utilisez par exemple `2h`, `2h30` ou `90m`, entre 5 minutes et 24 heures."
+      }
+    },
     "automod_ai": {
       "description": "Modération automatique des messages problématiques (IA)",
       "config": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1482,6 +1482,94 @@
         "internal_error": "<:error:1519790252594827264> Algo deu errado. Tente novamente."
       }
     },
+    "bump_reminder": {
+      "name": "Lembrete de bump",
+      "description": "Agradece quem dá bump no servidor e avisa o canal quando ele pode receber bump de novo",
+      "config": {
+        "title": "Lembrete de bump",
+        "description": "Uma janela de bump perdida é visibilidade perdida. O Moddy reconhece um bump **bem-sucedido** no canal que você indicar, agradece quem o executou e chama o canal de volta assim que o comando fica disponível de novo.",
+        "limit": "{max} lembrete(s) por diretório.",
+        "add_placeholder": "Adicionar um lembrete para um diretório",
+        "manage_placeholder": "Gerenciar um lembrete existente",
+        "all_configured": "Você atingiu sua cota em todos os diretórios compatíveis.",
+        "list": {
+          "title": "Lembretes configurados",
+          "count": "{count} lembrete(s)",
+          "empty": "Nenhum lembrete ainda. Escolha um diretório abaixo para começar.",
+          "every": "A cada {interval}",
+          "paused": "Pausado"
+        },
+        "state": {
+          "waiting": "Aguardando um primeiro bump.",
+          "scheduled": "Próximo lembrete {timestamp}.",
+          "ready": "O servidor pode receber bump agora mesmo."
+        }
+      },
+      "modal": {
+        "title": "Lembrete de bump",
+        "bot_label": "Diretório",
+        "bot_description": "A lista cujo comando o Moddy deve vigiar.",
+        "bot_option": "{command} · a cada {interval}",
+        "channel_label": "Canal",
+        "channel_description": "O Moddy vigia o bump aqui e publica o lembrete aqui.",
+        "roles_label": "Cargos a mencionar",
+        "roles_description": "Opcional. Deixe vazio para não mencionar ninguém.",
+        "ping_label": "Mencionar a última pessoa que deu bump",
+        "ping_description": "O que o Moddy faz com quem executou o comando.",
+        "interval_label": "Intervalo antes do lembrete",
+        "interval_description": "Por exemplo 2h, 2h30 ou 90m. Entre 5 minutos e 24 horas."
+      },
+      "ping": {
+        "auto": "Sempre",
+        "auto_description": "Ela é mencionada em todos os lembretes.",
+        "button": "A pedido",
+        "button_description": "Um botão no agradecimento permite que ela peça.",
+        "never": "Nunca",
+        "never_description": "Apenas os cargos escolhidos são mencionados."
+      },
+      "card": {
+        "thanks_title": "Obrigado {user}!",
+        "thanks_title_anonymous": "Obrigado!",
+        "thanks_body": "O servidor acabou de subir em {emoji} **{name}**.\nPróximo bump possível {timestamp}.",
+        "optin": "Me lembrar",
+        "optin_armed": "Você será mencionado",
+        "optin_expired": "Um bump mais recente já substituiu este.",
+        "reminder_title": "Hora de dar bump",
+        "reminder_body": "O servidor pode receber bump em {emoji} **{name}** novamente.\n{command}",
+        "reminder_last": "Último bump por {user}, há {duration}.",
+        "reminder_late": "Lembrete enviado com atraso: o Moddy estava indisponível."
+      },
+      "manage": {
+        "subtitle": "A cada {interval} · {command}",
+        "channel": "**Canal:** {channel}",
+        "roles": "**Cargos mencionados:** {roles}",
+        "no_roles": "nenhum",
+        "ping": "**Última pessoa que deu bump:** {mode}",
+        "paused_notice": "Este lembrete está pausado: o Moddy ignora os bumps deste diretório.",
+        "edit": "Editar",
+        "pause": "Pausar",
+        "resume": "Retomar",
+        "remove": "Excluir",
+        "removed": "Lembrete excluído.",
+        "saved": "Lembrete salvo."
+      },
+      "add": {
+        "success": "Lembrete criado. O Moddy já está vigiando esse canal."
+      },
+      "errors": {
+        "guild_not_found": "Servidor não encontrado.",
+        "unknown_bot": "Este diretório não é mais compatível.",
+        "quota": "Você atingiu sua cota de {max} lembrete(s) para {name}. Assine o premium para configurar mais.",
+        "duplicate_id": "Dois lembretes têm o mesmo identificador.",
+        "duplicate_target": "Já existe um lembrete de {name} em {channel}: os dois publicariam a mesma mensagem.",
+        "channel_required": "Escolha um canal.",
+        "channel_not_found": "Esse canal não existe mais.",
+        "channel_type": "O canal deve ser um canal de texto.",
+        "no_send_permission": "O Moddy não pode publicar em {channel}.",
+        "too_many_roles": "No máximo {max} cargos.",
+        "invalid_interval": "Intervalo inválido. Use por exemplo `2h`, `2h30` ou `90m`, entre 5 minutos e 24 horas."
+      }
+    },
     "automod_ai": {
       "description": "Moderação automática de mensagens problemáticas (IA)",
       "config": {

--- a/modules/bump_reminder.py
+++ b/modules/bump_reminder.py
@@ -1,0 +1,323 @@
+"""
+Bump Reminder module — never miss a bump window again.
+
+Server directories (DISBOARD, DiscordL, French.gg…) let a server climb back to
+the top of their listing with a ``/bump`` command, reusable every one to four
+hours. The window is trivial to miss, and a missed window is visibility lost.
+
+This module watches the configured channel, recognises that a bump actually
+**went through** (never merely that the command was run — a cooldown reply looks
+almost identical), thanks whoever did it, and calls the channel back the moment
+the command becomes available again.
+
+Configuration lives in ``guilds.data.modules.bump_reminder`` (JSONB): one entry
+per watched channel, capped **per directory** (one on a free server, three on a
+premium one). The live half — what is pending right now — lives in the
+``bump_reminders`` table, one row per *directory*, because a cooldown belongs to
+the server and not to a channel: one bump arms every reminder that server has
+for that directory. Nothing is held in memory, so a restart loses nothing.
+
+The pieces:
+
+- ``bumpreminder/``            — the pure detection core (registry + markers)
+- ``cogs/bump_reminder.py``    — the listener and the sweeper loop
+- ``utils/bump_views.py``      — the thank-you and reminder cards
+- ``modules/configs/bump_reminder_config.py`` — the /config panel
+
+See docs/BUMP_REMINDER.md.
+"""
+
+import logging
+import secrets
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import discord
+
+from bumpreminder import MAX_INTERVAL, MIN_INTERVAL, bot_by_key, detect
+from modules.module_manager import ModuleBase
+from utils.emojis import ROCKET_LAUNCH
+from utils.i18n import t
+
+logger = logging.getLogger('moddy.modules.bump_reminder')
+
+
+# --------------------------------------------------------------------------- #
+# Limits & constants
+# --------------------------------------------------------------------------- #
+CONFIG_VERSION = 1
+
+# Reminders **per directory**. One is all a normal server needs: a bump puts the
+# whole server on cooldown, so a second entry for the same listing only makes
+# sense to call a *second channel* back — which is a large-server need, hence
+# premium. The cap is per directory rather than a global total so that a free
+# server can still cover every listing it bumps on.
+FREE_REMINDERS_PER_BOT = 1
+PREMIUM_REMINDERS_PER_BOT = 3
+
+MAX_ROLE_MENTIONS = 5
+
+# How the last bumper gets mentioned in the reminder.
+#   auto   — always
+#   button — only if they asked, via the button on the thank-you card
+#   never  — the configured roles and nothing else
+PING_MODES: Tuple[str, ...] = ("auto", "button", "never")
+DEFAULT_PING_MODE = "button"
+
+CHANNEL_TYPES = [discord.ChannelType.text, discord.ChannelType.news]
+
+
+# --------------------------------------------------------------------------- #
+# Config normalization
+# --------------------------------------------------------------------------- #
+def new_reminder_id() -> str:
+    """Stable, collision-resistant id for one reminder entry."""
+    return f"br_{secrets.token_hex(4)}"
+
+
+def normalize_config(raw: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return the stored shape with every key filled in.
+
+    Pure: it never writes back. Entries naming a directory Moddy no longer
+    supports are dropped here rather than crashing something downstream — a
+    retired listing must not brick a server's whole panel.
+    """
+    if not raw:
+        return {'version': CONFIG_VERSION, 'reminders': []}
+
+    reminders = raw.get('reminders')
+    if not isinstance(reminders, list):
+        return {'version': CONFIG_VERSION, 'reminders': []}
+
+    normalized = []
+    for entry in reminders:
+        if not isinstance(entry, dict):
+            continue
+        spec = bot_by_key(str(entry.get('bot') or ''))
+        if spec is None:
+            continue
+        normalized.append(_normalize_entry(entry, spec))
+
+    return {'version': CONFIG_VERSION, 'reminders': normalized}
+
+
+def _normalize_entry(entry: Dict[str, Any], spec) -> Dict[str, Any]:
+    interval = entry.get('interval')
+    if not isinstance(interval, int) or not MIN_INTERVAL <= interval <= MAX_INTERVAL:
+        interval = spec.default_interval
+
+    ping_mode = entry.get('ping_mode')
+    if ping_mode not in PING_MODES:
+        ping_mode = DEFAULT_PING_MODE
+
+    role_ids = entry.get('role_ids')
+    if not isinstance(role_ids, list):
+        role_ids = []
+
+    return {
+        'id': entry.get('id') or new_reminder_id(),
+        'bot': spec.key,
+        'channel_id': entry.get('channel_id'),
+        'role_ids': [int(r) for r in role_ids if isinstance(r, (int, str)) and str(r).isdigit()][:MAX_ROLE_MENTIONS],
+        'ping_mode': ping_mode,
+        'interval': interval,
+        'enabled': bool(entry.get('enabled', True)),
+        'created_by': entry.get('created_by'),
+        'created_at': entry.get('created_at'),
+    }
+
+
+def new_entry(bot_key: str, *, channel_id: int, role_ids: List[int],
+              ping_mode: str, interval: int, created_by: Optional[int]) -> Dict[str, Any]:
+    """Build a fresh entry, already normalized."""
+    spec = bot_by_key(bot_key)
+    return _normalize_entry({
+        'id': new_reminder_id(),
+        'bot': bot_key,
+        'channel_id': channel_id,
+        'role_ids': role_ids,
+        'ping_mode': ping_mode,
+        'interval': interval,
+        'enabled': True,
+        'created_by': created_by,
+        'created_at': datetime.now(timezone.utc).isoformat(),
+    }, spec)
+
+
+async def reminders_per_bot(bot, guild_id: int) -> int:
+    """How many reminders this guild may keep **per directory**.
+
+    Uses the subscription helper, never a guild attribute — there is no PREMIUM
+    guild attribute (docs/PREMIUM.md), and the helper is the Redis-cached path
+    the config panel can afford to call on every render.
+    """
+    from utils.subscription import is_guild_premium
+    return (PREMIUM_REMINDERS_PER_BOT if await is_guild_premium(bot, guild_id)
+            else FREE_REMINDERS_PER_BOT)
+
+
+def count_by_bot(reminders: List[Dict[str, Any]]) -> Dict[str, int]:
+    """How many entries each directory already has."""
+    counts: Dict[str, int] = {}
+    for entry in reminders:
+        counts[entry['bot']] = counts.get(entry['bot'], 0) + 1
+    return counts
+
+
+# --------------------------------------------------------------------------- #
+# Module
+# --------------------------------------------------------------------------- #
+class BumpReminderModule(ModuleBase):
+    """Detects successful bumps and schedules the follow-up reminder."""
+
+    MODULE_ID = "bump_reminder"
+    MODULE_NAME = "Bump Reminder"
+    MODULE_DESCRIPTION = "Thanks whoever bumps and calls the channel back when it can be bumped again"
+    MODULE_EMOJI = ROCKET_LAUNCH
+    MODULE_ORDER = 85
+
+    def __init__(self, bot, guild_id: int):
+        super().__init__(bot, guild_id)
+        self.reminders: List[Dict[str, Any]] = []
+        # (channel_id, bot_key) -> entry, rebuilt on every load. Keyed on the
+        # pair, not the channel: one #bump channel hosting DISBOARD *and*
+        # DiscordL is the normal case, not the exception. The listener runs for
+        # every message a directory posts, so this has to be a dict lookup.
+        self._watch: Dict[Tuple[int, str], Dict[str, Any]] = {}
+
+    async def load_config(self, config_data: Dict[str, Any]) -> bool:
+        try:
+            normalized = normalize_config(config_data)
+            self.config = normalized
+            self.reminders = normalized['reminders']
+            self._watch = {
+                (entry['channel_id'], entry['bot']): entry
+                for entry in self.reminders
+                if entry.get('enabled', True) and entry.get('channel_id')
+            }
+            self.enabled = bool(self._watch)
+            return True
+        except Exception as e:
+            logger.error(f"Error loading bump_reminder config: {e}", exc_info=True)
+            return False
+
+    async def validate_config(self, config_data: Dict[str, Any]) -> tuple[bool, Optional[str]]:
+        guild = self.bot.get_guild(self.guild_id)
+        locale = await self._locale()
+        if not guild:
+            return False, t('modules.bump_reminder.errors.guild_not_found', locale=locale)
+
+        reminders = normalize_config(config_data)['reminders']
+
+        cap = await reminders_per_bot(self.bot, self.guild_id)
+        for bot_key, count in count_by_bot(reminders).items():
+            if count > cap:
+                spec = bot_by_key(bot_key)
+                return False, t('modules.bump_reminder.errors.quota',
+                                locale=locale, name=spec.name if spec else bot_key,
+                                max=cap)
+
+        seen_ids = set()
+        seen_targets = set()
+        for entry in reminders:
+            spec = bot_by_key(entry['bot'])
+            if spec is None:
+                return False, t('modules.bump_reminder.errors.unknown_bot', locale=locale)
+
+            if entry['id'] in seen_ids:
+                return False, t('modules.bump_reminder.errors.duplicate_id', locale=locale)
+            seen_ids.add(entry['id'])
+
+            channel_id = entry.get('channel_id')
+            if not channel_id:
+                return False, t('modules.bump_reminder.errors.channel_required', locale=locale)
+
+            channel = guild.get_channel(channel_id)
+            if not channel:
+                return False, t('modules.bump_reminder.errors.channel_not_found', locale=locale)
+            if not isinstance(channel, discord.TextChannel):
+                return False, t('modules.bump_reminder.errors.channel_type', locale=locale)
+
+            perms = channel.permissions_for(guild.me)
+            if not perms.view_channel or not perms.send_messages:
+                return False, t('modules.bump_reminder.errors.no_send_permission',
+                                locale=locale, channel=channel.mention)
+
+            # Two reminders for the same directory in the same channel would
+            # post the same card twice, every time.
+            target = (entry['bot'], channel_id)
+            if target in seen_targets:
+                return False, t('modules.bump_reminder.errors.duplicate_target',
+                                locale=locale, name=spec.name, channel=channel.mention)
+            seen_targets.add(target)
+
+            if len(entry['role_ids']) > MAX_ROLE_MENTIONS:
+                return False, t('modules.bump_reminder.errors.too_many_roles',
+                                locale=locale, max=MAX_ROLE_MENTIONS)
+
+            interval = entry.get('interval')
+            if not isinstance(interval, int) or not MIN_INTERVAL <= interval <= MAX_INTERVAL:
+                return False, t('modules.bump_reminder.errors.invalid_interval', locale=locale)
+
+        return True, None
+
+    def get_default_config(self) -> Dict[str, Any]:
+        return {'version': CONFIG_VERSION, 'reminders': []}
+
+    async def _locale(self) -> str:
+        """Server language — this module only ever writes to a whole channel."""
+        from utils.guild_language import guild_locale
+        return await guild_locale(self.bot, self.guild_id)
+
+    async def on_external_config_change(self, action: str) -> Dict[str, Any]:
+        """Drop pending rows the config no longer accounts for.
+
+        The module posts no persistent panel, so there is nothing to repair in
+        Discord — but a reminder whose entry was deleted from the dashboard must
+        not still fire an hour later.
+        """
+        try:
+            keys = {entry['bot'] for entry in self.reminders}
+            states = await self.bot.db.get_guild_bump_states(self.guild_id)
+            for stale in set(states) - keys:
+                await self.bot.db.drop_bump_reminder(self.guild_id, stale)
+        except Exception as e:
+            logger.error(f"Error syncing bump reminders after {action}: {e}", exc_info=True)
+        return {}
+
+    # ----------------------------------------------------------------- events
+    def entry_for(self, channel_id: int, bot_key: str) -> Optional[Dict[str, Any]]:
+        """The reminder watching this directory in this channel, if any."""
+        return self._watch.get((channel_id, bot_key))
+
+    def entries_for_bot(self, bot_key: str) -> List[Dict[str, Any]]:
+        """Every enabled reminder for one directory.
+
+        A bump puts the **whole server** on that directory's cooldown, not one
+        channel — so one detected bump is owed to every channel the server
+        pointed at that directory, not only the one the reply landed in. That is
+        the entire point of a premium server configuring three of them.
+        """
+        return [entry for (_, key), entry in self._watch.items() if key == bot_key]
+
+    async def on_message(self, message: discord.Message, spec) -> Optional[Dict[str, Any]]:
+        """Read a successful bump out of a directory's reply.
+
+        ``spec`` is the directory the cog already resolved from the author, so
+        the guard here is a single dict lookup on the pair the config actually
+        keys on. A bump run in a channel this server did not point at is
+        ignored on purpose: the reminder belongs to a channel, and answering in
+        one the server never chose would be Moddy talking out of turn.
+
+        Returns the hit and its entry for the cog to act on, or ``None``. It
+        sends nothing itself, which is what keeps the decision testable.
+        """
+        entry = self._watch.get((message.channel.id, spec.key))
+        if entry is None:
+            return None
+
+        hit = detect(message, entry['interval'])
+        if hit is None:
+            return None
+
+        return {'hit': hit, 'entry': entry}

--- a/modules/configs/bump_reminder_config.py
+++ b/modules/configs/bump_reminder_config.py
@@ -1,0 +1,793 @@
+"""
+Configuration UI for the Bump Reminder module (`/config`).
+
+Two screens and one modal:
+
+  Main panel ──► (pick a directory) ──► modal ──► created
+            └──► Manage a reminder ──► modal / pause / delete
+
+The modal is where a whole reminder is defined in one pass — directory, channel,
+roles, how the last bumper gets mentioned, and the delay — because a bump
+reminder has exactly five things to say and a Modal V2 holds exactly five
+components. Nothing is a wizard that could be abandoned half-done.
+
+**Why adding starts from a select rather than a button.** The delay field must
+open pre-filled with the directory's own cooldown, and a Discord modal is static
+— it cannot react to a choice made inside itself. Picking the directory on the
+panel means the modal opens already knowing it, so every field including the
+delay arrives filled in. Same number of clicks, nothing left for the reader to
+look up.
+
+Actions apply immediately (no Save/Cancel batching): each one writes the whole
+list back through ``module_manager.save_module_config``, so the module is
+revalidated and reloaded on every change.
+
+Persistence (docs/PERSISTENT_VIEWS.md): stable namespaced custom_ids, no
+timeouts, and every callback re-derives its context from ``interaction`` + the
+database rather than from ``self``.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import discord
+from discord import ui
+
+from bumpreminder import BUMP_BOTS, bot_by_key, format_interval, parse_interval
+from cogs.error_handler import BaseModal, BaseView
+from modules.bump_reminder import (
+    CHANNEL_TYPES,
+    MAX_ROLE_MENTIONS,
+    PING_MODES,
+    count_by_bot,
+    new_entry,
+    normalize_config,
+    reminders_per_bot,
+)
+from modules.configs._common import check_guild_perms
+from utils.emojis import (
+    ADD, BACK, DELETE, EDIT, INFO, PAUSE, PLAY, REQUIRED_FIELDS, ROCKET_LAUNCH, TIME,
+)
+from utils.i18n import i18n, t
+
+logger = logging.getLogger('moddy.modules.bump_reminder_config')
+
+_MODULE_ID = 'bump_reminder'
+
+# --------------------------------------------------------------------------- #
+# Namespaced custom_id constants (persistent dispatch).
+# Format: moddy:bump:<view>:<action>. Guild context is re-derived from
+# ``interaction.guild_id`` so the ids stay static (one shell, all guilds).
+# --------------------------------------------------------------------------- #
+_CID_MAIN_ADD = "moddy:bump:main:add"
+_CID_MAIN_MANAGE = "moddy:bump:main:manage"
+_CID_MAIN_BACK = "moddy:bump:main:back"
+
+_CID_MANAGE_EDIT = "moddy:bump:manage:edit"
+_CID_MANAGE_TOGGLE = "moddy:bump:manage:toggle"
+_CID_MANAGE_REMOVE = "moddy:bump:manage:remove"
+_CID_MANAGE_BACK = "moddy:bump:manage:back"
+
+_CID_MODAL_BOT = "moddy:bump:modal:bot"
+_CID_MODAL_CHANNEL = "moddy:bump:modal:channel"
+_CID_MODAL_ROLES = "moddy:bump:modal:roles"
+_CID_MODAL_PING = "moddy:bump:modal:ping"
+_CID_MODAL_INTERVAL = "moddy:bump:modal:interval"
+
+
+# --------------------------------------------------------------------------- #
+# Storage helpers
+# --------------------------------------------------------------------------- #
+async def _load(bot, guild_id: int) -> List[Dict[str, Any]]:
+    saved = await bot.module_manager.get_module_config(guild_id, _MODULE_ID)
+    return normalize_config(saved)['reminders']
+
+
+async def _save(bot, guild_id: int, reminders: List[Dict[str, Any]],
+                actor_id: Optional[int] = None) -> Tuple[bool, Optional[str]]:
+    """Persist the whole list (revalidates + reloads the module instance)."""
+    return await bot.module_manager.save_module_config(
+        guild_id, _MODULE_ID, normalize_config({'reminders': reminders}),
+        actor_id=actor_id,
+    )
+
+
+async def _render_main(interaction: discord.Interaction) -> None:
+    bot = interaction.client
+    locale = i18n.get_user_locale(interaction)
+    view = await BumpReminderConfigView.create(
+        bot, interaction.guild_id, interaction.user.id, locale)
+    if interaction.response.is_done():
+        await interaction.edit_original_response(view=view)
+    else:
+        await interaction.response.edit_message(view=view)
+
+
+def _ping_label(mode: str, locale: str) -> str:
+    return t(f'modules.bump_reminder.ping.{mode}', locale=locale)
+
+
+# =========================================================================== #
+# Modal (V2) — one reminder, start to finish
+# =========================================================================== #
+class BumpReminderModal(BaseModal):
+    """Creates or edits one reminder.
+
+    Exactly five top-level components, which is the Modal V2 ceiling — the form
+    is full, so anything else a reminder can do (pause, delete) lives on the
+    manage screen rather than being squeezed in here.
+
+    Every field opens on its current value: the directory pre-selected, the
+    channel and roles pre-picked, the ping mode on its radio, and the delay
+    written out as the caller stored it — or, for a brand-new reminder, as the
+    directory itself advertises it.
+    """
+
+    def __init__(self, locale: str, *, bot_key: str, callback_func,
+                 channel_id: Optional[int] = None,
+                 role_ids: Optional[List[int]] = None,
+                 ping_mode: str = "button",
+                 interval: Optional[int] = None,
+                 available: Optional[List[str]] = None):
+        spec = bot_by_key(bot_key)
+        super().__init__(
+            title=t('modules.bump_reminder.modal.title', locale=locale)[:45],
+            timeout=None,
+        )
+        self.locale = locale
+        self.callback_func = callback_func
+        self.original_bot = bot_key
+
+        # 1 — the directory. Only the ones with room left are offered, plus
+        #     whichever one is already selected (editing must never be blocked
+        #     by the quota an entry is itself part of).
+        offered = list(dict.fromkeys([bot_key] + list(available or [])))
+        self.bot_select = ui.Select(
+            options=[
+                discord.SelectOption(
+                    label=other.name,
+                    value=other.key,
+                    description=t('modules.bump_reminder.modal.bot_option',
+                                  locale=locale,
+                                  interval=format_interval(other.default_interval),
+                                  command=other.command_hint)[:100],
+                    emoji=discord.PartialEmoji.from_str(other.emoji),
+                    default=(other.key == bot_key),
+                )
+                for other in BUMP_BOTS if other.key in offered
+            ],
+            min_values=1, max_values=1, required=True, custom_id=_CID_MODAL_BOT,
+        )
+        self.add_item(ui.Label(
+            text=f"{t('modules.bump_reminder.modal.bot_label', locale=locale)}",
+            description=t('modules.bump_reminder.modal.bot_description', locale=locale)[:100],
+            component=self.bot_select,
+        ))
+
+        # 2 — the channel. Also the channel Moddy watches for the bump: a
+        #     reminder answers where the server bumps.
+        self.channel_select = ui.ChannelSelect(
+            channel_types=CHANNEL_TYPES,
+            min_values=1, max_values=1, required=True,
+            custom_id=_CID_MODAL_CHANNEL,
+            default_values=([discord.Object(id=channel_id)] if channel_id else []),
+        )
+        self.add_item(ui.Label(
+            text=t('modules.bump_reminder.modal.channel_label', locale=locale),
+            description=t('modules.bump_reminder.modal.channel_description', locale=locale)[:100],
+            component=self.channel_select,
+        ))
+
+        # 3 — roles to ping. Optional: plenty of servers just want the bumper.
+        self.role_select = ui.RoleSelect(
+            min_values=0, max_values=MAX_ROLE_MENTIONS, required=False,
+            custom_id=_CID_MODAL_ROLES,
+            default_values=[discord.Object(id=r) for r in (role_ids or [])],
+        )
+        self.add_item(ui.Label(
+            text=t('modules.bump_reminder.modal.roles_label', locale=locale),
+            description=t('modules.bump_reminder.modal.roles_description', locale=locale)[:100],
+            component=self.role_select,
+        ))
+
+        # 4 — how the last bumper is mentioned.
+        self.ping_group = ui.RadioGroup(
+            options=[
+                discord.RadioGroupOption(
+                    label=_ping_label(mode, locale)[:100],
+                    value=mode,
+                    description=t(f'modules.bump_reminder.ping.{mode}_description',
+                                  locale=locale)[:100],
+                    default=(mode == ping_mode),
+                )
+                for mode in PING_MODES
+            ],
+            required=True, custom_id=_CID_MODAL_PING,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.bump_reminder.modal.ping_label', locale=locale),
+            description=t('modules.bump_reminder.modal.ping_description', locale=locale)[:100],
+            component=self.ping_group,
+        ))
+
+        # 5 — the delay, pre-filled with what this directory actually enforces.
+        self.interval_input = ui.TextInput(
+            style=discord.TextStyle.short,
+            default=format_interval(interval if interval is not None
+                                    else spec.default_interval),
+            max_length=8, required=True, custom_id=_CID_MODAL_INTERVAL,
+        )
+        self.add_item(ui.Label(
+            text=t('modules.bump_reminder.modal.interval_label', locale=locale),
+            description=t('modules.bump_reminder.modal.interval_description', locale=locale)[:100],
+            component=self.interval_input,
+        ))
+
+    async def on_submit(self, interaction: discord.Interaction):
+        channels = self.channel_select.values
+        await self.callback_func(
+            interaction,
+            bot_key=self.bot_select.values[0],
+            channel_id=channels[0].id if channels else None,
+            role_ids=[role.id for role in self.role_select.values],
+            ping_mode=self.ping_group.values[0],
+            raw_interval=self.interval_input.value,
+        )
+
+
+# =========================================================================== #
+# Main panel
+# =========================================================================== #
+class BumpReminderConfigView(BaseView):
+    """Lists the guild's reminders and opens the add/manage flows.
+
+    Persistent: yes. Auth: Manage Server, re-checked on every click via
+    ``check_guild_perms`` — never a stored user_id, which a restarted shell
+    cannot carry.
+    """
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, guild_id: Optional[int] = None,
+                 user_id: Optional[int] = None, locale: str = "en-US",
+                 reminders: Optional[List[Dict[str, Any]]] = None,
+                 states: Optional[Dict[str, Dict[str, Any]]] = None,
+                 cap: int = 1):
+        super().__init__()  # timeout=None
+        self.bot = bot
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.locale = locale
+        self.reminders = reminders or []
+        self.states = states or {}
+        self.cap = cap
+
+        self._build_view()
+
+    @classmethod
+    async def create(cls, bot, guild_id: int, user_id: int, locale: str):
+        """Async factory: config, live state and quota in one go.
+
+        The live state is what lets each row show its real countdown instead of
+        a dead form — reading the panel answers "is this working?" without
+        anyone having to wait for the next bump to find out.
+        """
+        reminders = await _load(bot, guild_id)
+        states = await bot.db.get_guild_bump_states(guild_id)
+        cap = await reminders_per_bot(bot, guild_id)
+        return cls(bot, guild_id, user_id, locale, reminders, states, cap)
+
+    # -- construction ----------------------------------------------------- #
+    def _available_bots(self) -> List[str]:
+        """Directories that still have room under this guild's quota."""
+        counts = count_by_bot(self.reminders)
+        return [spec.key for spec in BUMP_BOTS if counts.get(spec.key, 0) < self.cap]
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container()
+
+        container.add_item(ui.TextDisplay(
+            f"### {ROCKET_LAUNCH} {t('modules.bump_reminder.config.title', locale=self.locale)}"
+        ))
+        container.add_item(ui.TextDisplay(
+            t('modules.bump_reminder.config.description', locale=self.locale)
+        ))
+        container.add_item(ui.TextDisplay(
+            f"-# {t('modules.bump_reminder.config.limit', locale=self.locale, max=self.cap)}"
+        ))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        if self.reminders:
+            container.add_item(ui.TextDisplay(
+                f"**{t('modules.bump_reminder.config.list.title', locale=self.locale)}**\n"
+                f"-# {t('modules.bump_reminder.config.list.count', locale=self.locale, count=len(self.reminders))}"
+            ))
+            for entry in self.reminders:
+                container.add_item(ui.TextDisplay(self._render_entry(entry)))
+        else:
+            container.add_item(ui.TextDisplay(
+                f"{INFO} {t('modules.bump_reminder.config.list.empty', locale=self.locale)}"
+            ))
+
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
+        # Add: pick the directory here so the modal opens fully pre-filled.
+        available = self._available_bots()
+        add_row = ui.ActionRow()
+        add_select = ui.Select(
+            placeholder=t('modules.bump_reminder.config.add_placeholder', locale=self.locale),
+            options=[
+                discord.SelectOption(
+                    label=spec.name,
+                    value=spec.key,
+                    description=t('modules.bump_reminder.modal.bot_option',
+                                  locale=self.locale,
+                                  interval=format_interval(spec.default_interval),
+                                  command=spec.command_hint)[:100],
+                    emoji=discord.PartialEmoji.from_str(spec.emoji),
+                )
+                for spec in BUMP_BOTS if spec.key in available
+            ] or [discord.SelectOption(label="—", value="none")],
+            min_values=1, max_values=1, custom_id=_CID_MAIN_ADD,
+            disabled=not available,
+        )
+        add_select.callback = self.on_add_select
+        add_row.add_item(add_select)
+        container.add_item(add_row)
+
+        if not available:
+            container.add_item(ui.TextDisplay(
+                f"-# {t('modules.bump_reminder.config.all_configured', locale=self.locale)}"
+            ))
+
+        # Manage: always registered so a restarted shell can still dispatch it.
+        manage_row = ui.ActionRow()
+        manage_select = ui.Select(
+            placeholder=t('modules.bump_reminder.config.manage_placeholder', locale=self.locale),
+            options=[
+                discord.SelectOption(
+                    label=self._entry_label(entry)[:100],
+                    value=entry['id'],
+                    description=self._entry_channel_name(entry)[:100] or None,
+                    emoji=discord.PartialEmoji.from_str(bot_by_key(entry['bot']).emoji),
+                )
+                for entry in self.reminders[:25]
+            ] or [discord.SelectOption(label="—", value="none")],
+            min_values=1, max_values=1, custom_id=_CID_MAIN_MANAGE,
+            disabled=not self.reminders,
+        )
+        manage_select.callback = self.on_manage_select
+        manage_row.add_item(manage_select)
+        container.add_item(manage_row)
+
+        self.add_item(container)
+
+        button_row = ui.ActionRow()
+        back_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str(BACK),
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary, custom_id=_CID_MAIN_BACK,
+        )
+        back_btn.callback = self.on_back
+        button_row.add_item(back_btn)
+        self.add_item(button_row)
+
+    def _entry_channel_name(self, entry: Dict[str, Any]) -> str:
+        channel = (self.bot.get_channel(entry['channel_id'])
+                   if self.bot and entry.get('channel_id') else None)
+        return f"#{channel.name}" if channel else f"#{entry.get('channel_id', '')}"
+
+    def _entry_label(self, entry: Dict[str, Any]) -> str:
+        spec = bot_by_key(entry['bot'])
+        return f"{spec.name if spec else entry['bot']} → {self._entry_channel_name(entry)}"
+
+    def _render_entry(self, entry: Dict[str, Any]) -> str:
+        """One reminder as it reads on the panel: what it is, then how it is doing."""
+        spec = bot_by_key(entry['bot'])
+        channel = (self.bot.get_channel(entry['channel_id'])
+                   if self.bot and entry.get('channel_id') else None)
+        channel_ref = channel.mention if channel else f"`{entry.get('channel_id', '')}`"
+
+        line = f"{spec.emoji if spec else ''} **{spec.name if spec else entry['bot']}** → {channel_ref}"
+
+        extras = [t('modules.bump_reminder.config.list.every', locale=self.locale,
+                    interval=format_interval(entry['interval']))]
+        if entry['role_ids']:
+            extras.append(" ".join(f"<@&{r}>" for r in entry['role_ids']))
+        extras.append(_ping_label(entry['ping_mode'], self.locale))
+        if not entry.get('enabled', True):
+            extras.append(t('modules.bump_reminder.config.list.paused', locale=self.locale))
+        line += f"\n-# {' · '.join(extras)}"
+        line += f"\n-# {self._render_state(entry)}"
+        return line
+
+    def _render_state(self, entry: Dict[str, Any]) -> str:
+        """The live half: counting down, ready to bump, or never bumped yet."""
+        state = self.states.get(entry['bot'])
+        if not state:
+            return t('modules.bump_reminder.config.state.waiting', locale=self.locale)
+        if state.get('sent'):
+            return t('modules.bump_reminder.config.state.ready', locale=self.locale)
+        return t('modules.bump_reminder.config.state.scheduled', locale=self.locale,
+                 timestamp=f"<t:{int(state['due_at'].timestamp())}:R>")
+
+    # -- callbacks -------------------------------------------------------- #
+    async def on_add_select(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        bot_key = interaction.data['values'][0]
+
+        # Re-check against live config: the panel may have been open a while.
+        reminders = await _load(bot, interaction.guild_id)
+        cap = await reminders_per_bot(bot, interaction.guild_id)
+        counts = count_by_bot(reminders)
+        spec = bot_by_key(bot_key)
+        if spec is None or counts.get(bot_key, 0) >= cap:
+            await interaction.response.send_message(
+                t('modules.bump_reminder.errors.quota', locale=locale,
+                  name=spec.name if spec else bot_key, max=cap),
+                ephemeral=True,
+            )
+            return
+
+        available = [s.key for s in BUMP_BOTS if counts.get(s.key, 0) < cap]
+        modal = BumpReminderModal(
+            locale, bot_key=bot_key, callback_func=_create_reminder,
+            available=available,
+        )
+        modal.bot = bot
+        await interaction.response.send_modal(modal)
+
+    async def on_manage_select(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        entry_id = interaction.data['values'][0]
+        reminders = await _load(bot, interaction.guild_id)
+        entry = next((r for r in reminders if r['id'] == entry_id), None)
+        if not entry:
+            await _render_main(interaction)
+            return
+        states = await bot.db.get_guild_bump_states(interaction.guild_id)
+        view = ManageBumpReminderView(bot, interaction.guild_id, locale, entry,
+                                      states.get(entry['bot']))
+        await interaction.response.edit_message(view=view)
+
+    async def on_back(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        from cogs.config import ConfigMainView
+        locale = i18n.get_user_locale(interaction)
+        main_view = ConfigMainView(interaction.client, interaction.guild_id,
+                                   interaction.user.id, locale)
+        await interaction.response.edit_message(view=main_view)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_guild_perms(interaction)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: Manage Server in the guild (checked on every click)."""
+        bot.add_view(cls())
+
+
+# =========================================================================== #
+# Manage one reminder
+# =========================================================================== #
+class ManageBumpReminderView(BaseView):
+    """One reminder: what it does, and the four things you can do to it."""
+
+    __persistent__ = True
+
+    def __init__(self, bot=None, guild_id: Optional[int] = None,
+                 locale: str = "en-US", entry: Optional[Dict[str, Any]] = None,
+                 state: Optional[Dict[str, Any]] = None):
+        super().__init__()  # timeout=None
+        self.bot = bot
+        self.guild_id = guild_id
+        self.locale = locale
+        self.entry = entry or {}
+        self.state = state
+
+        self._build_view()
+
+    def _build_view(self):
+        self.clear_items()
+        container = ui.Container()
+        spec = bot_by_key(self.entry.get('bot') or '')
+
+        if spec is None:
+            container.add_item(ui.TextDisplay(
+                f"{INFO} {t('modules.bump_reminder.errors.unknown_bot', locale=self.locale)}"
+            ))
+        else:
+            container.add_item(ui.TextDisplay(f"### {spec.emoji} {spec.name}"))
+            container.add_item(ui.TextDisplay(
+                f"-# {t('modules.bump_reminder.manage.subtitle', locale=self.locale, interval=format_interval(self.entry.get('interval') or spec.default_interval), command=spec.command)}"
+            ))
+            container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+            container.add_item(ui.TextDisplay(self._render_summary()))
+
+        self.add_item(container)
+
+        button_row = ui.ActionRow()
+        back_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str(BACK),
+            label=t('modules.config.buttons.back', locale=self.locale),
+            style=discord.ButtonStyle.secondary, custom_id=_CID_MANAGE_BACK,
+        )
+        back_btn.callback = self.on_back
+        button_row.add_item(back_btn)
+
+        edit_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str(EDIT),
+            label=t('modules.bump_reminder.manage.edit', locale=self.locale),
+            style=discord.ButtonStyle.primary, custom_id=_CID_MANAGE_EDIT,
+        )
+        edit_btn.callback = self.on_edit
+        button_row.add_item(edit_btn)
+
+        enabled = self.entry.get('enabled', True)
+        toggle_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str(PAUSE if enabled else PLAY),
+            label=t('modules.bump_reminder.manage.pause' if enabled
+                    else 'modules.bump_reminder.manage.resume', locale=self.locale),
+            style=discord.ButtonStyle.secondary, custom_id=_CID_MANAGE_TOGGLE,
+        )
+        toggle_btn.callback = self.on_toggle
+        button_row.add_item(toggle_btn)
+
+        remove_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str(DELETE),
+            label=t('modules.bump_reminder.manage.remove', locale=self.locale),
+            style=discord.ButtonStyle.danger, custom_id=_CID_MANAGE_REMOVE,
+        )
+        remove_btn.callback = self.on_remove
+        button_row.add_item(remove_btn)
+        self.add_item(button_row)
+
+    def _render_summary(self) -> str:
+        """Every stored value, because none of them is shown by a live control.
+
+        The manage screen has no channel picker or role picker of its own — the
+        modal owns all of that — so this text is the only place the current
+        configuration can be read.
+        """
+        channel = (self.bot.get_channel(self.entry['channel_id'])
+                   if self.bot and self.entry.get('channel_id') else None)
+        channel_ref = channel.mention if channel else f"`{self.entry.get('channel_id', '')}`"
+
+        roles = self.entry.get('role_ids') or []
+        roles_ref = (" ".join(f"<@&{r}>" for r in roles) if roles
+                     else t('modules.bump_reminder.manage.no_roles', locale=self.locale))
+
+        lines = [
+            t('modules.bump_reminder.manage.channel', locale=self.locale, channel=channel_ref),
+            t('modules.bump_reminder.manage.roles', locale=self.locale, roles=roles_ref),
+            t('modules.bump_reminder.manage.ping', locale=self.locale,
+              mode=_ping_label(self.entry.get('ping_mode', 'button'), self.locale)),
+        ]
+        if not self.entry.get('enabled', True):
+            lines.append(t('modules.bump_reminder.manage.paused_notice', locale=self.locale))
+
+        state_line = self._state_line()
+        if state_line:
+            lines.append(f"-# {state_line}")
+        return "\n".join(lines)
+
+    def _state_line(self) -> str:
+        if not self.state:
+            return t('modules.bump_reminder.config.state.waiting', locale=self.locale)
+        if self.state.get('sent'):
+            return t('modules.bump_reminder.config.state.ready', locale=self.locale)
+        return t('modules.bump_reminder.config.state.scheduled', locale=self.locale,
+                 timestamp=f"<t:{int(self.state['due_at'].timestamp())}:R>")
+
+    # -- write-back ------------------------------------------------------- #
+    async def _apply(self, interaction: discord.Interaction,
+                     **fields) -> Optional[Tuple[bool, Optional[str]]]:
+        """Write ``fields`` onto this entry inside the guild's list.
+
+        ``None`` means the entry is gone — deleted from another panel, or from
+        the dashboard — and the caller falls back to the main screen.
+        """
+        bot = interaction.client
+        reminders = await _load(bot, interaction.guild_id)
+        target = next((r for r in reminders if r['id'] == self.entry.get('id')), None)
+        if not target:
+            return None
+        target.update(fields)
+        success, error = await _save(bot, interaction.guild_id, reminders, interaction.user.id)
+        if success:
+            self.entry = target
+        return success, error
+
+    async def _refresh(self, interaction: discord.Interaction,
+                       result: Optional[Tuple[bool, Optional[str]]]) -> None:
+        locale = i18n.get_user_locale(interaction)
+        if result is None:
+            await _render_main(interaction)
+            return
+        success, error = result
+        if not success:
+            await interaction.response.send_message(
+                t('modules.config.save.error', locale=locale, error=error or ''),
+                ephemeral=True)
+            return
+        bot = interaction.client
+        states = await bot.db.get_guild_bump_states(interaction.guild_id)
+        view = ManageBumpReminderView(bot, interaction.guild_id, locale, self.entry,
+                                      states.get(self.entry['bot']))
+        await interaction.response.edit_message(view=view)
+
+    # -- callbacks -------------------------------------------------------- #
+    async def on_edit(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+
+        reminders = await _load(bot, interaction.guild_id)
+        entry = next((r for r in reminders if r['id'] == self.entry.get('id')), None)
+        if not entry:
+            await _render_main(interaction)
+            return
+
+        cap = await reminders_per_bot(bot, interaction.guild_id)
+        counts = count_by_bot(reminders)
+        available = [s.key for s in BUMP_BOTS if counts.get(s.key, 0) < cap]
+
+        modal = BumpReminderModal(
+            locale, bot_key=entry['bot'],
+            callback_func=_edit_reminder(entry['id']),
+            channel_id=entry.get('channel_id'),
+            role_ids=entry.get('role_ids'),
+            ping_mode=entry.get('ping_mode', 'button'),
+            interval=entry.get('interval'),
+            available=available,
+        )
+        modal.bot = bot
+        await interaction.response.send_modal(modal)
+
+    async def on_toggle(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        await self._refresh(
+            interaction,
+            await self._apply(interaction, enabled=not self.entry.get('enabled', True)),
+        )
+
+    async def on_remove(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        await interaction.response.defer()
+
+        reminders = await _load(bot, interaction.guild_id)
+        entry = next((r for r in reminders if r['id'] == self.entry.get('id')), None)
+        remaining = [r for r in reminders if r['id'] != self.entry.get('id')]
+        success, error = await _save(bot, interaction.guild_id, remaining, interaction.user.id)
+
+        if success and entry:
+            # Nothing left points at this directory: forget the pending row too,
+            # or a reminder deleted at 3pm still fires at 4.
+            if not any(r['bot'] == entry['bot'] for r in remaining):
+                await bot.db.drop_bump_reminder(interaction.guild_id, entry['bot'])
+
+        await _render_main(interaction)
+        if success:
+            await interaction.followup.send(
+                t('modules.bump_reminder.manage.removed', locale=locale), ephemeral=True)
+        else:
+            await interaction.followup.send(
+                t('modules.config.save.error', locale=locale, error=error or ''),
+                ephemeral=True)
+
+    async def on_back(self, interaction: discord.Interaction):
+        if not await check_guild_perms(interaction):
+            return
+        await _render_main(interaction)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_guild_perms(interaction)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: Manage Server in the guild (checked on every click)."""
+        bot.add_view(cls())
+
+
+# =========================================================================== #
+# Modal submit handlers
+# =========================================================================== #
+async def _write(interaction: discord.Interaction, reminders: List[Dict[str, Any]],
+                 success_key: str) -> None:
+    bot = interaction.client
+    locale = i18n.get_user_locale(interaction)
+    success, error = await _save(bot, interaction.guild_id, reminders, interaction.user.id)
+    await _render_main(interaction)
+    await interaction.followup.send(
+        t(success_key, locale=locale) if success
+        else t('modules.config.save.error', locale=locale, error=error or ''),
+        ephemeral=True,
+    )
+
+
+async def _create_reminder(interaction: discord.Interaction, *, bot_key: str,
+                           channel_id: Optional[int], role_ids: List[int],
+                           ping_mode: str, raw_interval: str) -> None:
+    bot = interaction.client
+    locale = i18n.get_user_locale(interaction)
+    await interaction.response.defer()
+
+    interval = parse_interval(raw_interval)
+    if interval is None:
+        await interaction.followup.send(
+            t('modules.bump_reminder.errors.invalid_interval', locale=locale), ephemeral=True)
+        return
+
+    reminders = await _load(bot, interaction.guild_id)
+    reminders.append(new_entry(
+        bot_key, channel_id=channel_id, role_ids=role_ids,
+        ping_mode=ping_mode, interval=interval, created_by=interaction.user.id,
+    ))
+    await _write(interaction, reminders, 'modules.bump_reminder.add.success')
+
+
+def _edit_reminder(entry_id: str):
+    """Bind the entry being edited to a submit handler.
+
+    A closure rather than a bound method: the modal outlives the view that
+    opened it, and the entry id is the only thing the write actually needs.
+    """
+    async def handler(interaction: discord.Interaction, *, bot_key: str,
+                      channel_id: Optional[int], role_ids: List[int],
+                      ping_mode: str, raw_interval: str) -> None:
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+        await interaction.response.defer()
+
+        interval = parse_interval(raw_interval)
+        if interval is None:
+            await interaction.followup.send(
+                t('modules.bump_reminder.errors.invalid_interval', locale=locale),
+                ephemeral=True)
+            return
+
+        reminders = await _load(bot, interaction.guild_id)
+        target = next((r for r in reminders if r['id'] == entry_id), None)
+        if target is None:
+            await _render_main(interaction)
+            return
+
+        previous_bot = target['bot']
+        target.update({
+            'bot': bot_key,
+            'channel_id': channel_id,
+            'role_ids': role_ids,
+            'ping_mode': ping_mode,
+            'interval': interval,
+        })
+        success, error = await _save(bot, interaction.guild_id, reminders,
+                                     interaction.user.id)
+
+        # Re-pointed at another directory: the old one's pending row is now
+        # orphaned unless a sibling entry still claims it.
+        if success and previous_bot != bot_key:
+            if not any(r['bot'] == previous_bot for r in reminders):
+                await bot.db.drop_bump_reminder(interaction.guild_id, previous_bot)
+
+        await _render_main(interaction)
+        await interaction.followup.send(
+            t('modules.bump_reminder.manage.saved', locale=locale) if success
+            else t('modules.config.save.error', locale=locale, error=error or ''),
+            ephemeral=True,
+        )
+
+    return handler

--- a/tests/data/bump_payloads.json
+++ b/tests/data/bump_payloads.json
@@ -1,0 +1,187 @@
+{
+  "dl": {
+    "id": "1545012109421576192",
+    "createdTimestamp": 1788429991823,
+    "content": "",
+    "authorId": "528557940811104258",
+    "embeds": [],
+    "components": [
+      {
+        "type": 17,
+        "id": 1,
+        "accent_color": 5531135,
+        "components": [
+          { "type": 10, "id": 2, "content": "## Résultat du Bump sur DiscordL" },
+          { "type": 10, "id": 3, "content": "✅ **Moddev** a été BUMP par <@1164597199594852395> 🚀\n\n[Ton propre serveur généré par IA](https://aiguild.me/fr?source=bot_dl&page=home) **gratuitement** ✨" },
+          { "type": 14, "id": 4, "divider": true },
+          { "type": 12, "id": 5, "items": [ { "media": { "url": "https://shr.discordl.org/v2/bump/1/1421493239579676682/1164597199594852395.jpg?324", "proxy_url": "https://images-ext-1.discordapp.net/external/9eckuJqm1nV8Ko2fU2ZsuvGTpb9K9P9pTF6cTZiSsFU/%3F324/https/shr.discordl.org/v2/bump/1/1421493239579676682/1164597199594852395.jpg" } } ] },
+          { "type": 14, "id": 6, "divider": true },
+          { "type": 1, "id": 7, "components": [
+            { "type": 2, "style": 5, "label": "👑 Bump chaque heure", "url": "https://www.discordl.org/upgrade/1421493239579676682?source=bump_btn" },
+            { "type": 2, "style": 5, "label": "🎰 Tourner la Roue", "url": "https://www.discordl.org/roue-fortune?source=bump_btn" },
+            { "type": 2, "style": 5, "label": "🏠 Voir le bump sur DiscordL", "url": "https://www.discordl.org?source=bump_btn#bump" },
+            { "type": 2, "style": 5, "label": "🌐 Voir la page du serveur", "url": "https://www.discordl.org/serveurs/1421493239579676682?source=bump_btn" }
+          ] },
+          { "type": 10, "id": 12, "content": "-# Serveurs Discord sur https://www.discordl.org • <t:1788429994:R>" }
+        ]
+      }
+    ],
+    "attachments": [],
+    "applicationId": "528557940811104258",
+    "interactionMetadata": { "id": "1545012107978739823", "type": 2, "user": "1164597199594852395" },
+    "interaction": { "id": "1545012107978739823", "type": 2, "commandName": "bump", "user": "1164597199594852395" }
+  },
+
+  "disboard": {
+    "id": "1544847369382662267",
+    "createdTimestamp": 1788390714737,
+    "content": "",
+    "authorId": "302050872383242240",
+    "embeds": [
+      {
+        "url": "https://disboard.org/",
+        "type": "rich",
+        "title": "DISBOARD : La liste des serveurs publics",
+        "image": { "url": "https://disboard.org/images/bot-command-image-bump.png", "proxy_url": "https://images-ext-1.discordapp.net/external/tAuRcs-FCy2M8OaTS9Ims62J1vrFiviahjBDtpZrrBs/https/disboard.org/images/bot-command-image-bump.png" },
+        "description": "Bump effectué !\nJette un coup d'oeil [sur DISBOARD](https://disboard.org/server/843109055610224640).\n\n\n*Je développe et maintiens ce bot avec passion, avec le soutien précieux de modérateurs et de contributeurs incroyables en coulisses.\nJe couvre tous les frais moi-même — et pour être honnête, votre soutien fait vraiment la différence.\nMême un petit don aide à faire vivre le bot 💖\n🙏 Faire un don ici : https://www.paypal.com/ncp/payment/V2257AKBQS2S6*",
+        "color": 2406327
+      }
+    ],
+    "components": [],
+    "attachments": [],
+    "applicationId": "302050872383242240",
+    "interactionMetadata": { "id": "1544847366476136519", "type": 2, "user": "1394804016051126293" },
+    "interaction": { "id": "1544847366476136519", "type": 2, "commandName": "bump", "user": "1394804016051126293" }
+  },
+
+  "dinvites": {
+    "id": "1544986031231860747",
+    "createdTimestamp": 1788423774298,
+    "content": "",
+    "authorId": "678211574183362571",
+    "embeds": [],
+    "components": [
+      {
+        "type": 17,
+        "id": 1,
+        "components": [
+          { "type": 12, "id": 2, "items": [ { "media": { "url": "https://cdn.discordapp.com/attachments/1043850925028159499/1544986051289026581/bump.png?ex=6a9a7fe3&is=6a992e63&hm=3de6624b04b617d0d4025389c45a3fbd67d92fb62d5e26f2593a76fcf95dbd16&", "proxy_url": "https://media.discordapp.net/attachments/1043850925028159499/1544986051289026581/bump.png?ex=6a9a7fe3&is=6a992e63&hm=3de6624b04b617d0d4025389c45a3fbd67d92fb62d5e26f2593a76fcf95dbd16&" } } ] },
+          { "type": 1, "id": 3, "components": [ { "type": 2, "style": 5, "label": "Voir le serveur", "url": "https://discordinvites.net/servers/1043202164740329513" } ] }
+        ]
+      }
+    ],
+    "attachments": [],
+    "applicationId": "678211574183362571",
+    "interactionMetadata": { "id": "1544986030216577055", "type": 2, "user": "1036948336017686579" },
+    "interaction": { "id": "1544986030216577055", "type": 2, "commandName": "bump", "user": "1036948336017686579" }
+  },
+
+  "frenchgg": {
+    "id": "1538727826256297994",
+    "createdTimestamp": 1786931701960,
+    "content": "",
+    "authorId": "1313443824483307531",
+    "embeds": [],
+    "components": [
+      {
+        "type": 17,
+        "id": 1,
+        "components": [
+          { "type": 10, "id": 2, "content": "<:votepositif:1319736817406181489> [**NOUVEAU BUMP**](https://french.gg/serveurs)\n <a:aFlecheDroite:1071771640213545011> Le serveur Modération France a été bumpé !" },
+          { "type": 1, "id": 3, "components": [ { "type": 2, "style": 1, "label": "⏰ Me rappeler dans 2h", "custom_id": "buttons-custom-reminder-782248491895750706" } ] },
+          { "type": 14, "id": 5, "divider": true },
+          { "type": 10, "id": 6, "content": "-# <:frggBadgeSupporterOr:1437463042802716712>  **French.gg est un projet en grande majorité gratuit, nous développons ce projet avec passion et entretenons son coût de notre poche.** \n-# Pour soutenir notre projet et continuer à le faire vivre, vous pouvez nous soutenir avec [nos badges supporter](https://french.gg/premium)" }
+        ]
+      }
+    ],
+    "attachments": [],
+    "applicationId": "1313443824483307531",
+    "interactionMetadata": { "id": "1538727824385638400", "type": 2, "user": "782248491895750706" },
+    "interaction": { "id": "1538727824385638400", "type": 2, "commandName": "bump", "user": "782248491895750706" }
+  },
+
+  "dtop": {
+    "id": "1545016250751655956",
+    "createdTimestamp": 1788430979193,
+    "content": "",
+    "authorId": "1071460654839517184",
+    "embeds": [],
+    "components": [
+      {
+        "type": 17,
+        "id": 1,
+        "accent_color": 4278969,
+        "components": [
+          { "type": 12, "id": 2, "items": [ { "media": { "url": "https://cdn.discordapp.com/attachments/640677064705441822/1545016250990862447/boost-success.png?ex=6a9a9c03&is=6a994a83&hm=878e19fba3dc54f852b03680d472a35975fa80cb69f6cdbdbc11f794c4108603&", "proxy_url": "https://media.discordapp.net/attachments/640677064705441822/1545016250990862447/boost-success.png?ex=6a9a9c03&is=6a994a83" } } ] },
+          { "type": 14, "id": 3, "divider": true },
+          { "type": 10, "id": 4, "content": "# 🚀 Boost envoyé" },
+          { "type": 10, "id": 5, "content": "**Creators Area** vient d’être propulsé en première page.\n\nC’est le meilleur moment pour attirer de nouveaux visiteurs : le serveur gagne un coup de projecteur immédiat sur DiscordTop." },
+          { "type": 14, "id": 6, "divider": true },
+          { "type": 10, "id": 7, "content": "Prochain boost disponible <t:1788434578:R>.\n\nAstuce : alterner votes réguliers et boosts aide un serveur à rester visible plus longtemps." },
+          { "type": 14, "id": 8, "divider": true },
+          { "type": 1, "id": 9, "components": [
+            { "type": 2, "style": 5, "label": "Voir le serveur", "url": "https://discordtop.net/guild/223070469148901376" },
+            { "type": 2, "style": 5, "label": "Voter aussi", "url": "https://discordtop.net/guild/223070469148901376/vote" },
+            { "type": 2, "style": 5, "label": "Voir le classement", "url": "https://discordtop.net" }
+          ] }
+        ]
+      }
+    ],
+    "attachments": [],
+    "applicationId": "1071460654839517184",
+    "interactionMetadata": { "id": "1545016247400271952", "type": 2, "user": "1164597199594852395" },
+    "interaction": { "id": "1545016247400271952", "type": 2, "commandName": "boost", "user": "1164597199594852395" }
+  },
+
+  "beemp": {
+    "id": "1545016714075447307",
+    "createdTimestamp": 1788431089658,
+    "content": "",
+    "authorId": "1293636927337136269",
+    "embeds": [
+      {
+        "url": "https://beemp.gg/en/bumps",
+        "type": "rich",
+        "title": "Find the BUMPS on our website !",
+        "timestamp": "2026-09-03T10:24:50.340000+00:00",
+        "image": { "url": "https://cdn.discordapp.com/attachments/960209644373016627/1545016720140533761/banner.png?ex=6a9a9c73&is=6a994af3", "proxy_url": "https://media.discordapp.net/attachments/960209644373016627/1545016720140533761/banner.png" },
+        "fields": [ { "name": "", "value": "`😎` Bump faster !\n> **You can configure a BUMP and VOTE panel [by clicking here](https://beemp.gg/en/dashboard/959269961572962314/bump).**", "inline": false } ],
+        "description": "> Beemp done **successfully**, a little </vote:1470530261245628556> now ?",
+        "color": 16758272,
+        "author": { "url": "https://discord.gg/h3PAgWRE5M", "name": "John-Bot・BUMP !" }
+      }
+    ],
+    "components": [
+      { "type": 1, "id": 1, "components": [
+        { "type": 2, "style": 5, "label": "Add Beemp", "url": "https://discord.com/oauth2/authorize?client_id=1293636927337136269&scope=bot%20applications.commands&permissions=545460321791&redirect_uri=https://discord.gg/h3PAgWRE5M&response_type=code" },
+        { "type": 2, "style": 5, "label": "John-Bot", "url": "https://beemp.gg/en/guilds/959269961572962314" }
+      ] }
+    ],
+    "attachments": [],
+    "applicationId": "1293636927337136269",
+    "interactionMetadata": { "id": "1545016713077067846", "type": 2, "user": "1164597199594852395" },
+    "interaction": { "id": "1545016713077067846", "type": 2, "commandName": "bump", "user": "1164597199594852395" }
+  },
+
+  "dsmonitoring": {
+    "id": "1545017159309205516",
+    "createdTimestamp": 1788431195810,
+    "content": "",
+    "authorId": "575776004233232386",
+    "embeds": [
+      {
+        "type": "rich",
+        "timestamp": "2026-09-03T14:26:35+00:00",
+        "footer": { "text": "Next Like" },
+        "description": "You successfully liked the server.\nYou were faster than **0.00%** users!\n\n*We have a mobile application: [discordserver.info/app](https://discordserver.info/app)*",
+        "color": 5271975,
+        "author": { "name": "juthing_", "icon_url": "https://cdn.discordapp.com/avatars/1164597199594852395/34ce3b287b33797c0c009aa2ed1d55ef.png" }
+      }
+    ],
+    "components": [],
+    "attachments": [],
+    "applicationId": "575776004233232386",
+    "interactionMetadata": { "id": "1545017156385775637", "type": 2, "user": "1164597199594852395" },
+    "interaction": { "id": "1545017156385775637", "type": 2, "commandName": "bump", "user": "1164597199594852395" }
+  }
+}

--- a/tests/data/bump_refusals.json
+++ b/tests/data/bump_refusals.json
@@ -166,5 +166,59 @@
       "commandName": "boost",
       "user": "1164597199594852395"
     }
+  },
+  "dsmonitoring": {
+    "id": "1545042389406584903",
+    "createdTimestamp": 1788437211134,
+    "content": "",
+    "authorId": "575776004233232386",
+    "embeds": [
+      {
+        "type": "rich",
+        "timestamp": "2026-09-03T14:26:35+00:00",
+        "footer": {
+          "text": "Next Like"
+        },
+        "description": "You are so hot! 2 hours 19 minutes until the next like.\n\n*We have a mobile application: [discordserver.info/app](https://discordserver.info/app)*",
+        "color": 5271975,
+        "author": {
+          "name": "juthing_",
+          "icon_url": "https://cdn.discordapp.com/avatars/1164597199594852395/34ce3b287b33797c0c009aa2ed1d55ef.png"
+        }
+      }
+    ],
+    "components": [],
+    "attachments": [],
+    "applicationId": "575776004233232386",
+    "interactionMetadata": {
+      "user": "1164597199594852395"
+    },
+    "interaction": {
+      "commandName": "bump",
+      "user": "1164597199594852395"
+    }
+  },
+  "beemp": {
+    "id": "1545017939629969438",
+    "createdTimestamp": 1788431381853,
+    "content": "",
+    "authorId": "1293636927337136269",
+    "embeds": [
+      {
+        "type": "rich",
+        "description": "`⏱️` **You can bump again <t:1788434690:R> !**",
+        "color": 16711680
+      }
+    ],
+    "components": [],
+    "attachments": [],
+    "applicationId": "1293636927337136269",
+    "interactionMetadata": {
+      "user": "1164597199594852395"
+    },
+    "interaction": {
+      "commandName": "bump",
+      "user": "1164597199594852395"
+    }
   }
 }

--- a/tests/data/bump_refusals.json
+++ b/tests/data/bump_refusals.json
@@ -48,5 +48,123 @@
       "commandName": "bump",
       "user": "1164597199594852395"
     }
+  },
+  "dl": {
+    "id": "1545040315486834698",
+    "createdTimestamp": 1788436716673,
+    "content": "",
+    "authorId": "528557940811104258",
+    "embeds": [],
+    "components": [
+      {
+        "type": 17,
+        "accent_color": 5531135,
+        "components": [
+          {
+            "type": 10,
+            "content": "## Résultat du Bump sur DiscordL"
+          },
+          {
+            "type": 10,
+            "content": "❌  Tu dois attendre encore **59min 43sec** avant de pouvoir bump à nouveau ⏳\n\nLe temps de découvrir le **__[Super Bump](https://www.discordl.org/power?source=bump)__** Gratuit"
+          },
+          {
+            "type": 14,
+            "divider": true
+          },
+          {
+            "type": 1,
+            "components": [
+              {
+                "type": 2,
+                "style": 2,
+                "label": "⚡ Bump instant",
+                "custom_id": "bump_instant"
+              },
+              {
+                "type": 2,
+                "style": 5,
+                "label": "🎰 Tourner la Roue",
+                "url": "https://www.discordl.org/roue-fortune?source=bump_btn"
+              },
+              {
+                "type": 2,
+                "style": 5,
+                "label": "🌐 Voir la page du serveur",
+                "url": "https://www.discordl.org/serveurs/223070469148901376?source=bump_btn"
+              }
+            ]
+          },
+          {
+            "type": 10,
+            "content": "-# Top List Discord sur https://www.discordl.org • <t:1788436718:R>"
+          }
+        ]
+      }
+    ],
+    "attachments": [],
+    "applicationId": "528557940811104258",
+    "interactionMetadata": {
+      "user": "1164597199594852395"
+    },
+    "interaction": {
+      "commandName": "bump",
+      "user": "1164597199594852395"
+    }
+  },
+  "dtop": {
+    "id": "1545040626595266641",
+    "createdTimestamp": 1788436790847,
+    "content": "",
+    "authorId": "1071460654839517184",
+    "embeds": [],
+    "components": [
+      {
+        "type": 17,
+        "accent_color": 15158332,
+        "components": [
+          {
+            "type": 12,
+            "items": [
+              {
+                "media": {
+                  "url": "https://cdn.discordapp.com/attachments/640677064705441822/1545040627157176430/boost-error.png?ex=6a9ab2b6&is=6a996136&hm=9f03abfdfb0e1568f6966dabe125925c2be976082a9661e555798974b53b591e&",
+                  "proxy_url": "https://media.discordapp.net/attachments/640677064705441822/1545040627157176430/boost-error.png?ex=6a9ab2b6&is=6a996136"
+                }
+              }
+            ]
+          },
+          {
+            "type": 14,
+            "divider": true
+          },
+          {
+            "type": 10,
+            "content": "# 🚀 Boost impossible"
+          },
+          {
+            "type": 10,
+            "content": "Ce serveur vient déjà d’être propulsé.\n\nTu pourras le booster à nouveau <t:1788440384:R>."
+          },
+          {
+            "type": 14,
+            "divider": true
+          },
+          {
+            "type": 10,
+            "content": "Le boost permet de replacer un serveur en première page pour lui donner un vrai coup de visibilité."
+          }
+        ]
+      }
+    ],
+    "attachments": [],
+    "applicationId": "1071460654839517184",
+    "interactionMetadata": {
+      "user": "1164597199594852395"
+    },
+    "interaction": {
+      "commandName": "boost",
+      "user": "1164597199594852395"
+    }
   }
 }

--- a/tests/data/bump_refusals.json
+++ b/tests/data/bump_refusals.json
@@ -1,0 +1,52 @@
+{
+  "dinvites": {
+    "id": "1545019804581109810",
+    "createdTimestamp": 1788431826492,
+    "content": "",
+    "authorId": "678211574183362571",
+    "embeds": [],
+    "components": [
+      {
+        "type": 17,
+        "accent_color": 15548997,
+        "components": [
+          {
+            "type": 10,
+            "content": "Tu pourras bump à nouveau <t:1788439014:R>."
+          },
+          {
+            "type": 12,
+            "items": [
+              {
+                "media": {
+                  "url": "https://cdn.discordapp.com/attachments/640677064705441822/1545019807148285953/bump-error.png?ex=6a9a9f53&is=6a994dd3&hm=a87f2f027c3b958c007dce3b40f533094cb3bba960f7d70038084faacfdc5aeb&",
+                  "proxy_url": "https://media.discordapp.net/attachments/640677064705441822/1545019807148285953/bump-error.png?ex=6a9a9f53&is=6a994dd3"
+                }
+              }
+            ]
+          },
+          {
+            "type": 1,
+            "components": [
+              {
+                "type": 2,
+                "style": 5,
+                "label": "Voir le serveur",
+                "url": "https://discordinvites.net/servers/223070469148901376"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "attachments": [],
+    "applicationId": "678211574183362571",
+    "interactionMetadata": {
+      "user": "1164597199594852395"
+    },
+    "interaction": {
+      "commandName": "bump",
+      "user": "1164597199594852395"
+    }
+  }
+}

--- a/tests/test_bump_reminder.py
+++ b/tests/test_bump_reminder.py
@@ -39,6 +39,13 @@ LOCALES = ("fr", "en-US", "es-ES", "pt-BR", "de")
 
 PAYLOADS = json.loads((ROOT / "tests" / "data" / "bump_payloads.json").read_text(encoding="utf-8"))
 
+#: Captured **refusals** — a real cooldown reply, per directory. Far more
+#: valuable than the synthetic ones below, because a guessed refusal only tests
+#: the guess: the D-INVITES failure markers were wrong (``cooldown.png``,
+#: ``error.png``) until a real refusal showed the file is called
+#: ``bump-error.png``. Add one whenever a real refusal is seen in the wild.
+REFUSALS = json.loads((ROOT / "tests" / "data" / "bump_refusals.json").read_text(encoding="utf-8"))
+
 
 # --------------------------------------------------------------------------- #
 # Turning a captured payload back into something Message-shaped
@@ -231,14 +238,14 @@ class TestFailure:
     reply in one of the two languages these directories actually answer in.
     """
 
+    #: Plausible cooldown replies, written by hand. Weaker evidence than
+    #: ``REFUSALS`` — see :class:`TestCapturedRefusals`.
     CASES = [
         ("disboard", embed_reply(
             "disboard", "Veuillez attendre encore 47 minutes.",
             image="https://disboard.org/images/bot-command-image-notification.png")),
         ("dsmonitoring", embed_reply("dsmonitoring", "You have already liked this server today.")),
         ("dsmonitoring", embed_reply("dsmonitoring", "Vous avez déjà aimé le serveur récemment.")),
-        ("dinvites", v2_reply("dinvites", media="https://cdn.discordapp.com/a/b/cooldown.png?ex=1")),
-        ("dinvites", v2_reply("dinvites", media="https://cdn.discordapp.com/a/b/error.png?ex=1")),
         ("dl", v2_reply("dl", text="❌ Tu dois attendre avant de bump à nouveau.")),
         ("dl", v2_reply("dl", text="You must wait before bumping again.")),
         ("beemp", embed_reply("beemp", "> Beemp already done, please wait a bit.")),
@@ -252,6 +259,18 @@ class TestFailure:
                              ids=[f"{k}-{i}" for i, (k, _) in enumerate(CASES)])
     def test_a_cooldown_reply_arms_nothing(self, key, payload):
         assert detect(message(payload), 7200, now=sent_at(payload)) is None
+
+    def test_a_success_asset_name_cannot_match_a_failure_one(self):
+        """``bump.png`` and ``bump-error.png`` must stay distinguishable.
+
+        D-INVITES has no text on a success, so the filename is the whole
+        detector. A success marker loose enough to also match the error asset
+        would turn every refusal into a reminder.
+        """
+        spec = bot_by_key("dinvites")
+        error_url = "https://cdn.discordapp.com/a/b/bump-error.png?ex=1"
+        assert not any(marker in error_url for marker in spec.success_media)
+        assert any(marker in error_url for marker in spec.failure_media)
 
     def test_a_failure_marker_outranks_a_success_marker(self):
         """Success wording plus a failure asset is a message we do not understand.
@@ -287,6 +306,48 @@ class TestFailure:
             "disboard", "Bump effectué !",
             image="https://disboard.org/images/bot-command-image-notification.png")
         assert detect(message(payload), 7200, now=sent_at(payload)) is None
+
+
+class TestCapturedRefusals:
+    """Real cooldown replies, replayed through the real code.
+
+    These matter more than the hand-written ones: a guessed refusal only ever
+    tests the guess. D-INVITES' failure markers were ``cooldown.png`` /
+    ``error.png`` — both invented, both wrong — until a captured refusal showed
+    the asset is named ``bump-error.png`` and the message reads "Tu pourras bump
+    à nouveau". The refusal was rejected before the fix, but only because no
+    success marker happened to fire; nothing vetoed it. That is the weakest
+    reason a detector can be right, and it is what this class exists to prevent.
+    """
+
+    @pytest.mark.parametrize("key", sorted(REFUSALS), ids=sorted(REFUSALS))
+    def test_a_captured_refusal_arms_nothing(self, key):
+        payload = REFUSALS[key]
+        assert detect(message(payload), 7200, now=sent_at(payload)) is None
+
+    @pytest.mark.parametrize("key", sorted(REFUSALS), ids=sorted(REFUSALS))
+    def test_a_captured_refusal_is_vetoed_not_merely_unmatched(self, key):
+        """It must trip an explicit failure marker, not just miss the success ones.
+
+        Otherwise the day a directory adds a success marker to its refusal — a
+        banner, a phrase — the rejection silently becomes an acceptance.
+        """
+        from bumpreminder.detect import _FAILURE_TEXT, _harvest, _matches
+
+        spec = bot_by_key(key)
+        text, media, _ = _harvest(message(REFUSALS[key]))
+        vetoed = (
+            _matches(spec.failure_text, text)
+            or any(marker in media for marker in spec.failure_media)
+            or (not spec.refusal_is_ephemeral and _matches(_FAILURE_TEXT, text))
+        )
+        assert vetoed, f"{key}: the refusal is only rejected by omission"
+
+    @pytest.mark.parametrize("key", sorted(REFUSALS), ids=sorted(REFUSALS))
+    def test_the_refusal_carries_the_same_command_as_the_success(self, key):
+        """Which is the whole problem: the command name cannot tell them apart."""
+        assert (REFUSALS[key]["interaction"]["commandName"]
+                == PAYLOADS[key]["interaction"]["commandName"])
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_bump_reminder.py
+++ b/tests/test_bump_reminder.py
@@ -1,0 +1,712 @@
+"""Bump Reminder — detection, config, cards and i18n.
+
+Everything here is pure Python: no gateway, no database. The detection tests
+replay the **real captured payload** of each of the seven directories
+(``tests/data/bump_payloads.json``) through the real code, which is the only way
+to be honest about a feature whose entire job is reading somebody else's message
+format.
+
+Three properties matter more than the rest, and each has its own class:
+
+- a genuine bump is recognised, in whatever language it arrives (`TestSuccess`)
+- a cooldown reply never is — a reminder fired an hour early pings a channel for
+  nothing (`TestFailure`)
+- one directory's markers never fire on another's message (`TestCrossTalk`)
+"""
+
+import json
+import pathlib
+import re
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from bumpreminder import (
+    BUMP_BOTS,
+    MAX_INTERVAL,
+    MIN_INTERVAL,
+    bot_by_app_id,
+    bot_by_key,
+    detect,
+    evaluate,
+    format_interval,
+    parse_interval,
+)
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+LOCALES = ("fr", "en-US", "es-ES", "pt-BR", "de")
+
+PAYLOADS = json.loads((ROOT / "tests" / "data" / "bump_payloads.json").read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------- #
+# Turning a captured payload back into something Message-shaped
+# --------------------------------------------------------------------------- #
+def _dt(raw):
+    return datetime.fromisoformat(raw.replace("Z", "+00:00")) if raw else None
+
+
+def _node(raw):
+    """Components keep their raw key names — the harvester reads by duck typing."""
+    if isinstance(raw, dict):
+        return SimpleNamespace(**{k: _node(v) for k, v in raw.items()})
+    if isinstance(raw, list):
+        return [_node(v) for v in raw]
+    return raw
+
+
+def _embed(raw):
+    return SimpleNamespace(
+        title=raw.get("title"),
+        description=raw.get("description"),
+        url=raw.get("url"),
+        timestamp=_dt(raw.get("timestamp")),
+        author=_node(raw["author"]) if raw.get("author") else None,
+        footer=_node(raw["footer"]) if raw.get("footer") else None,
+        image=_node(raw["image"]) if raw.get("image") else None,
+        thumbnail=_node(raw["thumbnail"]) if raw.get("thumbnail") else None,
+        fields=[_node(f) for f in raw.get("fields") or ()],
+    )
+
+
+def message(payload, *, author_id=None, is_bot=True, channel_id=42, guild_id=7):
+    author_id = int(author_id or payload["authorId"])
+    interaction = payload.get("interaction")
+    metadata = payload.get("interactionMetadata")
+    return SimpleNamespace(
+        id=int(payload["id"]),
+        content=payload.get("content") or "",
+        author=SimpleNamespace(id=author_id, bot=is_bot),
+        application_id=int(payload.get("applicationId") or author_id),
+        embeds=[_embed(e) for e in payload.get("embeds") or ()],
+        components=[_node(c) for c in payload.get("components") or ()],
+        attachments=[_node(a) for a in payload.get("attachments") or ()],
+        channel=SimpleNamespace(id=channel_id),
+        guild=SimpleNamespace(id=guild_id),
+        interaction=SimpleNamespace(
+            name=interaction["commandName"],
+            user=SimpleNamespace(id=int(interaction["user"])),
+        ) if interaction else None,
+        interaction_metadata=SimpleNamespace(
+            user=SimpleNamespace(id=int(metadata["user"])),
+        ) if metadata else None,
+    )
+
+
+def sent_at(payload):
+    return datetime.fromtimestamp(payload["createdTimestamp"] / 1000, tz=timezone.utc)
+
+
+def embed_reply(key, text, image=None, timestamp=None):
+    """A payload of ``key`` rewritten as a one-embed reply."""
+    payload = json.loads(json.dumps(PAYLOADS[key]))
+    payload["components"] = []
+    embed = {"type": "rich", "description": text}
+    if image:
+        embed["image"] = {"url": image}
+    if timestamp:
+        embed["timestamp"] = timestamp
+    payload["embeds"] = [embed]
+    return payload
+
+
+def v2_reply(key, text=None, media=None, custom_id=None):
+    """A payload of ``key`` rewritten as a Components V2 reply."""
+    payload = json.loads(json.dumps(PAYLOADS[key]))
+    payload["embeds"] = []
+    children = []
+    if text:
+        children.append({"type": 10, "content": text})
+    if media:
+        children.append({"type": 12, "items": [{"media": {"url": media}}]})
+    if custom_id:
+        children.append({"type": 1, "components": [
+            {"type": 2, "style": 1, "label": "x", "custom_id": custom_id}]})
+    payload["components"] = [{"type": 17, "components": children}]
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# The registry
+# --------------------------------------------------------------------------- #
+class TestRegistry:
+
+    def test_every_directory_is_uniquely_addressable(self):
+        assert len({spec.key for spec in BUMP_BOTS}) == len(BUMP_BOTS)
+        assert len({spec.app_id for spec in BUMP_BOTS}) == len(BUMP_BOTS)
+
+    def test_a_payload_exists_for_every_directory(self):
+        """A directory nobody captured a real reply for cannot be trusted."""
+        assert {spec.key for spec in BUMP_BOTS} == set(PAYLOADS)
+
+    @pytest.mark.parametrize("spec", BUMP_BOTS, ids=lambda s: s.key)
+    def test_default_interval_is_in_range(self, spec):
+        assert MIN_INTERVAL <= spec.default_interval <= MAX_INTERVAL
+
+    @pytest.mark.parametrize("spec", BUMP_BOTS, ids=lambda s: s.key)
+    def test_the_captured_command_is_declared(self, spec):
+        """The registry's command names must cover what the payload actually used."""
+        assert PAYLOADS[spec.key]["interaction"]["commandName"] in spec.command_names
+
+    @pytest.mark.parametrize("spec", BUMP_BOTS, ids=lambda s: s.key)
+    def test_every_directory_can_be_detected_at_all(self, spec):
+        """A directory with no marker and no private-refusal flag is dead code."""
+        assert (spec.refusal_is_ephemeral or spec.success_text
+                or spec.success_media or spec.success_custom_id)
+
+    def test_lookup_by_app_id(self):
+        for spec in BUMP_BOTS:
+            assert bot_by_app_id(spec.app_id) is spec
+        assert bot_by_app_id(1) is None
+
+
+# --------------------------------------------------------------------------- #
+# A real bump is recognised
+# --------------------------------------------------------------------------- #
+class TestSuccess:
+
+    @pytest.mark.parametrize("key", sorted(PAYLOADS), ids=sorted(PAYLOADS))
+    def test_the_captured_reply_is_a_bump(self, key):
+        spec = bot_by_key(key)
+        payload = PAYLOADS[key]
+        hit = detect(message(payload), spec.default_interval, now=sent_at(payload))
+        assert hit is not None, f"{key}: the real reply was not recognised"
+        assert hit.bot is spec
+
+    @pytest.mark.parametrize("key", sorted(PAYLOADS), ids=sorted(PAYLOADS))
+    def test_the_bumper_is_identified(self, key):
+        payload = PAYLOADS[key]
+        spec = bot_by_key(key)
+        hit = detect(message(payload), spec.default_interval, now=sent_at(payload))
+        assert hit.bumper_id == int(payload["interactionMetadata"]["user"])
+
+    def test_the_bumper_survives_missing_interaction_data(self):
+        """French.gg suffixes its own button with the bumper's id — our fallback."""
+        payload = json.loads(json.dumps(PAYLOADS["frenchgg"]))
+        expected = int(payload["interactionMetadata"]["user"])
+        payload.pop("interactionMetadata")
+        payload.pop("interaction")
+        hit = detect(message(payload), 7200, now=sent_at(payload))
+        assert hit is not None and hit.bumper_id == expected
+
+    @pytest.mark.parametrize("key", sorted(PAYLOADS), ids=sorted(PAYLOADS))
+    def test_a_non_bump_command_is_ignored(self, key):
+        """Same bot, same channel, a different command: not our business."""
+        payload = json.loads(json.dumps(PAYLOADS[key]))
+        payload["interaction"]["commandName"] = "help"
+        assert detect(message(payload), 7200, now=sent_at(payload)) is None
+
+    def test_a_human_saying_bump_is_ignored(self):
+        payload = dict(PAYLOADS["disboard"], content="allez tout le monde, /bump !", embeds=[])
+        assert detect(message(payload, is_bot=False), 7200, now=sent_at(payload)) is None
+
+    def test_an_unknown_bot_is_ignored(self):
+        payload = dict(PAYLOADS["disboard"], authorId="999999999999999999")
+        assert detect(message(payload), 7200, now=sent_at(payload)) is None
+
+    @pytest.mark.parametrize("text", [
+        "表示順をアップしたよ :) DISBOARDでサーバーをチェックしてね",
+        "범프 완료! DISBOARD에서 서버를 확인하세요.",
+        "Сервер поднят! Посмотрите на DISBOARD.",
+        "Bump tamamlandı! Sunucuyu DISBOARD'da gör.",
+    ], ids=["ja", "ko", "ru", "tr"])
+    def test_disboard_is_language_proof(self, text):
+        """DISBOARD refuses privately, so anything visible went through.
+
+        That is what lets it work in languages no phrase list here covers —
+        see ``BumpBot.refusal_is_ephemeral``.
+        """
+        payload = embed_reply("disboard", text)
+        assert detect(message(payload), 7200, now=sent_at(payload)) is not None
+
+
+# --------------------------------------------------------------------------- #
+# A refusal never is
+# --------------------------------------------------------------------------- #
+class TestFailure:
+    """A reminder armed off a failed bump pings a channel for nothing.
+
+    So every one of these must come back ``None``. Each is a plausible cooldown
+    reply in one of the two languages these directories actually answer in.
+    """
+
+    CASES = [
+        ("disboard", embed_reply(
+            "disboard", "Veuillez attendre encore 47 minutes.",
+            image="https://disboard.org/images/bot-command-image-notification.png")),
+        ("dsmonitoring", embed_reply("dsmonitoring", "You have already liked this server today.")),
+        ("dsmonitoring", embed_reply("dsmonitoring", "Vous avez déjà aimé le serveur récemment.")),
+        ("dinvites", v2_reply("dinvites", media="https://cdn.discordapp.com/a/b/cooldown.png?ex=1")),
+        ("dinvites", v2_reply("dinvites", media="https://cdn.discordapp.com/a/b/error.png?ex=1")),
+        ("dl", v2_reply("dl", text="❌ Tu dois attendre avant de bump à nouveau.")),
+        ("dl", v2_reply("dl", text="You must wait before bumping again.")),
+        ("beemp", embed_reply("beemp", "> Beemp already done, please wait a bit.")),
+        ("beemp", embed_reply("beemp", "> Beemp impossible, vous devez attendre 12 minutes.")),
+        ("dtop", v2_reply("dtop", text="Vous devez attendre avant le prochain boost.")),
+        ("frenchgg", v2_reply("frenchgg", text="Vous avez déjà bump ce serveur, patientez 1h.")),
+        ("frenchgg", v2_reply("frenchgg", text="You already bumped this server, please wait.")),
+    ]
+
+    @pytest.mark.parametrize("key,payload", CASES,
+                             ids=[f"{k}-{i}" for i, (k, _) in enumerate(CASES)])
+    def test_a_cooldown_reply_arms_nothing(self, key, payload):
+        assert detect(message(payload), 7200, now=sent_at(payload)) is None
+
+    def test_a_failure_marker_outranks_a_success_marker(self):
+        """Success wording plus a failure asset is a message we do not understand.
+
+        Staying quiet is the safe way to be wrong: a missed reminder costs one
+        bump window, a false one pings the whole channel for nothing.
+        """
+        payload = v2_reply("dtop", text="# Boost envoyé",
+                           media="https://cdn.discordapp.com/a/b/boost-error.png")
+        assert detect(message(payload), 3600, now=sent_at(payload)) is None
+
+    def test_disboard_still_needs_the_bump_command(self):
+        """Visible-means-success applies to a /bump reply, not to anything DISBOARD posts.
+
+        Strip the interaction data and the shortcut is withheld: an unmarked
+        message from the directory could be an announcement, another command's
+        reply, anything. It falls back to the ordinary markers.
+        """
+        import json as _json
+        payload = _json.loads(_json.dumps(PAYLOADS["disboard"]))
+        payload["embeds"] = [{"type": "rich", "description": "Merci d'utiliser DISBOARD !"}]
+        payload.pop("interaction")
+        payload.pop("interactionMetadata")
+        assert detect(message(payload), 7200, now=sent_at(payload)) is None
+
+        # …but a real success phrase still gets through without it.
+        payload["embeds"] = [{"type": "rich", "description": "Bump effectué !"}]
+        assert detect(message(payload), 7200, now=sent_at(payload)) is not None
+
+    def test_a_private_refusal_directory_still_honours_its_own_markers(self):
+        """DISBOARD skips the shared blocklist, not its own failure asset."""
+        payload = embed_reply(
+            "disboard", "Bump effectué !",
+            image="https://disboard.org/images/bot-command-image-notification.png")
+        assert detect(message(payload), 7200, now=sent_at(payload)) is None
+
+
+# --------------------------------------------------------------------------- #
+# Directories are never confused for one another
+# --------------------------------------------------------------------------- #
+class TestCrossTalk:
+
+    MARKER_BASED = [spec for spec in BUMP_BOTS if not spec.refusal_is_ephemeral]
+
+    @pytest.mark.parametrize("spec", MARKER_BASED, ids=lambda s: s.key)
+    def test_markers_do_not_fire_on_another_directory(self, spec):
+        """Every other directory's real reply, through this one's markers.
+
+        In production the author id already decides, so this can never happen —
+        which is exactly why it is worth asserting: it keeps the markers
+        *specific* rather than letting them rot into "contains the word bump".
+        DISBOARD is excluded because its detection is deliberately not
+        marker-based (``refusal_is_ephemeral``).
+        """
+        for key, payload in PAYLOADS.items():
+            if key == spec.key:
+                continue
+            hit = evaluate(message(payload), spec, spec.default_interval,
+                           now=sent_at(payload))
+            assert hit is None, f"{spec.key} markers matched {key}'s reply"
+
+
+# --------------------------------------------------------------------------- #
+# When the next bump is owed
+# --------------------------------------------------------------------------- #
+class TestNextDue:
+
+    def test_the_configured_interval_is_the_default(self):
+        payload = PAYLOADS["dl"]
+        now = sent_at(payload)
+        hit = detect(message(payload), 5400, now=now)
+        assert not hit.stated_by_bot
+        assert hit.due_at == now + timedelta(seconds=5400)
+
+    def test_a_directory_stating_its_own_cooldown_wins(self):
+        """DiscordTop prints "next boost <t:…>" — it is the authority, not us."""
+        payload = PAYLOADS["dtop"]
+        hit = detect(message(payload), 99999, now=sent_at(payload))
+        assert hit.stated_by_bot
+        assert hit.due_at == datetime.fromtimestamp(1788434578, tz=timezone.utc)
+
+    def test_an_embed_timestamp_can_state_it_too(self):
+        """DSMonitoring stamps the embed with the next like, four hours out."""
+        payload = PAYLOADS["dsmonitoring"]
+        hit = detect(message(payload), 99999, now=sent_at(payload))
+        assert hit.stated_by_bot
+        assert hit.due_at == datetime.fromisoformat("2026-09-03T14:26:35+00:00")
+
+    def test_a_timestamp_meaning_now_is_rejected(self):
+        """DiscordL's footer stamp is the *current* time, not the next bump.
+
+        Believing it would schedule a reminder three seconds out. This is the
+        freshness window earning its place.
+        """
+        payload = PAYLOADS["dl"]
+        now = sent_at(payload)
+        hit = detect(message(payload), 3600, now=now)
+        assert not hit.stated_by_bot
+        assert hit.due_at == now + timedelta(seconds=3600)
+
+    def test_a_stated_time_beyond_a_day_is_rejected(self):
+        payload = v2_reply("dtop", text="Prochain boost <t:1900000000:R>.",
+                           media="https://cdn.discordapp.com/a/b/boost-success.png")
+        now = sent_at(payload)
+        hit = detect(message(payload), 3600, now=now)
+        assert hit is not None and not hit.stated_by_bot
+        assert hit.due_at == now + timedelta(seconds=3600)
+
+
+# --------------------------------------------------------------------------- #
+# Intervals as a human types them
+# --------------------------------------------------------------------------- #
+class TestIntervalParsing:
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("2h", 7200), ("2H", 7200), ("2h30", 9000), ("1h05", 3900),
+        ("90m", 5400), ("90 min", 5400), ("120", 7200), ("5m", 300),
+        (" 2h ", 7200), ("24h", 86400),
+    ])
+    def test_readable_forms(self, raw, expected):
+        assert parse_interval(raw) == expected
+
+    @pytest.mark.parametrize("raw", [
+        "", "   ", "0", "4m", "25h", "abc", "2j", "-2h", "2h70x", None,
+    ])
+    def test_unreadable_or_out_of_range_is_none(self, raw):
+        """One return value to check: unreadable and out-of-range are both None."""
+        assert parse_interval(raw) is None
+
+    @pytest.mark.parametrize("seconds,text", [
+        (7200, "2h"), (5400, "1h30"), (3600, "1h"), (300, "5m"), (86400, "24h"),
+    ])
+    def test_formatting_round_trips(self, seconds, text):
+        assert format_interval(seconds) == text
+        assert parse_interval(text) == seconds
+
+
+# --------------------------------------------------------------------------- #
+# Config normalization and validation
+# --------------------------------------------------------------------------- #
+class TestConfig:
+
+    def test_an_empty_config_is_valid(self):
+        from modules.bump_reminder import normalize_config
+        assert normalize_config(None) == {"version": 1, "reminders": []}
+        assert normalize_config({}) == {"version": 1, "reminders": []}
+
+    def test_missing_keys_are_filled_from_the_directory(self):
+        from modules.bump_reminder import normalize_config
+        entry = normalize_config({"reminders": [{"bot": "disboard", "channel_id": 5}]})["reminders"][0]
+        assert entry["interval"] == bot_by_key("disboard").default_interval
+        assert entry["ping_mode"] == "button"
+        assert entry["role_ids"] == []
+        assert entry["enabled"] is True
+        assert entry["id"].startswith("br_")
+
+    def test_a_retired_directory_is_dropped_not_raised(self):
+        """A listing Moddy stops supporting must not brick the whole panel."""
+        from modules.bump_reminder import normalize_config
+        config = normalize_config({"reminders": [
+            {"bot": "disboard", "channel_id": 5},
+            {"bot": "some_dead_listing", "channel_id": 6},
+        ]})
+        assert [e["bot"] for e in config["reminders"]] == ["disboard"]
+
+    def test_an_absurd_interval_falls_back_to_the_default(self):
+        from modules.bump_reminder import normalize_config
+        entry = normalize_config({"reminders": [
+            {"bot": "dtop", "channel_id": 5, "interval": 3},
+        ]})["reminders"][0]
+        assert entry["interval"] == bot_by_key("dtop").default_interval
+
+    def test_several_reminders_may_share_one_directory(self):
+        """Premium buys extra channels for the same listing, not extra listings."""
+        from modules.bump_reminder import count_by_bot, normalize_config
+        config = normalize_config({"reminders": [
+            {"id": "br_1", "bot": "disboard", "channel_id": 5},
+            {"id": "br_2", "bot": "disboard", "channel_id": 6},
+        ]})
+        assert len(config["reminders"]) == 2
+        assert count_by_bot(config["reminders"]) == {"disboard": 2}
+
+    def test_quota_constants_are_ordered(self):
+        from modules.bump_reminder import FREE_REMINDERS_PER_BOT, PREMIUM_REMINDERS_PER_BOT
+        assert 1 <= FREE_REMINDERS_PER_BOT < PREMIUM_REMINDERS_PER_BOT
+
+
+# --------------------------------------------------------------------------- #
+# The module's own routing
+# --------------------------------------------------------------------------- #
+class TestWatching:
+
+    def _module(self, entries):
+        import asyncio
+        from modules.bump_reminder import BumpReminderModule
+        module = BumpReminderModule(SimpleNamespace(), 7)
+        asyncio.run(module.load_config({"reminders": entries}))
+        return module
+
+    def test_a_bump_in_a_watched_channel_is_taken(self):
+        module = self._module([{"bot": "disboard", "channel_id": 42}])
+        import asyncio
+        payload = PAYLOADS["disboard"]
+        found = asyncio.run(module.on_message(message(payload, channel_id=42),
+                                              bot_by_key("disboard")))
+        assert found is not None and found["entry"]["bot"] == "disboard"
+
+    def test_a_bump_elsewhere_is_left_alone(self):
+        """The reminder belongs to a channel the server chose; Moddy answers there."""
+        module = self._module([{"bot": "disboard", "channel_id": 42}])
+        import asyncio
+        payload = PAYLOADS["disboard"]
+        assert asyncio.run(module.on_message(message(payload, channel_id=99),
+                                             bot_by_key("disboard"))) is None
+
+    def test_two_directories_can_share_one_channel(self):
+        """A single #bump channel for every listing is the normal setup."""
+        module = self._module([
+            {"bot": "disboard", "channel_id": 42},
+            {"bot": "dl", "channel_id": 42},
+        ])
+        import asyncio
+        for key in ("disboard", "dl"):
+            found = asyncio.run(module.on_message(
+                message(PAYLOADS[key], channel_id=42), bot_by_key(key)))
+            assert found is not None and found["entry"]["bot"] == key
+
+    def test_one_bump_arms_every_channel_of_that_directory(self):
+        """The cooldown is the server's, so all of its channels are owed a call."""
+        module = self._module([
+            {"bot": "disboard", "channel_id": 42},
+            {"bot": "disboard", "channel_id": 43},
+            {"bot": "dl", "channel_id": 44},
+        ])
+        assert len(module.entries_for_bot("disboard")) == 2
+        assert len(module.entries_for_bot("dl")) == 1
+
+    def test_a_paused_reminder_watches_nothing(self):
+        module = self._module([{"bot": "disboard", "channel_id": 42, "enabled": False}])
+        assert module.enabled is False
+        assert module.entries_for_bot("disboard") == []
+
+
+# --------------------------------------------------------------------------- #
+# i18n
+# --------------------------------------------------------------------------- #
+def _block(locale):
+    data = json.loads((ROOT / "locales" / f"{locale}.json").read_text(encoding="utf-8"))
+    return data["modules"]["bump_reminder"]
+
+
+def _flatten(node, prefix=""):
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from _flatten(value, f"{prefix}.{key}" if prefix else key)
+    else:
+        yield prefix
+
+
+class TestTranslations:
+
+    @pytest.mark.parametrize("locale", [l for l in LOCALES if l != "en-US"])
+    def test_every_locale_has_the_same_keys(self, locale):
+        reference = set(_flatten(_block("en-US")))
+        translated = set(_flatten(_block(locale)))
+        assert reference - translated == set(), f"locales/{locale}.json is missing keys"
+        assert translated - reference == set(), f"locales/{locale}.json has keys English does not"
+
+    @pytest.mark.parametrize("locale", LOCALES)
+    def test_every_key_the_code_uses_resolves(self, locale):
+        """A key that resolves to ``[the.key]`` ships that literal to a user."""
+        from utils.i18n import i18n, t
+        i18n.load_translations()
+
+        pattern = re.compile(r"""['"](modules\.bump_reminder[a-z_.]*)['"]""")
+        keys = set()
+        for name in ("modules/bump_reminder.py",
+                     "modules/configs/bump_reminder_config.py",
+                     "utils/bump_views.py", "cogs/bump_reminder.py"):
+            keys |= set(pattern.findall((ROOT / name).read_text(encoding="utf-8")))
+        for mode in ("auto", "button", "never"):
+            keys.add(f"modules.bump_reminder.ping.{mode}")
+            keys.add(f"modules.bump_reminder.ping.{mode}_description")
+
+        missing = [k for k in sorted(keys)
+                   if (v := t(k, locale=locale)).startswith("[") and v.endswith("]")]
+        assert not missing, f"locales/{locale}.json is missing: {missing}"
+
+    @pytest.mark.parametrize("locale", LOCALES)
+    def test_the_config_menu_can_name_the_module(self, locale):
+        """`/config`'s dropdown reads modules.<id>.description and caps it at 100."""
+        from utils.i18n import i18n, t
+        i18n.load_translations()
+        description = t("modules.bump_reminder.description", locale=locale)
+        assert not description.startswith("[")
+        assert description == description.strip()
+        # Discord caps a SelectOption description at 100 characters. cogs/config.py
+        # slices to fit, so going over does not raise — it silently truncates the
+        # sentence mid-word in the module picker.
+        assert len(description) <= 100, f"{locale}: {len(description)} chars"
+
+    @pytest.mark.parametrize("locale", LOCALES)
+    def test_modal_labels_fit_discords_limits(self, locale):
+        """Modal V2: title <= 45, Label.text <= 45, Label.description <= 100."""
+        from utils.i18n import i18n, t
+        i18n.load_translations()
+        block = _block(locale)
+        assert len(block["modal"]["title"]) <= 45
+        for field in ("bot", "channel", "roles", "ping", "interval"):
+            assert len(block["modal"][f"{field}_label"]) <= 45, f"{locale}: {field}_label"
+
+
+# --------------------------------------------------------------------------- #
+# Components V2 constraints
+# --------------------------------------------------------------------------- #
+_CID_RE = re.compile(r"^moddy:[a-z0-9_]+:[a-z0-9_]+:[a-z0-9_]+(:.+)?$")
+
+
+def _custom_ids(items, found):
+    for item in items:
+        custom_id = getattr(item, "custom_id", None)
+        if isinstance(custom_id, str):
+            found.append(custom_id)
+        for attribute in ("children", "component"):
+            nested = getattr(item, attribute, None)
+            if nested is None:
+                continue
+            _custom_ids(nested if isinstance(nested, list) else [nested], found)
+    return found
+
+
+class TestComponents:
+
+    def _modal(self, locale="fr"):
+        from modules.configs.bump_reminder_config import BumpReminderModal
+
+        async def _noop(*args, **kwargs):
+            pass
+
+        return BumpReminderModal(locale, bot_key="disboard", callback_func=_noop,
+                                 channel_id=1, role_ids=[2], ping_mode="button",
+                                 interval=7200, available=["dl"])
+
+    def test_the_modal_fits_the_five_component_ceiling(self):
+        assert len(self._modal().children) == 5
+
+    def test_the_modal_serialises(self):
+        """Catches an illegal component *shape* before Discord 400s on it."""
+        assert len(self._modal().to_dict()["components"]) == 5
+
+    def test_every_custom_id_is_namespaced_and_fits(self):
+        from modules.configs.bump_reminder_config import (
+            BumpReminderConfigView, ManageBumpReminderView)
+        views = [BumpReminderConfigView(), ManageBumpReminderView(), self._modal()]
+        found = []
+        for view in views:
+            _custom_ids(view.children, found)
+        assert found
+        for custom_id in found:
+            assert _CID_RE.match(custom_id), custom_id
+            assert len(custom_id) <= 100, custom_id
+
+    def test_no_content_is_ever_sent_with_a_layout_view(self):
+        """Discord 400s on ``content=`` alongside IS_COMPONENTS_V2.
+
+        Which is why the reminder's mentions ride in a top-level TextDisplay
+        instead — a real ping, in the same message, outside the container.
+        """
+        for name in ("cogs/bump_reminder.py", "utils/bump_views.py",
+                     "modules/bump_reminder.py"):
+            source = (ROOT / name).read_text(encoding="utf-8")
+
+            # A raw Discord send may never carry both. (``send_channel`` is the
+            # notification API — its ``content`` is a NotificationContent
+            # payload, an unrelated thing that never reaches Discord's field.)
+            for call in re.findall(r"(?<!_channel)\.send\((.*?)\n\s*\)", source, re.S):
+                assert not ("view=" in call and "content=" in call), f"{name}: {call}"
+
+            # And a notification's content is always that payload, never a
+            # bare string somebody hoped Discord would render.
+            for call in re.findall(r"send_channel\((.*?)\n\s*\)", source, re.S):
+                assert not re.search(r"content=[\"']", call), f"{name}: {call}"
+
+    def test_the_reminder_card_carries_its_mentions_outside_the_container(self):
+        """The ping must sit at the view's top level, above the container.
+
+        Inside the container it would read as part of the card; as a separate
+        message it would be a ghost ping nobody can scroll back to.
+        """
+        import discord
+        from utils.bump_views import build_reminder_card
+        from utils.i18n import i18n
+        i18n.load_translations()
+
+        view = build_reminder_card(
+            bot_by_key("disboard"), locale="fr", role_ids=[1234],
+            bumper_id=5678, mention_bumper=True, elapsed=7200)
+        first = view.children[0]
+        assert isinstance(first, discord.ui.TextDisplay)
+        assert "<@&1234>" in first.content and "<@5678>" in first.content
+        assert isinstance(view.children[1], discord.ui.Container)
+
+    def test_the_reminder_card_shows_the_last_bumper_without_pinging_them(self):
+        """The "last bumped by" line renders a mention whatever the ping mode.
+
+        It stays informative because notifying is decided by allowed_mentions,
+        not by what the card draws — so a server that turned the bumper ping off
+        still gets the credit line, and nobody gets buzzed.
+        """
+        from utils.bump_views import build_reminder_card
+        from utils.i18n import i18n
+        i18n.load_translations()
+
+        view = build_reminder_card(
+            bot_by_key("disboard"), locale="fr", role_ids=[1234],
+            bumper_id=5678, mention_bumper=False, elapsed=7200)
+        top = view.children[0].content
+        assert "<@5678>" not in top, "the bumper must not be in the ping line"
+        body = "\n".join(
+            child.content for child in view.children[1].children
+            if hasattr(child, "content"))
+        assert "<@5678>" in body, "the credit line should still name them"
+
+    def test_allowed_mentions_never_opens_roles_wholesale(self):
+        """Only resolved role objects, so a deleted role simply drops out."""
+        import discord
+        from utils.bump_views import reminder_mentions
+
+        alive = SimpleNamespace(id=1234)
+        guild = SimpleNamespace(get_role=lambda rid: alive if rid == 1234 else None)
+        roles, allowed = reminder_mentions(guild, [1234, 9999], None, False)
+
+        assert roles == [alive]
+        assert allowed.roles == [alive]
+        assert allowed.everyone is False
+        assert allowed.users == []
+
+    def test_the_optin_button_only_appears_when_it_can_be_used(self):
+        from utils.bump_views import BumpOptInButton, build_thanks_card
+        from utils.i18n import i18n
+        i18n.load_translations()
+
+        due = datetime.now(timezone.utc) + timedelta(hours=2)
+
+        def has_button(view):
+            return any(
+                isinstance(item, BumpOptInButton)
+                for child in view.children
+                for row in getattr(child, "children", [])
+                for item in getattr(row, "children", [])
+            )
+
+        spec = bot_by_key("disboard")
+        assert has_button(build_thanks_card(spec, 42, due, locale="fr", ping_mode="button"))
+        assert not has_button(build_thanks_card(spec, 42, due, locale="fr", ping_mode="auto"))
+        assert not has_button(build_thanks_card(spec, 42, due, locale="fr", ping_mode="never"))
+        # Nobody to arm it for.
+        assert not has_button(build_thanks_card(spec, None, due, locale="fr", ping_mode="button"))

--- a/tests/test_bump_reminder.py
+++ b/tests/test_bump_reminder.py
@@ -22,6 +22,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from bumpreminder.detect import _harvest
 from bumpreminder import (
     BUMP_BOTS,
     MAX_INTERVAL,
@@ -161,6 +162,18 @@ class TestRegistry:
         """A directory with no marker and no private-refusal flag is dead code."""
         assert (spec.refusal_is_ephemeral or spec.success_text
                 or spec.success_media or spec.success_custom_id)
+
+    @pytest.mark.parametrize("spec", BUMP_BOTS, ids=lambda s: s.key)
+    def test_the_blocklist_is_only_skipped_where_it_could_backfire(self, spec):
+        """Dropping the shared cooldown blocklist needs both reasons, not one.
+
+        Private refusals alone are not enough: the flag is an assumption about
+        someone else's product, and the blocklist is the net under it. Only a
+        directory that *also* answers in languages we cannot enumerate has
+        anything to lose by keeping it.
+        """
+        if spec.answers_in_any_language:
+            assert spec.refusal_is_ephemeral, f"{spec.key}: skips the net for free"
 
     def test_lookup_by_app_id(self):
         for spec in BUMP_BOTS:
@@ -342,6 +355,25 @@ class TestCapturedRefusals:
             or (not spec.refusal_is_ephemeral and _matches(_FAILURE_TEXT, text))
         )
         assert vetoed, f"{key}: the refusal is only rejected by omission"
+
+    @pytest.mark.parametrize("key", sorted(REFUSALS), ids=sorted(REFUSALS))
+    def test_no_success_marker_fires_on_a_captured_refusal(self, key):
+        """The sharp one. A success marker present on the refusal is a live bug.
+
+        It survives only as long as some veto happens to fire first — reword the
+        refusal and the detector starts arming reminders off failed bumps. Two
+        markers were caught exactly this way: DiscordL's "Résultat du Bump",
+        which is the message *header* and prints on both, and DiscordTop's
+        "propulsé", because its refusal reads "vient **déjà** d'être propulsé".
+        """
+        spec = bot_by_key(key)
+        text, media, custom_ids = _harvest(message(REFUSALS[key]))
+
+        fired = [r.pattern for r in spec.success_text if r.search(text)]
+        fired += [f"media:{m}" for m in spec.success_media if m in media]
+        fired += [f"custom_id:{m}" for m in spec.success_custom_id
+                  for c in custom_ids if c.startswith(m)]
+        assert not fired, f"{key}: success marker(s) {fired} match its own refusal"
 
     @pytest.mark.parametrize("key", sorted(REFUSALS), ids=sorted(REFUSALS))
     def test_the_refusal_carries_the_same_command_as_the_success(self, key):

--- a/tests/test_persistent_views.py
+++ b/tests/test_persistent_views.py
@@ -131,6 +131,7 @@ def _dynamic_item_cases():
     from utils.notification_views import (
         NotifReviewClaimButton, NotifReviewPreviewButton, NotifReviewDecisionButton,
     )
+    from utils.bump_views import BumpOptInButton
     from modules.configs.tickets_panel_config import (
         TicketPanelButton, TicketPanelSelect, TicketPanelChannelSelect,
     )
@@ -183,6 +184,9 @@ def _dynamic_item_cases():
         (NotifReviewClaimButton, (_U,)),
         (NotifReviewPreviewButton, (_U,)),
         (NotifReviewDecisionButton, ("accept", _U)),
+        # Bump reminder — the "ping me next time" button on a thank-you card,
+        # scoped to the person who ran the bump.
+        (BumpOptInButton, ("disboard", _SNOWFLAKE)),
     ]
 
 

--- a/utils/bump_views.py
+++ b/utils/bump_views.py
@@ -1,0 +1,257 @@
+"""Cards for the Bump Reminder module.
+
+Two messages, and the whole design of the feature is in the difference between
+them.
+
+**The thank-you** goes out the instant a bump lands. It names the person, says
+when the next window opens, and — depending on the server's setting — offers
+them a button to be pinged when it does. It renders their mention but does not
+notify them: they typed the command one second ago and are looking straight at
+the channel; buzzing them for their own action would be noise.
+
+**The reminder** goes out when that window opens. Here the mention *is* the
+message, so it sits in a text display at the top level of the view, above and
+outside the container — visible, permanent, and actually notifying. Which roles
+and which people it may notify is stated explicitly at send time rather than
+left to Discord's defaults, so a stale config can never ping something the
+server did not choose.
+
+See docs/BUMP_REMINDER.md.
+"""
+
+import logging
+import re
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import discord
+from discord import ui
+
+from bumpreminder import BumpBot, bot_by_key, format_interval
+from cogs.error_handler import BaseView
+from config import COLORS
+from utils import i18n
+from utils.emojis import ROCKET_LAUNCH, TIME, TOGGLE_ON
+from utils.i18n import t
+
+logger = logging.getLogger('moddy.bump_views')
+
+ACCENT = COLORS["primary"]
+
+# Nothing on the thank-you card notifies anyone: the bumper is reading the
+# channel they just typed in, and the roles are for the reminder an hour later.
+NO_MENTIONS = discord.AllowedMentions.none()
+
+_CID_PREFIX = "moddy:bump:optin"
+
+# A reminder that fires well after it was due — the bot was down, or a sweep was
+# delayed — says so, rather than silently pretending it is on time.
+LATE_AFTER = 300
+
+
+def _guarded(callback):
+    """Route a dynamic-item callback error to the central handler (no live view)."""
+    async def wrapper(self, interaction: discord.Interaction):
+        try:
+            await callback(self, interaction)
+        except Exception as e:  # noqa: BLE001
+            from cogs.error_handler import report_component_error
+            await report_component_error(interaction, e, self.__class__.__name__)
+    return wrapper
+
+
+async def card_locale(interaction: discord.Interaction) -> str:
+    """Language of a **public** bump card — the server's, not the clicker's."""
+    from utils.guild_language import guild_locale
+
+    if interaction.guild is None:
+        return i18n.get_user_locale(interaction)
+    return await guild_locale(interaction.client, interaction.guild)
+
+
+# --------------------------------------------------------------------------- #
+# The "ping me next time" button
+# --------------------------------------------------------------------------- #
+class BumpOptInButton(
+    ui.DynamicItem[ui.Button],
+    template=rf"{_CID_PREFIX}:(?P<bot>[a-z]{{1,16}}):(?P<user>\d{{1,20}})",
+):
+    """Lets the person who just bumped ask to be mentioned by the reminder.
+
+    Only on the thank-you card, only when the server picked the ``button`` ping
+    mode, and only for the bumper: their id is baked into the custom_id, so
+    authorisation is re-read from the click itself and a card left in a channel
+    for a month is exactly as safe as a fresh one.
+
+    It toggles. Somebody who armed it by reflex and changed their mind clicks
+    again — a reminder nobody asked for is the thing this module exists to
+    avoid, and that includes its own ping.
+
+    ``\\d{1,20}`` rather than ``\\d{17,20}``: the bare shell the persistence
+    tests build uses zeros, and it has to match its own template.
+    """
+
+    def __init__(self, bot_key: str, user_id: int, *,
+                 locale: str = "en-US", armed: bool = False):
+        super().__init__(
+            ui.Button(
+                label=t(
+                    "modules.bump_reminder.card.optin_armed" if armed
+                    else "modules.bump_reminder.card.optin",
+                    locale=locale,
+                )[:80],
+                style=discord.ButtonStyle.secondary,
+                emoji=discord.PartialEmoji.from_str(TOGGLE_ON if armed else TIME),
+                custom_id=f"{_CID_PREFIX}:{bot_key}:{user_id}",
+            )
+        )
+        self.bot_key = bot_key
+        self.user_id = user_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction: discord.Interaction,
+                             item: ui.Button, match: re.Match):
+        return cls(match["bot"], int(match["user"]))
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        locale = i18n.get_user_locale(interaction)
+
+        if interaction.user.id != self.user_id:
+            from utils.components_v2 import create_error_message
+            await interaction.response.send_message(
+                view=create_error_message(
+                    t("errors.not_your_message.title", locale=locale),
+                    t("errors.not_your_message.description", locale=locale),
+                ),
+                ephemeral=True,
+            )
+            return
+
+        bot = interaction.client
+        # Read the live row rather than the card: the card may be describing a
+        # bump that a later one has already replaced.
+        states = await bot.db.get_guild_bump_states(interaction.guild_id)
+        state = states.get(self.bot_key)
+        if not state or state.get("bumper_id") != self.user_id or state.get("sent"):
+            await interaction.response.send_message(
+                t("modules.bump_reminder.card.optin_expired", locale=locale),
+                ephemeral=True,
+            )
+            return
+
+        armed = not bool(state.get("opt_in"))
+        await bot.db.set_bump_opt_in(interaction.guild_id, self.bot_key,
+                                     self.user_id, armed)
+
+        public_locale = await card_locale(interaction)
+        spec = bot_by_key(self.bot_key)
+        view = build_thanks_card(
+            spec, self.user_id, state["due_at"],
+            locale=public_locale, ping_mode="button", armed=armed,
+        )
+        await interaction.response.edit_message(view=view, allowed_mentions=NO_MENTIONS)
+
+
+class BumpReminderPersistence(BaseView):
+    """Marker view: registers the opt-in button's dynamic item at startup."""
+
+    __persistent__ = True
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        # Auth model: the bumper's id is in the custom_id and re-checked on
+        # every click, so no guild or owner context needs storing anywhere.
+        bot.add_dynamic_items(BumpOptInButton)
+
+
+# --------------------------------------------------------------------------- #
+# Cards
+# --------------------------------------------------------------------------- #
+def build_thanks_card(spec: BumpBot, bumper_id: Optional[int], due_at,
+                      *, locale: str, ping_mode: str,
+                      armed: bool = False) -> ui.LayoutView:
+    """The card posted right after a successful bump."""
+    view = ui.LayoutView(timeout=None)
+    container = ui.Container(accent_colour=discord.Colour(ACCENT))
+
+    if bumper_id:
+        heading = t("modules.bump_reminder.card.thanks_title",
+                    locale=locale, user=f"<@{bumper_id}>")
+    else:
+        heading = t("modules.bump_reminder.card.thanks_title_anonymous", locale=locale)
+    container.add_item(ui.TextDisplay(f"### {ROCKET_LAUNCH} {heading}"))
+
+    container.add_item(ui.TextDisplay(
+        t("modules.bump_reminder.card.thanks_body",
+          locale=locale, emoji=spec.emoji, name=spec.name,
+          timestamp=f"<t:{int(due_at.timestamp())}:R>")
+    ))
+
+    if ping_mode == "button" and bumper_id:
+        row = ui.ActionRow()
+        row.add_item(BumpOptInButton(spec.key, bumper_id, locale=locale, armed=armed))
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+        container.add_item(row)
+
+    view.add_item(container)
+    return view
+
+
+def build_reminder_card(spec: BumpBot, *, locale: str,
+                        role_ids: Sequence[int], bumper_id: Optional[int],
+                        mention_bumper: bool, elapsed: Optional[int],
+                        late_by: int = 0) -> ui.LayoutView:
+    """The card posted when the command becomes available again.
+
+    The mentions ride in a text display added to the **view**, above the
+    container — the one place a Components V2 message can carry a real ping,
+    since ``content=`` is rejected outright alongside a ``LayoutView``. Which of
+    them actually notifies is decided by the ``allowed_mentions`` the caller
+    passes, never by what this renders.
+    """
+    view = ui.LayoutView(timeout=None)
+
+    mentions = [f"<@&{role_id}>" for role_id in role_ids]
+    if mention_bumper and bumper_id:
+        mentions.append(f"<@{bumper_id}>")
+    if mentions:
+        view.add_item(ui.TextDisplay(" ".join(mentions)))
+
+    container = ui.Container(accent_colour=discord.Colour(ACCENT))
+    container.add_item(ui.TextDisplay(
+        f"### {ROCKET_LAUNCH} {t('modules.bump_reminder.card.reminder_title', locale=locale)}"
+    ))
+    container.add_item(ui.TextDisplay(
+        t("modules.bump_reminder.card.reminder_body",
+          locale=locale, emoji=spec.emoji, name=spec.name, command=spec.command)
+    ))
+
+    footnotes = []
+    if bumper_id and elapsed is not None:
+        footnotes.append(t("modules.bump_reminder.card.reminder_last",
+                           locale=locale, user=f"<@{bumper_id}>",
+                           duration=format_interval(elapsed)))
+    if late_by >= LATE_AFTER:
+        footnotes.append(t("modules.bump_reminder.card.reminder_late", locale=locale))
+    if footnotes:
+        container.add_item(ui.TextDisplay("\n".join(f"-# {line}" for line in footnotes)))
+
+    view.add_item(container)
+    return view
+
+
+def reminder_mentions(guild: discord.Guild, role_ids: Sequence[int],
+                      bumper: Optional[discord.Member],
+                      mention_bumper: bool) -> Tuple[List[discord.Role], discord.AllowedMentions]:
+    """Resolve who the reminder is allowed to notify.
+
+    Returns the surviving roles alongside an ``AllowedMentions`` listing those
+    exact objects. Never ``roles=True``: a role deleted since the config was
+    written simply drops out, and the bumper is only ever in the list when the
+    server's ping mode put them there — which is what keeps the "last bumped by"
+    line in the card informative without it becoming a ping of its own.
+    """
+    roles = [role for role in (guild.get_role(rid) for rid in role_ids) if role is not None]
+    users = [bumper] if (mention_bumper and bumper is not None) else []
+    allowed = discord.AllowedMentions(everyone=False, roles=roles, users=users)
+    return roles, allowed

--- a/utils/emojis.py
+++ b/utils/emojis.py
@@ -103,6 +103,7 @@ HAND = "<:hand:1521517865348632706>"       # appeal "claim" button
 LINK = "<:link:1521517863607734385>"       # appeal "invite" button
 PENDING = "<:pending:1521282587962900611>"  # appeal "pending" status
 ROCKET = "<a:Rocket:1535783839870353499>"  # bot customization bio attribution
+ROCKET_LAUNCH = "<:rocket_launch:1545028494298447873>"  # Bump Reminder module
 ALTGUARD = "<a:DisguisedFace:1539405255576657981>"  # AltGuard verification panel message
 CLAIM = "<:claim:1541239118888181770>"      # take a ticket in charge
 THREADS = "<:threads:1541216661699436675>"  # private staff thread
@@ -237,6 +238,7 @@ EMOJIS = {
     "dev": DEV,
     "blacklist": BLACKLIST,
     "time": TIME,
+    "rocket_launch": ROCKET_LAUNCH,
     "snowflake": SNOWFLAKE,
     "web": WEB,
     "history": HISTORY,

--- a/utils/persistent_views.py
+++ b/utils/persistent_views.py
@@ -48,6 +48,10 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
     from modules.configs.welcome_dm_config import (
         WelcomeDmConfigView, ManageWelcomeDmView,
     )
+    from modules.configs.bump_reminder_config import (
+        BumpReminderConfigView, ManageBumpReminderView,
+    )
+    from utils.bump_views import BumpReminderPersistence
     from cogs.config import ConfigMainView
     from modules.configs.server_settings_config import ServerSettingsConfigView
     from modules.configs.adaptive_slowmode_config import AdaptiveSlowmodeConfigView
@@ -119,6 +123,14 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
         ManageWelcomeMessageView,
         WelcomeDmConfigView,
         ManageWelcomeDmView,
+        # Group 10b — /config bump reminder panel (guild permission auth), plus
+        # the marker registering the thank-you card's opt-in button. That button
+        # is a DynamicItem carrying the bumper's user id, re-checked on every
+        # click, so a card left in a channel for a month stays exactly as safe
+        # as a fresh one.
+        BumpReminderConfigView,
+        ManageBumpReminderView,
+        BumpReminderPersistence,
         # Group 11 — /config router (guild permission auth) and the
         # server-wide settings screen it opens (language of the server —
         # see utils/guild_language.py)


### PR DESCRIPTION
## Summary

Adds a complete **Bump Reminder** module that detects successful bumps on seven server directories (DISBOARD, DiscordL, French.gg, etc.), thanks whoever ran the command, and calls the channel back when the bump window reopens. The module includes detection logic, database persistence, Discord UI components, configuration panel, and comprehensive i18n support.

## Key Changes

### Core Detection (`bumpreminder/`)
- **`registry.py`** — Registry of seven supported directories with their markers (success text patterns, media URLs, button IDs) and cooldown intervals
- **`detect.py`** — Pure Python detection funnel that distinguishes successful bumps from cooldown replies by checking for success markers while rejecting cooldown wording; returns `BumpHit` with bumper ID and next-due timestamp

### Database & Persistence
- **`db/repositories/bump.py`** — `BumpReminderRepository` managing live reminder state (one row per guild + directory); upsert on new bump, sweep for due reminders
- **`bump_reminders` table** — Stores pending reminders with `(guild_id, bot_key)` as key, ensuring one cooldown per server regardless of channel count

### Module & Cog Integration
- **`modules/bump_reminder.py`** — `ModuleBase` with config schema, validation, and normalization; supports free (1 reminder/directory) and premium (3/directory) tiers
- **`cogs/bump_reminder.py`** — Dedicated `on_message` listener (not in shared `module_events.py` since it reads bot-authored messages) and 30-second sweeper loop; sends thank-you cards and reminder notifications

### UI & Views
- **`utils/bump_views.py`** — Two cards: thank-you (instant, names bumper, offers opt-in button) and reminder (when window reopens, pings configured roles/people); persistent opt-in button with stable custom_id
- **`modules/configs/bump_reminder_config.py`** — Full `/config` panel with Modal V2 for creating/editing reminders; directory selection pre-fills delay field with that directory's cooldown

### Testing & Documentation
- **`tests/test_bump_reminder.py`** — 141 tests replaying real captured payloads from all seven directories; validates detection accuracy, failure rejection, and cross-talk prevention
- **`tests/data/bump_payloads.json`** — Real message payloads from each directory (Components V2 format)
- **`docs/BUMP_REMINDER.md`** — Complete feature documentation covering detection logic, supported directories, configuration, and design decisions

### Localization
- Added `modules.bump_reminder.*` keys (68 per locale) across all five supported languages (French, English, Spanish, Portuguese, German)

## Notable Implementation Details

- **Detection is asymmetric by design:** Failure markers veto (never compete with success markers), so a message carrying both is rejected rather than guessed on. A false reminder is worse than a missed one.
- **No timers in memory:** Reminders live as database rows with `sent = FALSE` and `due_at` in the future. A restart loses nothing; the sweeper picks up whatever came due while offline.
- **One row per directory:** Cooldown belongs to the server, not the channel. A premium server with three channels pointing at DISBOARD owns one row; the sweeper fans it out to all three channels.
- **Modal V2 design:** The form has exactly five components (directory, channel, roles, ping mode, interval) because Modal V2 has a five-component ceiling. Nothing is a wizard that could be abandoned half-done.
- **Persistent views:** Config panel uses stable namespaced `custom_id`s with no timeouts; every callback re-derives context from `interaction` + database rather than `self`.

## Testing

Full test suite passes: **1683 passed** (includes 141 new bump reminder tests).

https://claude.ai/code/session_01XaKuddmbcYAUjcdpY5npVr