### PR TITLE
Replace get_user_locale with get_locale in bump_views

### DIFF
--- a/utils/bump_views.py
+++ b/utils/bump_views.py
@@ -64,7 +64,7 @@ async def card_locale(interaction: discord.Interaction) -> str:
     from utils.guild_language import guild_locale
 
     if interaction.guild is None:
-        return i18n.get_user_locale(interaction)
+        return i18n.get_locale(interaction)
     return await guild_locale(interaction.client, interaction.guild)
 
 
@@ -114,7 +114,7 @@ class BumpOptInButton(
 
     @_guarded
     async def callback(self, interaction: discord.Interaction):
-        locale = i18n.get_user_locale(interaction)
+        locale = i18n.get_locale(interaction)
 
         if interaction.user.id != self.user_id:
             from utils.components_v2 import create_error_message


### PR DESCRIPTION
## Summary
Simplifies locale retrieval in `utils/bump_views.py` by replacing calls to `i18n.get_user_locale()` with the more general `i18n.get_locale()` method.

## Changes
- **Line 67**: In `card_locale()`, replaced `i18n.get_user_locale(interaction)` with `i18n.get_locale(interaction)` for DM fallback case
- **Line 117**: In `callback()`, replaced `i18n.get_user_locale(interaction)` with `i18n.get_locale(interaction)` for locale resolution

## Details
Both occurrences were in the bump reminder views module. The `get_locale()` method appears to be a more appropriate general-purpose locale getter that handles both user and guild contexts, making the code more consistent with the i18n API design.

https://claude.ai/code/session_01V8kWn3HkCjsK1iJ2qS7Zzy