### PR TITLE
Add announcement translation for support server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ moddy/
 │   ├── stats_events.py        #   Statistics emitters (commands, members, guild joins)
 │   ├── saved_messages.py      #   Message bookmarking
 │   ├── translate.py           #   /translate (DeepL)
+│   ├── announcement_translation.py #  Support-server announcements translated once → flag buttons
 │   ├── text_tools.py          #   /fix, /rephrase, /summarize (OpenAI, Modal V2 + context menus)
 │   ├── voice_transcription.py #   "Transcribe" context menu (Groq Whisper)
 │   ├── webhook.py             #   Webhook management
@@ -188,6 +189,7 @@ moddy/
 │       ├── support_requests.py #  Bug reports / config-help requests + their exchange
 │       ├── social.py          #   Social notifications subscriptions
 │       ├── bump.py            #   Pending bump reminders (bump_reminders)
+│       ├── announcement_translations.py # Stored announcement translations
 │       ├── stats.py           #   Statistics: counters, snapshots, guild lifecycle,
 │       │                      #   acquisition (guild_installs), partitions
 │       └── _utils.py
@@ -489,6 +491,7 @@ All documentation is in [docs/](docs/). Read the relevant file **before** workin
 | [docs/MODDY_FRAMEWORK.md](docs/MODDY_FRAMEWORK.md) | Internal framework public API and migration |
 | [docs/COMMAND_LOCALIZATION.md](docs/COMMAND_LOCALIZATION.md) | Translating slash command names/descriptions (32 Discord locales) |
 | [docs/TEXT_TOOLS.md](docs/TEXT_TOOLS.md) | AI text tools — `/fix`, `/rephrase`, `/summarize` (models, presets, mention stripping) |
+| [docs/ANNOUNCEMENT_TRANSLATION.md](docs/ANNOUNCEMENT_TRANSLATION.md) | **Announcement translation** — support-server announcements translated once into every language, one flag button per language |
 | [docs/VOICE_TRANSCRIPTION.md](docs/VOICE_TRANSCRIPTION.md) | Voice transcription — context menu, module, Groq Whisper, cost control |
 | [docs/MODULE_SYSTEM.md](docs/MODULE_SYSTEM.md) | Creating or modifying server modules |
 | [docs/SERVER_LANGUAGE.md](docs/SERVER_LANGUAGE.md) | **Server language** — the single setting every module reads; what follows the server vs. the user |

--- a/cogs/announcement_translation.py
+++ b/cogs/announcement_translation.py
@@ -1,0 +1,280 @@
+"""
+Announcement translation — support server only.
+
+Every message posted in one of the support server's announcement channels
+(``ANNOUNCEMENT_TRANSLATION_CHANNEL_IDS``) is translated through DeepL into all
+five languages Moddy speaks **once, at post time**, and stored in
+``announcement_translations``. Moddy then replies with a bare container holding
+one flag button per language; clicking a flag reads the stored translation back
+and shows it ephemerally, as plain text, with nothing around it.
+
+Translating up front rather than on click is the whole design: an announcement
+read by a thousand people costs five DeepL calls, not a thousand.
+
+See docs/ANNOUNCEMENT_TRANSLATION.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Dict, Optional
+
+import discord
+from discord import ui
+from discord.ext import commands
+
+from cogs.error_handler import BaseView
+from config import ANNOUNCEMENT_TRANSLATION_CHANNEL_IDS, MODDY_TEAM_GUILD_ID
+from utils.i18n import i18n, t
+
+logger = logging.getLogger('moddy.announcement_translation')
+
+# The languages Moddy speaks, in button order. Each entry is
+# code → (DeepL target language, flag, label written in that language).
+# The label is deliberately *not* i18n'd: a button offering German is labelled
+# "Deutsch" whoever is looking at it, which is the only way a reader who does
+# not speak the announcement's language can find their own.
+LANGUAGES: Dict[str, tuple] = {
+    "fr": ("FR", "🇫🇷", "Français"),
+    "en": ("EN-US", "🇺🇸", "English"),
+    "es": ("ES", "🇪🇸", "Español"),
+    "pt": ("PT-BR", "🇧🇷", "Português"),
+    "de": ("DE", "🇩🇪", "Deutsch"),
+}
+
+# DeepL reports the source language as a bare code (FR, EN, PT…); this maps it
+# back to our button codes so the announcement's own language is stored as the
+# original text instead of being sent on a pointless round trip.
+_SOURCE_TO_CODE = {
+    "FR": "fr", "EN": "en", "ES": "es", "PT": "pt", "DE": "de",
+}
+
+_CID_PREFIX = "moddy:anntr:lang"
+
+# Discord caps a message at 4000 characters and a TextDisplay at 4000 too; a
+# translation can come back slightly longer than its source, so both ends are
+# bounded.
+_MAX_SOURCE = 3500
+_MAX_RENDERED = 3900
+
+
+def _guarded(callback):
+    """Funnel a dynamic-item callback error to the central handler (no live view)."""
+    async def wrapper(self, interaction: discord.Interaction):
+        try:
+            await callback(self, interaction)
+        except Exception as e:  # noqa: BLE001
+            from cogs.error_handler import report_component_error
+            await report_component_error(interaction, e, self.__class__.__name__)
+    return wrapper
+
+
+def sanitize_mentions(text: str, guild: Optional[discord.Guild]) -> str:
+    """Turn mentions into plain text so DeepL sees words, not raw ids."""
+    text = text.replace('@everyone', '@​everyone')
+    text = text.replace('@here', '@​here')
+
+    def replace_user(match: re.Match) -> str:
+        if guild:
+            member = guild.get_member(int(match.group(1)))
+            if member:
+                return f"@{member.display_name}"
+        return "@user"
+
+    def replace_role(match: re.Match) -> str:
+        if guild:
+            role = guild.get_role(int(match.group(1)))
+            if role:
+                return f"@{role.name}"
+        return "@role"
+
+    text = re.sub(r'<@!?(\d+)>', replace_user, text)
+    text = re.sub(r'<@&(\d+)>', replace_role, text)
+    return text
+
+
+# --------------------------------------------------------------------------- #
+# The language button (DynamicItem, persistent)
+# --------------------------------------------------------------------------- #
+
+class AnnouncementLanguageButton(
+    ui.DynamicItem[ui.Button],
+    template=rf"{_CID_PREFIX}:(?P<code>fr|en|es|pt|de):(?P<mid>\d{{15,25}})",
+):
+    """One flag button under an announcement. Auth: public (read-only)."""
+
+    def __init__(self, code: str, message_id: int):
+        _, flag, label = LANGUAGES[code]
+        super().__init__(
+            ui.Button(
+                label=label,
+                style=discord.ButtonStyle.secondary,
+                emoji=discord.PartialEmoji.from_str(flag),
+                custom_id=f"{_CID_PREFIX}:{code}:{message_id}",
+            )
+        )
+        self.code = code
+        self.message_id = message_id
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match: re.Match):
+        return cls(match["code"], int(match["mid"]))
+
+    @_guarded
+    async def callback(self, interaction: discord.Interaction):
+        # Everything is re-derived from the click: the custom_id names the
+        # announcement, the row names the text. `self` holds nothing else.
+        from utils.components_v2 import create_error_message
+
+        bot = interaction.client
+        locale = i18n.get_user_locale(interaction)
+
+        row = None
+        if getattr(bot, "db", None):
+            row = await bot.db.get_announcement_translations(self.message_id)
+        text = (row or {}).get("translations", {}).get(self.code)
+
+        if not text:
+            await interaction.response.send_message(
+                view=create_error_message(
+                    t("announcement_translation.error.title", locale=locale),
+                    t("announcement_translation.error.missing", locale=locale)),
+                ephemeral=True)
+            return
+
+        view = ui.LayoutView(timeout=None)
+        container = ui.Container()
+        container.add_item(ui.TextDisplay(text[:_MAX_RENDERED]))
+        view.add_item(container)
+        await interaction.response.send_message(view=view, ephemeral=True)
+
+
+class AnnouncementTranslationView(BaseView):
+    """The buttons-only card replying to an announcement. Auth: public."""
+
+    __persistent__ = True
+
+    def __init__(self, message_id: int = 0, codes=None):
+        super().__init__()
+        self.message_id = message_id
+        self.codes = list(codes or [])
+        self.build_view()
+
+    def build_view(self):
+        self.clear_items()
+        if not self.message_id or not self.codes:
+            # Shell instance (registration only): the buttons are DynamicItems,
+            # registered by class, so an empty shell is all that is needed.
+            return
+        container = ui.Container()
+        row = ui.ActionRow()
+        for code in self.codes:
+            row.add_item(AnnouncementLanguageButton(code, self.message_id))
+        container.add_item(row)
+        self.add_item(container)
+
+    @classmethod
+    def register_persistent(cls, bot) -> None:
+        """Auth model: public — anyone who can read the announcement may click."""
+        bot.add_dynamic_items(AnnouncementLanguageButton)
+
+
+# --------------------------------------------------------------------------- #
+# Cog
+# --------------------------------------------------------------------------- #
+
+class AnnouncementTranslation(commands.Cog):
+    """Translates support-server announcements once and offers them per language."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    def _is_announcement_channel(self, message: discord.Message) -> bool:
+        if not message.guild or message.guild.id != MODDY_TEAM_GUILD_ID:
+            return False
+        return message.channel.id in ANNOUNCEMENT_TRANSLATION_CHANNEL_IDS
+
+    async def _translate_all(
+        self, text: str, *, user_id: int
+    ) -> tuple[Dict[str, str], Optional[str]]:
+        """Translate one announcement into every language. One call per language.
+
+        The language the announcement is already written in is not sent to
+        DeepL: once the first call has reported the detected source, that
+        language is filled in with the original text.
+        """
+        from gateway import QuotaTarget
+
+        translations: Dict[str, str] = {}
+        source_code: Optional[str] = None
+
+        for code, (target, _flag, _label) in LANGUAGES.items():
+            if source_code == code:
+                translations[code] = text
+                continue
+            try:
+                result = await self.bot.gateway.translation.translate(
+                    text,
+                    target,
+                    quota=[QuotaTarget.user(user_id, "translation")],
+                    call_type="translation",
+                    metadata={"user_id": user_id, "feature": "announcement"},
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Announcement translation to %s failed: %s", target, exc)
+                continue
+
+            if not result or not result.get("text"):
+                continue
+            translations[code] = result["text"]
+            if source_code is None:
+                detected = (result.get("detected_source_language") or "").upper()
+                source_code = _SOURCE_TO_CODE.get(detected.split("-")[0])
+
+        return translations, source_code
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author.bot or not self._is_announcement_channel(message):
+            return
+        content = (message.content or "").strip()
+        if not content:
+            return
+
+        gateway = getattr(self.bot, "gateway", None)
+        if not gateway or not gateway.deepl_available():
+            logger.warning("DeepL unavailable — announcement %s not translated",
+                           message.id)
+            return
+
+        source = sanitize_mentions(content, message.guild)[:_MAX_SOURCE]
+        translations, source_code = await self._translate_all(
+            source, user_id=message.author.id)
+        if not translations:
+            logger.error("No translation produced for announcement %s", message.id)
+            return
+
+        if getattr(self.bot, "db", None):
+            try:
+                await self.bot.db.save_announcement_translations(
+                    message.id,
+                    guild_id=message.guild.id,
+                    channel_id=message.channel.id,
+                    source_lang=source_code,
+                    translations=translations,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Storing announcement %s failed: %s", message.id, exc)
+                return
+
+        view = AnnouncementTranslationView(message.id, list(translations.keys()))
+        try:
+            await message.reply(view=view, mention_author=False)
+        except discord.HTTPException as exc:
+            logger.error("Posting translation buttons for %s failed: %s",
+                         message.id, exc)
+
+
+async def setup(bot):
+    await bot.add_cog(AnnouncementTranslation(bot))

--- a/cogs/announcement_translation.py
+++ b/cogs/announcement_translation.py
@@ -198,11 +198,14 @@ class AnnouncementTranslation(commands.Cog):
     async def _translate_all(
         self, text: str, *, user_id: int
     ) -> tuple[Dict[str, str], Optional[str]]:
-        """Translate one announcement into every language. One call per language.
+        """Translate one announcement into every language but its own.
 
-        The language the announcement is already written in is not sent to
-        DeepL: once the first call has reported the detected source, that
-        language is filled in with the original text.
+        DeepL reports the detected source language with the first translation,
+        so from the second call on the announcement's own language is skipped —
+        and if it happened to be the language of that first call, its result is
+        dropped. An announcement written in English therefore ends up with no
+        English entry, hence no English button: offering to translate a message
+        into the language it is already written in is noise.
         """
         from gateway import QuotaTarget
 
@@ -211,7 +214,6 @@ class AnnouncementTranslation(commands.Cog):
 
         for code, (target, _flag, _label) in LANGUAGES.items():
             if source_code == code:
-                translations[code] = text
                 continue
             try:
                 result = await self.bot.gateway.translation.translate(
@@ -231,6 +233,10 @@ class AnnouncementTranslation(commands.Cog):
             if source_code is None:
                 detected = (result.get("detected_source_language") or "").upper()
                 source_code = _SOURCE_TO_CODE.get(detected.split("-")[0])
+                # The very first call is the one that can land on the source
+                # language itself — DeepL simply handed the text back.
+                if source_code == code:
+                    translations.pop(code, None)
 
         return translations, source_code
 

--- a/config.py
+++ b/config.py
@@ -38,6 +38,19 @@ MODDY_NOTIF_REPORT_CHANNEL_ID: int = int(
 MODDY_NOTIF_REPORT_LOG_CHANNEL_ID: int = int(
     os.environ.get("MODDY_NOTIF_REPORT_LOG_CHANNEL_ID", "1541233478522241034"))
 
+# Announcement translation (docs/ANNOUNCEMENT_TRANSLATION.md): the Moddy team
+# channels whose messages are translated into every language the bot speaks the
+# moment they are posted. Deliberately a hardcoded list and not a module: this
+# is a support-server tool, not a feature offered to servers.
+ANNOUNCEMENT_TRANSLATION_CHANNEL_IDS: list[int] = [
+    int(part.strip())
+    for part in os.environ.get(
+        "ANNOUNCEMENT_TRANSLATION_CHANNEL_IDS",
+        "1398625728467173376,1444505508546478232",
+    ).split(",")
+    if part.strip().isdigit()
+]
+
 # Support requests (docs/SUPPORT_REQUESTS.md): where /bug-report lands, and
 # where a server owner asking the team to configure Moddy for them lands. Both
 # live in the Moddy team guild and are answered from the card itself.

--- a/db/base.py
+++ b/db/base.py
@@ -38,6 +38,7 @@ from db.repositories.tickets import TicketsRepository
 from db.repositories.notifications import NotificationRepository
 from db.repositories.support_requests import SupportRequestRepository
 from db.repositories.bump import BumpReminderRepository
+from db.repositories.announcement_translations import AnnouncementTranslationRepository
 from db.repositories.stats import StatsRepository
 
 logger = logging.getLogger('moddy.database')
@@ -78,6 +79,7 @@ class ModdyDatabase(
     NotificationRepository,
     SupportRequestRepository,
     BumpReminderRepository,
+    AnnouncementTranslationRepository,
     StatsRepository,
 ):
     """Gestionnaire principal de la base de données"""
@@ -736,6 +738,24 @@ class ModdyDatabase(
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_bump_reminders_due "
                 "ON bump_reminders (due_at) WHERE sent = FALSE")
+
+            # announcement_translations — one row per announcement posted in a
+            # support-server announcement channel, holding the message already
+            # translated into every language the bot speaks. Written once at
+            # post time (one DeepL call per language), read on every button
+            # click. The translation buttons carry the message id, so this row
+            # is the only thing they need to survive a restart.
+            # See docs/ANNOUNCEMENT_TRANSLATION.md.
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS announcement_translations (
+                    message_id   BIGINT      PRIMARY KEY,
+                    guild_id     BIGINT      NOT NULL,
+                    channel_id   BIGINT      NOT NULL,
+                    source_lang  TEXT,
+                    translations JSONB       NOT NULL DEFAULT '{}'::jsonb,
+                    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
 
             # automod_eval_candidates — the annotation corpus that feeds the
             # offline golden set (automod/eval). A row is created for every

--- a/db/repositories/announcement_translations.py
+++ b/db/repositories/announcement_translations.py
@@ -1,0 +1,71 @@
+"""Stored translations of the announcements posted in the support server.
+
+An announcement is translated **once**, when it is posted: DeepL is called one
+time per language and the whole set is written here, keyed by the announcement's
+message id. Every later button click is a single indexed read — clicking the
+five flags twenty times costs zero API calls, which is the entire point of
+storing this rather than translating on demand.
+
+The row is the only state the buttons have: they are ``DynamicItem``s carrying
+the message id in their ``custom_id``, so a restart changes nothing.
+
+See docs/ANNOUNCEMENT_TRANSLATION.md.
+"""
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger('moddy.database')
+
+
+class AnnouncementTranslationRepository:
+    """Announcement translations (``announcement_translations``)."""
+
+    async def save_announcement_translations(
+        self,
+        message_id: int,
+        *,
+        guild_id: int,
+        channel_id: int,
+        source_lang: Optional[str],
+        translations: Dict[str, str],
+    ) -> None:
+        """Store the full translation set of one announcement.
+
+        Upsert rather than insert: re-running the translation of an announcement
+        (a manual re-post, an edit handled later) must replace the set, never
+        stack a second one.
+        """
+        async with self.pool.acquire() as conn:
+            await conn.execute("""
+                INSERT INTO announcement_translations (
+                    message_id, guild_id, channel_id, source_lang, translations
+                ) VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (message_id) DO UPDATE SET
+                    guild_id     = EXCLUDED.guild_id,
+                    channel_id   = EXCLUDED.channel_id,
+                    source_lang  = EXCLUDED.source_lang,
+                    translations = EXCLUDED.translations,
+                    created_at   = now()
+            """, message_id, guild_id, channel_id, source_lang,
+                 json.dumps(translations))
+
+    async def get_announcement_translations(
+        self, message_id: int
+    ) -> Optional[Dict[str, Any]]:
+        """Read back one announcement's translations, or ``None`` if unknown."""
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT * FROM announcement_translations WHERE message_id = $1",
+                message_id)
+        if not row:
+            return None
+        return {
+            "message_id": row["message_id"],
+            "guild_id": row["guild_id"],
+            "channel_id": row["channel_id"],
+            "source_lang": row["source_lang"],
+            "translations": self._parse_jsonb(row["translations"]),
+            "created_at": row["created_at"],
+        }

--- a/docs/ANNOUNCEMENT_TRANSLATION.md
+++ b/docs/ANNOUNCEMENT_TRANSLATION.md
@@ -1,0 +1,100 @@
+# Announcement Translation
+
+> Support-server only. Every announcement posted in the Moddy support server's
+> announcement channels is translated into the five languages Moddy speaks, once,
+> and offered behind one flag button per language.
+
+---
+
+## What it does
+
+1. Somebody posts a message in one of the watched channels.
+2. Moddy sends the message to DeepL **once per language** (at most five calls,
+   and one fewer when the announcement is already written in one of them).
+3. The whole set is stored in `announcement_translations`, keyed by the
+   announcement's message id.
+4. Moddy replies to the announcement with a container holding **only** five
+   buttons — flag + language name written in that language.
+5. Clicking a button shows the stored translation ephemerally, as plain text in
+   a container: no title, no code block, no attribution line.
+
+Translating at post time rather than on click is the point of the design: an
+announcement read by a thousand people costs five DeepL calls, not a thousand.
+A click is an indexed primary-key read.
+
+---
+
+## Scope
+
+| | |
+|---|---|
+| Guild | `MODDY_TEAM_GUILD_ID` (support server) |
+| Channels | `ANNOUNCEMENT_TRANSLATION_CHANNEL_IDS` — defaults to `1398625728467173376` and `1444505508546478232` |
+| Languages | `fr`, `en` (EN-US), `es`, `pt` (PT-BR), `de` |
+| Provider | DeepL, through the API gateway (`bot.gateway.translation`) |
+
+This is **not** a module: servers cannot enable it, there is no `/config`
+screen, and nothing is stored under `guilds.data.modules`. It is a support-server
+tool, hardcoded to those channels (overridable by env var so a staging server
+can point it elsewhere).
+
+Messages from bots and messages with no text content are ignored. Mentions are
+neutralised (`@everyone` → zero-width-joined, `<@id>` → `@display name`) before
+the text reaches DeepL, so the translation contains words rather than raw ids
+and nothing can ping from a translated copy.
+
+---
+
+## Files
+
+| File | Role |
+|---|---|
+| `cogs/announcement_translation.py` | The listener, the language table, the buttons-only view and the `AnnouncementLanguageButton` dynamic item |
+| `db/repositories/announcement_translations.py` | `save_announcement_translations()` / `get_announcement_translations()` |
+| `db/base.py` | `announcement_translations` table creation |
+| `config.py` | `ANNOUNCEMENT_TRANSLATION_CHANNEL_IDS` |
+| `locales/*.json` | `announcement_translation.error.*` (the one error a click can produce) |
+
+---
+
+## Storage
+
+```sql
+CREATE TABLE announcement_translations (
+    message_id   BIGINT      PRIMARY KEY,  -- the announcement itself
+    guild_id     BIGINT      NOT NULL,
+    channel_id   BIGINT      NOT NULL,
+    source_lang  TEXT,                     -- detected by DeepL: fr/en/es/pt/de
+    translations JSONB       NOT NULL,     -- {"fr": "...", "en": "...", …}
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+One row per announcement, upserted. A language whose DeepL call failed is simply
+absent from `translations` — and gets no button, rather than a button that
+apologises.
+
+---
+
+## Persistence
+
+The buttons are `discord.ui.DynamicItem`s whose `custom_id` is
+`moddy:anntr:lang:<code>:<message_id>`. The class is registered at startup via
+`AnnouncementTranslationView.register_persistent()`
+(`utils/persistent_views.py`), so a click after a restart reconstructs the item
+from its custom_id and reads the row back — nothing is kept in memory. Auth is
+public: the button only ever shows a translation of a message its clicker can
+already read.
+
+---
+
+## Adding a language
+
+Add an entry to `LANGUAGES` in `cogs/announcement_translation.py`
+(`code → (DeepL target, flag, label in that language)`) and extend the button's
+`template=` alternation to accept the new code. Five buttons is the per-ActionRow
+maximum, so a sixth language needs a second row in `build_view()`.
+
+The labels are deliberately **not** translated: a button offering German reads
+"Deutsch" whoever is looking at it, which is the only way a reader who does not
+speak the announcement's language can find their own.

--- a/docs/ANNOUNCEMENT_TRANSLATION.md
+++ b/docs/ANNOUNCEMENT_TRANSLATION.md
@@ -1,26 +1,29 @@
 # Announcement Translation
 
 > Support-server only. Every announcement posted in the Moddy support server's
-> announcement channels is translated into the five languages Moddy speaks, once,
-> and offered behind one flag button per language.
+> announcement channels is translated once into every language Moddy speaks
+> except its own, and offered behind one flag button per language.
 
 ---
 
 ## What it does
 
 1. Somebody posts a message in one of the watched channels.
-2. Moddy sends the message to DeepL **once per language** (at most five calls,
-   and one fewer when the announcement is already written in one of them).
+2. Moddy sends the message to DeepL **once per language other than its own**.
+   DeepL reports the detected source language with the first translation, so an
+   announcement written in English is never translated into English.
 3. The whole set is stored in `announcement_translations`, keyed by the
    announcement's message id.
-4. Moddy replies to the announcement with a container holding **only** five
-   buttons — flag + language name written in that language.
+4. Moddy replies to the announcement with a container holding **only** buttons
+   — flag + language name written in that language, one per stored translation.
+   The announcement's own language gets no button: offering to translate a
+   message into the language it is already written in is noise.
 5. Clicking a button shows the stored translation ephemerally, as plain text in
    a container: no title, no code block, no attribution line.
 
 Translating at post time rather than on click is the point of the design: an
-announcement read by a thousand people costs five DeepL calls, not a thousand.
-A click is an indexed primary-key read.
+announcement read by a thousand people costs four or five DeepL calls, not a
+thousand. A click is an indexed primary-key read.
 
 ---
 
@@ -70,9 +73,9 @@ CREATE TABLE announcement_translations (
 );
 ```
 
-One row per announcement, upserted. A language whose DeepL call failed is simply
-absent from `translations` — and gets no button, rather than a button that
-apologises.
+One row per announcement, upserted. The detected source language is **not** a
+key of `translations`, and neither is a language whose DeepL call failed: a
+missing key simply means no button, rather than a button that apologises.
 
 ---
 
@@ -91,9 +94,11 @@ already read.
 ## Adding a language
 
 Add an entry to `LANGUAGES` in `cogs/announcement_translation.py`
-(`code → (DeepL target, flag, label in that language)`) and extend the button's
-`template=` alternation to accept the new code. Five buttons is the per-ActionRow
-maximum, so a sixth language needs a second row in `build_view()`.
+(`code → (DeepL target, flag, label in that language)`), map DeepL's source code
+for it in `_SOURCE_TO_CODE`, and extend the button's `template=` alternation to
+accept the new code. Five buttons is the per-ActionRow maximum — with the source
+language dropped, five languages fit; a sixth needs a second row in
+`build_view()`.
 
 The labels are deliberately **not** translated: a button offering German reads
 "Deutsch" whoever is looking at it, which is the only way a reader who does not

--- a/docs/sessions/2026-09-09_announcement-translation.md
+++ b/docs/sessions/2026-09-09_announcement-translation.md
@@ -1,0 +1,58 @@
+# 2026-09-09 — Announcement translation (support server)
+
+## What was done
+
+Announcements posted in the two support-server announcement channels are now
+translated automatically into the five languages Moddy speaks, and offered under
+the announcement as one flag button per language.
+
+- A message posted in a watched channel is sent to DeepL **once per language**
+  (through the gateway), and the full set is stored in a new
+  `announcement_translations` table keyed by the announcement's message id.
+- Moddy replies with a container holding **only** the five buttons (flag +
+  language name written in that language, e.g. `🇩🇪 Deutsch`).
+- A click reads the stored row and answers ephemerally with the translated text
+  alone, in a container: no title, no code block, no attribution line.
+
+DeepL is therefore called at most five times per announcement, whatever the
+number of readers or clicks — the requirement that drove the whole shape.
+
+## Files
+
+| File | Change |
+|---|---|
+| `cogs/announcement_translation.py` | New — listener, language table, buttons-only view, `AnnouncementLanguageButton` dynamic item |
+| `db/repositories/announcement_translations.py` | New — save/get one announcement's translations |
+| `db/base.py` | New `announcement_translations` table + repository mixin |
+| `config.py` | New `ANNOUNCEMENT_TRANSLATION_CHANNEL_IDS` (defaults to the two channels, env-overridable) |
+| `utils/persistent_views.py` | Registers the flag buttons (group 12l) |
+| `tests/test_persistent_views.py` | Covers `AnnouncementLanguageButton` |
+| `locales/{fr,en-US,es-ES,pt-BR,de}.json` | `announcement_translation.error.*` |
+| `docs/ANNOUNCEMENT_TRANSLATION.md`, `CLAUDE.md` | Documentation |
+
+## Decisions
+
+- **Not a module.** Servers cannot enable this; it is hardcoded to the support
+  guild and its two announcement channels. The channel list lives in `config.py`
+  behind an env var so a staging server can point it elsewhere without a code
+  change.
+- **Buttons are `DynamicItem`s** carrying the announcement's message id, so they
+  keep working across restarts with nothing held in memory — the stored row is
+  the only state.
+- **Button labels are not i18n'd.** A German reader looking at a French
+  announcement finds their language because the button says "Deutsch", not
+  because it was translated into the language they cannot read.
+- **A language whose DeepL call failed gets no button** rather than a button
+  that apologises on click; the error string exists only for a row that has gone
+  missing.
+- Mentions are neutralised before translation, so DeepL sees words and a
+  translated copy cannot ping anyone.
+
+## Follow-ups
+
+- Message **edits** are not re-translated: the stored set is the announcement as
+  first posted. An `on_message_edit` hook re-running the translation would be a
+  small addition if it turns out to matter.
+- Announcements posted by bots/webhooks are ignored (loop safety). If the team
+  starts publishing through a webhook, that guard needs relaxing to "ignore
+  Moddy itself" only.

--- a/docs/sessions/2026-09-09_announcement-translation.md
+++ b/docs/sessions/2026-09-09_announcement-translation.md
@@ -3,14 +3,18 @@
 ## What was done
 
 Announcements posted in the two support-server announcement channels are now
-translated automatically into the five languages Moddy speaks, and offered under
-the announcement as one flag button per language.
+translated automatically into every language Moddy speaks except the one they
+are written in, and offered under the announcement as one flag button per
+language.
 
-- A message posted in a watched channel is sent to DeepL **once per language**
-  (through the gateway), and the full set is stored in a new
+- A message posted in a watched channel is sent to DeepL **once per language
+  other than its own** (through the gateway), and the set is stored in a new
   `announcement_translations` table keyed by the announcement's message id.
-- Moddy replies with a container holding **only** the five buttons (flag +
-  language name written in that language, e.g. `🇩🇪 Deutsch`).
+  DeepL reports the detected source language with the first translation, so an
+  English announcement is never translated into English.
+- Moddy replies with a container holding **only** the buttons (flag + language
+  name written in that language, e.g. `🇩🇪 Deutsch`) — one per stored
+  translation, so the announcement's own language gets no button.
 - A click reads the stored row and answers ephemerally with the translated text
   alone, in a container: no title, no code block, no attribution line.
 
@@ -42,9 +46,10 @@ number of readers or clicks — the requirement that drove the whole shape.
 - **Button labels are not i18n'd.** A German reader looking at a French
   announcement finds their language because the button says "Deutsch", not
   because it was translated into the language they cannot read.
-- **A language whose DeepL call failed gets no button** rather than a button
-  that apologises on click; the error string exists only for a row that has gone
-  missing.
+- **The source language gets no button**, and neither does a language whose
+  DeepL call failed — a missing key in the stored set simply means no button,
+  rather than a button that apologises on click. The error string exists only
+  for a row that has gone missing.
 - Mentions are neutralised before translation, so DeepL sees words and a
   translated copy cannot ping anyone.
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -4617,5 +4617,11 @@
         "description": "Anfragen können momentan nicht gespeichert werden. Nutze bitte den Support-Server."
       }
     }
+  },
+  "announcement_translation": {
+    "error": {
+      "title": "Übersetzung nicht verfügbar",
+      "missing": "Die Übersetzung dieser Ankündigung ist nicht mehr verfügbar."
+    }
   }
 }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -4703,5 +4703,11 @@
       "no_permission_title": "I can't create the channel",
       "no_permission": "I need the **Manage Channels** permission to create the channel."
     }
+  },
+  "announcement_translation": {
+    "error": {
+      "title": "Translation unavailable",
+      "missing": "The translation of this announcement is no longer available."
+    }
   }
 }

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -4617,5 +4617,11 @@
         "description": "Las solicitudes no se pueden registrar en este momento. Usa el servidor de soporte."
       }
     }
+  },
+  "announcement_translation": {
+    "error": {
+      "title": "Traducción no disponible",
+      "missing": "La traducción de este anuncio ya no está disponible."
+    }
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -4702,5 +4702,11 @@
       "no_permission_title": "Je ne peux pas créer le salon",
       "no_permission": "Il me faut la permission **Gérer les salons** pour créer le salon."
     }
+  },
+  "announcement_translation": {
+    "error": {
+      "title": "Traduction indisponible",
+      "missing": "La traduction de cette annonce n'est plus disponible."
+    }
   }
 }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -4617,5 +4617,11 @@
         "description": "Os pedidos não podem ser registrados no momento. Use o servidor de suporte."
       }
     }
+  },
+  "announcement_translation": {
+    "error": {
+      "title": "Tradução indisponível",
+      "missing": "A tradução deste anúncio não está mais disponível."
+    }
   }
 }

--- a/tests/test_persistent_views.py
+++ b/tests/test_persistent_views.py
@@ -132,6 +132,7 @@ def _dynamic_item_cases():
         NotifReviewClaimButton, NotifReviewPreviewButton, NotifReviewDecisionButton,
     )
     from utils.bump_views import BumpOptInButton
+    from cogs.announcement_translation import AnnouncementLanguageButton
     from modules.configs.tickets_panel_config import (
         TicketPanelButton, TicketPanelSelect, TicketPanelChannelSelect,
     )
@@ -187,6 +188,9 @@ def _dynamic_item_cases():
         # Bump reminder — the "ping me next time" button on a thank-you card,
         # scoped to the person who ran the bump.
         (BumpOptInButton, ("disboard", _SNOWFLAKE)),
+        # Announcement translation — one flag button per language under a
+        # support-server announcement, keyed by that announcement's id.
+        (AnnouncementLanguageButton, ("fr", _SNOWFLAKE)),
     ]
 
 

--- a/utils/persistent_views.py
+++ b/utils/persistent_views.py
@@ -82,6 +82,7 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
     from utils.notification_views import NotificationsPersistence
     from utils.support_request_views import SupportPersistence
     from utils.beta_announcement import BetaPersistence
+    from cogs.announcement_translation import AnnouncementTranslationView
 
     return [
         # Group 1 — /moddy (public informational, no user auth)
@@ -194,6 +195,11 @@ def _collect_persistent_view_classes() -> List[Type["BaseView"]]:
         # re-renders the DM its reader already has). Temporary: goes away with
         # utils/beta_announcement.py when the campaign is over.
         BetaPersistence,
+        # Group 12l — support-server announcement translations: one flag button
+        # per language under an announcement (dynamic items keyed by the
+        # announcement's message id; public — clicking only shows the stored
+        # translation of a message the reader can already see).
+        AnnouncementTranslationView,
         # Group 13 — /config automod AI panel (guild permission auth;
         # AutomodAIPrecedentsView is deliberately excluded, see
         # docs/PERSISTENT_VIEWS.md Step 12)


### PR DESCRIPTION
## Summary

Adds automatic translation of announcements posted in the support server's announcement channels. Messages are translated once at post time (via DeepL) into all five languages Moddy speaks, stored in a new database table, and offered to readers via flag buttons that display translations ephemerally on click.

## Key Changes

- **New cog** (`cogs/announcement_translation.py`): Listens for messages in designated announcement channels, translates them to all five languages (FR, EN-US, ES, PT-BR, DE) via the gateway, stores results, and replies with a buttons-only view containing one flag button per language.

- **New database table** (`announcement_translations`): Stores message_id, guild_id, channel_id, detected source language, and a JSONB map of translations. Written once at post time, read on every button click.

- **Dynamic button item** (`AnnouncementLanguageButton`): A persistent `DynamicItem` that reconstructs from its custom_id (`moddy:anntr:lang:<code>:<message_id>`) and fetches the stored translation on click. Auth is public (read-only access to already-visible announcements).

- **Configuration** (`config.py`): New `ANNOUNCEMENT_TRANSLATION_CHANNEL_IDS` env var (defaults to two support server channels, overridable for staging).

- **Localization**: Error messages for missing translations added to all five language files.

- **Database layer** (`db/repositories/announcement_translations.py`): Save/get methods with upsert semantics.

- **Persistent view registration** (`utils/persistent_views.py`): Registers the button class at startup.

## Implementation Details

- **Efficiency by design**: DeepL is called at most 5 times per announcement (once per language), regardless of how many readers or clicks occur. The announcement's detected source language is filled in with the original text rather than being re-translated.

- **Mention sanitization**: User and role mentions are converted to plain text (`@display_name`, `@role_name`) before translation, so DeepL sees words and translated copies cannot ping anyone.

- **Graceful degradation**: Languages whose DeepL call fails simply don't appear as buttons; no error button is shown.

- **Not a module**: This is a support-server-only tool, hardcoded to specific channels and not configurable per guild via `/config`.

- **Stateless buttons**: Buttons carry only the message id in their custom_id; the database row is the sole state, allowing seamless operation across restarts.

https://claude.ai/code/session_01W3Ux9YXf95FMCQPH4gBoWM