### PR TITLE
Keep bump opt-in button's label/icon fixed, toggle color instead

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1533,6 +1533,7 @@
         "thanks_body": "Der Server ist gerade auf {emoji} **{name}** wieder nach oben gerutscht.\nNächster Bump möglich {timestamp}.",
         "optin": "Erinnere mich",
         "optin_armed": "Du wirst erwähnt",
+        "optin_disarmed": "Du wirst nicht mehr erwähnt",
         "optin_expired": "Ein neuerer Bump hat diesen bereits ersetzt.",
         "reminder_title": "Zeit für den nächsten Bump",
         "reminder_body": "Der Server kann auf {emoji} **{name}** wieder gebumpt werden.\n{command}",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1533,6 +1533,7 @@
         "thanks_body": "The server just climbed back up on {emoji} **{name}**.\nNext bump possible {timestamp}.",
         "optin": "Remind me",
         "optin_armed": "You will be mentioned",
+        "optin_disarmed": "You will no longer be mentioned",
         "optin_expired": "A more recent bump has already replaced this one.",
         "reminder_title": "Time to bump again",
         "reminder_body": "The server can be bumped on {emoji} **{name}** again.\n{command}",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1533,6 +1533,7 @@
         "thanks_body": "El servidor acaba de subir en {emoji} **{name}**.\nPróximo bump posible {timestamp}.",
         "optin": "Recuérdamelo",
         "optin_armed": "Se te mencionará",
+        "optin_disarmed": "Ya no se te mencionará",
         "optin_expired": "Un bump más reciente ya ha reemplazado a este.",
         "reminder_title": "Toca hacer bump",
         "reminder_body": "El servidor puede recibir bump de nuevo en {emoji} **{name}**.\n{command}",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1532,6 +1532,7 @@
         "thanks_body": "Le serveur vient de remonter sur {emoji} **{name}**.\nProchain bump possible {timestamp}.",
         "optin": "Me rappeler",
         "optin_armed": "Tu seras mentionné",
+        "optin_disarmed": "Tu ne seras plus mentionné",
         "optin_expired": "Ce bump a déjà été remplacé par un plus récent.",
         "reminder_title": "C'est reparti",
         "reminder_body": "Le serveur peut de nouveau être bumpé sur {emoji} **{name}**.\n{command}",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1533,6 +1533,7 @@
         "thanks_body": "O servidor acabou de subir em {emoji} **{name}**.\nPróximo bump possível {timestamp}.",
         "optin": "Me lembrar",
         "optin_armed": "Você será mencionado",
+        "optin_disarmed": "Você não será mais mencionado",
         "optin_expired": "Um bump mais recente já substituiu este.",
         "reminder_title": "Hora de dar bump",
         "reminder_body": "O servidor pode receber bump em {emoji} **{name}** novamente.\n{command}",

--- a/utils/bump_views.py
+++ b/utils/bump_views.py
@@ -30,7 +30,7 @@ from bumpreminder import BumpBot, bot_by_key, format_interval
 from cogs.error_handler import BaseView
 from config import COLORS
 from utils import i18n
-from utils.emojis import ROCKET_LAUNCH, TIME, TOGGLE_ON
+from utils.emojis import ROCKET_LAUNCH, TIME
 from utils.i18n import t
 
 logger = logging.getLogger('moddy.bump_views')
@@ -94,13 +94,9 @@ class BumpOptInButton(
                  locale: str = "en-US", armed: bool = False):
         super().__init__(
             ui.Button(
-                label=t(
-                    "modules.bump_reminder.card.optin_armed" if armed
-                    else "modules.bump_reminder.card.optin",
-                    locale=locale,
-                )[:80],
-                style=discord.ButtonStyle.secondary,
-                emoji=discord.PartialEmoji.from_str(TOGGLE_ON if armed else TIME),
+                label=t("modules.bump_reminder.card.optin", locale=locale)[:80],
+                style=discord.ButtonStyle.success if armed else discord.ButtonStyle.secondary,
+                emoji=discord.PartialEmoji.from_str(TIME),
                 custom_id=f"{_CID_PREFIX}:{bot_key}:{user_id}",
             )
         )
@@ -150,6 +146,14 @@ class BumpOptInButton(
             locale=public_locale, ping_mode="button", armed=armed,
         )
         await interaction.response.edit_message(view=view, allowed_mentions=NO_MENTIONS)
+        await interaction.followup.send(
+            t(
+                "modules.bump_reminder.card.optin_armed" if armed
+                else "modules.bump_reminder.card.optin_disarmed",
+                locale=locale,
+            ),
+            ephemeral=True,
+        )
 
 
 class BumpReminderPersistence(BaseView):


### PR DESCRIPTION
## Summary
- The "remind me" button on the bump thank-you card no longer swaps its label/emoji when armed — it now keeps the same text and icon and switches between `secondary` (off) and `success`/green (on) button styles.
- Every click now sends an ephemeral confirmation message ("You will be mentioned" / "You will no longer be mentioned") in addition to the color change.
- Added the `optin_disarmed` i18n key in all 5 locales (fr, en-US, es-ES, pt-BR, de).

## Test plan
- [x] `pytest tests/test_bump_reminder.py` (169 passed)
- [x] `pytest tests/test_persistent_views.py` (asserts persistence + no custom_id collisions)
- [x] `pytest tests/test_logs_i18n.py` (i18n completeness across the 5 locales)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8kWn3HkCjsK1iJ2qS7Zzy

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8kWn3HkCjsK1iJ2qS7Zzy)_