### PR TITLE
Add comprehensive statistics system with aggregation and rollup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ moddy/
 │   ├── emoji.py               #   Emoji management
 │   ├── reminder.py            #   /reminder command
 │   ├── bump_reminder.py       #   Bump Reminder listener + 30s sweeper loop
+│   ├── stats_events.py        #   Statistics emitters (commands, members, guild joins)
 │   ├── saved_messages.py      #   Message bookmarking
 │   ├── translate.py           #   /translate (DeepL)
 │   ├── text_tools.py          #   /fix, /rephrase, /summarize (OpenAI, Modal V2 + context menus)
@@ -113,6 +114,11 @@ moddy/
 │                              #   invites, assets, scheduled_events, stage, polls,
 │                              #   integrations, automod, moderation
 │
+├── stats/                     # Statistics (aggregate before writing)
+│   ├── registry.py            #   Every metric declared once (no migration to add one)
+│   ├── service.py             #   bot.stats — incr()/observe_unique(), 60s flush to PG
+│   └── rollup.py              #   Daily snapshots, hourly→daily ageing, partition purge
+│
 ├── notifications/             # Centralized notifications (EVERY DM goes through it)
 │   ├── models.py              #   Uniform payload + source + service registry + hashing
 │   ├── render.py              #   Payload → Components V2 + `sent by` attribution line
@@ -182,6 +188,8 @@ moddy/
 │       ├── support_requests.py #  Bug reports / config-help requests + their exchange
 │       ├── social.py          #   Social notifications subscriptions
 │       ├── bump.py            #   Pending bump reminders (bump_reminders)
+│       ├── stats.py           #   Statistics: counters, snapshots, guild lifecycle,
+│       │                      #   acquisition (guild_installs), partitions
 │       └── _utils.py
 │
 ├── utils/                     # Utility modules
@@ -301,6 +309,7 @@ moddy/
     ├── test_bump_reminder.py  #   Bump detection (real payloads + refusals), config, cards, i18n
     ├── test_logs.py           #   Server logs: registry, routing, rendering, delivery
     ├── test_logs_i18n.py      #   Server logs: i18n completeness on the 5 locales
+    ├── test_stats.py          #   Statistics: registry guards, aggregation, flush, rollup
     ├── test_heartbeat.py      #   Health Monitor heartbeat: payload, lifecycle, status decisions
     └── test_staff_user_command.py # /team user: sections, personal-data gate, i18n (5 locales)
 ```
@@ -503,6 +512,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/GLOBAL_SANCTIONS.md](docs/GLOBAL_SANCTIONS.md) | **Global sanctions** — Moddy-team warn / limited / suspended, on users *and* servers |
 | [docs/TECHNICAL_LOGS.md](docs/TECHNICAL_LOGS.md) | Internal technical staff logs (webhook-based, per-event channels) |
 | [docs/HEALTH_MONITOR.md](docs/HEALTH_MONITOR.md) | **Health Monitor heartbeats** — dead man's switch push to `moddy-health-monitor` (`HM_URL`/`HM_INGEST_TOKEN`) and the Better Stack cron ping (`BETTERSTACK_HEARTBEAT_URL`) |
+| [docs/STATS.md](docs/STATS.md) | **Statistics** — recording anything (`bot.stats`), the metric registry, what is stored and for how long, the growth/retention/acquisition queries, the backend UTM contract |
 | [docs/DATABASE.md](docs/DATABASE.md) | Database schema, queries, repository pattern |
 
 ### Infrastructure

--- a/bot.py
+++ b/bot.py
@@ -159,6 +159,13 @@ class ModdyBot(ModdyFrameworkBot):
         self.support_requests = SupportRequestService(self)
         from gateway import Gateway
         self.gateway = Gateway()
+        from stats import StatsRollup, StatsService
+        # Statistics. `incr()` is synchronous and never raises: it adds to an
+        # in-memory aggregate that a background flush carries to Postgres once
+        # a minute, so measuring something can never slow down or break the
+        # feature being measured (see docs/STATS.md).
+        self.stats = StatsService(self)
+        self.stats_rollup = StatsRollup(self)
         from services.heartbeat import HeartbeatClient
         # Dead man's switch push to the Moddy Health Monitor (docs/HEALTH_MONITOR.md).
         # Started in on_ready (a bot that was never ready has nothing to report).
@@ -1048,6 +1055,10 @@ class ModdyBot(ModdyFrameworkBot):
         else:
             logger.warning("[WARN] REDIS_URL not set - Redis features disabled")
 
+        # Start the statistics flush loop (needs the DB pool; Redis is
+        # optional — without it only the distinct-people counts are lost).
+        self.stats.start()
+
         # Initialize API gateway (requires Redis + DB pool)
         logger.info("Starting API gateway...")
         try:
@@ -1055,6 +1066,7 @@ class ModdyBot(ModdyFrameworkBot):
                 redis=self.redis,
                 pool=self.db.pool if self.db else None,
                 tech_logger=getattr(self, "tech_logger", None),
+                stats=self.stats,
             )
             logger.info("API gateway ready")
         except Exception as e:
@@ -1662,6 +1674,10 @@ class ModdyBot(ModdyFrameworkBot):
         # loop with a dead gateway connection has nothing worth reporting.
         self.heartbeat.start()
         self.betterstack_heartbeat.start()
+
+        # Daily statistics pass: snapshots, rollup, partition maintenance.
+        # Here rather than in setup_hook because it photographs self.guilds.
+        self.stats_rollup.start()
 
     async def _is_bot_healthy(self) -> bool:
         """Whether the bot is healthy enough to ping the Better Stack
@@ -2362,6 +2378,13 @@ class ModdyBot(ModdyFrameworkBot):
 
         # Wait a bit for tasks to finish
         await asyncio.sleep(0.1)
+
+        # Stop the statistics service (flushes the pending aggregate)
+        try:
+            await self.stats_rollup.stop()
+            await self.stats.stop()
+        except Exception as e:
+            logger.error(f"[FAIL] Error stopping the stats service: {e}")
 
         # Stop API gateway (flushes log buffer)
         await self.gateway.stop()

--- a/cogs/bump_reminder.py
+++ b/cogs/bump_reminder.py
@@ -221,6 +221,10 @@ class BumpReminder(commands.Cog):
         for entry in entries:
             await self._post(guild, spec, entry, state, locale,
                              bumper=bumper, bumped_at=bumped_at, late_by=late_by)
+            stats = getattr(self.bot, "stats", None)
+            if stats is not None:
+                stats.incr("bump.reminded", guild_id=guild.id,
+                           dims={"bot": state['bot_key']})
 
     async def _post(self, guild: discord.Guild, spec, entry: Dict[str, Any],
                     state: Dict[str, Any], locale: str, *,

--- a/cogs/stats_events.py
+++ b/cogs/stats_events.py
@@ -1,0 +1,180 @@
+"""The listeners that feed the statistics system.
+
+Every emitter lives here rather than being sprinkled across sixty files. A
+statistic is not a feature: nobody reading ``cogs/tickets.py`` should have to
+step over a counter, and gathering the emitters in one place makes "what do
+we actually measure" answerable by reading a single file alongside
+``stats/registry.py``.
+
+The two exceptions are the ones that would be wrong here: the API gateway
+counts its own calls where it already logs them (``gateway/logger.py``), and
+anything a module knows and Discord does not has to be emitted by that
+module.
+
+The Discord side of it costs nothing measurable: each listener is a handful
+of dictionary operations, and ``bot.stats.incr`` neither awaits nor raises.
+
+See docs/STATS.md.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+import discord
+from discord.ext import commands
+
+from moddy import Cog
+
+logger = logging.getLogger('moddy.stats.events')
+
+
+class StatsEvents(Cog):
+    """Turns Discord events into counters and lifecycle rows."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    # ------------------------------------------------------------------ #
+    # Commands
+    # ------------------------------------------------------------------ #
+
+    @Cog.listener()
+    async def on_app_command_completion(
+        self,
+        interaction: discord.Interaction,
+        command,
+    ):
+        kind = "context" if isinstance(command, discord.app_commands.ContextMenu) else "slash"
+        self._count_command(interaction.guild_id, interaction.user.id,
+                            getattr(command, "qualified_name", str(command)), kind)
+
+    @Cog.listener()
+    async def on_command_completion(self, ctx: commands.Context):
+        self._count_command(ctx.guild.id if ctx.guild else None, ctx.author.id,
+                            ctx.command.qualified_name if ctx.command else "unknown",
+                            "prefix")
+
+    def _count_command(self, guild_id: Optional[int], user_id: int,
+                       name: str, kind: str) -> None:
+        self.bot.stats.incr(
+            "command.used", guild_id=guild_id,
+            dims={"command": name, "kind": kind},
+        )
+        # Distinct people, both in this server and across all of them. The
+        # ids are folded into a HyperLogLog at the next flush and never
+        # stored (see StatsService.observe_unique).
+        if guild_id:
+            self.bot.stats.observe_unique("user.active", user_id, guild_id=guild_id)
+        self.bot.stats.observe_unique("user.active", user_id)
+
+    @Cog.listener()
+    async def on_app_command_error(
+        self,
+        interaction: discord.Interaction,
+        error: discord.app_commands.AppCommandError,
+    ):
+        command = interaction.command
+        self.bot.stats.incr(
+            "command.error", guild_id=interaction.guild_id,
+            dims={
+                "command": getattr(command, "qualified_name", "unknown"),
+                "error": type(error).__name__,
+            },
+        )
+
+    @Cog.listener()
+    async def on_command_error(self, ctx: commands.Context, error: Exception):
+        self.bot.stats.incr(
+            "command.error", guild_id=ctx.guild.id if ctx.guild else None,
+            dims={
+                "command": ctx.command.qualified_name if ctx.command else "unknown",
+                "error": type(error).__name__,
+            },
+        )
+
+    # ------------------------------------------------------------------ #
+    # Members
+    # ------------------------------------------------------------------ #
+
+    @Cog.listener()
+    async def on_member_join(self, member: discord.Member):
+        self.bot.stats.incr("member.join", guild_id=member.guild.id)
+
+    @Cog.listener()
+    async def on_member_remove(self, member: discord.Member):
+        self.bot.stats.incr("member.leave", guild_id=member.guild.id)
+
+    # ------------------------------------------------------------------ #
+    # The bot's own footprint
+    # ------------------------------------------------------------------ #
+
+    @Cog.listener()
+    async def on_guild_join(self, guild: discord.Guild):
+        """One row in ``guild_events``, plus the acquisition confirmation.
+
+        This is the only place that writes a row per occurrence without
+        hesitation: arrivals happen a few thousand times a month at most, and
+        they are what the growth curve and the retention cohorts are computed
+        from. Aggregating them would destroy exactly the detail that makes
+        them worth having.
+        """
+        db = getattr(self.bot, "db", None)
+        if not db or not getattr(db, "pool", None):
+            return
+        source = None
+        try:
+            # The backend wrote the UTM at the OAuth2 callback; all the bot
+            # can add is that the install actually landed. No row means a
+            # direct invite — not an error (see docs/STATS.md).
+            source = await db.confirm_install(guild.id)
+        except Exception as exc:
+            logger.debug("stats: could not confirm the install of %s: %s", guild.id, exc)
+        try:
+            await db.record_guild_event(
+                guild.id, "join",
+                member_count=guild.member_count,
+                owner_id=guild.owner_id,
+                guild_age=self._age(guild.created_at),
+                source=source,
+            )
+        except Exception as exc:
+            logger.warning("stats: could not record the join of %s: %s", guild.id, exc)
+        self.bot.stats.incr("guild.join", dims={"source": source or "unknown"})
+
+    @Cog.listener()
+    async def on_guild_remove(self, guild: discord.Guild):
+        db = getattr(self.bot, "db", None)
+        if not db or not getattr(db, "pool", None):
+            return
+        source = None
+        lifetime = None
+        try:
+            source = await db.install_source(guild.id)
+            joined_at = await db.last_guild_join(guild.id)
+            if joined_at:
+                lifetime = datetime.now(timezone.utc) - joined_at
+        except Exception as exc:
+            logger.debug("stats: could not resolve the history of %s: %s", guild.id, exc)
+        try:
+            await db.record_guild_event(
+                guild.id, "leave",
+                member_count=guild.member_count,
+                owner_id=guild.owner_id,
+                guild_age=self._age(guild.created_at),
+                lifetime=lifetime,
+                source=source,
+            )
+        except Exception as exc:
+            logger.warning("stats: could not record the leave of %s: %s", guild.id, exc)
+        self.bot.stats.incr("guild.leave", dims={"source": source or "unknown"})
+
+    @staticmethod
+    def _age(created_at: Optional[datetime]):
+        if not created_at:
+            return None
+        return datetime.now(timezone.utc) - created_at
+
+
+async def setup(bot):
+    await bot.add_cog(StatsEvents(bot))

--- a/db/base.py
+++ b/db/base.py
@@ -38,6 +38,7 @@ from db.repositories.tickets import TicketsRepository
 from db.repositories.notifications import NotificationRepository
 from db.repositories.support_requests import SupportRequestRepository
 from db.repositories.bump import BumpReminderRepository
+from db.repositories.stats import StatsRepository
 
 logger = logging.getLogger('moddy.database')
 
@@ -77,6 +78,7 @@ class ModdyDatabase(
     NotificationRepository,
     SupportRequestRepository,
     BumpReminderRepository,
+    StatsRepository,
 ):
     """Gestionnaire principal de la base de données"""
 
@@ -1443,6 +1445,156 @@ class ModdyDatabase(
                     """,
                     scope, qtype, tier, limit,
                 )
+
+            # ----------------------------------------------------------- #
+            # Statistics (see docs/STATS.md)
+            #
+            # Frequent events never write a row: they are counted in Redis
+            # and upserted here in aggregate, so a server that runs ten
+            # thousand commands in a day costs one row, not ten thousand.
+            # ----------------------------------------------------------- #
+
+            # Pre-aggregated counters. `dims` holds whatever the metric
+            # declared in stats/registry.py, so a new statistic never needs a
+            # new column; `dims_hash` keeps the primary key short and
+            # fixed-width whatever those dimensions are.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS stats_counters (
+                    metric      TEXT        NOT NULL,
+                    scope       TEXT        NOT NULL,
+                    scope_id    BIGINT      NOT NULL DEFAULT 0,
+                    bucket      TIMESTAMPTZ NOT NULL,
+                    dims        JSONB       NOT NULL DEFAULT '{}'::jsonb,
+                    dims_hash   BYTEA       NOT NULL,
+                    value       BIGINT      NOT NULL DEFAULT 0,
+                    PRIMARY KEY (metric, scope, scope_id, bucket, dims_hash)
+                ) PARTITION BY RANGE (bucket)
+            """)
+            # Purging a month is then a DROP, never a DELETE that blocks the
+            # writers and leaves bloat behind.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS stats_counters_default
+                PARTITION OF stats_counters DEFAULT
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_stats_counters_scope
+                ON stats_counters (scope, scope_id, bucket DESC)
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_stats_counters_metric
+                ON stats_counters (metric, bucket DESC)
+            """)
+
+            # Gauges: "how many are there", photographed once a day. A few
+            # dozen rows a day, kept forever — this is the curve of the bot.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS stats_snapshots (
+                    metric    TEXT    NOT NULL,
+                    scope     TEXT    NOT NULL,
+                    scope_id  BIGINT  NOT NULL DEFAULT 0,
+                    day       DATE    NOT NULL,
+                    dims      JSONB   NOT NULL DEFAULT '{}'::jsonb,
+                    value     NUMERIC NOT NULL,
+                    PRIMARY KEY (metric, scope, scope_id, day, dims)
+                )
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_stats_snapshots_metric
+                ON stats_snapshots (metric, day DESC)
+            """)
+
+            # Every arrival and departure of Moddy, one row each, forever.
+            # Retention is *computed* from this table (cohorts by join month),
+            # never stored — and at a few thousand rows a month it costs
+            # nothing to keep the detail.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS guild_events (
+                    id           BIGSERIAL   PRIMARY KEY,
+                    guild_id     BIGINT      NOT NULL,
+                    event        TEXT        NOT NULL,
+                    member_count INTEGER,
+                    owner_id     BIGINT,
+                    guild_age    INTERVAL,
+                    lifetime     INTERVAL,
+                    source       TEXT,
+                    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_guild_events_guild
+                ON guild_events (guild_id, created_at DESC)
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_guild_events_type
+                ON guild_events (event, created_at DESC)
+            """)
+
+            # Where an installation came from. The backend writes the row at
+            # the OAuth2 callback (it is the only side that sees the UTM in
+            # the `state`); the bot stamps `confirmed_at` when the guild
+            # actually shows up, which is what makes a conversion rate per
+            # source computable. See docs/STATS.md.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS guild_installs (
+                    guild_id      BIGINT      PRIMARY KEY,
+                    installer_id  BIGINT,
+                    source        TEXT,
+                    utm           JSONB       NOT NULL DEFAULT '{}'::jsonb,
+                    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    confirmed_at  TIMESTAMPTZ
+                )
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_guild_installs_source
+                ON guild_installs (source, first_seen_at DESC)
+            """)
+
+            # The raw window: one row per occurrence, for the handful of
+            # metrics marked raw=True, dropped a fortnight later by the
+            # partition. The insurance against questions nobody anticipated.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS stats_events (
+                    id         BIGSERIAL,
+                    event      TEXT        NOT NULL,
+                    guild_id   BIGINT,
+                    user_id    BIGINT,
+                    payload    JSONB       NOT NULL DEFAULT '{}'::jsonb,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    PRIMARY KEY (id, created_at)
+                ) PARTITION BY RANGE (created_at)
+            """)
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS stats_events_default
+                PARTITION OF stats_events DEFAULT
+            """)
+            await conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_stats_events_event
+                ON stats_events (event, created_at DESC)
+            """)
+
+            # Reading surface for the dashboard: daily numbers, no
+            # partitioning detail, no dims_hash.
+            await conn.execute("""
+                CREATE OR REPLACE VIEW stats_guild_daily_v AS
+                SELECT metric,
+                       scope_id AS guild_id,
+                       (bucket AT TIME ZONE 'UTC')::date AS day,
+                       dims,
+                       SUM(value)::bigint AS value
+                FROM stats_counters
+                WHERE scope = 'guild'
+                GROUP BY metric, scope_id, day, dims
+            """)
+            await conn.execute("""
+                CREATE OR REPLACE VIEW stats_global_daily_v AS
+                SELECT metric,
+                       (bucket AT TIME ZONE 'UTC')::date AS day,
+                       dims,
+                       SUM(value)::bigint AS value
+                FROM stats_counters
+                WHERE scope = 'global'
+                GROUP BY metric, day, dims
+            """)
 
             logger.info("[OK] Tables initialisées")
 

--- a/db/repositories/stats.py
+++ b/db/repositories/stats.py
@@ -1,0 +1,541 @@
+"""Statistics storage — writes in aggregate, reads for the dashboard.
+
+Everything here follows one rule: **the number of rows written must not grow
+with Discord traffic**. Counters arrive already summed by
+:class:`stats.service.StatsService` and land as a single upsert per
+``(metric, scope, scope_id, bucket, dims)``, so a server that runs ten
+thousand commands in a day costs one row, not ten thousand.
+
+The two tables that do keep one row per occurrence — ``guild_events`` and
+``guild_installs`` — hold events that happen a few thousand times a *month*,
+and they earn it: they are what the growth curve, the retention cohorts and
+the acquisition report are computed from.
+
+See docs/STATS.md.
+"""
+
+import json
+import logging
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger('moddy.database')
+
+#: Partitions are named after the window they hold, so the maintenance task
+#: can work out what to drop from the name alone.
+_COUNTER_PARTITION_FMT = "stats_counters_%Y%m"
+_EVENT_PARTITION_FMT = "stats_events_%Y%m%d"
+
+
+def _month_start(moment: datetime) -> datetime:
+    return moment.astimezone(timezone.utc).replace(
+        day=1, hour=0, minute=0, second=0, microsecond=0
+    )
+
+
+def _next_month(moment: datetime) -> datetime:
+    start = _month_start(moment)
+    return _month_start(start + timedelta(days=32))
+
+
+class StatsRepository:
+    """``stats_counters``, ``stats_snapshots``, ``guild_events``,
+    ``guild_installs`` and ``stats_events``."""
+
+    # ------------------------------------------------------------------ #
+    # Counters
+    # ------------------------------------------------------------------ #
+
+    async def upsert_counters(
+        self,
+        rows: Sequence[Tuple[str, str, int, datetime, Dict[str, str], bytes, int]],
+    ) -> None:
+        """Add pre-aggregated counter values.
+
+        ``rows`` are ``(metric, scope, scope_id, bucket, dims, dims_hash,
+        value)``. The write is an addition, not a replacement, which is what
+        makes a flush safe to replay: the same batch applied twice after a
+        failed commit adds the same numbers once per successful commit, and a
+        concurrent flush from another process interleaves without locking.
+        """
+        if not rows:
+            return
+        async with self.pool.acquire() as conn:
+            await conn.executemany(
+                """
+                INSERT INTO stats_counters
+                    (metric, scope, scope_id, bucket, dims, dims_hash, value)
+                VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)
+                ON CONFLICT (metric, scope, scope_id, bucket, dims_hash)
+                DO UPDATE SET value = stats_counters.value + EXCLUDED.value
+                """,
+                [
+                    (metric, scope, scope_id, bucket, json.dumps(dims, sort_keys=True),
+                     dims_hash, value)
+                    for metric, scope, scope_id, bucket, dims, dims_hash, value in rows
+                ],
+            )
+
+    async def get_counters(
+        self,
+        metric: str,
+        *,
+        scope: str = "guild",
+        scope_id: int = 0,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+    ) -> List[Dict[str, Any]]:
+        """Daily series for one metric — what a dashboard chart reads."""
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT (bucket AT TIME ZONE 'UTC')::date AS day,
+                       dims,
+                       SUM(value)::bigint AS value
+                FROM stats_counters
+                WHERE metric = $1 AND scope = $2 AND scope_id = $3
+                  AND ($4::timestamptz IS NULL OR bucket >= $4)
+                  AND ($5::timestamptz IS NULL OR bucket < $5)
+                GROUP BY day, dims
+                ORDER BY day
+                """,
+                metric, scope, scope_id, since, until,
+            )
+        return [
+            {"day": r["day"], "dims": self._parse_jsonb(r["dims"]), "value": r["value"]}
+            for r in rows
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Snapshots (gauges)
+    # ------------------------------------------------------------------ #
+
+    async def write_snapshot(
+        self,
+        metric: str,
+        value: float,
+        *,
+        scope: str = "global",
+        scope_id: int = 0,
+        day: Optional[date] = None,
+        dims: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Record "how many there are" for a day.
+
+        Replaces rather than adds, so re-running the daily rollup is a no-op
+        instead of a doubling.
+        """
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO stats_snapshots (metric, scope, scope_id, day, dims, value)
+                VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+                ON CONFLICT (metric, scope, scope_id, day, dims)
+                DO UPDATE SET value = EXCLUDED.value
+                """,
+                metric, scope, scope_id,
+                day or datetime.now(timezone.utc).date(),
+                json.dumps(dims or {}, sort_keys=True),
+                value,
+            )
+
+    async def write_snapshots(
+        self,
+        rows: Sequence[Tuple[str, str, int, date, Dict[str, str], float]],
+    ) -> None:
+        """Bulk form of :meth:`write_snapshot` — ``(metric, scope, scope_id,
+        day, dims, value)``."""
+        if not rows:
+            return
+        async with self.pool.acquire() as conn:
+            await conn.executemany(
+                """
+                INSERT INTO stats_snapshots (metric, scope, scope_id, day, dims, value)
+                VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+                ON CONFLICT (metric, scope, scope_id, day, dims)
+                DO UPDATE SET value = EXCLUDED.value
+                """,
+                [
+                    (metric, scope, scope_id, day,
+                     json.dumps(dims or {}, sort_keys=True), value)
+                    for metric, scope, scope_id, day, dims, value in rows
+                ],
+            )
+
+    async def latest_snapshot_values(self, metric: str, *,
+                                     scope: str = "guild") -> Dict[int, float]:
+        """Last recorded value of a gauge, per subject.
+
+        Used by the rollup to skip writing a number that has not moved: a
+        server whose member count is flat costs nothing, and the dashboard
+        carries the last known value forward.
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT DISTINCT ON (scope_id) scope_id, value
+                FROM stats_snapshots
+                WHERE metric = $1 AND scope = $2
+                ORDER BY scope_id, day DESC
+                """,
+                metric, scope,
+            )
+        return {r["scope_id"]: float(r["value"]) for r in rows}
+
+    async def get_snapshots(
+        self,
+        metric: str,
+        *,
+        scope: str = "global",
+        scope_id: int = 0,
+        days: int = 90,
+    ) -> List[Dict[str, Any]]:
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT day, dims, value
+                FROM stats_snapshots
+                WHERE metric = $1 AND scope = $2 AND scope_id = $3
+                  AND day >= (CURRENT_DATE - $4::int)
+                ORDER BY day
+                """,
+                metric, scope, scope_id, days,
+            )
+        return [
+            {"day": r["day"], "dims": self._parse_jsonb(r["dims"]), "value": float(r["value"])}
+            for r in rows
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Guild lifecycle — the growth curve and the retention cohorts
+    # ------------------------------------------------------------------ #
+
+    async def record_guild_event(
+        self,
+        guild_id: int,
+        event: str,
+        *,
+        member_count: Optional[int] = None,
+        owner_id: Optional[int] = None,
+        guild_age: Optional[timedelta] = None,
+        lifetime: Optional[timedelta] = None,
+        source: Optional[str] = None,
+    ) -> None:
+        """One arrival or departure. ``event`` is ``join`` or ``leave``."""
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO guild_events
+                    (guild_id, event, member_count, owner_id, guild_age, lifetime, source)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                """,
+                guild_id, event, member_count, owner_id, guild_age, lifetime, source,
+            )
+
+    async def last_guild_join(self, guild_id: int) -> Optional[datetime]:
+        """When Moddy was last added here — used to fill ``lifetime`` on leave."""
+        async with self.pool.acquire() as conn:
+            return await conn.fetchval(
+                """
+                SELECT created_at FROM guild_events
+                WHERE guild_id = $1 AND event = 'join'
+                ORDER BY created_at DESC LIMIT 1
+                """,
+                guild_id,
+            )
+
+    async def guild_growth(self, days: int = 90) -> List[Dict[str, Any]]:
+        """Joins, leaves and the net movement, per day."""
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT (created_at AT TIME ZONE 'UTC')::date AS day,
+                       COUNT(*) FILTER (WHERE event = 'join')  AS joins,
+                       COUNT(*) FILTER (WHERE event = 'leave') AS leaves
+                FROM guild_events
+                WHERE created_at >= now() - ($1::int * INTERVAL '1 day')
+                GROUP BY day
+                ORDER BY day
+                """,
+                days,
+            )
+        return [
+            {
+                "day": r["day"],
+                "joins": r["joins"],
+                "leaves": r["leaves"],
+                "net": r["joins"] - r["leaves"],
+            }
+            for r in rows
+        ]
+
+    async def retention_cohorts(self, months: int = 12) -> List[Dict[str, Any]]:
+        """Of the servers that added Moddy in month M, how many stayed.
+
+        Retention is derived, never stored: a server is still there if its
+        latest event is a join.
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                WITH latest AS (
+                    SELECT DISTINCT ON (guild_id)
+                           guild_id, event, created_at
+                    FROM guild_events
+                    ORDER BY guild_id, created_at DESC
+                ),
+                first_join AS (
+                    SELECT guild_id, MIN(created_at) AS joined_at
+                    FROM guild_events WHERE event = 'join'
+                    GROUP BY guild_id
+                )
+                SELECT date_trunc('month', f.joined_at)::date AS cohort,
+                       COUNT(*) AS acquired,
+                       COUNT(*) FILTER (WHERE l.event = 'join') AS retained
+                FROM first_join f
+                JOIN latest l USING (guild_id)
+                WHERE f.joined_at >= date_trunc('month', now()) - ($1::int * INTERVAL '1 month')
+                GROUP BY cohort
+                ORDER BY cohort
+                """,
+                months,
+            )
+        return [
+            {
+                "cohort": r["cohort"],
+                "acquired": r["acquired"],
+                "retained": r["retained"],
+                "rate": (r["retained"] / r["acquired"]) if r["acquired"] else 0.0,
+            }
+            for r in rows
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Acquisition — the half of the story the backend owns
+    # ------------------------------------------------------------------ #
+
+    async def confirm_install(self, guild_id: int) -> Optional[str]:
+        """Mark an installation as having actually landed, return its source.
+
+        The backend writes the row at the OAuth2 callback, where the UTM
+        lives; the bot only learns the install succeeded. Returns ``None``
+        when there is no row — a direct invite, or a backend that does not
+        write this table yet, and neither is an error.
+        """
+        async with self.pool.acquire() as conn:
+            return await conn.fetchval(
+                """
+                UPDATE guild_installs
+                SET confirmed_at = COALESCE(confirmed_at, now())
+                WHERE guild_id = $1
+                RETURNING source
+                """,
+                guild_id,
+            )
+
+    async def install_source(self, guild_id: int) -> Optional[str]:
+        async with self.pool.acquire() as conn:
+            return await conn.fetchval(
+                "SELECT source FROM guild_installs WHERE guild_id = $1", guild_id
+            )
+
+    async def acquisition_report(self, days: int = 30) -> List[Dict[str, Any]]:
+        """Per source: clicks that reached the callback, and how many landed."""
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT COALESCE(source, 'unknown') AS source,
+                       COUNT(*) AS started,
+                       COUNT(*) FILTER (WHERE confirmed_at IS NOT NULL) AS installed
+                FROM guild_installs
+                WHERE first_seen_at >= now() - ($1::int * INTERVAL '1 day')
+                GROUP BY source
+                ORDER BY installed DESC
+                """,
+                days,
+            )
+        return [
+            {
+                "source": r["source"],
+                "started": r["started"],
+                "installed": r["installed"],
+                "conversion": (r["installed"] / r["started"]) if r["started"] else 0.0,
+            }
+            for r in rows
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Raw events (short-lived)
+    # ------------------------------------------------------------------ #
+
+    async def insert_raw_events(
+        self,
+        rows: Sequence[Tuple[str, Optional[int], Optional[int], Dict[str, Any], datetime]],
+    ) -> None:
+        if not rows:
+            return
+        async with self.pool.acquire() as conn:
+            await conn.executemany(
+                """
+                INSERT INTO stats_events (event, guild_id, user_id, payload, created_at)
+                VALUES ($1, $2, $3, $4::jsonb, $5)
+                """,
+                [
+                    (event, guild_id, user_id, json.dumps(payload), created_at)
+                    for event, guild_id, user_id, payload, created_at in rows
+                ],
+            )
+
+    # ------------------------------------------------------------------ #
+    # Partition maintenance
+    # ------------------------------------------------------------------ #
+
+    async def ensure_stats_partitions(self, *, months_ahead: int = 1,
+                                      days_ahead: int = 2) -> None:
+        """Create the partitions the next writes will need.
+
+        Both tables carry a DEFAULT partition, so a missed maintenance pass
+        never loses a write — it just lands somewhere that cannot be dropped
+        cheaply. Attaching a range partition while conflicting rows sit in the
+        default fails; that is logged and skipped rather than raised, because
+        a statistic must never take the bot down.
+        """
+        now = datetime.now(timezone.utc)
+        month = _month_start(now)
+        for _ in range(months_ahead + 1):
+            await self._ensure_partition(
+                "stats_counters", month.strftime(_COUNTER_PARTITION_FMT),
+                month, _next_month(month),
+            )
+            month = _next_month(month)
+
+        day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        for _ in range(days_ahead + 1):
+            await self._ensure_partition(
+                "stats_events", day.strftime(_EVENT_PARTITION_FMT),
+                day, day + timedelta(days=1),
+            )
+            day += timedelta(days=1)
+
+    async def _ensure_partition(self, parent: str, name: str,
+                                start: datetime, end: datetime) -> None:
+        async with self.pool.acquire() as conn:
+            exists = await conn.fetchval("SELECT to_regclass($1)", f"public.{name}")
+            if exists:
+                return
+            try:
+                await conn.execute(
+                    f"CREATE TABLE {name} PARTITION OF {parent} "
+                    f"FOR VALUES FROM ('{start.isoformat()}') TO ('{end.isoformat()}')"
+                )
+                logger.info("[stats] Created partition %s", name)
+            except Exception as exc:
+                logger.warning("[stats] Could not create partition %s: %s", name, exc)
+
+    async def drop_old_partitions(self, *, counter_months: int = 12,
+                                  event_days: int = 14) -> List[str]:
+        """Drop what is past its retention. Returns the partitions dropped.
+
+        A DROP is instantaneous and returns the disk; the DELETE it replaces
+        would lock the writers and leave the space behind as bloat.
+        """
+        dropped: List[str] = []
+        now = datetime.now(timezone.utc)
+        counter_cutoff = _month_start(now)
+        for _ in range(counter_months):
+            counter_cutoff = _month_start(counter_cutoff - timedelta(days=1))
+        event_cutoff = now.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=event_days)
+
+        async with self.pool.acquire() as conn:
+            names = await conn.fetch(
+                """
+                SELECT c.relname AS name
+                FROM pg_class c
+                JOIN pg_inherits i ON i.inhrelid = c.oid
+                JOIN pg_class p ON p.oid = i.inhparent
+                WHERE p.relname IN ('stats_counters', 'stats_events')
+                """
+            )
+            for row in names:
+                name = row["name"]
+                window = self._partition_window(name)
+                if window is None:
+                    continue  # the DEFAULT partition, or something hand-made
+                start, kind = window
+                cutoff = counter_cutoff if kind == "counter" else event_cutoff
+                if start >= cutoff:
+                    continue
+                try:
+                    await conn.execute(f"DROP TABLE IF EXISTS {name}")
+                    dropped.append(name)
+                    logger.info("[stats] Dropped partition %s", name)
+                except Exception as exc:
+                    logger.warning("[stats] Could not drop partition %s: %s", name, exc)
+        return dropped
+
+    @staticmethod
+    def _partition_window(name: str) -> Optional[Tuple[datetime, str]]:
+        """Read a partition's start back from its name."""
+        for prefix, fmt, kind in (
+            ("stats_counters_", "%Y%m", "counter"),
+            ("stats_events_", "%Y%m%d", "event"),
+        ):
+            if not name.startswith(prefix):
+                continue
+            suffix = name[len(prefix):]
+            try:
+                return datetime.strptime(suffix, fmt).replace(tzinfo=timezone.utc), kind
+            except ValueError:
+                return None
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Rollup
+    # ------------------------------------------------------------------ #
+
+    async def rollup_hourly_to_daily(self, older_than_days: int = 90) -> int:
+        """Collapse aged hourly buckets into their day.
+
+        Hourly detail is worth keeping while someone might look at it, and
+        worth 24× its size in nothing afterwards. Idempotent: the daily rows
+        are written first, and the hourly ones deleted in the same
+        transaction, so an interrupted run resumes without double-counting.
+        """
+        cutoff = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) - timedelta(days=older_than_days)
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                moved = await conn.fetch(
+                    """
+                    WITH aged AS (
+                        DELETE FROM stats_counters
+                        WHERE bucket < $1
+                          AND bucket <> date_trunc('day', bucket)
+                        RETURNING metric, scope, scope_id, bucket, dims, dims_hash, value
+                    )
+                    SELECT metric, scope, scope_id,
+                           date_trunc('day', bucket) AS day,
+                           dims, dims_hash, SUM(value)::bigint AS value
+                    FROM aged
+                    GROUP BY metric, scope, scope_id, day, dims, dims_hash
+                    """,
+                    cutoff,
+                )
+                if moved:
+                    await conn.executemany(
+                        """
+                        INSERT INTO stats_counters
+                            (metric, scope, scope_id, bucket, dims, dims_hash, value)
+                        VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)
+                        ON CONFLICT (metric, scope, scope_id, bucket, dims_hash)
+                        DO UPDATE SET value = stats_counters.value + EXCLUDED.value
+                        """,
+                        [
+                            (r["metric"], r["scope"], r["scope_id"], r["day"],
+                             r["dims"] if isinstance(r["dims"], str) else json.dumps(r["dims"]),
+                             r["dims_hash"], r["value"])
+                            for r in moved
+                        ],
+                    )
+        return len(moved)

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -782,6 +782,62 @@ redémarrage en plein balayage.
 
 See → [BUMP_REMINDER.md](BUMP_REMINDER.md).
 
+### 20. Tables de statistiques
+
+Cinq tables, un seul principe : **agréger avant d'écrire**. Un événement
+fréquent (une commande, un appel IA, un log) n'écrit jamais de ligne — il est
+compté en mémoire par `bot.stats` et un flush périodique en enregistre le
+total. Dix mille commandes dans une journée sur un serveur coûtent une ligne,
+pas dix mille. Voir → [STATS.md](STATS.md).
+
+**`stats_counters`** — les compteurs pré-agrégés, partitionnée par mois.
+
+- `metric` (TEXT) — la clé déclarée dans `stats/registry.py`
+- `scope` (TEXT) / `scope_id` (BIGINT) — `global` (0), `guild` ou `user`
+- `bucket` (TIMESTAMPTZ) — début d'heure ou de jour, UTC
+- `dims` (JSONB) — les dimensions déclarées par la métrique. C'est ce qui rend
+  le système extensible **sans colonne** : ajouter une statistique ne demande
+  aucune migration
+- `dims_hash` (BYTEA) — SHA-1 du JSON canonique, pour que la clé primaire reste
+  courte et de taille fixe quelles que soient les dimensions
+- `value` (BIGINT) — l'argent est stocké en millionièmes de dollar (`ai.cost`)
+- PRIMARY KEY `(metric, scope, scope_id, bucket, dims_hash)`
+
+L'écriture est une **addition** (`ON CONFLICT DO UPDATE SET value = value +
+EXCLUDED.value`) : un flush rejoué après un commit raté ne double rien, et deux
+process ajoutent simplement leurs totaux à la même ligne. Le partitionnement
+rend la purge gratuite — un `DROP TABLE` au lieu d'un `DELETE` qui bloque les
+écrivains et laisse du bloat.
+
+**`stats_snapshots`** — les jauges (« combien y en a-t-il »), une photo par
+jour : nombre de serveurs, de membres, adoption de chaque module, utilisateurs
+distincts. Quelques dizaines de lignes par jour, gardées à vie : c'est la
+courbe d'évolution du bot. PRIMARY KEY `(metric, scope, scope_id, day, dims)`,
+écriture par remplacement — relancer le rollup ne double rien.
+
+**`guild_events`** — chaque arrivée et chaque départ de Moddy (`event` =
+`join` | `leave`), avec `member_count`, `owner_id`, `guild_age`, `lifetime` et
+`source`. La **rétention se calcule** depuis cette table (cohortes par mois
+d'ajout), elle ne se stocke pas.
+
+**`guild_installs`** — d'où vient une installation. La **seule table de stats
+que le bot ne remplit pas seul** : le backend écrit la ligne au callback OAuth2
+(lui seul voit les UTM du `state`), le bot pose `confirmed_at` à
+`on_guild_join`. `guild_id` (PK), `installer_id`, `source`, `utm` (JSONB),
+`first_seen_at`, `confirmed_at`. Contrat exact → [STATS.md](STATS.md) §6.
+
+**`stats_events`** — la fenêtre brute : une ligne par occurrence pour les rares
+métriques marquées `raw=True`, partitionnée par jour et supprimée à 14 jours.
+L'assurance contre les questions non anticipées.
+
+**Vues de lecture** (dashboard) : `stats_guild_daily_v` et
+`stats_global_daily_v` exposent des chiffres journaliers sans le
+partitionnement ni le `dims_hash`.
+
+**Repository:** `db/repositories/stats.py` — `StatsRepository`
+
+---
+
 ---
 
 ## Système d'attributs et de données

--- a/docs/REDIS_COMMUNICATION.md
+++ b/docs/REDIS_COMMUNICATION.md
@@ -110,6 +110,7 @@ the event was produced: task queues, command/reply RPC, notification feeds.
 | `task:seen:{task_id}` | Bot | Anti-replay marker for `moddy:tasks`, `SET NX EX 600` ([TASK_SIGNATURE.md](TASK_SIGNATURE.md)) |
 | `feeds:heartbeat` | `moddy-feeds` service | Health check, TTL ~90s |
 | `quota:{scope}:{key}:{type}:{date}` | Bot (`gateway/quota.py`) | Daily API quota counters |
+| `stats:hll:{metric}:{scope}:{id}:{day}` | Bot (`stats/service.py`) | HyperLogLog of distinct people per day, TTL 3 days. Never holds a list of ids — the daily rollup reads `PFCOUNT` and stores one number ([STATS.md](STATS.md)) |
 
 ---
 
@@ -172,6 +173,10 @@ order live in [TASK_SIGNATURE.md](TASK_SIGNATURE.md).
   integration (not `feeds:notifications`); don't reuse it for anything else.
 - `bot:*` — bot-only cache keys with no cross-service meaning (per
   `docs/BACKEND-INTEGRATION.md` §9).
+- `stats:*` — the statistics system's own keys ([STATS.md](STATS.md)). Counters
+  do **not** live here: they are aggregated in the bot's memory and flushed
+  straight to Postgres, so a Redis outage costs only the distinct-people
+  counts.
 - JSON payloads on Pub/Sub and Streams commonly carry a `type`/`action` field
   to dispatch on, and a `request_id` when a reply is expected. Discord IDs
   travel as strings in stream fields (`XADD` only accepts strings) — always

--- a/docs/STATS.md
+++ b/docs/STATS.md
@@ -1,0 +1,265 @@
+# Statistics
+
+> How Moddy measures everything without paying for it. Read this before
+> adding a statistic, and before writing anything that reads one.
+
+---
+
+## 1. The idea in one paragraph
+
+A Discord bot produces millions of measurable events a month and gets asked
+maybe fifty questions a quarter. Storing one row per event to answer those
+fifty questions is how a statistics system becomes the most expensive table
+in the database. So Moddy never writes a row per event: it **counts in
+memory and writes the total**. Ten thousand commands on one server in a day
+cost one row. What that costs in exchange is precision nobody asked for —
+the exact second a command ran — and a fortnight-long raw window exists for
+the times that turns out to matter.
+
+Adding a metric is one entry in `stats/registry.py`. No migration, no
+column, no schema change — ever.
+
+---
+
+## 2. The pieces
+
+| File | Role |
+|---|---|
+| `stats/registry.py` | **The source of truth.** Every metric, its scope, its bucket size and its allowed dimensions |
+| `stats/service.py` | `bot.stats` — records (`incr`, `observe_unique`) and flushes the aggregate every 60 s |
+| `stats/rollup.py` | `bot.stats_rollup` — daily snapshots, ageing, partition maintenance |
+| `db/repositories/stats.py` | The writes and the dashboard reads |
+| `cogs/stats_events.py` | The Discord listeners that emit |
+| `db/base.py` | The DDL of the five tables |
+
+---
+
+## 3. Recording a statistic
+
+```python
+bot.stats.incr("command.used", guild_id=guild.id,
+               dims={"command": "config", "kind": "slash"})
+```
+
+Three properties matter, and all three are deliberate:
+
+* **It is synchronous.** No `await`, no I/O on the hot path.
+* **It never raises.** A bad dimension, an unknown key, a broken database —
+  every one of them is logged once and swallowed. Measuring a feature must
+  never be able to break it.
+* **It aggregates.** The call adds to a dictionary; the flush writes the sum.
+
+Inside a module, use the shorthand — it fills in the module id and the guild:
+
+```python
+self.count("sent")          # ModuleBase.count(), see modules/module_manager.py
+```
+
+For distinct people, never a list of ids:
+
+```python
+bot.stats.observe_unique("user.active", user.id, guild_id=guild.id)
+```
+
+The ids are folded into a Redis HyperLogLog at the next flush (~12 KB per
+key, 0.8 % error) and the daily rollup stores only its cardinality.
+
+### Adding a metric
+
+Add one entry to `_ALL` in `stats/registry.py`:
+
+```python
+Metric("ticket.opened", dimensions=("panel",))
+```
+
+Then emit it. That is the whole change. Two rules decide whether the metric
+will be cheap:
+
+1. **Every dimension must have bounded cardinality.** A command name, a
+   module id, a boolean, a provider — yes. A user id, a message id, a
+   channel id, free-text — never: each distinct value is a row per day.
+   Undeclared dimensions are dropped before they reach the database, so the
+   mistake cannot be made by accident, only by declaring it.
+2. **Leave the resolution alone.** Per-server metrics are daily, global ones
+   hourly. Making a per-server metric hourly multiplies its rows by 24.
+
+---
+
+## 4. What is stored
+
+| Table | What | Retention |
+|---|---|---|
+| `stats_counters` | Pre-aggregated counters, partitioned by month | hourly buckets 90 days, then daily; partitions dropped at 12 months |
+| `stats_snapshots` | Daily gauges: servers, members, adoption, distinct users | forever (a few dozen rows a day) |
+| `guild_events` | Every arrival and departure of Moddy | forever |
+| `guild_installs` | Where an installation came from (UTM) — **written by the backend** | forever |
+| `stats_events` | Raw rows for metrics marked `raw=True`, partitioned by day | 14 days |
+
+### `stats_counters`
+
+```
+metric | scope | scope_id | bucket | dims (jsonb) | dims_hash | value
+```
+
+`dims` holds whatever the metric declared, which is what makes the system
+extensible without columns; `dims_hash` (SHA-1 of the canonical JSON) keeps
+the primary key short and fixed-width. The write is
+`INSERT … ON CONFLICT DO UPDATE SET value = value + EXCLUDED.value`: an
+**addition**, so a replayed flush after a failed commit cannot double-count,
+and two bot processes simply add their own totals to the same row.
+
+Partitioning is what makes retention free — dropping a month is a `DROP
+TABLE`, not a `DELETE` that locks writers and leaves bloat. Both partitioned
+tables also carry a `DEFAULT` partition so a missed maintenance pass never
+loses a write; rows that land there are queryable but cannot be dropped
+cheaply, so `stats_counters_default` should stay empty in normal operation.
+
+### Gauges vs counters
+
+A counter answers "how many times", a gauge answers "how many are there".
+The bot's own curve — servers, members, premium, module adoption — is
+gauges, photographed once a day by the rollup. Per-server member counts are
+photographed **only when they change**: a server whose size is flat stores
+nothing, and a chart carries the last known value forward.
+
+---
+
+## 5. The bot's growth and its retention
+
+`guild_events` is the one place that keeps a row per occurrence without
+apology: arrivals happen a few thousand times a month, and aggregating them
+would destroy the detail that makes them worth having.
+
+Retention is **computed, never stored** — a server is still there if its
+latest event is a join:
+
+```sql
+-- Net growth per day
+SELECT day, joins, leaves, joins - leaves AS net
+FROM (
+  SELECT (created_at AT TIME ZONE 'UTC')::date AS day,
+         COUNT(*) FILTER (WHERE event = 'join')  AS joins,
+         COUNT(*) FILTER (WHERE event = 'leave') AS leaves
+  FROM guild_events GROUP BY 1
+) g ORDER BY day;
+```
+
+`StatsRepository.guild_growth()` and `retention_cohorts()` are these queries,
+ready to call.
+
+---
+
+## 6. Acquisition — the contract with the backend
+
+`guild_installs` is the only stats table the bot does not fill in on its own,
+because neither side knows the whole story: the **backend** sees the UTM
+parameters carried in the OAuth2 `state`, but not whether the install
+succeeded; the **bot** sees the guild appear, but not where it came from.
+
+**The backend writes the row** at the OAuth2 callback:
+
+```sql
+INSERT INTO guild_installs (guild_id, installer_id, source, utm)
+VALUES ($1, $2, $3, $4::jsonb)
+ON CONFLICT (guild_id) DO UPDATE
+SET source = EXCLUDED.source, utm = EXCLUDED.utm,
+    first_seen_at = now(), confirmed_at = NULL;
+```
+
+* `source` — a short, bounded label: `topgg`, `discovery`, `profile`, `ads`,
+  `command`, `direct`. Keep the vocabulary small; it is a dimension.
+* `utm` — the full detail: `{"medium": …, "campaign": …, "content": …,
+  "term": …}`. Free-form, queried rarely, never used as a dimension.
+
+**The bot stamps `confirmed_at`** at `on_guild_join` (`confirm_install()`)
+and copies `source` onto the `guild_events` row. A missing row is not an
+error — it means a direct invite, or a backend that does not write this table
+yet. Nothing in the bot depends on it.
+
+That split is what makes both halves computable:
+
+```sql
+-- Conversion by source: clicks that reached the callback vs installs that landed
+SELECT COALESCE(source,'unknown') AS source,
+       COUNT(*) AS started,
+       COUNT(*) FILTER (WHERE confirmed_at IS NOT NULL) AS installed
+FROM guild_installs GROUP BY 1 ORDER BY installed DESC;
+
+-- And retention by source: which channel brings servers that stay
+SELECT e.source, COUNT(*) FILTER (WHERE e.event = 'join') AS acquired,
+       COUNT(*) FILTER (WHERE latest.event = 'join')      AS still_here
+FROM guild_events e
+JOIN LATERAL (
+  SELECT event FROM guild_events x
+  WHERE x.guild_id = e.guild_id ORDER BY created_at DESC LIMIT 1
+) latest ON TRUE
+WHERE e.event = 'join'
+GROUP BY e.source;
+```
+
+A source that converts well but retains badly is a source that is buying the
+wrong servers — which is the actual question the UTMs were added to answer.
+
+---
+
+## 7. Reading (dashboard)
+
+The backend shares the database and reads it directly. Two views hide the
+partitioning and the `dims_hash`:
+
+| View | Columns |
+|---|---|
+| `stats_guild_daily_v` | `metric, guild_id, day, dims, value` |
+| `stats_global_daily_v` | `metric, day, dims, value` |
+
+```sql
+-- Top commands on one server over 30 days
+SELECT dims->>'command' AS command, SUM(value) AS uses
+FROM stats_guild_daily_v
+WHERE metric = 'command.used' AND guild_id = $1
+  AND day >= CURRENT_DATE - 30
+GROUP BY 1 ORDER BY uses DESC LIMIT 20;
+
+-- What a server cost in AI last month, in dollars
+SELECT SUM(value) / 1e6 AS usd
+FROM stats_guild_daily_v
+WHERE metric = 'ai.cost' AND guild_id = $1
+  AND day >= date_trunc('month', CURRENT_DATE - INTERVAL '1 month');
+
+-- The bot's curve
+SELECT day, value FROM stats_snapshots
+WHERE metric = 'bot.guilds' AND scope = 'global' ORDER BY day;
+
+-- Module adoption over time
+SELECT day, dims->>'module' AS module, value FROM stats_snapshots
+WHERE metric = 'module.enabled' ORDER BY day;
+```
+
+Money is stored as **millionths of a dollar** (`ai.cost`): the counter column
+is a `BIGINT`, and a float would not survive the additive upsert intact.
+
+`api_calls` remains the fine-grained truth for API calls — one row per call,
+with the correlation id, the latency and the error. `ai.*` are the same facts
+pre-aggregated, so "what did this server cost us in August" is a three-row
+read instead of a scan.
+
+---
+
+## 8. What can go wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| A metric records nothing | Its key is not in `stats/registry.py`, or a per-server metric was called without a `guild_id` | Check the logs: both are logged once as a warning |
+| A dimension is missing from the rows | It was not declared on the metric | Add it to `dimensions=` — and check its cardinality first |
+| `stats_counters` grows faster than expected | A dimension with unbounded values, or a per-server metric set to hourly | `SELECT metric, COUNT(*) FROM stats_counters GROUP BY 1 ORDER BY 2 DESC` names the culprit immediately |
+| Counters stop after a Redis outage | They do not — only distinct-people counts need Redis | — |
+| Up to a minute of counters missing after a crash | The aggregate had not been flushed | By design; a graceful shutdown flushes |
+
+---
+
+## 9. See also
+
+- [DATABASE.md](DATABASE.md) — the tables in the wider schema
+- [API_GATEWAY.md](API_GATEWAY.md) — `api_calls`, the raw side of `ai.*`
+- [REDIS_COMMUNICATION.md](REDIS_COMMUNICATION.md) — the `stats:*` namespace
+- [RAILWAY.md](RAILWAY.md) — why storage and memory are the cost that matters

--- a/docs/sessions/2026-09-07_stats-system.md
+++ b/docs/sessions/2026-09-07_stats-system.md
@@ -1,0 +1,93 @@
+# Statistics system — storage design and implementation
+
+## What was done
+
+Built the statistics system from nothing: Moddy had no way to measure
+anything except `api_calls` (one raw row per gateway call). The system now
+records commands, modules, AI cost, server activity, the bot's own growth
+curve, server retention and acquisition sources.
+
+The design constraint was cost, not schema. Railway bills RAM and storage,
+and a "one row per event" table on a Discord bot produces millions of rows a
+month to answer questions asked once a quarter. So the system **aggregates
+before writing**: frequent events are counted in memory and a flush writes
+the total once a minute. Ten thousand commands on one server in a day cost
+one row.
+
+## Files
+
+**New**
+- `stats/registry.py` — every metric declared once: scope, bucket size,
+  allowed dimensions. Adding a metric needs no migration.
+- `stats/service.py` — `bot.stats`: `incr()` (synchronous, never raises,
+  aggregates), `observe_unique()` (HyperLogLog), 60 s flush with merge-back
+  on failure.
+- `stats/rollup.py` — daily snapshots, hourly→daily ageing, partition
+  maintenance and purge.
+- `db/repositories/stats.py` — `StatsRepository`: additive upserts, dashboard
+  reads, growth/cohort/acquisition queries, partition management.
+- `cogs/stats_events.py` — the Discord listeners that emit.
+- `docs/STATS.md`, `tests/test_stats.py`.
+
+**Modified**
+- `db/base.py` — DDL for `stats_counters`, `stats_snapshots`, `guild_events`,
+  `guild_installs`, `stats_events` + the two dashboard views.
+- `bot.py` — instantiation, flush loop in `setup_hook`, rollup in `on_ready`,
+  flush on shutdown.
+- `gateway/logger.py`, `gateway/__init__.py` — AI counters alongside the
+  existing `api_calls` row.
+- `modules/module_manager.py` — `ModuleBase.count()` shorthand; emitters in
+  `welcome_channel`, `auto_role`, `starboard`, `automod_ai`.
+- `notifications/service.py`, `services/case_service.py`,
+  `services/ticket_service.py`, `cogs/bump_reminder.py`,
+  `serverlogs/service.py` — one counter each at their existing choke point.
+- `CLAUDE.md`, `docs/DATABASE.md`, `docs/REDIS_COMMUNICATION.md`.
+
+## Decisions
+
+**Aggregation in memory, not in Redis.** The plan called for `HINCRBY` per
+event. In-process aggregation is strictly better here: `incr()` becomes
+synchronous, so recording a statistic cannot slow down or break the feature
+it measures — a property `await redis.hincrby()` cannot offer. The additive
+upsert makes it correct across processes anyway. Cost: up to one flush
+interval of counters lost on a hard kill (a graceful shutdown flushes).
+Redis is still used for the distinct-people HyperLogLogs.
+
+**`dims` JSONB + `dims_hash`.** Dimensions in JSONB is what makes a new
+metric free; hashing them keeps the primary key short and fixed-width. The
+registry drops undeclared dimensions before they can reach the database,
+which is the guard rail against the classic cardinality explosion (a user id
+as a dimension turns one row a day into a hundred thousand).
+
+**Daily buckets per server, hourly globally.** The single biggest cost lever:
+hourly per-server buckets are 24× the rows for a precision nobody reads at
+that scope.
+
+**Partitioning over DELETE.** Retention is a `DROP TABLE`, instantaneous and
+it returns the disk. Both partitioned tables keep a `DEFAULT` partition so a
+missed maintenance pass never loses a write.
+
+**Retention and cohorts are computed, not stored.** `guild_events` keeps one
+row per arrival/departure — a few thousand a month — and every retention
+question is a query over it.
+
+**Per-server member counts are only written when they change.** A flat server
+stores nothing; a chart carries the last known value forward.
+
+## Verification
+
+- `python3 -m pytest -q` — 1760 passed (29 new).
+- The DDL, the additive upsert, the rollup, the views, the partition creation
+  and the growth/cohort/acquisition queries were all executed against a live
+  PostgreSQL 16, including checks that a re-run of the rollup changes nothing.
+
+## Follow-ups
+
+- **`guild_installs` is not filled in yet.** The backend must write the row at
+  the OAuth2 callback (contract in `docs/STATS.md` §6). Until it does,
+  `source` stays NULL everywhere and the acquisition report is empty — the bot
+  works fine with the table empty.
+- More emitters can be added as needed; each is one line at an existing choke
+  point plus one entry in the registry.
+- If `stats_counters_default` ever accumulates rows, a maintenance pass missed
+  its window — the rows are queryable but not cheaply droppable.

--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -97,7 +97,7 @@ class Gateway:
         self.translation = None
         self.transcription = None
 
-    async def start(self, redis, pool, tech_logger=None) -> None:
+    async def start(self, redis, pool, tech_logger=None, stats=None) -> None:
         """Boot the gateway. Call after Redis + DB pool are ready."""
         from .quota import QuotaManager
         from .ratelimit import RateLimiter
@@ -117,7 +117,7 @@ class Gateway:
             failure_threshold=self.config.cb_failure_threshold,
             cooldown=self.config.cb_cooldown,
         )
-        self._gw_logger = GatewayLogger(redis, pool, self.config, tech_logger)
+        self._gw_logger = GatewayLogger(redis, pool, self.config, tech_logger, stats)
 
         if self.config.openai_api_key:
             try:

--- a/gateway/logger.py
+++ b/gateway/logger.py
@@ -37,15 +37,24 @@ class GatewayLogger:
     2. Buffered PG writes via Redis list flushed by a background task.
     """
 
-    def __init__(self, redis, pool, config: GatewayConfig, tech_logger=None):
+    def __init__(self, redis, pool, config: GatewayConfig, tech_logger=None,
+                 stats=None):
         self._redis = redis
         self._pool = pool
         self._config = config
         self._tech_logger = tech_logger
+        # bot.stats, when the gateway runs inside the bot. api_calls stays the
+        # fine-grained truth; these counters are the same facts pre-aggregated
+        # per guild and per day, so "what did this server cost us in August"
+        # is a three-row read instead of a scan (see docs/STATS.md).
+        self._stats = stats
         self._flush_task: Optional[asyncio.Task] = None
 
     def set_tech_logger(self, tech_logger) -> None:
         self._tech_logger = tech_logger
+
+    def set_stats(self, stats) -> None:
+        self._stats = stats
 
     def start(self) -> None:
         self._flush_task = asyncio.create_task(
@@ -108,6 +117,8 @@ class GatewayLogger:
             "ts": datetime.now(timezone.utc).isoformat(),
         }
 
+        self._count(entry)
+
         # Push to Redis buffer (non-blocking)
         try:
             await self._redis.rpush(self._config.log_buffer_key, json.dumps(entry))
@@ -120,6 +131,33 @@ class GatewayLogger:
                 self._safe_webhook(entry, request_payload, response_data),
                 name="gateway-webhook-log",
             )
+
+    def _count(self, entry: dict) -> None:
+        """Fold one call into the daily counters. Synchronous and unfailing."""
+        if self._stats is None:
+            return
+        try:
+            dims = {
+                "provider": entry["provider"],
+                "model": entry.get("model") or "none",
+                "call_type": entry["call_type"],
+            }
+            guild_id = entry.get("guild_id")
+            self._stats.incr("ai.calls", guild_id=guild_id,
+                             dims={**dims, "ok": entry["success"]})
+            tokens = entry.get("tokens_total") or 0
+            if tokens:
+                self._stats.incr("ai.tokens", guild_id=guild_id,
+                                 value=tokens, dims=dims)
+            cost = entry.get("estimated_cost")
+            if cost:
+                # Stored in millionths of a dollar: the counter column is a
+                # BIGINT, and a float would not survive the additive upsert.
+                self._stats.incr("ai.cost", guild_id=guild_id,
+                                 value=int(round(float(cost) * 1_000_000)),
+                                 dims=dims)
+        except Exception as exc:
+            logger.debug("Gateway stats counting failed: %s", exc)
 
     async def _safe_webhook(
         self,

--- a/modules/auto_role.py
+++ b/modules/auto_role.py
@@ -228,6 +228,7 @@ class AutoRoleModule(ModuleBase):
             # Attribue les rôles si il y en a
             if roles_to_add:
                 await member.add_roles(*roles_to_add, reason="Auto Role")
+                self.count("roles_added", len(roles_to_add))
                 role_names = ", ".join([role.name for role in roles_to_add])
                 logger.info(
                     f"✅ Added {len(roles_to_add)} auto role(s) to {member.name} ({'bot' if member.bot else 'member'}) "

--- a/modules/automod_ai.py
+++ b/modules/automod_ai.py
@@ -817,6 +817,21 @@ class AutomodModule(ModuleBase):
         if not decision.actions:
             return
 
+        # Counted here — after the barème settled the sanction, before shadow
+        # mode short-circuits — so a server running in simulation produces the
+        # same statistics as one applying them (see docs/STATS.md).
+        self.count("decision")
+        heaviest = next(
+            (a for a in ("ban", "mute", "warn", "delete") if a in decision.actions),
+            decision.actions[0],
+        )
+        stats = getattr(self.bot, "stats", None)
+        if stats is not None:
+            stats.incr(
+                "automod.decision", guild_id=self.guild_id,
+                dims={"sanction": heaviest, "dry_run": bool(self.dry_run)},
+            )
+
         # Shadow mode (session 3): run the whole funnel + barème but apply NOTHING
         # — no delete, no sanction, no case, no DM. Post a SIMULATION card with
         # annotation buttons that feed the eval corpus instead.

--- a/modules/module_manager.py
+++ b/modules/module_manager.py
@@ -65,6 +65,21 @@ class ModuleBase(ABC):
         self.config: Dict[str, Any] = {}
         self.enabled = False
 
+    def count(self, action: str, value: int = 1) -> None:
+        """Record that this module actually *did* something.
+
+        Being enabled and being used are different questions, and only the
+        second one says whether a feature earns its place. Synchronous and
+        unfailing, like every statistic (see docs/STATS.md).
+        """
+        stats = getattr(self.bot, "stats", None)
+        if stats is None:
+            return
+        stats.incr(
+            "module.action", guild_id=self.guild_id, value=value,
+            dims={"module": self.MODULE_ID, "action": action},
+        )
+
     @abstractmethod
     async def load_config(self, config_data: Dict[str, Any]) -> bool:
         """

--- a/modules/starboard.py
+++ b/modules/starboard.py
@@ -616,6 +616,7 @@ class StarboardModule(ModuleBase):
 
             # Track it for future updates/removal
             self.starboard_messages[original_message.id] = starboard_msg.id
+            self.count("starred")
 
             logger.info(f"Created starboard entry for {original_message.id}")
         except discord.Forbidden:

--- a/modules/welcome_channel.py
+++ b/modules/welcome_channel.py
@@ -295,6 +295,7 @@ class WelcomeChannelModule(ModuleBase):
 
                 view, allowed = build_welcome_view(entry, member, guild)
                 await channel.send(view=view, allowed_mentions=allowed)
+                self.count("sent")
                 logger.info(
                     f"Channel welcome sent for {member.id} in channel {entry['channel_id']} "
                     f"(guild {self.guild_id}, message {entry['id']})"

--- a/notifications/service.py
+++ b/notifications/service.py
@@ -202,6 +202,22 @@ class NotificationService:
         except Exception as exc:  # noqa: BLE001
             logger.error("Failed to update delivery status: %s", exc)
 
+    def _count_delivery(self, record: Optional[Dict[str, Any]],
+                        platform: Platform, ok: bool) -> None:
+        """Fold one delivery into the daily counters (see docs/STATS.md)."""
+        stats = getattr(self.bot, "stats", None)
+        if stats is None:
+            return
+        stats.incr(
+            "notification.sent",
+            guild_id=(record or {}).get("source_guild_id"),
+            dims={
+                "kind": (record or {}).get("kind") or "unknown",
+                "platform": platform.value,
+                "ok": ok,
+            },
+        )
+
     async def mark_delivered(self, record: Optional[Dict[str, Any]],
                              message: Optional[discord.Message] = None,
                              platform: Platform = Platform.DISCORD) -> None:
@@ -219,6 +235,7 @@ class NotificationService:
             channel_id=getattr(getattr(message, "channel", None), "id", None),
             message_id=getattr(message, "id", None),
         )
+        self._count_delivery(record, platform, True)
 
     async def mark_failed(self, record: Optional[Dict[str, Any]],
                           error: Optional[str] = None,
@@ -227,6 +244,7 @@ class NotificationService:
         if not record:
             return
         await self._mark(record["id"], platform, DeliveryStatus.FAILED, error=error)
+        self._count_delivery(record, platform, False)
 
     # ------------------------------------------------------------------ #
     # Sending
@@ -372,10 +390,12 @@ class NotificationService:
         except discord.Forbidden as exc:
             await self._mark(notification_id, Platform.DISCORD, DeliveryStatus.FAILED,
                              error="forbidden")
+            self._count_delivery(record, Platform.DISCORD, False)
             return DeliveryResult(notification_id, None, DeliveryStatus.FAILED, exc)
         except discord.HTTPException as exc:
             await self._mark(notification_id, Platform.DISCORD, DeliveryStatus.FAILED,
                              error=str(exc))
+            self._count_delivery(record, Platform.DISCORD, False)
             return DeliveryResult(notification_id, None, DeliveryStatus.FAILED, exc)
 
         # ``message`` is always a Message from a real Discord send; guard
@@ -386,6 +406,7 @@ class NotificationService:
             channel_id=getattr(getattr(message, "channel", None), "id", None),
             message_id=getattr(message, "id", None),
         )
+        self._count_delivery(record, Platform.DISCORD, True)
         # The mail and the dashboard are served by the backend from the stored
         # row; the bot only declares them as targeted and leaves them pending.
         return DeliveryResult(notification_id, message, DeliveryStatus.SENT, None)

--- a/serverlogs/service.py
+++ b/serverlogs/service.py
@@ -134,6 +134,12 @@ class LogService:
         """Render once and queue the result for each destination channel."""
         if not channel_ids:
             return
+        # One counter per *entry*, not per destination: a server sending the
+        # same event to three channels logged one thing (see docs/STATS.md).
+        stats = getattr(self.bot, "stats", None)
+        if stats is not None:
+            stats.incr("log.dispatched", guild_id=getattr(module, "guild_id", None),
+                       dims={"category": entry.event.split(".", 1)[0]})
         if not module.attach_transcripts:
             entry.files.clear()
 

--- a/services/case_service.py
+++ b/services/case_service.py
@@ -203,12 +203,35 @@ class CaseService:
             group_id=group_id,
         )
         result["created"] = True
+        self._count(spec, scope_id, action_value)
         self._invalidate_global(spec, subject_id)
         await self._log_to_server(
             spec, scope_id, subject_id, action_value, issuer_id, reason,
             expires_at, result.get("reference"),
         )
         return result
+
+    def _count(self, spec, scope_id, action: str) -> None:
+        """One counter per case opened (see docs/STATS.md).
+
+        A guild-scoped case counts for that guild; a platform-scoped one is
+        not a server's business, so it counts globally.
+        """
+        stats = getattr(self.bot, "stats", None)
+        if stats is None:
+            return
+        guild_id = None
+        if spec.case_type is CaseType.GUILD and scope_id:
+            try:
+                guild_id = int(scope_id)
+            except (TypeError, ValueError):
+                guild_id = None
+        stats.incr(
+            "case.created",
+            guild_id=guild_id,
+            scope="guild" if guild_id else "global",
+            dims={"type": spec.case_type.value, "action": action},
+        )
 
     async def revoke_sanction(
         self,

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -499,6 +499,10 @@ class TicketService:
 
         logger.info(f"[Tickets] #{ticket['number']} opened in guild {guild.id} "
                     f"by {member.id} (category {category['id']})")
+        stats = getattr(self.bot, "stats", None)
+        if stats is not None:
+            stats.incr("ticket.opened", guild_id=guild.id,
+                       dims={"panel": str(panel.get('id'))})
         return channel
 
     def _open_ping_content(self, guild: discord.Guild, category: Dict[str, Any],
@@ -741,6 +745,14 @@ class TicketService:
 
         await self._notify_owner_closed(channel, ticket, category, actor, reason)
         logger.info(f"[Tickets] #{ticket['number']} closed by {actor.id}")
+        stats = getattr(self.bot, "stats", None)
+        if stats is not None:
+            stats.incr(
+                "ticket.closed", guild_id=channel.guild.id,
+                # Not the free-text reason — a dimension has to have bounded
+                # cardinality (see stats/registry.py).
+                dims={"reason": "with_reason" if reason else "none"},
+            )
         return ticket
 
     async def _notify_owner_closed(self, channel, ticket, category, actor, reason):

--- a/stats/__init__.py
+++ b/stats/__init__.py
@@ -1,0 +1,17 @@
+"""Moddy's statistics system.
+
+Three pieces, one rule — aggregate before writing:
+
+* :mod:`stats.registry` declares every metric (adding one needs no migration),
+* :mod:`stats.service` records them (``bot.stats.incr(...)``, synchronous and
+  unfailing), flushing an aggregate to Postgres once a minute,
+* :mod:`stats.rollup` photographs the gauges daily and ages the data out.
+
+See docs/STATS.md.
+"""
+
+from stats.registry import Metric
+from stats.rollup import StatsRollup
+from stats.service import StatsService
+
+__all__ = ["Metric", "StatsService", "StatsRollup"]

--- a/stats/registry.py
+++ b/stats/registry.py
@@ -1,0 +1,286 @@
+"""Single source of truth for every statistic Moddy measures.
+
+A metric is declared **once**, here. The service that records it, the rollup
+that ages it and the dashboard that reads it all resolve the same entry, so
+adding a new statistic is one entry in :data:`METRICS` — no migration, no
+column, no change anywhere else:
+
+.. code-block:: python
+
+    Metric("ticket.opened", scope=SCOPE_GUILD, dimensions=("category",))
+
+    bot.stats.incr("ticket.opened", guild_id=guild.id, dims={"category": cat})
+
+The registry is also the guard rail. Storage cost is driven by *cardinality*
+— the number of distinct ``(metric, scope_id, bucket, dims)`` tuples — and
+the classic way to blow it up is to record a user id as a dimension, turning
+one row a day into a hundred thousand. :func:`normalise_dims` drops anything
+the metric did not declare, so that mistake is impossible to make by
+accident.
+
+The second cost lever is :attr:`Metric.resolution`. Per-server metrics are
+daily by default: hourly buckets multiply their volume by 24 for a precision
+nobody reads at that scope. Global metrics are hourly, because there is only
+one of them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, Optional, Tuple
+
+# --------------------------------------------------------------------------- #
+# Vocabulary
+# --------------------------------------------------------------------------- #
+
+#: "How many times did this happen" — summed into ``stats_counters``.
+KIND_COUNTER = "counter"
+#: "How many are there right now" — photographed daily into ``stats_snapshots``.
+KIND_GAUGE = "gauge"
+#: "How many *distinct* somethings" — a Redis HyperLogLog counted daily into
+#: ``stats_snapshots``. Never stores the ids themselves.
+KIND_UNIQUE = "unique"
+
+SCOPE_GLOBAL = "global"
+SCOPE_GUILD = "guild"
+SCOPE_USER = "user"
+
+RESOLUTION_HOUR = "hour"
+RESOLUTION_DAY = "day"
+
+#: Money is stored as an integer count of millionths of a dollar: the counter
+#: column is a BIGINT, and a float would not survive the ``+=`` upsert intact.
+UNIT_COUNT = "count"
+UNIT_MICRO_USD = "micro_usd"
+UNIT_TOKENS = "tokens"
+UNIT_MILLISECONDS = "ms"
+
+#: A dimension value longer than this is truncated. Long values are almost
+#: always an id or a free-text string that has no business being a dimension.
+MAX_DIM_VALUE_LEN = 64
+
+
+@dataclass(frozen=True)
+class Metric:
+    """One measurable thing.
+
+    :param key: ``namespace.name`` — the identity stored in the database.
+    :param kind: :data:`KIND_COUNTER`, :data:`KIND_GAUGE` or :data:`KIND_UNIQUE`.
+    :param scope: whose number this is — global, one server, or one user.
+    :param resolution: bucket size for counters. Defaults to daily for
+        anything scoped to a server or a user, hourly for global metrics.
+    :param dimensions: the **only** keys accepted in ``dims``. Every one of
+        them must have bounded cardinality (a command name, a boolean, a
+        module id — never an id of a user, a message or a channel).
+    :param raw: also write one row per occurrence to ``stats_events``, kept
+        for a fortnight. Reserve it for the handful of events whose detail is
+        worth the storage.
+    """
+
+    key: str
+    kind: str = KIND_COUNTER
+    scope: str = SCOPE_GUILD
+    resolution: Optional[str] = None
+    dimensions: Tuple[str, ...] = ()
+    unit: str = UNIT_COUNT
+    raw: bool = False
+    doc: str = ""
+
+    def __post_init__(self) -> None:
+        if self.resolution is None:
+            default = RESOLUTION_HOUR if self.scope == SCOPE_GLOBAL else RESOLUTION_DAY
+            object.__setattr__(self, "resolution", default)
+
+
+# --------------------------------------------------------------------------- #
+# The metrics
+# --------------------------------------------------------------------------- #
+
+_ALL: Tuple[Metric, ...] = (
+    # -- Commands ---------------------------------------------------------- #
+    Metric(
+        "command.used",
+        dimensions=("command", "kind"),
+        doc="A command finished. `kind` is slash | context | prefix.",
+    ),
+    Metric(
+        "command.error",
+        dimensions=("command", "error"),
+        doc="A command raised. `error` is the exception class name.",
+    ),
+    # -- Modules ----------------------------------------------------------- #
+    Metric(
+        "module.action",
+        dimensions=("module", "action"),
+        doc="A module actually did something — which is not the same as being enabled.",
+    ),
+    # -- AI / API ---------------------------------------------------------- #
+    Metric(
+        "ai.calls",
+        dimensions=("provider", "model", "call_type", "ok"),
+        doc="One call through the gateway. api_calls keeps the fine detail.",
+    ),
+    Metric(
+        "ai.tokens",
+        dimensions=("provider", "model", "call_type"),
+        unit=UNIT_TOKENS,
+        doc="Tokens consumed, prompt + completion.",
+    ),
+    Metric(
+        "ai.cost",
+        dimensions=("provider", "model", "call_type"),
+        unit=UNIT_MICRO_USD,
+        doc="Estimated spend, in millionths of a dollar.",
+    ),
+    # -- The bot's own footprint ------------------------------------------- #
+    Metric("guild.join", scope=SCOPE_GLOBAL, dimensions=("source",), raw=False,
+           doc="Moddy was added to a server. guild_events keeps the per-server row."),
+    Metric("guild.leave", scope=SCOPE_GLOBAL, dimensions=("source",),
+           doc="Moddy was removed from a server."),
+    Metric("member.join", dimensions=(), doc="Someone joined a server Moddy is in."),
+    Metric("member.leave", dimensions=(), doc="Someone left a server Moddy is in."),
+    # -- Features ---------------------------------------------------------- #
+    Metric("notification.sent", dimensions=("kind", "platform", "ok"),
+           doc="One notification delivery attempt (see notifications/)."),
+    Metric("case.created", dimensions=("type", "action"),
+           doc="A moderation case was recorded in a server."),
+    Metric("case.created", scope=SCOPE_GLOBAL, dimensions=("type", "action"),
+           doc="A platform-scoped case (a Moddy-team sanction) was recorded."),
+    Metric("ticket.opened", dimensions=("panel",)),
+    Metric("ticket.closed", dimensions=("reason",)),
+    Metric("bump.reminded", dimensions=("bot",)),
+    Metric("log.dispatched", dimensions=("category",),
+           doc="A server-log entry was delivered to a webhook."),
+    Metric("automod.decision", dimensions=("sanction", "dry_run"),
+           doc="Automod AI reached a verdict."),
+    # -- Uniques (HyperLogLog, never a list of ids) ------------------------ #
+    Metric("user.active", kind=KIND_UNIQUE, scope=SCOPE_GUILD,
+           doc="Distinct people who used Moddy in this server, per day."),
+    Metric("user.active", kind=KIND_UNIQUE, scope=SCOPE_GLOBAL,
+           doc="Distinct people who used Moddy anywhere, per day."),
+    # -- Gauges (written by the daily rollup) ------------------------------- #
+    Metric("bot.guilds", kind=KIND_GAUGE, scope=SCOPE_GLOBAL,
+           doc="Servers Moddy is in, at the time of the snapshot."),
+    Metric("bot.members", kind=KIND_GAUGE, scope=SCOPE_GLOBAL,
+           doc="Members reachable across those servers (sum of member counts)."),
+    Metric("bot.known_users", kind=KIND_GAUGE, scope=SCOPE_GLOBAL,
+           doc="Rows in the users table."),
+    Metric("bot.premium_guilds", kind=KIND_GAUGE, scope=SCOPE_GLOBAL),
+    Metric("bot.premium_users", kind=KIND_GAUGE, scope=SCOPE_GLOBAL),
+    Metric("module.enabled", kind=KIND_GAUGE, scope=SCOPE_GLOBAL,
+           dimensions=("module",),
+           doc="Servers with this module enabled — module adoption over time."),
+    Metric("guild.members", kind=KIND_GAUGE, scope=SCOPE_GUILD,
+           doc="Member count of one server, daily — its growth curve."),
+)
+
+#: ``(key, scope)`` → metric. Two scopes may share a key (``user.active`` is
+#: measured both per server and globally); the pair is the real identity.
+METRICS: Dict[Tuple[str, str], Metric] = {(m.key, m.scope): m for m in _ALL}
+
+#: Convenience lookup for the common case where a key exists in one scope only.
+_BY_KEY: Dict[str, Tuple[Metric, ...]] = {}
+for _m in _ALL:
+    _BY_KEY[_m.key] = _BY_KEY.get(_m.key, ()) + (_m,)
+
+
+class UnknownMetric(KeyError):
+    """Raised by :func:`get` when a key was never declared here."""
+
+
+def get(key: str, scope: Optional[str] = None) -> Metric:
+    """Resolve a metric, or raise :class:`UnknownMetric`.
+
+    ``scope`` may be omitted when the key is declared in a single scope,
+    which is the case for all but ``user.active``.
+    """
+    if scope is not None:
+        try:
+            return METRICS[(key, scope)]
+        except KeyError:
+            raise UnknownMetric(f"{key} (scope={scope})") from None
+    candidates = _BY_KEY.get(key)
+    if not candidates:
+        raise UnknownMetric(key)
+    if len(candidates) > 1:
+        raise UnknownMetric(f"{key} is ambiguous, pass a scope")
+    return candidates[0]
+
+
+def all_metrics() -> Iterable[Metric]:
+    return _ALL
+
+
+def gauges() -> Tuple[Metric, ...]:
+    return tuple(m for m in _ALL if m.kind == KIND_GAUGE)
+
+
+def uniques() -> Tuple[Metric, ...]:
+    return tuple(m for m in _ALL if m.kind == KIND_UNIQUE)
+
+
+# --------------------------------------------------------------------------- #
+# Dimensions
+# --------------------------------------------------------------------------- #
+
+def normalise_dims(metric: Metric, dims: Optional[Dict]) -> Dict[str, str]:
+    """Keep only what ``metric`` declared, as short strings.
+
+    Undeclared keys are dropped rather than raising: a statistic must never
+    be able to break the feature it measures. Callers that want to know are
+    served by :func:`unknown_dims`.
+    """
+    if not dims:
+        return {}
+    clean: Dict[str, str] = {}
+    for name in metric.dimensions:
+        if name not in dims:
+            continue
+        value = dims[name]
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            text = "true" if value else "false"
+        else:
+            text = str(value)
+        clean[name] = text[:MAX_DIM_VALUE_LEN]
+    return clean
+
+
+def unknown_dims(metric: Metric, dims: Optional[Dict]) -> Tuple[str, ...]:
+    """The keys :func:`normalise_dims` would silently drop — for logging."""
+    if not dims:
+        return ()
+    return tuple(k for k in dims if k not in metric.dimensions)
+
+
+def dims_hash(dims: Dict[str, str]) -> bytes:
+    """Stable 20-byte identity of a dimension set.
+
+    Hashing the canonical JSON keeps the primary key of ``stats_counters``
+    short and fixed-width whatever the dimensions are, which is what lets the
+    same table hold every metric without a column per dimension.
+    """
+    canonical = json.dumps(dims, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha1(canonical.encode("utf-8")).digest()
+
+
+# --------------------------------------------------------------------------- #
+# Buckets
+# --------------------------------------------------------------------------- #
+
+def floor_bucket(resolution: str, when: Optional[datetime] = None) -> datetime:
+    """Start of the ``resolution``-sized window containing ``when`` (UTC)."""
+    moment = (when or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if resolution == RESOLUTION_HOUR:
+        return moment.replace(minute=0, second=0, microsecond=0)
+    return moment.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def next_bucket(resolution: str, bucket: datetime) -> datetime:
+    """The window that follows ``bucket``."""
+    step = timedelta(hours=1) if resolution == RESOLUTION_HOUR else timedelta(days=1)
+    return bucket + step

--- a/stats/rollup.py
+++ b/stats/rollup.py
@@ -1,0 +1,207 @@
+"""The daily pass: photographs, ageing and purging.
+
+Counters answer "how many times"; they cannot answer "how many are there".
+That second question — servers, members, adoption of a module, distinct
+people — is a *gauge*, and a gauge is photographed rather than incremented.
+This module takes those photographs, then does the housekeeping that keeps
+the database from growing without end:
+
+1. write today's snapshots (and rewrite yesterday's, so the last hours of a
+   day are never missing from its final value),
+2. read the distinct-people HyperLogLogs and store their cardinality — a
+   number, never a list of ids,
+3. collapse hourly buckets older than 90 days into daily ones,
+4. drop the partitions past their retention,
+5. create the partitions the coming days will need.
+
+Everything here is idempotent: snapshots are replaced rather than added, and
+the rollup deletes the hourly rows in the same transaction that writes the
+daily ones. Running it twice changes nothing, which is what makes it safe to
+run on every boot as well as on a schedule.
+
+See docs/STATS.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import date, datetime, timedelta, timezone
+from typing import Dict, List, Optional, Tuple
+
+from stats import registry
+from stats.service import hll_key
+
+logger = logging.getLogger("moddy.stats.rollup")
+
+#: The pass is cheap and idempotent, so it runs often enough that the current
+#: day is never more than a few hours stale on the dashboard.
+ROLLUP_INTERVAL = 6 * 3600
+
+#: Hourly buckets older than this are collapsed into daily ones.
+HOURLY_RETENTION_DAYS = 90
+#: Whole months of counters kept before the partition is dropped.
+COUNTER_RETENTION_MONTHS = 12
+#: The raw window.
+RAW_RETENTION_DAYS = 14
+
+
+class StatsRollup:
+    """Owns the periodic maintenance. Lives on ``bot.stats_rollup``."""
+
+    def __init__(self, bot, *, interval: float = ROLLUP_INTERVAL):
+        self.bot = bot
+        self.interval = interval
+        self._task: Optional[asyncio.Task] = None
+
+    def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._loop(), name="stats-rollup")
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                await self.run()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.warning("stats rollup failed: %s", exc)
+            try:
+                await asyncio.sleep(self.interval)
+            except asyncio.CancelledError:
+                break
+
+    # ------------------------------------------------------------------ #
+
+    async def run(self) -> None:
+        """One full pass. Safe to call at any time, as often as you like."""
+        db = getattr(self.bot, "db", None)
+        if not db or not getattr(db, "pool", None):
+            return
+
+        await db.ensure_stats_partitions()
+
+        today = datetime.now(timezone.utc).date()
+        yesterday = today - timedelta(days=1)
+
+        await self.snapshot_globals(today)
+        await self.snapshot_guild_gauges(today)
+        for day in (today, yesterday):
+            await self.snapshot_uniques(day)
+
+        moved = await db.rollup_hourly_to_daily(HOURLY_RETENTION_DAYS)
+        if moved:
+            logger.info("stats: rolled %d hourly rows into daily buckets", moved)
+        await db.drop_old_partitions(
+            counter_months=COUNTER_RETENTION_MONTHS,
+            event_days=RAW_RETENTION_DAYS,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Gauges
+    # ------------------------------------------------------------------ #
+
+    async def snapshot_globals(self, day: date) -> None:
+        """The bot's own curve: servers, reachable members, adoption."""
+        db = self.bot.db
+        guilds = list(getattr(self.bot, "guilds", []) or [])
+        rows: List[Tuple[str, str, int, date, Dict[str, str], float]] = [
+            ("bot.guilds", "global", 0, day, {}, float(len(guilds))),
+            ("bot.members", "global", 0, day, {},
+             float(sum((g.member_count or 0) for g in guilds))),
+        ]
+
+        async with db.pool.acquire() as conn:
+            rows.append(("bot.known_users", "global", 0, day, {},
+                         float(await conn.fetchval("SELECT COUNT(*) FROM users") or 0)))
+            rows.append(("bot.premium_users", "global", 0, day, {}, float(
+                await conn.fetchval("SELECT COUNT(*) FROM users WHERE attributes ? 'PREMIUM'") or 0
+            )))
+            rows.append(("bot.premium_guilds", "global", 0, day, {}, float(
+                await conn.fetchval("SELECT COUNT(*) FROM guilds WHERE attributes ? 'PREMIUM'") or 0
+            )))
+            # Module adoption, straight from the stored configuration: one
+            # row per module per day, which is the whole adoption history for
+            # the price of a few dozen rows.
+            adoption = await conn.fetch(
+                """
+                SELECT m.key AS module, COUNT(*) AS enabled
+                FROM guilds g,
+                     LATERAL jsonb_each(COALESCE(g.data->'modules', '{}'::jsonb)) AS m(key, value)
+                WHERE m.value->>'enabled' = 'true'
+                GROUP BY m.key
+                """
+            )
+        for record in adoption:
+            rows.append(("module.enabled", "global", 0, day,
+                         {"module": record["module"]}, float(record["enabled"])))
+
+        await db.write_snapshots(rows)
+
+    async def snapshot_guild_gauges(self, day: date) -> None:
+        """Per-server member counts — but only when the number moved.
+
+        Writing every server every day would cost a row per server per day
+        forever, to record mostly that nothing happened. Storing only the
+        changes turns a flat server into zero rows; a curve is then read by
+        carrying the last known value forward, which the dashboard does when
+        it plots it.
+        """
+        db = self.bot.db
+        guilds = list(getattr(self.bot, "guilds", []) or [])
+        if not guilds:
+            return
+        previous = await db.latest_snapshot_values("guild.members", scope="guild")
+        rows = [
+            ("guild.members", "guild", g.id, day, {}, float(g.member_count or 0))
+            for g in guilds
+            if previous.get(g.id) != float(g.member_count or 0)
+        ]
+        if rows:
+            await db.write_snapshots(rows)
+
+    # ------------------------------------------------------------------ #
+    # Uniques
+    # ------------------------------------------------------------------ #
+
+    async def snapshot_uniques(self, day: date) -> None:
+        """Turn each HyperLogLog into a single number in ``stats_snapshots``."""
+        redis = getattr(self.bot, "redis", None)
+        if redis is None:
+            return
+        db = self.bot.db
+        stamp = day.strftime("%Y-%m-%d")
+        rows: List[Tuple[str, str, int, date, Dict[str, str], float]] = []
+        for metric in registry.uniques():
+            pattern = hll_key(metric.key, metric.scope, "*", stamp)
+            try:
+                async for key in redis.scan_iter(match=pattern, count=500):
+                    scope_id = _scope_id_from_key(key)
+                    if scope_id is None:
+                        continue
+                    count = await redis.pfcount(key)
+                    rows.append((metric.key, metric.scope, scope_id, day, {}, float(count)))
+            except Exception as exc:
+                logger.debug("stats: unique scan failed for %s: %s", metric.key, exc)
+        if rows:
+            await db.write_snapshots(rows)
+
+
+def _scope_id_from_key(key: str) -> Optional[int]:
+    """``stats:hll:<metric>:<scope>:<scope_id>:<day>`` → ``scope_id``."""
+    parts = key.split(":")
+    if len(parts) < 2:
+        return None
+    try:
+        return int(parts[-2])
+    except ValueError:
+        return None

--- a/stats/service.py
+++ b/stats/service.py
@@ -1,0 +1,341 @@
+"""Recording statistics — ``bot.stats``.
+
+The whole system rests on one move: **aggregate before writing**.
+
+.. code-block:: python
+
+    bot.stats.incr("command.used", guild_id=guild.id, dims={"command": "config"})
+
+That call adds one to a dictionary in memory. Sixty seconds later a single
+``INSERT … ON CONFLICT DO UPDATE`` carries the whole minute to Postgres, one
+row per ``(metric, scope, scope_id, bucket, dims)``. Ten thousand commands
+in a day on one server cost one row, not ten thousand — which is the entire
+reason this system can afford to measure everything.
+
+Why in memory rather than in Redis
+----------------------------------
+Because the alternative buys nothing here and costs a round trip on the hot
+path. ``incr()`` is **synchronous**: no ``await``, no I/O, no exception —
+recording a statistic can never slow down or break the feature it measures,
+which is not a property an ``await redis.hincrby()`` can offer. Nor is the
+process boundary a problem: the flush is an *addition*, so two processes (or
+a second one started mid-day) simply add their own totals to the same row.
+
+What is lost is up to one flush interval of counters if the container is
+killed without warning — an acceptable price for a statistic, and one
+``stop()`` pays back on every graceful shutdown.
+
+Redis is still used for one thing counting cannot do in a dictionary:
+distinct-people counts, through a HyperLogLog that survives a restart and
+never stores a single id (see :meth:`StatsService.observe_unique`).
+
+See docs/STATS.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from stats import registry
+from stats.registry import (
+    KIND_UNIQUE,
+    SCOPE_GLOBAL,
+    SCOPE_GUILD,
+    SCOPE_USER,
+    Metric,
+    UnknownMetric,
+)
+
+logger = logging.getLogger("moddy.stats")
+
+#: How often the aggregate is carried to Postgres.
+FLUSH_INTERVAL = 60.0
+
+#: Hard ceilings. They exist so that a bug in a caller — a dimension that
+#: turns out to be unbounded, a burst nobody predicted — degrades into lost
+#: statistics instead of an out-of-memory kill.
+MAX_PENDING_KEYS = 50_000
+MAX_RAW_EVENTS = 10_000
+MAX_UNIQUE_IDS = 100_000
+
+#: HyperLogLogs live a few days: long enough for the rollup to read yesterday
+#: after midnight, short enough that they never accumulate.
+HLL_TTL = 3 * 24 * 3600
+
+# (metric, scope, scope_id, bucket, dims_hash)
+_CounterKey = Tuple[str, str, int, datetime, bytes]
+# (metric, scope, scope_id, day)
+_UniqueKey = Tuple[str, str, int, str]
+
+
+class StatsService:
+    """Counts things. Lives on ``bot.stats``."""
+
+    def __init__(self, bot, *, flush_interval: float = FLUSH_INTERVAL):
+        self.bot = bot
+        self.flush_interval = flush_interval
+        self._pending: Dict[_CounterKey, Tuple[Dict[str, str], int]] = {}
+        self._raw: List[Tuple[str, Optional[int], Optional[int], Dict[str, Any], datetime]] = []
+        self._uniques: Dict[_UniqueKey, Set[int]] = {}
+        self._task: Optional[asyncio.Task] = None
+        self._warned: Set[str] = set()
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._flush_loop(), name="stats-flush")
+
+    async def stop(self) -> None:
+        """Cancel the loop and write what is still pending."""
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        await self.flush()
+
+    # ------------------------------------------------------------------ #
+    # Recording
+    # ------------------------------------------------------------------ #
+
+    def incr(
+        self,
+        key: str,
+        *,
+        guild_id: Optional[int] = None,
+        user_id: Optional[int] = None,
+        scope: Optional[str] = None,
+        value: int = 1,
+        dims: Optional[Dict[str, Any]] = None,
+        when: Optional[datetime] = None,
+    ) -> None:
+        """Add ``value`` to a counter. Never raises, never awaits.
+
+        The scope comes from the metric's declaration, not from the call:
+        passing a ``guild_id`` to a global metric counts it globally, which
+        is what the registry said the metric means.
+        """
+        try:
+            metric = self._resolve(key, scope, guild_id=guild_id, user_id=user_id)
+            if metric is None:
+                return
+            scope_id = self._scope_id(metric, guild_id, user_id)
+            if scope_id is None:
+                return
+            clean = registry.normalise_dims(metric, dims)
+            self._warn_unknown_dims(metric, dims)
+            bucket = registry.floor_bucket(metric.resolution, when)
+            ckey: _CounterKey = (
+                metric.key, metric.scope, scope_id, bucket, registry.dims_hash(clean),
+            )
+            current = self._pending.get(ckey)
+            if current is None:
+                if len(self._pending) >= MAX_PENDING_KEYS:
+                    self._warn_once(
+                        "pending-full",
+                        "stats buffer full (%d keys) — dropping %s until the next flush"
+                        % (MAX_PENDING_KEYS, metric.key),
+                    )
+                    return
+                self._pending[ckey] = (clean, value)
+            else:
+                self._pending[ckey] = (current[0], current[1] + value)
+
+            if metric.raw and len(self._raw) < MAX_RAW_EVENTS:
+                self._raw.append((
+                    metric.key, guild_id, user_id, dict(clean),
+                    when or datetime.now(timezone.utc),
+                ))
+        except Exception as exc:  # a statistic must never break its caller
+            logger.debug("stats.incr(%s) failed: %s", key, exc)
+
+    def observe_unique(
+        self,
+        key: str,
+        subject_id: int,
+        *,
+        guild_id: Optional[int] = None,
+        when: Optional[datetime] = None,
+    ) -> None:
+        """Record that ``subject_id`` was seen today, for a distinct count.
+
+        The ids are buffered only until the next flush, then folded into a
+        Redis HyperLogLog — roughly 12 KB per key for a 0.8 % error, and no
+        list of who was there. The daily rollup reads the cardinality and
+        stores a single number.
+        """
+        try:
+            metric = self._resolve(key, SCOPE_GUILD if guild_id else SCOPE_GLOBAL)
+            if metric is None or metric.kind != KIND_UNIQUE:
+                return
+            scope_id = self._scope_id(metric, guild_id, None)
+            if scope_id is None:
+                return
+            day = registry.floor_bucket(registry.RESOLUTION_DAY, when).strftime("%Y-%m-%d")
+            ukey: _UniqueKey = (metric.key, metric.scope, scope_id, day)
+            bucket = self._uniques.setdefault(ukey, set())
+            if len(bucket) < MAX_UNIQUE_IDS:
+                bucket.add(subject_id)
+        except Exception as exc:
+            logger.debug("stats.observe_unique(%s) failed: %s", key, exc)
+
+    # ------------------------------------------------------------------ #
+    # Flushing
+    # ------------------------------------------------------------------ #
+
+    async def _flush_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self.flush_interval)
+                await self.flush()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.warning("stats flush loop error: %s", exc)
+
+    async def flush(self) -> None:
+        """Carry the aggregate to Postgres and the uniques to Redis.
+
+        On a database failure the batch is merged back into the pending
+        aggregate rather than dropped: the next flush writes the sum, and the
+        additive upsert means nothing is double-counted if the failed write
+        had in fact committed.
+        """
+        await self._flush_counters()
+        await self._flush_raw()
+        await self._flush_uniques()
+
+    async def _flush_counters(self) -> None:
+        if not self._pending:
+            return
+        db = getattr(self.bot, "db", None)
+        if not db or not getattr(db, "pool", None):
+            return
+        batch, self._pending = self._pending, {}
+        rows = [
+            (metric, scope, scope_id, bucket, dims, dims_hash, value)
+            for (metric, scope, scope_id, bucket, dims_hash), (dims, value) in batch.items()
+        ]
+        try:
+            await db.upsert_counters(rows)
+            logger.debug("stats: flushed %d counter rows", len(rows))
+        except Exception as exc:
+            logger.warning("stats: counter flush failed (%d rows): %s", len(rows), exc)
+            self._merge_back(batch)
+
+    def _merge_back(self, batch: Dict[_CounterKey, Tuple[Dict[str, str], int]]) -> None:
+        for ckey, (dims, value) in batch.items():
+            current = self._pending.get(ckey)
+            if current is None:
+                if len(self._pending) >= MAX_PENDING_KEYS:
+                    return
+                self._pending[ckey] = (dims, value)
+            else:
+                self._pending[ckey] = (current[0], current[1] + value)
+
+    async def _flush_raw(self) -> None:
+        if not self._raw:
+            return
+        db = getattr(self.bot, "db", None)
+        if not db or not getattr(db, "pool", None):
+            self._raw.clear()  # the raw window is expendable by design
+            return
+        batch, self._raw = self._raw, []
+        try:
+            await db.insert_raw_events(batch)
+        except Exception as exc:
+            logger.warning("stats: raw event flush failed (%d rows): %s", len(batch), exc)
+
+    async def _flush_uniques(self) -> None:
+        if not self._uniques:
+            return
+        redis = getattr(self.bot, "redis", None)
+        if redis is None:
+            self._uniques.clear()
+            return
+        batch, self._uniques = self._uniques, {}
+        for (metric, scope, scope_id, day), ids in batch.items():
+            key = hll_key(metric, scope, scope_id, day)
+            try:
+                await redis.pfadd(key, *ids)
+                await redis.expire(key, HLL_TTL)
+            except Exception as exc:
+                logger.debug("stats: pfadd %s failed: %s", key, exc)
+
+    # ------------------------------------------------------------------ #
+    # Internals
+    # ------------------------------------------------------------------ #
+
+    def _resolve(self, key: str, scope: Optional[str] = None, *,
+                 guild_id: Optional[int] = None,
+                 user_id: Optional[int] = None) -> Optional[Metric]:
+        """Find the metric, inferring the scope when the key spans several.
+
+        A handful of keys are measured at more than one level (a case is
+        recorded for a server, or by the Moddy team for the platform). When
+        the caller did not say which, the arguments do: an id means that
+        level, no id means global.
+        """
+        try:
+            return registry.get(key, scope)
+        except UnknownMetric:
+            if scope is None:
+                inferred = (
+                    SCOPE_GUILD if guild_id
+                    else SCOPE_USER if user_id
+                    else SCOPE_GLOBAL
+                )
+                try:
+                    return registry.get(key, inferred)
+                except UnknownMetric:
+                    pass
+            self._warn_once(
+                f"unknown-{key}-{scope}",
+                "stats: %s is not declared in stats/registry.py — ignored" % key,
+            )
+            return None
+
+    @staticmethod
+    def _scope_id(metric: Metric, guild_id: Optional[int],
+                  user_id: Optional[int]) -> Optional[int]:
+        if metric.scope == SCOPE_GLOBAL:
+            return 0
+        if metric.scope == SCOPE_GUILD:
+            return guild_id if guild_id else None
+        if metric.scope == SCOPE_USER:
+            return user_id if user_id else None
+        return None
+
+    def _warn_unknown_dims(self, metric: Metric, dims: Optional[Dict]) -> None:
+        extra = registry.unknown_dims(metric, dims)
+        if extra:
+            self._warn_once(
+                f"dims-{metric.key}-{extra}",
+                "stats: %s does not declare %s — dropped (see stats/registry.py)"
+                % (metric.key, ", ".join(extra)),
+            )
+
+    def _warn_once(self, token: str, message: str) -> None:
+        if token in self._warned:
+            return
+        self._warned.add(token)
+        logger.warning(message)
+
+
+def hll_key(metric: str, scope: str, scope_id, day: str) -> str:
+    """Redis key of one day's HyperLogLog.
+
+    ``scope_id`` may be ``"*"`` to build a scan pattern.
+
+    ``stats:*`` is this system's own namespace — not ``moddy:*`` (the
+    backend's) nor a service's, per docs/REDIS_COMMUNICATION.md §5.
+    """
+    return f"stats:hll:{metric}:{scope}:{scope_id}:{day}"

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,340 @@
+"""Statistics: the registry, the aggregation, the rollup.
+
+The properties tested here are the ones the whole design rests on. If any of
+them breaks, the system stops being cheap — silently, and only visible on the
+Railway bill months later:
+
+* N events produce **one** row, not N,
+* a dimension nobody declared can never reach the database,
+* a failed flush loses nothing and double-counts nothing,
+* recording a statistic cannot raise, whatever the caller passes.
+"""
+
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from db.repositories.stats import StatsRepository  # noqa: E402
+from stats import registry  # noqa: E402
+from stats.rollup import StatsRollup, _scope_id_from_key  # noqa: E402
+from stats.service import StatsService, hll_key  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Doubles
+# --------------------------------------------------------------------------- #
+
+class FakeDB:
+    """Just enough of ModdyDatabase for the service to think it can write."""
+
+    def __init__(self, *, fail: bool = False):
+        self.pool = object()
+        self.fail = fail
+        self.counter_rows = []
+        self.raw_rows = []
+        self.snapshots = []
+
+    async def upsert_counters(self, rows):
+        if self.fail:
+            raise RuntimeError("postgres is having a day")
+        self.counter_rows.extend(rows)
+
+    async def insert_raw_events(self, rows):
+        self.raw_rows.extend(rows)
+
+    async def write_snapshots(self, rows):
+        self.snapshots.extend(rows)
+
+    async def latest_snapshot_values(self, metric, scope="guild"):
+        return {}
+
+    async def ensure_stats_partitions(self, **kwargs):
+        return None
+
+    async def rollup_hourly_to_daily(self, older_than_days=90):
+        return 0
+
+    async def drop_old_partitions(self, **kwargs):
+        return []
+
+
+class FakeRedis:
+    def __init__(self):
+        self.hll = {}
+        self.expired = []
+
+    async def pfadd(self, key, *ids):
+        self.hll.setdefault(key, set()).update(ids)
+
+    async def expire(self, key, ttl):
+        self.expired.append((key, ttl))
+
+    async def pfcount(self, key):
+        return len(self.hll.get(key, ()))
+
+    async def scan_iter(self, match=None, count=None):
+        import fnmatch
+        for key in list(self.hll):
+            if match is None or fnmatch.fnmatch(key, match):
+                yield key
+
+
+class FakeGuild:
+    def __init__(self, guild_id, member_count):
+        self.id = guild_id
+        self.member_count = member_count
+
+
+class FakeBot:
+    def __init__(self, db=None, redis=None, guilds=()):
+        self.db = db
+        self.redis = redis
+        self.guilds = list(guilds)
+
+
+# --------------------------------------------------------------------------- #
+# The registry
+# --------------------------------------------------------------------------- #
+
+class TestRegistry:
+    def test_every_metric_is_uniquely_addressable(self):
+        pairs = [(m.key, m.scope) for m in registry.all_metrics()]
+        assert len(pairs) == len(set(pairs))
+
+    def test_an_undeclared_metric_is_not_resolvable(self):
+        with pytest.raises(registry.UnknownMetric):
+            registry.get("something.invented")
+
+    def test_per_server_metrics_are_daily_and_global_ones_hourly(self):
+        # The single biggest cost lever: an hourly bucket per server is 24×
+        # the rows for a precision nobody reads at that scope.
+        assert registry.get("command.used").resolution == registry.RESOLUTION_DAY
+        assert registry.get("guild.join").resolution == registry.RESOLUTION_HOUR
+
+    def test_an_undeclared_dimension_cannot_reach_the_database(self):
+        metric = registry.get("command.used")
+        clean = registry.normalise_dims(metric, {"command": "config", "user_id": 42})
+        assert clean == {"command": "config"}
+        assert registry.unknown_dims(metric, {"user_id": 42}) == ("user_id",)
+
+    def test_a_long_dimension_value_is_truncated(self):
+        metric = registry.get("command.used")
+        clean = registry.normalise_dims(metric, {"command": "x" * 500})
+        assert len(clean["command"]) == registry.MAX_DIM_VALUE_LEN
+
+    def test_booleans_are_stored_readably(self):
+        metric = registry.get("ai.calls")
+        clean = registry.normalise_dims(
+            metric, {"provider": "openai", "model": "m", "call_type": "c", "ok": False}
+        )
+        assert clean["ok"] == "false"
+
+    def test_the_dimension_hash_ignores_key_order(self):
+        assert registry.dims_hash({"a": "1", "b": "2"}) == registry.dims_hash({"b": "2", "a": "1"})
+
+    def test_different_dimensions_hash_differently(self):
+        assert registry.dims_hash({"a": "1"}) != registry.dims_hash({"a": "2"})
+
+    def test_buckets_are_floored_in_utc(self):
+        moment = datetime(2026, 9, 7, 13, 45, 12, tzinfo=timezone.utc)
+        assert registry.floor_bucket("hour", moment).hour == 13
+        assert registry.floor_bucket("hour", moment).minute == 0
+        assert registry.floor_bucket("day", moment).hour == 0
+
+
+# --------------------------------------------------------------------------- #
+# Recording
+# --------------------------------------------------------------------------- #
+
+class TestAggregation:
+    def test_many_events_become_one_row(self):
+        """The whole point of the system, in one assertion."""
+        service = StatsService(FakeBot())
+        for _ in range(10_000):
+            service.incr("command.used", guild_id=1,
+                         dims={"command": "config", "kind": "slash"})
+        assert len(service._pending) == 1
+        assert list(service._pending.values())[0][1] == 10_000
+
+    def test_different_dimensions_stay_apart(self):
+        service = StatsService(FakeBot())
+        service.incr("command.used", guild_id=1, dims={"command": "config"})
+        service.incr("command.used", guild_id=1, dims={"command": "ping"})
+        assert len(service._pending) == 2
+
+    def test_different_servers_stay_apart(self):
+        service = StatsService(FakeBot())
+        service.incr("command.used", guild_id=1, dims={"command": "config"})
+        service.incr("command.used", guild_id=2, dims={"command": "config"})
+        assert len(service._pending) == 2
+
+    def test_an_undeclared_dimension_is_dropped_not_stored(self):
+        service = StatsService(FakeBot())
+        service.incr("command.used", guild_id=1,
+                     dims={"command": "config", "user_id": 12345})
+        (dims, _), = service._pending.values()
+        assert "user_id" not in dims
+
+    def test_an_unknown_metric_is_ignored(self):
+        service = StatsService(FakeBot())
+        service.incr("not.declared", guild_id=1)
+        assert service._pending == {}
+
+    def test_a_server_metric_without_a_server_is_ignored(self):
+        service = StatsService(FakeBot())
+        service.incr("command.used", dims={"command": "config"})
+        assert service._pending == {}
+
+    def test_the_scope_is_inferred_when_a_key_spans_several(self):
+        service = StatsService(FakeBot())
+        service.incr("case.created", dims={"type": "global", "action": "ban"})
+        service.incr("case.created", guild_id=7, dims={"type": "guild", "action": "ban"})
+        scopes = sorted(key[1] for key in service._pending)
+        assert scopes == ["global", "guild"]
+
+    def test_recording_never_raises(self):
+        """A statistic must not be able to break the feature it measures."""
+        service = StatsService(FakeBot())
+        service.incr("command.used", guild_id=1, dims={"command": object()})
+        service.incr(None, guild_id=1)                      # type: ignore[arg-type]
+        service.incr("command.used", guild_id=1, when="not a date")  # type: ignore[arg-type]
+        service.observe_unique("user.active", "not an id", guild_id=1)  # type: ignore[arg-type]
+
+    def test_the_buffer_is_bounded(self):
+        service = StatsService(FakeBot())
+        from stats import service as service_module
+        for i in range(service_module.MAX_PENDING_KEYS + 50):
+            service.incr("command.used", guild_id=i, dims={"command": "config"})
+        assert len(service._pending) == service_module.MAX_PENDING_KEYS
+
+
+class TestFlush:
+    async def test_a_flush_writes_the_aggregate_and_clears_it(self):
+        db = FakeDB()
+        service = StatsService(FakeBot(db=db))
+        for _ in range(5):
+            service.incr("command.used", guild_id=1, dims={"command": "config"})
+        await service.flush()
+        assert len(db.counter_rows) == 1
+        assert db.counter_rows[0][-1] == 5
+        assert service._pending == {}
+
+    async def test_a_failed_flush_keeps_the_numbers(self):
+        db = FakeDB(fail=True)
+        service = StatsService(FakeBot(db=db))
+        service.incr("command.used", guild_id=1, dims={"command": "config"})
+        await service.flush()
+        assert sum(v for _, v in service._pending.values()) == 1
+
+        # And the retry adds up rather than losing the first attempt.
+        service.incr("command.used", guild_id=1, dims={"command": "config"})
+        db.fail = False
+        await service.flush()
+        assert db.counter_rows[0][-1] == 2
+
+    async def test_nothing_is_written_without_a_database(self):
+        service = StatsService(FakeBot(db=None))
+        service.incr("command.used", guild_id=1, dims={"command": "config"})
+        await service.flush()
+        assert len(service._pending) == 1  # kept for when the pool comes back
+
+    async def test_stopping_flushes_what_is_pending(self):
+        db = FakeDB()
+        service = StatsService(FakeBot(db=db), flush_interval=3600)
+        service.start()
+        service.incr("command.used", guild_id=1, dims={"command": "config"})
+        await service.stop()
+        assert len(db.counter_rows) == 1
+
+    async def test_distinct_people_become_a_hyperloglog_not_a_list(self):
+        redis = FakeRedis()
+        service = StatsService(FakeBot(db=FakeDB(), redis=redis))
+        for user_id in range(50):
+            service.observe_unique("user.active", user_id, guild_id=1)
+        await service.flush()
+        key = hll_key("user.active", "guild", 1,
+                      datetime.now(timezone.utc).strftime("%Y-%m-%d"))
+        assert await redis.pfcount(key) == 50
+        assert service._uniques == {}
+        assert redis.expired  # the key is not kept forever
+
+
+# --------------------------------------------------------------------------- #
+# The daily pass
+# --------------------------------------------------------------------------- #
+
+class TestRollup:
+    async def test_the_global_snapshot_photographs_the_bot(self):
+        db = FakeDB()
+
+        class Conn:
+            async def fetchval(self, *args):
+                return 3
+
+            async def fetch(self, *args):
+                return [{"module": "tickets", "enabled": 12}]
+
+        class Pool:
+            def acquire(self):
+                class Ctx:
+                    async def __aenter__(self):
+                        return Conn()
+
+                    async def __aexit__(self, *exc):
+                        return False
+                return Ctx()
+
+        db.pool = Pool()
+        bot = FakeBot(db=db, guilds=[FakeGuild(1, 100), FakeGuild(2, 250)])
+        await StatsRollup(bot).snapshot_globals(date(2026, 9, 7))
+        values = {row[0]: row[5] for row in db.snapshots}
+        assert values["bot.guilds"] == 2
+        assert values["bot.members"] == 350
+        assert values["module.enabled"] == 12
+
+    async def test_a_server_whose_size_did_not_move_stores_nothing(self):
+        db = FakeDB()
+
+        async def latest(metric, scope="guild"):
+            return {1: 100.0}
+
+        db.latest_snapshot_values = latest
+        bot = FakeBot(db=db, guilds=[FakeGuild(1, 100), FakeGuild(2, 250)])
+        await StatsRollup(bot).snapshot_guild_gauges(date(2026, 9, 7))
+        assert [row[2] for row in db.snapshots] == [2]
+
+    async def test_uniques_are_stored_as_a_number(self):
+        redis = FakeRedis()
+        db = FakeDB()
+        day = date(2026, 9, 7)
+        stamp = day.strftime("%Y-%m-%d")
+        await redis.pfadd(hll_key("user.active", "guild", 5, stamp), 1, 2, 3)
+        await StatsRollup(FakeBot(db=db, redis=redis)).snapshot_uniques(day)
+        assert db.snapshots == [("user.active", "guild", 5, day, {}, 3.0)]
+
+    def test_a_hyperloglog_key_names_its_subject(self):
+        assert _scope_id_from_key("stats:hll:user.active:guild:99:2026-09-07") == 99
+        assert _scope_id_from_key("stats:hll:user.active:global:0:2026-09-07") == 0
+
+
+# --------------------------------------------------------------------------- #
+# Retention plumbing
+# --------------------------------------------------------------------------- #
+
+class TestPartitions:
+    def test_a_partition_names_the_window_it_holds(self):
+        window = StatsRepository._partition_window("stats_counters_202609")
+        assert window == (datetime(2026, 9, 1, tzinfo=timezone.utc), "counter")
+        window = StatsRepository._partition_window("stats_events_20260907")
+        assert window == (datetime(2026, 9, 7, tzinfo=timezone.utc), "event")
+
+    def test_the_default_partition_is_never_dropped(self):
+        # It is the safety net for a missed maintenance pass: dropping it
+        # would delete whatever landed there.
+        assert StatsRepository._partition_window("stats_counters_default") is None
+        assert StatsRepository._partition_window("stats_events_default") is None
+        assert StatsRepository._partition_window("api_calls") is None


### PR DESCRIPTION
## Summary

Implements a complete statistics system for Moddy that measures bot activity without the storage cost of per-event logging. The system aggregates counters in memory and writes pre-summed totals to the database once per minute, reducing a day's worth of ten thousand commands to a single row.

## Key Changes

**Core Statistics Infrastructure**
- `stats/registry.py`: Single source of truth declaring every measurable metric (scope, resolution, allowed dimensions). Adding a new statistic requires only one entry—no migrations or schema changes.
- `stats/service.py`: `bot.stats` service providing synchronous, non-raising `incr()` for counters and `observe_unique()` for distinct-people counts via Redis HyperLogLog. Flushes aggregated data every 60 seconds with merge-back on failure.
- `stats/rollup.py`: Daily maintenance task that snapshots gauges, collapses hourly buckets to daily after 90 days, and manages partition lifecycle.

**Database Layer**
- `db/repositories/stats.py`: `StatsRepository` with additive upserts (safe to replay), dashboard reads, growth/cohort/acquisition queries, and partition management.
- `db/base.py`: DDL for five new tables:
  - `stats_counters`: Pre-aggregated counters, partitioned by month
  - `stats_snapshots`: Daily gauges (servers, members, adoption, distinct users)
  - `guild_events`: Server joins/leaves for growth curves and retention cohorts
  - `guild_installs`: Installation sources (UTM tracking)
  - `stats_events`: Raw event rows for metrics marked `raw=True`, 14-day retention

**Discord Integration**
- `cogs/stats_events.py`: Listeners that emit statistics from Discord events (commands, errors, module actions, AI calls, server lifecycle).
- `gateway/logger.py`: API call counting integrated with the stats system.
- `bot.py`: Instantiation of `StatsService` and `StatsRollup` with lifecycle management.

**Module Integration**
- `modules/module_manager.py`: `ModuleBase.count()` shorthand for modules to record their own actions.
- `services/case_service.py`, `notifications/service.py`, `serverlogs/service.py`, `modules/automod_ai.py`, `modules/auto_role.py`, `modules/starboard.py`, `modules/welcome_channel.py`, `cogs/bump_reminder.py`: Integrated statistics recording at key decision points.

**Documentation & Testing**
- `docs/STATS.md`: Complete guide to the system design, cost model, and usage patterns.
- `tests/test_stats.py`: Comprehensive test suite verifying aggregation, dimension safety, idempotency, and failure resilience.
- `docs/sessions/2026-09-07_stats-system.md`: Implementation session notes.

## Design Highlights

- **Aggregation before writing**: Frequent events (commands, API calls) are counted in memory and flushed as a single upsert per `(metric, scope, scope_id, bucket, dims)`. Ten thousand events cost one row, not ten thousand.
- **Synchronous recording**: `incr()` never awaits or raises—measuring a feature can never break it.
- **Dimension safety**: Only declared dimensions reach the database; undeclared ones are silently dropped, preventing cardinality explosions.
- **Idempotent operations**: Snapshots replace rather than add; hourly→daily rollup deletes old rows in the same transaction. Safe to run multiple times.
- **Partition-based retention**: Monthly partitions for counters and daily for raw events allow cheap purging via `DROP TABLE` instead of `DELETE`.
- **Distinct-people counting**: Redis HyperLogLog for cardinality without storing ids, surviving restarts and never exceeding ~12 KB per key.

https://claude.ai/code/session_012aBmvSfF99ZRqGhXojjkej