### PR TITLE
Brocoli: one turn is one message, edited in place

### DIFF
--- a/cogs/brocoli_chat.py
+++ b/cogs/brocoli_chat.py
@@ -337,6 +337,18 @@ class BrocoliChat(commands.Cog):
         buffer: list[str] = []
         tool: Optional[str] = None
         last_edit = 0.0
+        # Set once a confirmation or an error has taken the card over. Without
+        # it the `run_end` that follows would repaint the answer on top and the
+        # buttons would vanish a fraction of a second after appearing.
+        halted = False
+
+        async def replace(view) -> None:
+            """Turn the placeholder into `view`, or post it if there is none."""
+            nonlocal card
+            if card is None:
+                card = await channel.send(view=view)
+            else:
+                await card.edit(view=view)
 
         async def paint(*, thinking: bool, force: bool = False) -> None:
             nonlocal card, last_edit
@@ -347,20 +359,15 @@ class BrocoliChat(commands.Cog):
 
             text = "".join(buffer)
             if not thinking and not text:
-                # The turn produced no prose — it went straight to a
-                # confirmation card, or ended empty. A container with no
-                # content is rejected by Discord, and a stranded "thinking"
-                # card would sit there forever, so the placeholder goes away.
+                # A turn that ends without a word and without a question is
+                # degenerate — but a container with no content is rejected by
+                # Discord, and a stranded "thinking" card would never clear.
                 if card is not None:
                     await card.delete()
                     card = None
                 return
 
-            view = answer_card(text, locale=locale, thinking=thinking, tool=tool)
-            if card is None:
-                card = await channel.send(view=view)
-            else:
-                await card.edit(view=view)
+            await replace(answer_card(text, locale=locale, thinking=thinking, tool=tool))
 
         async for event in stream:
             name, data = event.get("event"), event.get("data") or {}
@@ -377,23 +384,32 @@ class BrocoliChat(commands.Cog):
                 tool = None
 
             elif name == "permission_request":
-                # Finalise whatever Brocoli said first, then ask separately: the
-                # question must be a card with buttons, never a sentence in the
-                # middle of a paragraph.
-                await paint(thinking=False, force=True)
-                await channel.send(
-                    view=confirmation_card(data, conversation_id, locale=locale)
+                # The question takes over the very card the member is watching,
+                # prose included. Deleting the placeholder and posting a second
+                # message would make one turn look like two, and would leave
+                # them reading upwards to see what they are agreeing to.
+                await replace(
+                    confirmation_card(
+                        data, conversation_id, locale=locale, text="".join(buffer)
+                    )
                 )
+                halted = True
 
             elif name == "error":
                 logger.warning("[Brocoli] stream error: %s", data.get("code"))
-                await channel.send(view=notice_card("unavailable", locale))
+                # Same rule: the failure replaces the placeholder instead of
+                # being a second message next to an orphaned "thinking" card.
+                await replace(notice_card("unavailable", locale))
+                halted = True
 
             elif name == "run_end":
                 tool = None
                 if data.get("status") == "max_iterations":
                     buffer.append("\n\n" + t("brocoli.max_iterations", locale=locale))
-                if buffer or card is not None:
+                if not halted:
+                    # A confirmation or an error already owns the card. Painting
+                    # the answer on top would make the buttons vanish a fraction
+                    # of a second after appearing.
                     await paint(thinking=False, force=True)
 
     # ------------------------------------------------------------------

--- a/docs/BROCOLI_CHANNEL.md
+++ b/docs/BROCOLI_CHANNEL.md
@@ -55,9 +55,24 @@ pendant la rédaction, pour que le passage de l'un à l'autre soit un changement
 contenu et non un saut de mise en page. La couleur n'apparaît qu'une fois la
 réponse finale.
 
-Si le tour ne produit aucun texte (il part directement sur une carte de
-confirmation), la carte de chargement est **supprimée** : Discord refuse un
-conteneur vide, et un « réfléchit… » resté en place ne partirait plus jamais.
+**Un tour = un message.** La carte de chargement n'est jamais supprimée puis
+remplacée : elle est **éditée**, quoi qu'il arrive au bout.
+
+- réponse en texte → elle devient la réponse ;
+- demande de confirmation → elle devient la carte de confirmation, **et porte
+  aussi ce que Brocoli a dit en chemin**. Déplacer la question dans un second
+  message obligerait à relire vers le haut pour savoir ce qu'on approuve ;
+- erreur → elle devient la carte d'erreur, au lieu de laisser un « réfléchit… »
+  orphelin à côté d'un second message.
+
+Le seul cas de suppression reste le tour dégénéré : ni un mot, ni une question.
+Discord refuse un conteneur vide, et un placeholder resté en place ne partirait
+plus jamais.
+
+Piège d'ordonnancement à connaître : `run_end` arrive **juste après**
+`permission_request`. Sans le drapeau `halted` du moteur de rendu, la réponse
+serait repeinte par-dessus la confirmation et les boutons disparaîtraient une
+fraction de seconde après être apparus.
 
 ### Pourquoi la carte est éditée et non renvoyée
 

--- a/tests/test_brocoli_integration.py
+++ b/tests/test_brocoli_integration.py
@@ -256,8 +256,16 @@ def test_the_member_sees_the_loading_card_before_anything_else():
     assert first == "<a:spinner:1534857169667883078> **Moddy** réfléchit..."
 
 
-def test_a_confirmation_replaces_the_placeholder_with_a_card_that_has_buttons():
+def test_a_confirmation_edits_the_placeholder_instead_of_replacing_it():
+    """One turn must stay one message: edit, never delete-and-repost.
+
+    Also guards the ordering trap: `run_end` arrives right after
+    `permission_request`, and repainting the answer on top of it would make the
+    buttons vanish a fraction of a second after appearing.
+    """
     backend = FakeBackend([
+        ("text_delta", {"delta": "Le starboard n'est pas activé. "}),
+        ("text_delta", {"delta": "Je peux l'activer à 5 étoiles."}),
         ("permission_request", {
             "action_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "kind": "set_module_config",
@@ -297,14 +305,19 @@ def test_a_confirmation_replaces_the_placeholder_with_a_card_that_has_buttons():
 
     channel, card = _run(scenario())
 
-    # The turn produced no prose, so the placeholder is removed rather than
-    # edited into an empty container (which Discord rejects).
-    assert card.deleted is True
+    # One message, never deleted: the placeholder became the question.
+    assert card.deleted is False
+    assert len(channel.sent) == 1
+    assert card.views[0][0] == "send"
+    assert all(kind == "edit" for kind, _ in card.views[1:])
 
-    # A second message carries the question, with two buttons.
-    assert len(channel.sent) == 2
-    question = channel.sent[1].views[0][1]
+    # The last state is the question — `run_end` did not repaint over it.
+    question = card.views[-1][1]
     text = _first_text(question)
+
+    # It carries what Brocoli said on the way to asking, so the member does not
+    # have to read upwards to know what they are agreeing to.
+    assert "Le starboard n'est pas activé." in text
     assert "Active le starboard à 5 étoiles" in text
     assert "threshold" in text
 
@@ -319,6 +332,42 @@ def test_a_confirmation_replaces_the_placeholder_with_a_card_that_has_buttons():
     assert all(
         b["custom_id"].startswith("moddy:brocoli:decision:") for b in buttons
     )
+
+
+def test_a_stream_error_edits_the_placeholder_too():
+    """A failure must not leave an orphaned "thinking" card next to a notice."""
+    backend = FakeBackend([
+        ("error", {"code": "stream_error", "message": "boom"}),
+        ("run_end", {"status": "error"}),
+    ])
+
+    async def scenario():
+        runner, base = await _serve(backend)
+        try:
+            from cogs.brocoli_chat import BrocoliChat
+            from services.brocoli_client import BrocoliClient
+            from utils.brocoli_views import loading_card
+
+            cog = BrocoliChat.__new__(BrocoliChat)
+            cog.client = BrocoliClient(base, SECRET)
+
+            channel = FakeChannel()
+            card = await channel.send(view=loading_card("fr"))
+            conversation = await cog.client.open_conversation(USER, GUILD)
+            stream = cog.client.send_message(
+                conversation["id"], USER, GUILD, "coucou"
+            )
+            await cog._render(stream, channel, conversation["id"], "fr", card=card)
+            await cog.client.close()
+        finally:
+            await runner.cleanup()
+        return channel, card
+
+    channel, card = _run(scenario())
+
+    assert card.deleted is False
+    assert len(channel.sent) == 1
+    assert "réfléchit" not in _first_text(card.views[-1][1])
 
 
 def test_a_backend_error_becomes_a_notice_and_not_a_traceback():

--- a/utils/brocoli_views.py
+++ b/utils/brocoli_views.py
@@ -250,12 +250,18 @@ def confirmation_card(
     conversation_id: str,
     *,
     locale: str = "en-US",
+    text: str = "",
 ) -> ui.LayoutView:
     """The card that asks a human before Brocoli writes anything.
 
     Built from the backend's ``permission_request`` payload. ``params`` is never
     sent by the backend — it carries the full config — so everything shown here
     comes from ``preview``, which exists for exactly this.
+
+    ``text`` is whatever Brocoli said on the way to asking. It belongs on this
+    same card: the member is already looking at the message that was streaming,
+    and moving the question to a second one would leave them reading upwards to
+    understand what they are agreeing to.
     """
     preview = payload.get("preview") or {}
     risk = payload.get("risk", "low")
@@ -265,6 +271,10 @@ def confirmation_card(
     container = ui.Container(
         accent_colour=COLORS["error"] if risk == "critical" else COLORS["warning"]
     )
+    if text:
+        container.add_item(ui.TextDisplay(_truncate(text, MAX_TEXT // 2)))
+        container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
+
     container.add_item(
         ui.TextDisplay(f"### {SETTINGS} {t('brocoli.confirm.title', locale=locale)}")
     )
@@ -293,6 +303,8 @@ def confirmation_card(
     if diff:
         container.add_item(ui.Separator())
         container.add_item(ui.TextDisplay("\n".join(_render_diff(diff, locale))))
+
+    container.add_item(ui.Separator(spacing=discord.SeparatorSpacing.small))
 
     row = ui.ActionRow()
     row.add_item(


### PR DESCRIPTION
## The fix asked for

The loading card used to be **deleted and replaced** by a second message whenever a turn ended in a confirmation or an error. That made one turn look like two, and for a confirmation it left the member reading upwards to work out what they were agreeing to.

Now every outcome **edits** the card they are already watching:

| Turn ends in | Before | Now |
|---|---|---|
| prose | edited ✓ | edited ✓ |
| confirmation | placeholder deleted + new message | edited, **prose included**, above the buttons |
| error | placeholder deleted + new message | edited |
| nothing at all | deleted | deleted (Discord rejects an empty container) |

## An ordering trap this exposed

`run_end` arrives **immediately after** `permission_request`. The answer was being painted back over the question, so the buttons vanished a fraction of a second after appearing — invisible in the old flow because the confirmation was a separate message, fatal as soon as it shares one. A `halted` flag stops it, and two integration tests pin the behaviour rather than the implementation:

- the confirmation is still the last state after `run_end`, with two persistent `custom_id`s;
- an error edits the placeholder instead of orphaning it.

## Also

The separator before the action row that `DESIGN.md` asks for ("to separate action buttons from content").

**1732 passed.**

## Note on the previous PR

While writing this I found that two string replacements in #374 never actually applied — `if buffer or card is not None:` was still in the shipped code. It was harmless there (the confirmation was a separate message, so repainting `card` hit nothing), but it is why this change needed the `halted` flag rather than just a condition swap. Verified by test this time, not by grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)