### PR TITLE
Add guild name to bump reminder and thanks cards

### DIFF
--- a/cogs/bump_reminder.py
+++ b/cogs/bump_reminder.py
@@ -124,7 +124,7 @@ class BumpReminder(commands.Cog):
 
         view = build_thanks_card(
             hit.bot, hit.bumper_id, hit.due_at,
-            locale=locale, ping_mode=entry['ping_mode'],
+            locale=locale, ping_mode=entry['ping_mode'], guild_name=guild.name,
         )
 
         # The thank-you is a courtesy; the reminder is the promise. So a failed
@@ -258,6 +258,7 @@ class BumpReminder(commands.Cog):
             bumper_id=state.get('bumper_id'),
             mention_bumper=mention_bumper,
             bumped_at=bumped_at,
+            guild_name=guild.name,
             late_by=late_by,
         )
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -1530,7 +1530,7 @@
       "card": {
         "thanks_title": "Danke {user}!",
         "thanks_title_anonymous": "Danke!",
-        "thanks_body": "Der Server ist gerade auf {emoji} **{name}** wieder nach oben gerutscht.\nNächster Bump möglich {timestamp}.",
+        "thanks_body": "**{server}** ist gerade auf {emoji} **{name}** wieder nach oben gerutscht.\nNächster Bump möglich {timestamp}.",
         "optin": "Erinnere mich",
         "optin_on_title": "Erinnerung aktiviert",
         "optin_armed": "Du wirst erwähnt",
@@ -1538,7 +1538,7 @@
         "optin_disarmed": "Du wirst nicht mehr erwähnt",
         "optin_expired": "Ein neuerer Bump hat diesen bereits ersetzt.",
         "reminder_title": "Zeit für den nächsten Bump",
-        "reminder_body": "Der Server kann auf {emoji} **{name}** wieder gebumpt werden.\n{command}",
+        "reminder_body": "**{server}** kann auf {emoji} **{name}** wieder gebumpt werden.\n{command}",
         "reminder_last": "Letzter Bump von {user}, {timestamp}.",
         "reminder_late": "Erinnerung verspätet gesendet: Moddy war nicht erreichbar."
       },

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1530,7 +1530,7 @@
       "card": {
         "thanks_title": "Thanks {user}!",
         "thanks_title_anonymous": "Thanks!",
-        "thanks_body": "The server just climbed back up on {emoji} **{name}**.\nNext bump possible {timestamp}.",
+        "thanks_body": "**{server}** just climbed back up on {emoji} **{name}**.\nNext bump possible {timestamp}.",
         "optin": "Remind me",
         "optin_on_title": "Notification enabled",
         "optin_armed": "You will be mentioned",
@@ -1538,7 +1538,7 @@
         "optin_disarmed": "You will no longer be mentioned",
         "optin_expired": "A more recent bump has already replaced this one.",
         "reminder_title": "Time to bump again",
-        "reminder_body": "The server can be bumped on {emoji} **{name}** again.\n{command}",
+        "reminder_body": "**{server}** can be bumped on {emoji} **{name}** again.\n{command}",
         "reminder_last": "Last bumped by {user}, {timestamp}.",
         "reminder_late": "Reminder sent late: Moddy was unavailable."
       },

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1530,7 +1530,7 @@
       "card": {
         "thanks_title": "¡Gracias {user}!",
         "thanks_title_anonymous": "¡Gracias!",
-        "thanks_body": "El servidor acaba de subir en {emoji} **{name}**.\nPróximo bump posible {timestamp}.",
+        "thanks_body": "**{server}** acaba de subir en {emoji} **{name}**.\nPróximo bump posible {timestamp}.",
         "optin": "Recuérdamelo",
         "optin_on_title": "Notificación activada",
         "optin_armed": "Se te mencionará",
@@ -1538,7 +1538,7 @@
         "optin_disarmed": "Ya no se te mencionará",
         "optin_expired": "Un bump más reciente ya ha reemplazado a este.",
         "reminder_title": "Toca hacer bump",
-        "reminder_body": "El servidor puede recibir bump de nuevo en {emoji} **{name}**.\n{command}",
+        "reminder_body": "**{server}** puede recibir bump de nuevo en {emoji} **{name}**.\n{command}",
         "reminder_last": "Último bump por {user}, {timestamp}.",
         "reminder_late": "Recordatorio enviado con retraso: Moddy no estaba disponible."
       },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1529,7 +1529,7 @@
       "card": {
         "thanks_title": "Merci {user} !",
         "thanks_title_anonymous": "Merci !",
-        "thanks_body": "Le serveur vient de remonter sur {emoji} **{name}**.\nProchain bump possible {timestamp}.",
+        "thanks_body": "**{server}** vient de remonter sur {emoji} **{name}**.\nProchain bump possible {timestamp}.",
         "optin": "Me rappeler",
         "optin_on_title": "Notification activée",
         "optin_armed": "Tu seras mentionné",
@@ -1537,7 +1537,7 @@
         "optin_disarmed": "Tu ne seras plus mentionné",
         "optin_expired": "Ce bump a déjà été remplacé par un plus récent.",
         "reminder_title": "C'est reparti",
-        "reminder_body": "Le serveur peut de nouveau être bumpé sur {emoji} **{name}**.\n{command}",
+        "reminder_body": "**{server}** peut de nouveau être bumpé sur {emoji} **{name}**.\n{command}",
         "reminder_last": "Dernier bump par {user}, {timestamp}.",
         "reminder_late": "Rappel envoyé en retard : Moddy était indisponible."
       },

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1530,7 +1530,7 @@
       "card": {
         "thanks_title": "Obrigado {user}!",
         "thanks_title_anonymous": "Obrigado!",
-        "thanks_body": "O servidor acabou de subir em {emoji} **{name}**.\nPróximo bump possível {timestamp}.",
+        "thanks_body": "**{server}** acabou de subir em {emoji} **{name}**.\nPróximo bump possível {timestamp}.",
         "optin": "Me lembrar",
         "optin_on_title": "Notificação ativada",
         "optin_armed": "Você será mencionado",
@@ -1538,7 +1538,7 @@
         "optin_disarmed": "Você não será mais mencionado",
         "optin_expired": "Um bump mais recente já substituiu este.",
         "reminder_title": "Hora de dar bump",
-        "reminder_body": "O servidor pode receber bump em {emoji} **{name}** novamente.\n{command}",
+        "reminder_body": "**{server}** pode receber bump em {emoji} **{name}** novamente.\n{command}",
         "reminder_last": "Último bump por {user}, {timestamp}.",
         "reminder_late": "Lembrete enviado com atraso: o Moddy estava indisponível."
       },

--- a/tests/test_bump_reminder.py
+++ b/tests/test_bump_reminder.py
@@ -781,7 +781,7 @@ class TestComponents:
 
         view = build_reminder_card(
             bot_by_key("disboard"), locale="fr", role_ids=[1234],
-            bumper_id=5678, mention_bumper=True,
+            bumper_id=5678, mention_bumper=True, guild_name="Moddy support",
             bumped_at=datetime.now(timezone.utc) - timedelta(hours=2))
         first = view.children[0]
         assert isinstance(first, discord.ui.TextDisplay)
@@ -801,7 +801,7 @@ class TestComponents:
 
         view = build_reminder_card(
             bot_by_key("disboard"), locale="fr", role_ids=[1234],
-            bumper_id=5678, mention_bumper=False,
+            bumper_id=5678, mention_bumper=False, guild_name="Moddy support",
             bumped_at=datetime.now(timezone.utc) - timedelta(hours=2))
         top = view.children[0].content
         assert "<@5678>" not in top, "the bumper must not be in the ping line"
@@ -840,8 +840,12 @@ class TestComponents:
             )
 
         spec = bot_by_key("disboard")
-        assert has_button(build_thanks_card(spec, 42, due, locale="fr", ping_mode="button"))
-        assert not has_button(build_thanks_card(spec, 42, due, locale="fr", ping_mode="auto"))
-        assert not has_button(build_thanks_card(spec, 42, due, locale="fr", ping_mode="never"))
+        assert has_button(build_thanks_card(
+            spec, 42, due, locale="fr", ping_mode="button", guild_name="Moddy support"))
+        assert not has_button(build_thanks_card(
+            spec, 42, due, locale="fr", ping_mode="auto", guild_name="Moddy support"))
+        assert not has_button(build_thanks_card(
+            spec, 42, due, locale="fr", ping_mode="never", guild_name="Moddy support"))
         # Nobody to arm it for.
-        assert not has_button(build_thanks_card(spec, None, due, locale="fr", ping_mode="button"))
+        assert not has_button(build_thanks_card(
+            spec, None, due, locale="fr", ping_mode="button", guild_name="Moddy support"))

--- a/utils/bump_views.py
+++ b/utils/bump_views.py
@@ -181,7 +181,7 @@ class BumpReminderPersistence(BaseView):
 # Cards
 # --------------------------------------------------------------------------- #
 def build_thanks_card(spec: BumpBot, bumper_id: Optional[int], due_at,
-                      *, locale: str, ping_mode: str,
+                      *, locale: str, ping_mode: str, guild_name: str,
                       armed: bool = False) -> ui.LayoutView:
     """The card posted right after a successful bump."""
     view = ui.LayoutView(timeout=None)
@@ -197,6 +197,7 @@ def build_thanks_card(spec: BumpBot, bumper_id: Optional[int], due_at,
     container.add_item(ui.TextDisplay(
         t("modules.bump_reminder.card.thanks_body",
           locale=locale, emoji=spec.emoji, name=spec.name,
+          server=guild_name,
           timestamp=f"<t:{int(due_at.timestamp())}:R>")
     ))
 
@@ -213,7 +214,7 @@ def build_thanks_card(spec: BumpBot, bumper_id: Optional[int], due_at,
 def build_reminder_card(spec: BumpBot, *, locale: str,
                         role_ids: Sequence[int], bumper_id: Optional[int],
                         mention_bumper: bool, bumped_at: Optional[datetime],
-                        late_by: int = 0) -> ui.LayoutView:
+                        guild_name: str, late_by: int = 0) -> ui.LayoutView:
     """The card posted when the command becomes available again.
 
     The mentions ride in a text display added to the **view**, above the
@@ -236,7 +237,8 @@ def build_reminder_card(spec: BumpBot, *, locale: str,
     ))
     container.add_item(ui.TextDisplay(
         t("modules.bump_reminder.card.reminder_body",
-          locale=locale, emoji=spec.emoji, name=spec.name, command=spec.command)
+          locale=locale, emoji=spec.emoji, name=spec.name, command=spec.command,
+          server=guild_name)
     ))
 
     footnotes = []


### PR DESCRIPTION
## Summary
This change adds the guild name to the bump reminder and thanks cards displayed to users, making the messages more contextual and user-friendly by explicitly showing which server the bump action relates to.

## Key Changes
- **Function signatures**: Added required `guild_name: str` parameter to `build_thanks_card()` and `build_reminder_card()` in `utils/bump_views.py`
- **Card rendering**: Updated both card builders to pass `server=guild_name` to the translation system for message interpolation
- **Caller updates**: Modified `cogs/bump_reminder.py` to pass `guild.name` when building cards in both the `_on_bump()` and `_post()` methods
- **Localization**: Updated all 5 locale files (en-US, fr, de, es-ES, pt-BR) to include `{server}` placeholder in:
  - `thanks_body`: Changed "The server" → "**{server}**"
  - `reminder_body`: Changed "The server" → "**{server}**"
- **Tests**: Updated test cases in `tests/test_bump_reminder.py` to pass the new `guild_name` parameter to both card builders

## Implementation Details
The guild name is now prominently displayed in bold in both card messages, replacing the generic "The server" phrasing. This makes it immediately clear to users which specific server the bump reminder or thanks message refers to, improving clarity in multi-server Discord environments.

https://claude.ai/code/session_01MjQtzuY9UN1JwUNf3Q8Jo8