### PR TITLE
Never offer an announcement's own language as a translation button

### DIFF
--- a/cogs/announcement_translation.py
+++ b/cogs/announcement_translation.py
@@ -200,12 +200,19 @@ class AnnouncementTranslation(commands.Cog):
     ) -> tuple[Dict[str, str], Optional[str]]:
         """Translate one announcement into every language but its own.
 
-        DeepL reports the detected source language with the first translation,
-        so from the second call on the announcement's own language is skipped —
-        and if it happened to be the language of that first call, its result is
-        dropped. An announcement written in English therefore ends up with no
-        English entry, hence no English button: offering to translate a message
-        into the language it is already written in is noise.
+        DeepL reports the detected source language with every translation, so
+        the announcement's own language is skipped as soon as it is known — and
+        dropped at the end whatever the order the calls happened in. An
+        announcement written in English therefore ends up with no English entry,
+        hence no English button: offering to translate a message into the
+        language it is already written in is noise.
+
+        The final ``pop`` is what makes this order-independent. Skipping ahead of
+        the call only works for a language the loop has not reached yet; the one
+        translated *before* the source was known (the first call, always) has to
+        be removed afterwards. A result that comes back identical to the source
+        is dropped too, which catches the announcements whose language DeepL
+        detects wrongly or not at all.
         """
         from gateway import QuotaTarget
 
@@ -229,14 +236,24 @@ class AnnouncementTranslation(commands.Cog):
 
             if not result or not result.get("text"):
                 continue
-            translations[code] = result["text"]
+            # A "translation" identical to the announcement is the announcement:
+            # DeepL was handed a text already in that language and gave it back.
+            # The button would show the message the reader is looking at, so it
+            # is dropped — this also covers a detection DeepL got wrong or did
+            # not report, which language detection on a short text does.
+            if result["text"].strip().casefold() != text.strip().casefold():
+                translations[code] = result["text"]
+
             if source_code is None:
                 detected = (result.get("detected_source_language") or "").upper()
                 source_code = _SOURCE_TO_CODE.get(detected.split("-")[0])
-                # The very first call is the one that can land on the source
-                # language itself — DeepL simply handed the text back.
-                if source_code == code:
-                    translations.pop(code, None)
+                logger.debug("Announcement source detected as %r -> %r",
+                             detected, source_code)
+
+        # The announcement's own language never gets a button, including when it
+        # is the language the first call happened to translate into.
+        if source_code:
+            translations.pop(source_code, None)
 
         return translations, source_code
 

--- a/docs/ANNOUNCEMENT_TRANSLATION.md
+++ b/docs/ANNOUNCEMENT_TRANSLATION.md
@@ -10,8 +10,11 @@
 
 1. Somebody posts a message in one of the watched channels.
 2. Moddy sends the message to DeepL **once per language other than its own**.
-   DeepL reports the detected source language with the first translation, so an
-   announcement written in English is never translated into English.
+   DeepL reports the detected source language with every translation, so the
+   announcement's own language is skipped once it is known and dropped from the
+   set afterwards — the order the calls happen in does not matter. A result that
+   comes back identical to the announcement is dropped too, which covers a
+   detection DeepL got wrong or did not report (it happens on very short texts).
 3. The whole set is stored in `announcement_translations`, keyed by the
    announcement's message id.
 4. Moddy replies to the announcement with a container holding **only** buttons
@@ -74,8 +77,9 @@ CREATE TABLE announcement_translations (
 ```
 
 One row per announcement, upserted. The detected source language is **not** a
-key of `translations`, and neither is a language whose DeepL call failed: a
-missing key simply means no button, rather than a button that apologises.
+key of `translations`; neither is a language whose result came back identical to
+the announcement, nor one whose DeepL call failed. A missing key simply means no
+button, rather than a button that apologises.
 
 ---
 

--- a/docs/sessions/2026-09-09_announcement-translation.md
+++ b/docs/sessions/2026-09-09_announcement-translation.md
@@ -53,6 +53,24 @@ number of readers or clicks — the requirement that drove the whole shape.
 - Mentions are neutralised before translation, so DeepL sees words and a
   translated copy cannot ping anyone.
 
+## Follow-up in the same session
+
+An English announcement still showed an English button in production. Two
+changes, both in `_translate_all`:
+
+- the source language is now dropped **after** the loop rather than only when it
+  was the first call's target, so the removal no longer depends on the order the
+  languages are translated in;
+- a result that comes back identical to the announcement (case- and
+  whitespace-insensitive) is never stored — whatever DeepL claims the source is,
+  a button showing the message the reader is already looking at is noise. This
+  is the safety net for detection on short texts, which is unreliable.
+
+`tests/test_announcement_translation.py` now pins both properties, plus the call
+count (one per language, never one per click) and the buttons-only card.
+`tests/internal_api/test_rules_check_route.py`'s session-wide `gateway` stub
+gained the `QuotaTarget.user`/`global_` constructors it was missing.
+
 ## Follow-ups
 
 - Message **edits** are not re-translated: the stored set is the announcement as

--- a/tests/internal_api/test_rules_check_route.py
+++ b/tests/internal_api/test_rules_check_route.py
@@ -36,10 +36,21 @@ def _install_gateway_stub():
     stub._moddy_test_stub = True
     stub.GatewayError = GatewayError
 
+    # The stub replaces `gateway` for the whole session, so it mirrors the real
+    # QuotaTarget surface rather than only the constructor this route needs —
+    # a missing one fails whichever unrelated test happens to run afterwards.
     class QuotaTarget:
         @staticmethod
         def guild(gid, call_type):
             return ("guild", gid, call_type)
+
+        @staticmethod
+        def user(uid, call_type):
+            return ("user", uid, call_type)
+
+        @staticmethod
+        def global_(call_type):
+            return ("global", "", call_type)
 
     stub.QuotaTarget = QuotaTarget
     sys.modules["gateway"] = stub

--- a/tests/test_announcement_translation.py
+++ b/tests/test_announcement_translation.py
@@ -1,0 +1,156 @@
+"""Announcement translation — which languages get a button, and what it costs.
+
+The whole feature is two promises: DeepL is called once per announcement (never
+once per click), and the announcement's own language never gets a button. Both
+are properties of ``_translate_all``, so that is what these tests drive, with a
+fake gateway recording every call.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from cogs.announcement_translation import (
+    LANGUAGES,
+    AnnouncementLanguageButton,
+    AnnouncementTranslation,
+    AnnouncementTranslationView,
+    sanitize_mentions,
+)
+
+
+class FakeTranslationClient:
+    """Records calls and answers with a fixed detected source language."""
+
+    def __init__(self, detected: str, fail_targets=()):
+        self.detected = detected
+        self.fail_targets = set(fail_targets)
+        self.calls = []
+
+    async def translate(self, text, target_lang, **kwargs):
+        self.calls.append(target_lang)
+        if target_lang in self.fail_targets:
+            raise RuntimeError("provider down")
+        return {"text": f"[{target_lang}] {text}",
+                "detected_source_language": self.detected}
+
+
+def make_cog(detected: str, fail_targets=()) -> tuple:
+    client = FakeTranslationClient(detected, fail_targets)
+    bot = SimpleNamespace(gateway=SimpleNamespace(translation=client))
+    return AnnouncementTranslation(bot), client
+
+
+class TestSourceLanguageHasNoButton:
+    """A message is never offered a translation into the language it is in."""
+
+    @pytest.mark.parametrize("detected,expected_missing", [
+        ("FR", "fr"),
+        ("EN", "en"),
+        ("ES", "es"),
+        ("PT", "pt"),
+        ("DE", "de"),
+    ])
+    async def test_source_language_is_dropped(self, detected, expected_missing):
+        cog, _client = make_cog(detected)
+        translations, source = await cog._translate_all("hello", user_id=1)
+
+        assert source == expected_missing
+        assert expected_missing not in translations
+        assert set(translations) == set(LANGUAGES) - {expected_missing}
+
+    async def test_english_source_keeps_the_other_four(self):
+        """The regression: EN is detected on the *first* (French) call.
+
+        The language translated before the source was known has to be dropped
+        afterwards, which is what "hello" showing an English button was missing.
+        """
+        cog, client = make_cog("EN")
+        translations, _ = await cog._translate_all("hello", user_id=1)
+
+        assert "en" not in translations
+        assert sorted(translations) == ["de", "es", "fr", "pt"]
+        # EN-US is never even requested: the skip happens before the call.
+        assert "EN-US" not in client.calls
+
+    async def test_identical_result_gets_no_button(self):
+        """Safety net for a detection DeepL gets wrong on a short text.
+
+        Whatever DeepL claims the source is, a "translation" that comes back
+        character-for-character identical to the announcement would show the
+        reader the message they are already looking at.
+        """
+        class Echo(FakeTranslationClient):
+            async def translate(self, text, target_lang, **kwargs):
+                self.calls.append(target_lang)
+                if target_lang == "EN-US":
+                    return {"text": text, "detected_source_language": "IT"}
+                return {"text": f"[{target_lang}] {text}",
+                        "detected_source_language": "IT"}
+
+        client = Echo("IT")
+        cog = AnnouncementTranslation(
+            SimpleNamespace(gateway=SimpleNamespace(translation=client)))
+        translations, _ = await cog._translate_all("hello", user_id=1)
+        assert "en" not in translations
+
+    async def test_unknown_source_keeps_every_language(self):
+        """An announcement in a language Moddy does not speak loses nothing."""
+        cog, _client = make_cog("IT")
+        translations, source = await cog._translate_all("ciao", user_id=1)
+
+        assert source is None
+        assert set(translations) == set(LANGUAGES)
+
+
+class TestCallCount:
+    """One call per language, at most — and never one per click."""
+
+    async def test_one_call_per_language_at_most(self):
+        cog, client = make_cog("EN")
+        await cog._translate_all("hello", user_id=1)
+        assert len(client.calls) == len(LANGUAGES) - 1
+        assert len(client.calls) == len(set(client.calls))
+
+    async def test_failed_language_gets_no_entry(self):
+        cog, _client = make_cog("FR", fail_targets={"DE"})
+        translations, _ = await cog._translate_all("bonjour", user_id=1)
+        assert "de" not in translations
+        assert sorted(translations) == ["en", "es", "pt"]
+
+    async def test_every_language_failing_yields_nothing(self):
+        cog, _client = make_cog("FR", fail_targets={
+            target for target, _f, _l in LANGUAGES.values()})
+        translations, _ = await cog._translate_all("bonjour", user_id=1)
+        assert translations == {}
+
+
+class TestCard:
+    """The reply is buttons and nothing else."""
+
+    def test_one_button_per_translation(self):
+        view = AnnouncementTranslationView(1234567890123456789, ["en", "es"])
+        buttons = [i for i in view.walk_children()
+                   if isinstance(i, AnnouncementLanguageButton)]
+        assert [b.code for b in buttons] == ["en", "es"]
+        assert view.is_persistent()
+
+    def test_no_text_in_the_card(self):
+        view = AnnouncementTranslationView(1234567890123456789, list(LANGUAGES))
+        payload = view.to_components()
+        container = payload[0]
+        # A single ActionRow, no TextDisplay: the card is buttons only.
+        assert [c["type"] for c in container["components"]] == [1]
+
+    def test_button_label_is_written_in_its_own_language(self):
+        button = AnnouncementLanguageButton("de", 1234567890123456789)
+        assert button.item.label == "Deutsch"
+        assert button.item.custom_id.endswith(":de:1234567890123456789")
+
+
+class TestSanitizeMentions:
+    def test_everyone_cannot_ping_from_a_translation(self):
+        assert "@everyone" not in sanitize_mentions("@everyone hi", None)
+
+    def test_ids_become_words(self):
+        assert sanitize_mentions("<@123> <@&456>", None) == "@user @role"


### PR DESCRIPTION
Follow-up to #395: an English announcement still showed an English button.

## What changed

**`cogs/announcement_translation.py` — `_translate_all()`**

- The announcement's own language is now dropped **after** the loop, not only when it happened to be the first call's target. The skip-ahead only ever worked for a language the loop had not reached yet; the one translated *before* DeepL reported the source (the first call, always) survived. The removal is now order-independent.
- A result that comes back **identical to the announcement** (case- and whitespace-insensitive) is never stored. Whatever DeepL claims the source language is, a button that shows the reader the message they are already looking at is noise — and this is the safety net for detection, which is unreliable on very short texts.
- Added a `DEBUG` log of the detected source language, so a wrong verdict in production is diagnosable instead of guessed at.

A missing key in the stored set simply means no button, which is what "failed language" already meant; the source language now joins it.

## Tests

`tests/test_announcement_translation.py` (new, 16 tests) pins the two promises the feature is made of:

- the source language never gets a button — parametrised over all five languages, plus the exact `"hello"` regression;
- an identical result gets no button, whatever the detection says;
- one DeepL call per language, never one per click;
- a failed language is absent rather than broken;
- the reply card is buttons and nothing else (no `TextDisplay` in the container).

`tests/internal_api/test_rules_check_route.py` replaces the `gateway` module for the whole session, so its `QuotaTarget` stub now mirrors the real surface (`user`, `global_`) instead of only the constructor that route needs — without it, whichever unrelated test ran afterwards failed.

Full suite: 1782 passed.

## Docs

`docs/ANNOUNCEMENT_TRANSLATION.md` and the session log updated to describe the order-independent drop and the identical-result net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3Ux9YXf95FMCQPH4gBoWM

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3Ux9YXf95FMCQPH4gBoWM)_