### PR TITLE
Fix the opt-in ping not firing and use a live relative timestamp

### DIFF
--- a/cogs/bump_reminder.py
+++ b/cogs/bump_reminder.py
@@ -41,6 +41,7 @@ from utils.bump_views import (
 )
 from utils.emojis import ROCKET_LAUNCH
 from utils.i18n import t
+from utils.members import get_or_fetch_member
 
 logger = logging.getLogger('moddy.cogs.bump_reminder')
 
@@ -209,20 +210,22 @@ class BumpReminder(commands.Cog):
         now = datetime.now(timezone.utc)
         late_by = int((now - state['due_at']).total_seconds())
         bumped_at = state.get('bumped_at')
-        elapsed = int((state['due_at'] - bumped_at).total_seconds()) if bumped_at else None
 
         bumper = None
         if state.get('bumper_id'):
-            bumper = guild.get_member(state['bumper_id'])
+            # A cache-only lookup misses whenever the bumper hasn't been seen
+            # since the bot last restarted (CHUNK_GUILDS_AT_STARTUP is off) —
+            # which would silently turn off their "ping me" opt-in below.
+            bumper = await get_or_fetch_member(guild, state['bumper_id'])
 
         for entry in entries:
             await self._post(guild, spec, entry, state, locale,
-                             bumper=bumper, elapsed=elapsed, late_by=late_by)
+                             bumper=bumper, bumped_at=bumped_at, late_by=late_by)
 
     async def _post(self, guild: discord.Guild, spec, entry: Dict[str, Any],
                     state: Dict[str, Any], locale: str, *,
                     bumper: Optional[discord.Member],
-                    elapsed: Optional[int], late_by: int) -> None:
+                    bumped_at: Optional[datetime], late_by: int) -> None:
         channel = guild.get_channel(entry['channel_id'])
         if not isinstance(channel, discord.TextChannel):
             logger.warning(
@@ -250,7 +253,7 @@ class BumpReminder(commands.Cog):
             role_ids=[role.id for role in roles],
             bumper_id=state.get('bumper_id'),
             mention_bumper=mention_bumper,
-            elapsed=elapsed,
+            bumped_at=bumped_at,
             late_by=late_by,
         )
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -1539,7 +1539,7 @@
         "optin_expired": "Ein neuerer Bump hat diesen bereits ersetzt.",
         "reminder_title": "Zeit für den nächsten Bump",
         "reminder_body": "Der Server kann auf {emoji} **{name}** wieder gebumpt werden.\n{command}",
-        "reminder_last": "Letzter Bump von {user}, vor {duration}.",
+        "reminder_last": "Letzter Bump von {user}, {timestamp}.",
         "reminder_late": "Erinnerung verspätet gesendet: Moddy war nicht erreichbar."
       },
       "manage": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1539,7 +1539,7 @@
         "optin_expired": "A more recent bump has already replaced this one.",
         "reminder_title": "Time to bump again",
         "reminder_body": "The server can be bumped on {emoji} **{name}** again.\n{command}",
-        "reminder_last": "Last bumped by {user}, {duration} ago.",
+        "reminder_last": "Last bumped by {user}, {timestamp}.",
         "reminder_late": "Reminder sent late: Moddy was unavailable."
       },
       "manage": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1539,7 +1539,7 @@
         "optin_expired": "Un bump más reciente ya ha reemplazado a este.",
         "reminder_title": "Toca hacer bump",
         "reminder_body": "El servidor puede recibir bump de nuevo en {emoji} **{name}**.\n{command}",
-        "reminder_last": "Último bump por {user}, hace {duration}.",
+        "reminder_last": "Último bump por {user}, {timestamp}.",
         "reminder_late": "Recordatorio enviado con retraso: Moddy no estaba disponible."
       },
       "manage": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1538,7 +1538,7 @@
         "optin_expired": "Ce bump a déjà été remplacé par un plus récent.",
         "reminder_title": "C'est reparti",
         "reminder_body": "Le serveur peut de nouveau être bumpé sur {emoji} **{name}**.\n{command}",
-        "reminder_last": "Dernier bump par {user}, il y a {duration}.",
+        "reminder_last": "Dernier bump par {user}, {timestamp}.",
         "reminder_late": "Rappel envoyé en retard : Moddy était indisponible."
       },
       "manage": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1539,7 +1539,7 @@
         "optin_expired": "Um bump mais recente já substituiu este.",
         "reminder_title": "Hora de dar bump",
         "reminder_body": "O servidor pode receber bump em {emoji} **{name}** novamente.\n{command}",
-        "reminder_last": "Último bump por {user}, há {duration}.",
+        "reminder_last": "Último bump por {user}, {timestamp}.",
         "reminder_late": "Lembrete enviado com atraso: o Moddy estava indisponível."
       },
       "manage": {

--- a/tests/test_bump_reminder.py
+++ b/tests/test_bump_reminder.py
@@ -781,7 +781,8 @@ class TestComponents:
 
         view = build_reminder_card(
             bot_by_key("disboard"), locale="fr", role_ids=[1234],
-            bumper_id=5678, mention_bumper=True, elapsed=7200)
+            bumper_id=5678, mention_bumper=True,
+            bumped_at=datetime.now(timezone.utc) - timedelta(hours=2))
         first = view.children[0]
         assert isinstance(first, discord.ui.TextDisplay)
         assert "<@&1234>" in first.content and "<@5678>" in first.content
@@ -800,7 +801,8 @@ class TestComponents:
 
         view = build_reminder_card(
             bot_by_key("disboard"), locale="fr", role_ids=[1234],
-            bumper_id=5678, mention_bumper=False, elapsed=7200)
+            bumper_id=5678, mention_bumper=False,
+            bumped_at=datetime.now(timezone.utc) - timedelta(hours=2))
         top = view.children[0].content
         assert "<@5678>" not in top, "the bumper must not be in the ping line"
         body = "\n".join(

--- a/utils/bump_views.py
+++ b/utils/bump_views.py
@@ -21,12 +21,13 @@ See docs/BUMP_REMINDER.md.
 
 import logging
 import re
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import discord
 from discord import ui
 
-from bumpreminder import BumpBot, bot_by_key, format_interval
+from bumpreminder import BumpBot, bot_by_key
 from cogs.error_handler import BaseView
 from config import COLORS
 from utils import i18n
@@ -211,7 +212,7 @@ def build_thanks_card(spec: BumpBot, bumper_id: Optional[int], due_at,
 
 def build_reminder_card(spec: BumpBot, *, locale: str,
                         role_ids: Sequence[int], bumper_id: Optional[int],
-                        mention_bumper: bool, elapsed: Optional[int],
+                        mention_bumper: bool, bumped_at: Optional[datetime],
                         late_by: int = 0) -> ui.LayoutView:
     """The card posted when the command becomes available again.
 
@@ -239,10 +240,10 @@ def build_reminder_card(spec: BumpBot, *, locale: str,
     ))
 
     footnotes = []
-    if bumper_id and elapsed is not None:
+    if bumper_id and bumped_at is not None:
         footnotes.append(t("modules.bump_reminder.card.reminder_last",
                            locale=locale, user=f"<@{bumper_id}>",
-                           duration=format_interval(elapsed)))
+                           timestamp=f"<t:{int(bumped_at.timestamp())}:R>"))
     if late_by >= LATE_AFTER:
         footnotes.append(t("modules.bump_reminder.card.reminder_late", locale=locale))
     if footnotes:


### PR DESCRIPTION
## Summary
- The reminder's bumper lookup used `guild.get_member()`, a cache-only call. `CHUNK_GUILDS_AT_STARTUP` defaults to `False`, so by the time a reminder fires — often hours after the bump — the bumper is frequently not in cache, `bumper` silently becomes `None`, and `mention_bumper` is forced off even though the person opted in via the "remind me" button. Switched to `get_or_fetch_member()` (`utils/members.py`), the helper that exists specifically for this cache-miss case.
- The "last bumped by … {duration} ago" footnote was a static string computed once at render time from a fixed interval. Replaced it with a live Discord relative timestamp (`<t:…:R>`) built from the actual `bumped_at` moment, so it reads correctly and stays live in the client like every other timestamp in this feature.
- Updated the `reminder_last` string in all 5 locales to use `{timestamp}` instead of `{duration}` (Discord's relative format already conveys "ago"/"il y a").

## Test plan
- [x] `pytest tests/test_bump_reminder.py` (169 passed, updated the two reminder-card tests for the new `bumped_at` parameter)
- [x] `pytest tests/test_persistent_views.py`
- [x] `pytest tests/test_logs_i18n.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8kWn3HkCjsK1iJ2qS7Zzy

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8kWn3HkCjsK1iJ2qS7Zzy)_