### PR TITLE
Fix the bump reminder modal crashing on submit

### DIFF
--- a/docs/MODALS_V2.md
+++ b/docs/MODALS_V2.md
@@ -254,6 +254,47 @@ self.checkbox_group.component.values  # list[str]
 
 Sélection unique exclusive via boutons radio. Valide dans un `Label`. *New in 2.7*.
 
+```python
+discord.ui.RadioGroup(
+    options=[
+        discord.RadioGroupOption(label="Toujours", value="auto", default=True),
+        discord.RadioGroupOption(label="Jamais", value="never"),
+    ],
+    required=True,
+)
+```
+
+| Paramètre | Limite |
+|---|---|
+| options | 2 à 10 |
+| `required` | défaut `True` |
+
+Chaque `RadioGroupOption` : `label` / `value` / `description`, chacun max 100
+caractères, plus `default=True` pour pré-sélectionner l'option à l'ouverture.
+
+⚠️ `RadioGroupOption` vit sur `discord`, **pas** sur `discord.ui` — contrairement
+à `ui.RadioGroup` lui-même.
+
+### Valeurs
+
+```python
+self.radio_group.value  # Optional[str] — le `value` de l'option choisie
+```
+
+⚠️ **`RadioGroup` est un choix unique : il expose `.value` (un `str` ou `None`),
+PAS `.values`.** C'est la différence avec `CheckboxGroup`, `Select` et les
+selects natifs, qui exposent tous une liste `.values`. Confondre les deux lève
+`AttributeError` **à la soumission** et nulle part avant : construire le modal,
+le sérialiser et l'afficher réussissent tous. Le bug est donc invisible en test
+tant que personne ne simule un `on_submit` — voir
+`tests/test_bump_reminder.py::TestComponents::test_on_submit_reads_each_component_the_way_its_class_allows`
+pour la garde qui l'attrape statiquement.
+
+| Composant | Accès |
+|---|---|
+| `TextInput`, `Checkbox`, **`RadioGroup`** | `.value` |
+| `Select`, `UserSelect`, `RoleSelect`, `ChannelSelect`, `MentionableSelect`, `CheckboxGroup`, `FileUpload` | `.values` |
+
 ---
 
 ## Checkbox obligatoire (technique officielle)

--- a/docs/sessions/2026-09-03_bump-reminder-module.md
+++ b/docs/sessions/2026-09-03_bump-reminder-module.md
@@ -144,6 +144,33 @@ becomes an acceptance. `tests/data/bump_refusals.json` now holds captured
 refusals, and `TestCapturedRefusals` asserts each one trips an **explicit** veto.
 That test fails against the old guessed markers, which is how it earns its place.
 
+## Fixed after the first deploy
+
+**`AttributeError: 'RadioGroup' object has no attribute 'values'`** on submitting
+the config modal. `ui.RadioGroup` is single-choice and exposes `.value`; I wrote
+`.values[0]` by analogy with `CheckboxGroup`. Two things let it ship:
+
+- `docs/MODALS_V2.md` documented `RadioGroup` in three lines and **never said
+  how to read it**, while every other component there has a "Valeurs" section.
+  I was also the repo's first `RadioGroup` user, so there was no precedent to
+  copy. That doc now carries the accessor, the option parameters, and a table of
+  which components are `.value` versus `.values`.
+- **The tests built the modal but never submitted it.** Construction,
+  serialisation and rendering all succeed with a wrong accessor — the failure
+  only exists at submit time. There is now a static guard that reads the
+  accessors `on_submit` actually uses and checks each against its component's
+  class. It fails on the shipped line, naming it:
+  `RadioGroup.values does not exist (self.ping_group.values)`.
+
+The other four accessors in the same `on_submit` were audited against the real
+discord.py 2.7.1 API and are correct.
+
+**Add moved from a dropdown to a button** (Jules): on a `/config` panel the
+dropdown edits, the button creates. My dropdown existed to pre-fill the delay
+field with the chosen directory's cooldown, which a static modal cannot do on
+its own — so blank now means "that directory's own cooldown" instead, which is
+the better default anyway and one less thing for the reader to look up.
+
 ## Bugs caught during the work
 
 - `_by_channel` keyed on the channel alone would have silently dropped a second

--- a/locales/de.json
+++ b/locales/de.json
@@ -1489,7 +1489,6 @@
         "title": "Bump-Erinnerung",
         "description": "Ein verpasstes Bump-Fenster ist verlorene Sichtbarkeit. Moddy erkennt einen **erfolgreichen** Bump im Kanal deiner Wahl, bedankt sich bei der Person und meldet sich im Kanal, sobald der Befehl wieder verfügbar ist.",
         "limit": "{max} Erinnerung(en) pro Verzeichnis.",
-        "add_placeholder": "Erinnerung für ein Verzeichnis hinzufügen",
         "manage_placeholder": "Bestehende Erinnerung verwalten",
         "all_configured": "Du hast dein Kontingent bei jedem unterstützten Verzeichnis erreicht.",
         "list": {
@@ -1517,7 +1516,8 @@
         "ping_label": "Die letzte Person erwähnen, die gebumpt hat",
         "ping_description": "Was Moddy mit der Person macht, die den Befehl ausgeführt hat.",
         "interval_label": "Wartezeit bis zur Erinnerung",
-        "interval_description": "Zum Beispiel 2h, 2h30 oder 90m. Zwischen 5 Minuten und 24 Stunden."
+        "interval_description": "Zum Beispiel 2h, 2h30 oder 90m. Leer lassen für die Wartezeit des Verzeichnisses.",
+        "interval_placeholder": "Leer lassen für die des Verzeichnisses"
       },
       "ping": {
         "auto": "Immer",
@@ -1568,6 +1568,9 @@
         "no_send_permission": "Moddy kann in {channel} nicht posten.",
         "too_many_roles": "Höchstens {max} Rollen.",
         "invalid_interval": "Ungültige Wartezeit. Nutze zum Beispiel `2h`, `2h30` oder `90m`, zwischen 5 Minuten und 24 Stunden."
+      },
+      "buttons": {
+        "add": "Hinzufügen"
       }
     },
     "automod_ai": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1489,7 +1489,6 @@
         "title": "Bump Reminder",
         "description": "A missed bump window is visibility lost. Moddy recognises a **successful** bump in the channel you point it at, thanks whoever ran it, and calls the channel back the moment the command is available again.",
         "limit": "{max} reminder(s) per directory.",
-        "add_placeholder": "Add a reminder for a directory",
         "manage_placeholder": "Manage an existing reminder",
         "all_configured": "You have reached your quota on every supported directory.",
         "list": {
@@ -1517,7 +1516,8 @@
         "ping_label": "Mention the last person who bumped",
         "ping_description": "What Moddy does about whoever ran the command.",
         "interval_label": "Delay before the reminder",
-        "interval_description": "For example 2h, 2h30 or 90m. Between 5 minutes and 24 hours."
+        "interval_description": "For example 2h, 2h30 or 90m. Leave empty for the chosen directory's own cooldown.",
+        "interval_placeholder": "Leave empty for the directory's own"
       },
       "ping": {
         "auto": "Always",
@@ -1568,6 +1568,9 @@
         "no_send_permission": "Moddy cannot post in {channel}.",
         "too_many_roles": "{max} roles at most.",
         "invalid_interval": "Invalid delay. Use for example `2h`, `2h30` or `90m`, between 5 minutes and 24 hours."
+      },
+      "buttons": {
+        "add": "Add"
       }
     },
     "automod_ai": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1489,7 +1489,6 @@
         "title": "Recordatorio de bump",
         "description": "Una ventana de bump perdida es visibilidad perdida. Moddy reconoce un bump **exitoso** en el canal que elijas, agradece a quien lo hizo y avisa al canal en cuanto el comando vuelve a estar disponible.",
         "limit": "{max} recordatorio(s) por directorio.",
-        "add_placeholder": "Añadir un recordatorio para un directorio",
         "manage_placeholder": "Gestionar un recordatorio existente",
         "all_configured": "Has alcanzado tu cuota en todos los directorios compatibles.",
         "list": {
@@ -1517,7 +1516,8 @@
         "ping_label": "Mencionar a la última persona que hizo bump",
         "ping_description": "Qué hace Moddy con quien ejecutó el comando.",
         "interval_label": "Retraso antes del recordatorio",
-        "interval_description": "Por ejemplo 2h, 2h30 o 90m. Entre 5 minutos y 24 horas."
+        "interval_description": "Por ejemplo 2h, 2h30 o 90m. Déjalo vacío para el propio del directorio elegido.",
+        "interval_placeholder": "Déjalo vacío para el del directorio"
       },
       "ping": {
         "auto": "Siempre",
@@ -1568,6 +1568,9 @@
         "no_send_permission": "Moddy no puede publicar en {channel}.",
         "too_many_roles": "{max} roles como máximo.",
         "invalid_interval": "Retraso no válido. Usa por ejemplo `2h`, `2h30` o `90m`, entre 5 minutos y 24 horas."
+      },
+      "buttons": {
+        "add": "Añadir"
       }
     },
     "automod_ai": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1488,7 +1488,6 @@
         "title": "Rappel de bump",
         "description": "Une fenêtre de bump ratée, c'est de la visibilité perdue. Moddy reconnaît un bump **réussi** dans le salon que vous désignez, remercie la personne, et rappelle le salon dès que la commande redevient disponible.",
         "limit": "{max} rappel(s) par site de référencement.",
-        "add_placeholder": "Ajouter un rappel pour un site",
         "manage_placeholder": "Gérer un rappel existant",
         "all_configured": "Vous avez atteint votre quota sur chaque site pris en charge.",
         "list": {
@@ -1516,7 +1515,8 @@
         "ping_label": "Mentionner la dernière personne à avoir bumpé",
         "ping_description": "Ce que Moddy fait de la personne qui a lancé la commande.",
         "interval_label": "Délai avant le rappel",
-        "interval_description": "Par exemple 2h, 2h30 ou 90m. Entre 5 minutes et 24 heures."
+        "interval_description": "Par exemple 2h, 2h30 ou 90m. Laissez vide pour le délai propre au site choisi.",
+        "interval_placeholder": "Laisse vide pour le délai du site"
       },
       "ping": {
         "auto": "Toujours",
@@ -1567,6 +1567,9 @@
         "no_send_permission": "Moddy ne peut pas écrire dans {channel}.",
         "too_many_roles": "{max} rôles au maximum.",
         "invalid_interval": "Délai invalide. Utilisez par exemple `2h`, `2h30` ou `90m`, entre 5 minutes et 24 heures."
+      },
+      "buttons": {
+        "add": "Ajouter"
       }
     },
     "automod_ai": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1489,7 +1489,6 @@
         "title": "Lembrete de bump",
         "description": "Uma janela de bump perdida é visibilidade perdida. O Moddy reconhece um bump **bem-sucedido** no canal que você indicar, agradece quem o executou e chama o canal de volta assim que o comando fica disponível de novo.",
         "limit": "{max} lembrete(s) por diretório.",
-        "add_placeholder": "Adicionar um lembrete para um diretório",
         "manage_placeholder": "Gerenciar um lembrete existente",
         "all_configured": "Você atingiu sua cota em todos os diretórios compatíveis.",
         "list": {
@@ -1517,7 +1516,8 @@
         "ping_label": "Mencionar a última pessoa que deu bump",
         "ping_description": "O que o Moddy faz com quem executou o comando.",
         "interval_label": "Intervalo antes do lembrete",
-        "interval_description": "Por exemplo 2h, 2h30 ou 90m. Entre 5 minutos e 24 horas."
+        "interval_description": "Por exemplo 2h, 2h30 ou 90m. Deixe vazio para o intervalo do próprio diretório.",
+        "interval_placeholder": "Deixe vazio para o do diretório"
       },
       "ping": {
         "auto": "Sempre",
@@ -1568,6 +1568,9 @@
         "no_send_permission": "O Moddy não pode publicar em {channel}.",
         "too_many_roles": "No máximo {max} cargos.",
         "invalid_interval": "Intervalo inválido. Use por exemplo `2h`, `2h30` ou `90m`, entre 5 minutos e 24 horas."
+      },
+      "buttons": {
+        "add": "Adicionar"
       }
     },
     "automod_ai": {

--- a/modules/configs/bump_reminder_config.py
+++ b/modules/configs/bump_reminder_config.py
@@ -37,6 +37,7 @@ from bumpreminder import BUMP_BOTS, bot_by_key, format_interval, parse_interval
 from cogs.error_handler import BaseModal, BaseView
 from modules.bump_reminder import (
     CHANNEL_TYPES,
+    DEFAULT_PING_MODE,
     MAX_ROLE_MENTIONS,
     PING_MODES,
     count_by_bot,
@@ -123,13 +124,12 @@ class BumpReminderModal(BaseModal):
     directory itself advertises it.
     """
 
-    def __init__(self, locale: str, *, bot_key: str, callback_func,
+    def __init__(self, locale: str, *, bot_key: Optional[str] = None, callback_func=None,
                  channel_id: Optional[int] = None,
                  role_ids: Optional[List[int]] = None,
                  ping_mode: str = "button",
                  interval: Optional[int] = None,
                  available: Optional[List[str]] = None):
-        spec = bot_by_key(bot_key)
         super().__init__(
             title=t('modules.bump_reminder.modal.title', locale=locale)[:45],
             timeout=None,
@@ -141,7 +141,7 @@ class BumpReminderModal(BaseModal):
         # 1 — the directory. Only the ones with room left are offered, plus
         #     whichever one is already selected (editing must never be blocked
         #     by the quota an entry is itself part of).
-        offered = list(dict.fromkeys([bot_key] + list(available or [])))
+        offered = list(dict.fromkeys(([bot_key] if bot_key else []) + list(available or [])))
         self.bot_select = ui.Select(
             options=[
                 discord.SelectOption(
@@ -210,12 +210,17 @@ class BumpReminderModal(BaseModal):
             component=self.ping_group,
         ))
 
-        # 5 — the delay, pre-filled with what this directory actually enforces.
+        # 5 — the delay. Pre-filled when editing, left blank when creating:
+        #     a Discord modal is static, so it cannot fill this in from the
+        #     directory picked in the select above it. Blank therefore means
+        #     "whatever that directory enforces", which is both the right
+        #     default and one less thing to look up.
         self.interval_input = ui.TextInput(
             style=discord.TextStyle.short,
-            default=format_interval(interval if interval is not None
-                                    else spec.default_interval),
-            max_length=8, required=True, custom_id=_CID_MODAL_INTERVAL,
+            default=format_interval(interval) if interval is not None else None,
+            placeholder=t('modules.bump_reminder.modal.interval_placeholder',
+                          locale=locale)[:100],
+            max_length=8, required=False, custom_id=_CID_MODAL_INTERVAL,
         )
         self.add_item(ui.Label(
             text=t('modules.bump_reminder.modal.interval_label', locale=locale),
@@ -230,7 +235,9 @@ class BumpReminderModal(BaseModal):
             bot_key=self.bot_select.values[0],
             channel_id=channels[0].id if channels else None,
             role_ids=[role.id for role in self.role_select.values],
-            ping_mode=self.ping_group.values[0],
+            # RadioGroup is single-choice: `.value`, not the `.values` list
+            # every select and CheckboxGroup exposes. See docs/MODALS_V2.md.
+            ping_mode=self.ping_group.value or DEFAULT_PING_MODE,
             raw_interval=self.interval_input.value,
         )
 
@@ -313,36 +320,15 @@ class BumpReminderConfigView(BaseView):
 
         container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
 
-        # Add: pick the directory here so the modal opens fully pre-filled.
         available = self._available_bots()
-        add_row = ui.ActionRow()
-        add_select = ui.Select(
-            placeholder=t('modules.bump_reminder.config.add_placeholder', locale=self.locale),
-            options=[
-                discord.SelectOption(
-                    label=spec.name,
-                    value=spec.key,
-                    description=t('modules.bump_reminder.modal.bot_option',
-                                  locale=self.locale,
-                                  interval=format_interval(spec.default_interval),
-                                  command=spec.command_hint)[:100],
-                    emoji=discord.PartialEmoji.from_str(spec.emoji),
-                )
-                for spec in BUMP_BOTS if spec.key in available
-            ] or [discord.SelectOption(label="—", value="none")],
-            min_values=1, max_values=1, custom_id=_CID_MAIN_ADD,
-            disabled=not available,
-        )
-        add_select.callback = self.on_add_select
-        add_row.add_item(add_select)
-        container.add_item(add_row)
-
         if not available:
             container.add_item(ui.TextDisplay(
                 f"-# {t('modules.bump_reminder.config.all_configured', locale=self.locale)}"
             ))
 
-        # Manage: always registered so a restarted shell can still dispatch it.
+        # Manage: the dropdown edits an existing reminder, never creates one —
+        # creating is the Add button below, as on every other /config panel.
+        # Always registered so a restarted shell can still dispatch it.
         manage_row = ui.ActionRow()
         manage_select = ui.Select(
             placeholder=t('modules.bump_reminder.config.manage_placeholder', locale=self.locale),
@@ -372,6 +358,15 @@ class BumpReminderConfigView(BaseView):
         )
         back_btn.callback = self.on_back
         button_row.add_item(back_btn)
+
+        add_btn = ui.Button(
+            emoji=discord.PartialEmoji.from_str(ADD),
+            label=t('modules.bump_reminder.buttons.add', locale=self.locale),
+            style=discord.ButtonStyle.success, custom_id=_CID_MAIN_ADD,
+            disabled=not available,
+        )
+        add_btn.callback = self.on_add
+        button_row.add_item(add_btn)
         self.add_item(button_row)
 
     def _entry_channel_name(self, entry: Dict[str, Any]) -> str:
@@ -414,31 +409,25 @@ class BumpReminderConfigView(BaseView):
                  timestamp=f"<t:{int(state['due_at'].timestamp())}:R>")
 
     # -- callbacks -------------------------------------------------------- #
-    async def on_add_select(self, interaction: discord.Interaction):
+    async def on_add(self, interaction: discord.Interaction):
         if not await check_guild_perms(interaction):
             return
         bot = interaction.client
         locale = i18n.get_user_locale(interaction)
-        bot_key = interaction.data['values'][0]
 
         # Re-check against live config: the panel may have been open a while.
         reminders = await _load(bot, interaction.guild_id)
         cap = await reminders_per_bot(bot, interaction.guild_id)
         counts = count_by_bot(reminders)
-        spec = bot_by_key(bot_key)
-        if spec is None or counts.get(bot_key, 0) >= cap:
+        available = [s.key for s in BUMP_BOTS if counts.get(s.key, 0) < cap]
+        if not available:
             await interaction.response.send_message(
-                t('modules.bump_reminder.errors.quota', locale=locale,
-                  name=spec.name if spec else bot_key, max=cap),
-                ephemeral=True,
-            )
+                t('modules.bump_reminder.config.all_configured', locale=locale),
+                ephemeral=True)
             return
 
-        available = [s.key for s in BUMP_BOTS if counts.get(s.key, 0) < cap]
         modal = BumpReminderModal(
-            locale, bot_key=bot_key, callback_func=_create_reminder,
-            available=available,
-        )
+            locale, callback_func=_create_reminder, available=available)
         modal.bot = bot
         await interaction.response.send_modal(modal)
 
@@ -706,6 +695,19 @@ class ManageBumpReminderView(BaseView):
 # =========================================================================== #
 # Modal submit handlers
 # =========================================================================== #
+def _resolve_interval(raw: Optional[str], bot_key: str) -> Optional[int]:
+    """Read the delay field, treating blank as "this directory's own cooldown".
+
+    The field cannot be pre-filled when creating — a Discord modal is static and
+    cannot react to the directory picked in its own select — so blank has to
+    mean something useful rather than being rejected.
+    """
+    if raw is None or not raw.strip():
+        spec = bot_by_key(bot_key)
+        return spec.default_interval if spec else None
+    return parse_interval(raw)
+
+
 async def _write(interaction: discord.Interaction, reminders: List[Dict[str, Any]],
                  success_key: str) -> None:
     bot = interaction.client
@@ -726,7 +728,7 @@ async def _create_reminder(interaction: discord.Interaction, *, bot_key: str,
     locale = i18n.get_user_locale(interaction)
     await interaction.response.defer()
 
-    interval = parse_interval(raw_interval)
+    interval = _resolve_interval(raw_interval, bot_key)
     if interval is None:
         await interaction.followup.send(
             t('modules.bump_reminder.errors.invalid_interval', locale=locale), ephemeral=True)
@@ -753,7 +755,7 @@ def _edit_reminder(entry_id: str):
         locale = i18n.get_user_locale(interaction)
         await interaction.response.defer()
 
-        interval = parse_interval(raw_interval)
+        interval = _resolve_interval(raw_interval, bot_key)
         if interval is None:
             await interaction.followup.send(
                 t('modules.bump_reminder.errors.invalid_interval', locale=locale),

--- a/tests/test_bump_reminder.py
+++ b/tests/test_bump_reminder.py
@@ -14,6 +14,7 @@ Three properties matter more than the rest, and each has its own class:
 - one directory's markers never fire on another's message (`TestCrossTalk`)
 """
 
+import inspect
 import json
 import pathlib
 import re
@@ -690,6 +691,45 @@ class TestComponents:
 
     def test_the_modal_fits_the_five_component_ceiling(self):
         assert len(self._modal().children) == 5
+
+    def test_on_submit_reads_each_component_the_way_its_class_allows(self):
+        """A wrong accessor here is invisible until somebody submits the modal.
+
+        ``RadioGroup`` is single-choice and exposes ``.value``; the selects and
+        ``CheckboxGroup`` are multi and expose ``.values``. Mixing them up
+        raises AttributeError at submit time and nowhere earlier — building the
+        modal, serialising it and rendering it all succeed. It shipped once.
+        """
+        modal = self._modal()
+        source = inspect.getsource(type(modal).on_submit)
+        accesses = re.findall(r"self\.(\w+)\.(value|values)\b", source)
+        assert accesses, "on_submit no longer reads its components — update this test"
+        for attribute, accessor in accesses:
+            component = getattr(modal, attribute)
+            assert hasattr(type(component), accessor), (
+                f"{type(component).__name__}.{accessor} does not exist "
+                f"(self.{attribute}.{accessor})")
+
+    def test_radiogroup_is_single_choice(self):
+        """The API fact behind the bug above, stated where a reader will see it."""
+        import discord
+        assert hasattr(discord.ui.RadioGroup, "value")
+        assert not hasattr(discord.ui.RadioGroup, "values")
+
+    def test_a_blank_delay_falls_back_to_the_directory_cooldown(self):
+        """The field cannot be pre-filled when creating, so blank must mean something.
+
+        A Discord modal is static: it cannot react to the directory picked in
+        its own select. Rejecting a blank field would make the common case the
+        awkward one.
+        """
+        from modules.configs.bump_reminder_config import _resolve_interval
+        for key in ("disboard", "dtop", "dsmonitoring"):
+            assert _resolve_interval("", key) == bot_by_key(key).default_interval
+            assert _resolve_interval(None, key) == bot_by_key(key).default_interval
+            assert _resolve_interval("   ", key) == bot_by_key(key).default_interval
+        assert _resolve_interval("90m", "disboard") == 5400
+        assert _resolve_interval("nope", "disboard") is None
 
     def test_the_modal_serialises(self):
         """Catches an illegal component *shape* before Discord 400s on it."""


### PR DESCRIPTION
AttributeError: 'RadioGroup' object has no attribute 'values'

ui.RadioGroup is single-choice and exposes .value; the modal read .values[0] by analogy with CheckboxGroup. The modal opened fine — only submitting it raised, so #385 shipped with the config panel unusable past the last field.

Two things let it through, and both are fixed here rather than just the line.

docs/MODALS_V2.md documented RadioGroup in three lines and never said how to read it, while every other component there has a "Valeurs" section — and this was the repo's first RadioGroup, so there was no precedent to copy either. The doc now carries the accessor, the option parameters, the fact that RadioGroupOption lives on discord rather than discord.ui, and a table of which components are .value versus .values.

And the tests built the modal without ever submitting it. Construction, serialisation and rendering all succeed with a wrong accessor: the failure exists only at submit time. There is now a static guard reading the accessors on_submit actually uses and checking each against its component's class. It fails on the shipped line and names it — RadioGroup.values does not exist (self.ping_group.values). The other four accessors were audited against the real discord.py 2.7.1 API and are correct.

Separately, adding a reminder moves from a dropdown to an Add button beside Back: on a /config panel the dropdown edits and the button creates, as everywhere else. That dropdown existed only to pre-fill the delay with the chosen directory's cooldown, which a static modal cannot do on its own — so a blank delay now means "that directory's own cooldown", which is the better default and one less thing to look up.


Claude-Session: https://claude.ai/code/session_01XaKuddmbcYAUjcdpY5npVr