### PR TITLE
Bump reminder: diagnose silent role pings and fix opt-in button

### DIFF
--- a/cogs/bump_reminder.py
+++ b/cogs/bump_reminder.py
@@ -38,6 +38,7 @@ from utils.bump_views import (
     build_reminder_card,
     build_thanks_card,
     reminder_mentions,
+    unnotifiable_roles,
 )
 from utils.emojis import ROCKET_LAUNCH
 from utils.i18n import t
@@ -252,6 +253,17 @@ class BumpReminder(commands.Cog):
         roles, allowed = reminder_mentions(
             guild, entry['role_ids'], bumper, mention_bumper)
 
+        # A reminder nobody is notified about is the one failure this feature
+        # cannot see: Discord drops the ping and still renders the tag, so the
+        # channel looks right. Name the reason before sending.
+        muted = unnotifiable_roles(roles, perms.mention_everyone)
+        if muted:
+            logger.warning(
+                f"Bump reminder in guild {guild.id} channel {channel.id} will not "
+                f"notify {', '.join(f'{r.name} ({r.id})' for r in muted)}: the role "
+                "is not mentionable and Moddy lacks Mention All Roles here"
+            )
+
         view = build_reminder_card(
             spec, locale=locale,
             role_ids=[role.id for role in roles],
@@ -274,6 +286,17 @@ class BumpReminder(commands.Cog):
             attribution=False,
         )
         if result.delivered:
+            # `raw_role_mentions` is Discord's own answer: the roles it accepted
+            # to notify. Comparing it to what was asked turns "the ping did not
+            # arrive" from a guess into a fact readable in the logs.
+            pinged = set(getattr(result.message, "raw_role_mentions", []) or [])
+            dropped = [role for role in roles if role.id not in pinged]
+            if dropped:
+                logger.warning(
+                    f"Discord dropped {len(dropped)} role ping(s) from the bump "
+                    f"reminder in guild {guild.id} channel {channel.id}: "
+                    f"{', '.join(f'{r.name} ({r.id})' for r in dropped)}"
+                )
             logger.info(
                 f"Bump reminder sent: guild {guild.id}, {spec.key}, channel {channel.id}"
                 f"{f' (late by {late_by}s)' if late_by >= LATE_AFTER else ''}"

--- a/docs/BUMP_REMINDER.md
+++ b/docs/BUMP_REMINDER.md
@@ -379,6 +379,26 @@ objects — never `roles=True` — so:
   ping mode**, and stays silent unless the mode put them in `allowed_mentions`.
   The credit survives; the unwanted ping cannot happen.
 
+#### When the mention renders but nobody is notified
+
+`allowed_mentions` asks; Discord decides. A role that is **not mentionable** is
+only notified when Moddy holds *Mention @everyone, @here and All Roles* in that
+channel — otherwise Discord drops the ping from the delivered message, returns
+no error, and still renders the tag in blue. The reminder then looks perfect and
+buzzes nobody.
+
+That case is now named in the logs rather than left to guesswork:
+
+- before sending, `unnotifiable_roles()` reports every configured role that is
+  neither mentionable nor covered by the permission;
+- after sending, the delivered message's own `raw_role_mentions` is compared to
+  what was asked, and anything Discord refused is logged as dropped.
+
+So `Discord dropped 1 role ping(s)` in the logs means the server has to make the
+role mentionable (or grant Moddy that permission). No such line, and the ping did
+leave — a member not seeing it is then a client-side notification setting
+(*Suppress role @mentions*, a muted channel, or simply not having the role).
+
 ### The three ping modes
 
 | Mode | The last bumper is mentioned |

--- a/docs/sessions/2026-09-09_bump-reminder-silent-ping.md
+++ b/docs/sessions/2026-09-09_bump-reminder-silent-ping.md
@@ -1,0 +1,51 @@
+# 2026-09-09 — Bump reminder: the ping that renders but does not notify
+
+## The report
+
+The reminder card mentions the right role, the tag renders in blue, and nobody
+receives a notification.
+
+## What was ruled out
+
+The send path is correct, end to end:
+
+- `cogs/bump_reminder.py::_post` builds `AllowedMentions(everyone=False,
+  roles=[…], users=[…])` from resolved role objects;
+- `notifications/service.py::send_channel` → `_deliver` passes it through to
+  `channel.send()` untouched;
+- no `silent=True` anywhere, and no global `allowed_mentions` on the bot;
+- the internal `moddy/` framework does not touch mentions;
+- mentions inside a Components V2 `TextDisplay` do notify, per Discord's
+  component reference — they simply obey `allowed_mentions`.
+
+## The actual gap
+
+`allowed_mentions` only ever *asks*. Discord refuses a role ping when the role is
+not mentionable and the sender lacks *Mention All Roles* in that channel — and it
+refuses **silently**: no error, no rejected request, and the tag still renders.
+The feature had no way to tell a delivered ping from a dropped one, which is why
+the failure was invisible.
+
+## What changed
+
+- `utils/bump_views.py` — new `unnotifiable_roles()`: the configured roles
+  Discord will render but refuse to notify, given the channel permission.
+- `cogs/bump_reminder.py::_post` — warns before sending when a role cannot
+  notify, and after sending compares the delivered message's own
+  `raw_role_mentions` against what was asked, logging anything Discord dropped.
+- `tests/test_bump_reminder.py` — covers the helper (mentionable vs not, and the
+  permission overriding the flag). 170 pass.
+- `docs/BUMP_REMINDER.md` — new section on the render/notify distinction and how
+  to read the two log lines.
+
+## Decisions
+
+Diagnosis, not a workaround. Temporarily flipping the role to mentionable around
+each send was rejected: it writes to the audit log, fires the server-logs module,
+and races with anyone editing the role. The server making the role mentionable
+(or granting the permission) is the correct fix, and the logs now say which.
+
+## Follow-up
+
+Surface the same warning in the `/config` panel, next to the role select, so the
+server sees it while configuring rather than only in the logs.

--- a/docs/sessions/2026-09-09_bump-reminder-silent-ping.md
+++ b/docs/sessions/2026-09-09_bump-reminder-silent-ping.md
@@ -49,3 +49,23 @@ and races with anyone editing the role. The server making the role mentionable
 
 Surface the same warning in the `/config` panel, next to the role select, so the
 server sees it while configuring rather than only in the logs.
+
+---
+
+## Second fix — `B2FC2E55`: the opt-in button crashed
+
+`TypeError: build_thanks_card() missing 1 required keyword-only argument:
+'guild_name'` on every click of the "ping me next time" button.
+
+A regression from b66a207 ("Show the server's name in bump reminder cards"),
+which made `guild_name` required but only updated the cog's two call sites. The
+third — `BumpOptInButton.callback` in `utils/bump_views.py`, which rebuilds the
+thank-you card from scratch on every click — was missed, so the button raised
+and the person got an error report instead of their opt-in.
+
+- `utils/bump_views.py:146` now passes `guild_name`.
+- `tests/test_bump_reminder.py` runs the callback end to end against stubs and
+  asserts `edit_message` was reached with the server's name in the card. It has
+  to assert on the outcome rather than on a raised exception, because
+  `@_guarded` swallows the error into the central handler — which is exactly why
+  the regression shipped. Verified failing without the fix, passing with it.

--- a/tests/test_bump_reminder.py
+++ b/tests/test_bump_reminder.py
@@ -39,6 +39,13 @@ from bumpreminder import (
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 LOCALES = ("fr", "en-US", "es-ES", "pt-BR", "de")
 
+
+def _async_return(value):
+    """An awaitable stub that answers `value` to any call."""
+    async def call(*args, **kwargs):
+        return value
+    return call
+
 PAYLOADS = json.loads((ROOT / "tests" / "data" / "bump_payloads.json").read_text(encoding="utf-8"))
 
 #: Captured **refusals** — a real cooldown reply, per directory. Far more
@@ -823,6 +830,58 @@ class TestComponents:
         assert allowed.roles == [alive]
         assert allowed.everyone is False
         assert allowed.users == []
+
+    def test_the_optin_button_rebuilds_a_complete_card(self, monkeypatch):
+        """Clicking the button must produce a card, not an error report.
+
+        The callback rebuilds the thank-you from scratch, so every argument the
+        card requires has to be restated there — a new one added to
+        build_thanks_card and not passed here raises at click time. The failure
+        is invisible to a caller: @_guarded routes it to the error handler, so
+        the assertion is that edit_message was actually reached.
+        """
+        import asyncio
+
+        import utils.bump_views as bump_views
+        from utils.bump_views import BumpOptInButton
+        from utils.i18n import i18n
+        i18n.load_translations()
+
+        monkeypatch.setattr(bump_views, "card_locale", _async_return("fr"))
+
+        due = datetime.now(timezone.utc) + timedelta(hours=2)
+        db = SimpleNamespace(
+            get_guild_bump_states=_async_return({
+                "disboard": {"bumper_id": 42, "due_at": due,
+                             "sent": False, "opt_in": False},
+            }),
+            set_bump_opt_in=_async_return(None),
+        )
+
+        edited = {}
+
+        async def edit_message(**kwargs):
+            edited.update(kwargs)
+
+        interaction = SimpleNamespace(
+            user=SimpleNamespace(id=42),
+            guild=SimpleNamespace(name="UnitedCord"),
+            guild_id=1350867709772042362,
+            locale="fr",
+            client=SimpleNamespace(db=db),
+            response=SimpleNamespace(edit_message=edit_message),
+            followup=SimpleNamespace(send=_async_return(None)),
+        )
+
+        item = BumpOptInButton("disboard", 42)
+        asyncio.run(item.callback(interaction))
+
+        assert edited, "the click produced no card — the rebuild raised"
+        body = "\n".join(
+            child.content
+            for child in edited["view"].children[0].children
+            if hasattr(child, "content"))
+        assert "UnitedCord" in body, "the rebuilt card lost the server name"
 
     def test_a_role_that_cannot_notify_is_reported(self):
         """The silent failure this feature could not previously see.

--- a/tests/test_bump_reminder.py
+++ b/tests/test_bump_reminder.py
@@ -824,6 +824,22 @@ class TestComponents:
         assert allowed.everyone is False
         assert allowed.users == []
 
+    def test_a_role_that_cannot_notify_is_reported(self):
+        """The silent failure this feature could not previously see.
+
+        Discord renders a non-mentionable role's tag and drops the ping unless
+        the sender may mention every role, so the channel looks right either
+        way. The helper is what lets the reminder say which roles went silent.
+        """
+        from utils.bump_views import unnotifiable_roles
+
+        open_role = SimpleNamespace(id=1, name="Bump", mentionable=True)
+        closed = SimpleNamespace(id=2, name="Bump", mentionable=False)
+
+        assert unnotifiable_roles([open_role, closed], False) == [closed]
+        # Mention All Roles overrides the flag: everything notifies.
+        assert unnotifiable_roles([open_role, closed], True) == []
+
     def test_the_optin_button_only_appears_when_it_can_be_used(self):
         from utils.bump_views import BumpOptInButton, build_thanks_card
         from utils.i18n import i18n

--- a/utils/bump_views.py
+++ b/utils/bump_views.py
@@ -143,9 +143,12 @@ class BumpOptInButton(
 
         public_locale = await card_locale(interaction)
         spec = bot_by_key(self.bot_key)
+        # The card is rebuilt from scratch on every click, so it has to restate
+        # everything the original one was given — the server's name included.
         view = build_thanks_card(
             spec, self.user_id, state["due_at"],
             locale=public_locale, ping_mode="button", armed=armed,
+            guild_name=interaction.guild.name if interaction.guild else "",
         )
         await interaction.response.edit_message(view=view, allowed_mentions=NO_MENTIONS)
         await interaction.followup.send(

--- a/utils/bump_views.py
+++ b/utils/bump_views.py
@@ -270,3 +270,19 @@ def reminder_mentions(guild: discord.Guild, role_ids: Sequence[int],
     users = [bumper] if (mention_bumper and bumper is not None) else []
     allowed = discord.AllowedMentions(everyone=False, roles=roles, users=users)
     return roles, allowed
+
+
+def unnotifiable_roles(roles: Sequence[discord.Role],
+                       can_mention_everyone: bool) -> List[discord.Role]:
+    """The roles Discord will render but refuse to notify.
+
+    A role that is **not mentionable** only pings when the sender may mention
+    every role in that channel. Discord enforces that by dropping the mention
+    from the delivered message — no error, no rejected request, and the tag
+    still renders in blue. So a reminder can look perfect in the channel and
+    notify nobody, which is indistinguishable from a working one unless
+    something says otherwise. That is what this list is for.
+    """
+    if can_mention_everyone:
+        return []
+    return [role for role in roles if not role.mentionable]


### PR DESCRIPTION
## Summary

Fixes two issues in the bump reminder feature:

1. **Silent role pings**: When a role is not mentionable and Moddy lacks *Mention All Roles* permission, Discord drops the ping from the delivered message while still rendering the tag in blue. The reminder looks perfect but notifies nobody. Added diagnostics to detect and log this failure.

2. **Opt-in button crash**: The "ping me next time" button raised `TypeError: build_thanks_card() missing 1 required keyword-only argument: 'guild_name'` on every click, a regression from commit b66a207 which made `guild_name` required but only updated two of three call sites.

## Key Changes

- **`utils/bump_views.py`**
  - New `unnotifiable_roles()` helper: returns roles that Discord will render but refuse to notify, given the channel's *Mention All Roles* permission state
  - Fixed `BumpOptInButton.callback()` to pass `guild_name` when rebuilding the thank-you card

- **`cogs/bump_reminder.py`**
  - Before sending: warns when a configured role cannot notify (not mentionable + no permission)
  - After sending: compares the delivered message's `raw_role_mentions` against what was requested, logs any roles Discord dropped
  - Imports the new `unnotifiable_roles` helper

- **`tests/test_bump_reminder.py`**
  - New `_async_return()` stub for mocking async callables
  - `test_the_optin_button_rebuilds_a_complete_card()`: end-to-end test of the button callback against stubs, asserts the card was rebuilt with the server name (would have failed before the fix due to `@_guarded` swallowing the TypeError)
  - `test_a_role_that_cannot_notify_is_reported()`: covers the `unnotifiable_roles()` helper with mentionable vs non-mentionable roles and the permission override

- **`docs/BUMP_REMINDER.md`**
  - New section explaining the render/notify distinction and how to read the two log lines (before-send warning + after-send dropped-ping report)

- **`docs/sessions/2026-09-09_bump-reminder-silent-ping.md`** (new)
  - Session notes documenting the investigation, root cause, and design decisions (diagnosis over workaround)

## Implementation Details

- Diagnosis, not a workaround: rejected temporarily flipping the role to mentionable (writes audit log, races with concurrent edits). The server making the role mentionable or granting the permission is the correct fix; the logs now say which.
- The opt-in button test asserts on the outcome (`edit_message` called with the card) rather than on a raised exception, because `@_guarded` swallows errors into the central handler — exactly why the regression shipped undetected.
- All 170 tests pass.

https://claude.ai/code/session_01RMExRSx3sjHquEfcmv8DQs