### PR TITLE
altguard: Change permission requirement from manage_roles to kick_members

### DIFF
--- a/cogs/altguard.py
+++ b/cogs/altguard.py
@@ -59,7 +59,7 @@ class AltGuard(commands.Cog):
         name="altguard",
         description="Manage AltGuard verifications on this server",
         guild_only=True,
-        default_permissions=discord.Permissions(manage_roles=True),
+        default_permissions=discord.Permissions(kick_members=True),
     )
 
     def __init__(self, bot):
@@ -305,7 +305,7 @@ class AltGuard(commands.Cog):
                                member: discord.Member, *, verify: bool):
         locale = i18n.get_user_locale(interaction)
 
-        if not interaction.user.guild_permissions.manage_roles:
+        if not interaction.user.guild_permissions.kick_members:
             await interaction.response.send_message(
                 view=create_error_message(
                     t('modules.altguard.errors.no_perms.title', locale=locale),

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -386,6 +386,7 @@ class Config(commands.Cog):
         description="Configure server modules"
     )
     @app_commands.guild_only()
+    @app_commands.default_permissions(manage_guild=True)
     @app_commands.describe(
         incognito="Make response visible only to you"
     )

--- a/docs/ALTGUARD.md
+++ b/docs/ALTGUARD.md
@@ -260,7 +260,8 @@ account rejoining) — a resync never resurrects a banned account.
 
 ## Commands
 
-### Server side — `/altguard` (requires **Manage Roles**)
+### Server side — `/altguard` (requires **Kick Members** — the same Discord
+permission that covers approving/rejecting membership applications)
 
 | Command | Effect |
 |---|---|


### PR DESCRIPTION
## Summary
Updates the AltGuard module to require the **Kick Members** permission instead of **Manage Roles** for accessing the `/altguard` command and manual verification decisions. This aligns the permission model with Discord's membership screening workflow.

## Changes
- **cogs/altguard.py**: 
  - Updated `@app_commands.default_permissions()` from `manage_roles=True` to `kick_members=True`
  - Updated permission check in `_manual_decision()` from `manage_roles` to `kick_members`
- **docs/ALTGUARD.md**: 
  - Updated command documentation to reflect the new permission requirement
  - Added clarification that Kick Members is the same permission covering membership application approvals/rejections
- **cogs/config.py**: 
  - Added missing `@app_commands.default_permissions(manage_guild=True)` decorator to the `/config` command for consistency

## Rationale
The Kick Members permission is more semantically appropriate for AltGuard operations, as it represents the ability to make membership decisions (similar to approving/rejecting applications), rather than role management which is broader in scope.

https://claude.ai/code/session_01RscMqhpwJaQKRwbGYT9Jrc