### PR TITLE
Add a check icon to bump reminder confirmation messages

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1532,7 +1532,9 @@
         "thanks_title_anonymous": "Danke!",
         "thanks_body": "Der Server ist gerade auf {emoji} **{name}** wieder nach oben gerutscht.\nNächster Bump möglich {timestamp}.",
         "optin": "Erinnere mich",
+        "optin_on_title": "Erinnerung aktiviert",
         "optin_armed": "Du wirst erwähnt",
+        "optin_off_title": "Erinnerung deaktiviert",
         "optin_disarmed": "Du wirst nicht mehr erwähnt",
         "optin_expired": "Ein neuerer Bump hat diesen bereits ersetzt.",
         "reminder_title": "Zeit für den nächsten Bump",
@@ -1555,6 +1557,7 @@
         "saved": "Erinnerung gespeichert."
       },
       "add": {
+        "title": "Erinnerung erstellt",
         "success": "Erinnerung erstellt. Moddy beobachtet diesen Kanal ab sofort."
       },
       "errors": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1532,7 +1532,9 @@
         "thanks_title_anonymous": "Thanks!",
         "thanks_body": "The server just climbed back up on {emoji} **{name}**.\nNext bump possible {timestamp}.",
         "optin": "Remind me",
+        "optin_on_title": "Notification enabled",
         "optin_armed": "You will be mentioned",
+        "optin_off_title": "Notification disabled",
         "optin_disarmed": "You will no longer be mentioned",
         "optin_expired": "A more recent bump has already replaced this one.",
         "reminder_title": "Time to bump again",
@@ -1555,6 +1557,7 @@
         "saved": "Reminder saved."
       },
       "add": {
+        "title": "Reminder created",
         "success": "Reminder created. Moddy is now watching that channel."
       },
       "errors": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1532,7 +1532,9 @@
         "thanks_title_anonymous": "¡Gracias!",
         "thanks_body": "El servidor acaba de subir en {emoji} **{name}**.\nPróximo bump posible {timestamp}.",
         "optin": "Recuérdamelo",
+        "optin_on_title": "Notificación activada",
         "optin_armed": "Se te mencionará",
+        "optin_off_title": "Notificación desactivada",
         "optin_disarmed": "Ya no se te mencionará",
         "optin_expired": "Un bump más reciente ya ha reemplazado a este.",
         "reminder_title": "Toca hacer bump",
@@ -1555,6 +1557,7 @@
         "saved": "Recordatorio guardado."
       },
       "add": {
+        "title": "Recordatorio creado",
         "success": "Recordatorio creado. Moddy ya vigila ese canal."
       },
       "errors": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1531,7 +1531,9 @@
         "thanks_title_anonymous": "Merci !",
         "thanks_body": "Le serveur vient de remonter sur {emoji} **{name}**.\nProchain bump possible {timestamp}.",
         "optin": "Me rappeler",
+        "optin_on_title": "Notification activée",
         "optin_armed": "Tu seras mentionné",
+        "optin_off_title": "Notification désactivée",
         "optin_disarmed": "Tu ne seras plus mentionné",
         "optin_expired": "Ce bump a déjà été remplacé par un plus récent.",
         "reminder_title": "C'est reparti",
@@ -1554,6 +1556,7 @@
         "saved": "Rappel enregistré."
       },
       "add": {
+        "title": "Rappel créé",
         "success": "Rappel créé. Moddy surveille désormais ce salon."
       },
       "errors": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1532,7 +1532,9 @@
         "thanks_title_anonymous": "Obrigado!",
         "thanks_body": "O servidor acabou de subir em {emoji} **{name}**.\nPróximo bump possível {timestamp}.",
         "optin": "Me lembrar",
+        "optin_on_title": "Notificação ativada",
         "optin_armed": "Você será mencionado",
+        "optin_off_title": "Notificação desativada",
         "optin_disarmed": "Você não será mais mencionado",
         "optin_expired": "Um bump mais recente já substituiu este.",
         "reminder_title": "Hora de dar bump",
@@ -1555,6 +1557,7 @@
         "saved": "Lembrete salvo."
       },
       "add": {
+        "title": "Lembrete criado",
         "success": "Lembrete criado. O Moddy já está vigiando esse canal."
       },
       "errors": {

--- a/modules/configs/bump_reminder_config.py
+++ b/modules/configs/bump_reminder_config.py
@@ -46,6 +46,7 @@ from modules.bump_reminder import (
     reminders_per_bot,
 )
 from modules.configs._common import check_guild_perms
+from utils.components_v2 import create_success_message
 from utils.emojis import (
     ADD, BACK, DELETE, EDIT, INFO, PAUSE, PLAY, REQUIRED_FIELDS, ROCKET_LAUNCH, TIME,
 )
@@ -709,16 +710,24 @@ def _resolve_interval(raw: Optional[str], bot_key: str) -> Optional[int]:
 
 
 async def _write(interaction: discord.Interaction, reminders: List[Dict[str, Any]],
-                 success_key: str) -> None:
+                 success_title_key: str, success_description_key: str) -> None:
     bot = interaction.client
     locale = i18n.get_user_locale(interaction)
     success, error = await _save(bot, interaction.guild_id, reminders, interaction.user.id)
     await _render_main(interaction)
-    await interaction.followup.send(
-        t(success_key, locale=locale) if success
-        else t('modules.config.save.error', locale=locale, error=error or ''),
-        ephemeral=True,
-    )
+    if success:
+        await interaction.followup.send(
+            view=create_success_message(
+                t(success_title_key, locale=locale),
+                t(success_description_key, locale=locale),
+            ),
+            ephemeral=True,
+        )
+    else:
+        await interaction.followup.send(
+            t('modules.config.save.error', locale=locale, error=error or ''),
+            ephemeral=True,
+        )
 
 
 async def _create_reminder(interaction: discord.Interaction, *, bot_key: str,
@@ -739,7 +748,8 @@ async def _create_reminder(interaction: discord.Interaction, *, bot_key: str,
         bot_key, channel_id=channel_id, role_ids=role_ids,
         ping_mode=ping_mode, interval=interval, created_by=interaction.user.id,
     ))
-    await _write(interaction, reminders, 'modules.bump_reminder.add.success')
+    await _write(interaction, reminders,
+                'modules.bump_reminder.add.title', 'modules.bump_reminder.add.success')
 
 
 def _edit_reminder(entry_id: str):

--- a/utils/bump_views.py
+++ b/utils/bump_views.py
@@ -30,6 +30,7 @@ from bumpreminder import BumpBot, bot_by_key, format_interval
 from cogs.error_handler import BaseView
 from config import COLORS
 from utils import i18n
+from utils.components_v2 import create_success_message
 from utils.emojis import ROCKET_LAUNCH, TIME
 from utils.i18n import t
 
@@ -147,10 +148,17 @@ class BumpOptInButton(
         )
         await interaction.response.edit_message(view=view, allowed_mentions=NO_MENTIONS)
         await interaction.followup.send(
-            t(
-                "modules.bump_reminder.card.optin_armed" if armed
-                else "modules.bump_reminder.card.optin_disarmed",
-                locale=locale,
+            view=create_success_message(
+                t(
+                    "modules.bump_reminder.card.optin_on_title" if armed
+                    else "modules.bump_reminder.card.optin_off_title",
+                    locale=locale,
+                ),
+                t(
+                    "modules.bump_reminder.card.optin_armed" if armed
+                    else "modules.bump_reminder.card.optin_disarmed",
+                    locale=locale,
+                ),
             ),
             ephemeral=True,
         )


### PR DESCRIPTION
## Summary
- The bump opt-in toggle's ephemeral confirmation and the "reminder created" confirmation were plain text. Both now go through `create_success_message()` so they carry the standard check icon and bold title, per CLAUDE.md's rule to use the Components V2 success helper for expected outcomes.
- Added `optin_on_title` / `optin_off_title` i18n keys for the opt-in toggle confirmation, and an `add.title` key for the "reminder created" confirmation, in all 5 locales (fr, en-US, es-ES, pt-BR, de).

## Test plan
- [x] `pytest tests/test_bump_reminder.py` (169 passed)
- [x] `pytest tests/test_persistent_views.py` (persistence + no custom_id collisions)
- [x] `pytest tests/test_logs_i18n.py` (i18n completeness across the 5 locales)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8kWn3HkCjsK1iJ2qS7Zzy

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8kWn3HkCjsK1iJ2qS7Zzy)_