### PR TITLE
Remove keyword prefilter from ticket closure detection

### DIFF
--- a/docs/TICKETS.md
+++ b/docs/TICKETS.md
@@ -68,8 +68,8 @@ services/ticket_transcript_service.py   Exports a closing ticket's conversation
 services/ticket_closure_detector.py     Spots a finished conversation and offers
                                         the closure (bot.ticket_closure).
 services/data/ticket_closure_references.json
-                                        The closing keywords (5 languages) and
-                                        the phrases embedded to score against.
+                                        The closing-intent reference phrases
+                                        (5 languages) embedded to score against.
 utils/compression.py                    zstd/zlib, one codec decision.
 utils/ticket_rating_views.py            The rating modal, the DM button, the
                                         "rate it" prompt.
@@ -742,15 +742,16 @@ checks is the design:
 1. `TicketService.is_open_ticket_channel` — an in-memory set of open ticket
    channel ids, hydrated once at boot. Answers "is this even a ticket?" without
    a query.
-2. `looks_like_closure` — a lexical test over ~90 multilingual roots
-   (`merci`, `thanks`, `gracias`, `obrigado`, `danke`, `résolu`, `solved`,
-   `you can close`, …). Free, no I/O. **No keyword hit, no API call, ever.**
-3. Structural checks, also free: 8–160 characters, no `?` (a question is not a
-   goodbye), no mention (still addressed to somebody), not a command, ticket
-   older than 120 s with at least 3 human messages.
-4. A **20 s debounce** per channel, so "merci" two seconds before "attends en
+2. `looks_like_closure` — a purely structural prefilter, free and no I/O:
+   8–160 characters, no `?` (a question is not a goodbye), no mention (still
+   addressed to somebody), not a command, ticket older than 120 s with at
+   least 3 human messages. There is no keyword gate: automod already embeds
+   every message of every server it watches, so this narrower, opt-in
+   feature doesn't save anything by gating itself behind a keyword list —
+   and a list only ever catches the closing lines it anticipated.
+3. A **20 s debounce** per channel, so "merci" two seconds before "attends en
    fait non" produces nothing.
-5. Only then is the message embedded and scored.
+4. Only then is the message embedded and scored.
 
 The embedding engine, its cosine maths and its LRU+TTL cache are reused from
 `automod/` rather than rewritten; only the reference corpus

--- a/services/data/ticket_closure_references.json
+++ b/services/data/ticket_closure_references.json
@@ -1,12 +1,5 @@
 {
-  "_comment": "Ticket-closure intent detection. `keywords` is the free local prefilter: a message must contain one of these roots before a single embedding is ever paid for. `categories.resolution.exemples` are the reference phrases embedded once per process and compared by cosine. Both cover the five languages Moddy speaks (fr, en-US, es-ES, pt-BR, de). Keep roots short and unaccented-tolerant: they are matched against a stripped, lowercased form of the message. See services/ticket_closure_detector.py.",
-  "keywords": {
-    "fr": ["merci", "resolu", "regle", "c'est bon", "cest bon", "ca marche", "ca fonctionne", "parfait", "nickel", "au revoir", "bonne journee", "bonne soiree", "vous pouvez fermer", "tu peux fermer", "on peut fermer", "fermer le ticket", "plus besoin", "tout est bon", "impec", "super"],
-    "en": ["thank", "thanks", "thx", "resolved", "solved", "fixed", "all good", "it works", "working now", "perfect", "goodbye", "bye", "have a good", "you can close", "please close", "close the ticket", "no longer need", "sorted", "all set", "appreciate it"],
-    "es": ["gracias", "resuelto", "solucionado", "arreglado", "ya esta", "funciona", "perfecto", "adios", "hasta luego", "buen dia", "pueden cerrar", "puedes cerrar", "cerrar el ticket", "ya no necesito", "todo bien", "genial"],
-    "pt": ["obrigado", "obrigada", "valeu", "resolvido", "solucionado", "arrumado", "ja esta", "funciona", "funcionou", "perfeito", "tchau", "ate logo", "bom dia", "podem fechar", "pode fechar", "fechar o ticket", "nao preciso mais", "tudo certo", "otimo"],
-    "de": ["danke", "dankeschon", "geloest", "gelost", "behoben", "erledigt", "funktioniert", "perfekt", "tschuss", "auf wiedersehen", "schonen tag", "ihr konnt schliessen", "du kannst schliessen", "ticket schliessen", "brauche nicht mehr", "alles gut", "super"]
-  },
+  "_comment": "Ticket-closure intent detection. `categories.resolution.exemples` are the reference phrases embedded once per process and compared by cosine against every message that clears the structural prefilter (services/ticket_closure_detector.py::looks_like_closure). No keyword gate: automod already embeds every message of every server it watches, so this narrower feature doesn't buy anything by gating itself behind one, and a keyword list only ever catches the closing lines it anticipated. Covers the five languages Moddy speaks (fr, en-US, es-ES, pt-BR, de).",
   "categories": {
     "resolution": {
       "exemples": [

--- a/services/ticket_closure_detector.py
+++ b/services/ticket_closure_detector.py
@@ -11,13 +11,17 @@ request, exactly as if they had run ``/ticket close-request`` themselves.
 The cost model matters more than the accuracy here, because this runs on every
 message of every ticket of every server:
 
-1. ``looks_like_closure`` is a lexical test over ~90 multilingual roots. It is
-   free, it runs in the cog before anything else, and it rules out the
-   overwhelming majority of messages. **No keyword hit, no API call, ever.**
-2. What survives goes through structural checks (length, questions, mentions,
-   how young the ticket is) that are also free.
-3. Only then is a message embedded, and even then the engine memoises scores
+1. ``looks_like_closure`` is a structural prefilter — length, questions,
+   mentions, commands, how young the ticket is. It is free, no I/O, and it
+   runs in the cog before anything else.
+2. Only then is a message embedded, and even then the engine memoises scores
    and coalesces identical concurrent requests (``automod.embeddings``).
+
+There is deliberately no lexical/keyword gate in front of the embedding: automod
+already embeds every message of every server it watches, so gating this
+narrower, opt-in feature behind a keyword list bought a false sense of savings
+it didn't need — and a keyword list is also a ceiling on recall (it only ever
+catches a closing line that happens to use one of the anticipated roots).
 
 The embedding engine, its cosine maths and its LRU+TTL cache are reused from
 ``automod`` rather than rewritten; only the reference phrases and the threshold
@@ -37,7 +41,6 @@ import asyncio
 import json
 import logging
 import time
-import unicodedata
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -76,12 +79,6 @@ _CACHE_MAX_ENTRIES = 512
 _CACHE_TTL = 1800.0
 
 
-def _strip_accents(text: str) -> str:
-    """Lowercase and drop diacritics, so "résolu" matches the root "resolu"."""
-    decomposed = unicodedata.normalize('NFD', text.lower())
-    return ''.join(c for c in decomposed if unicodedata.category(c) != 'Mn')
-
-
 class _ClosureReferences(EmbeddingEngine):
     """The automod engine, pointed at the ticket-closure phrases.
 
@@ -102,16 +99,6 @@ class _ClosureReferences(EmbeddingEngine):
         return texts, categories
 
 
-def load_keywords() -> List[str]:
-    """Every lexical root of the prefilter, flattened and accent-stripped."""
-    with open(_REFERENCES_PATH, 'r', encoding='utf-8') as f:
-        data = json.load(f)
-    roots: List[str] = []
-    for language_roots in data.get('keywords', {}).values():
-        roots.extend(_strip_accents(root) for root in language_roots)
-    return roots
-
-
 class _ChannelState:
     """What the detector remembers about one open ticket."""
 
@@ -128,7 +115,6 @@ class TicketClosureDetector:
 
     def __init__(self, bot):
         self.bot = bot
-        self._keywords: Optional[List[str]] = None
         self._engine: Optional[_ClosureReferences] = None
         self._engine_lock = asyncio.Lock()
         self._states: Dict[int, _ChannelState] = {}
@@ -136,18 +122,13 @@ class TicketClosureDetector:
     # ------------------------------------------------------------------ #
     # The free prefilter
     # ------------------------------------------------------------------ #
-    @property
-    def keywords(self) -> List[str]:
-        if self._keywords is None:
-            try:
-                self._keywords = load_keywords()
-            except (OSError, ValueError) as e:
-                logger.error(f"[Tickets] Could not load closure keywords: {e}")
-                self._keywords = []
-        return self._keywords
-
     def looks_like_closure(self, content: Optional[str]) -> bool:
         """Whether this message is even worth considering. Free, no I/O.
+
+        Purely structural — length, questions, mentions, commands. There is
+        no keyword gate: automod already embeds every message of every
+        server it watches, so this narrower feature gains nothing from one,
+        and a keyword list only ever catches the closing lines it anticipated.
 
         Called from the message listener before anything else: a message that
         fails here never reaches the database, let alone an embedding.
@@ -163,8 +144,7 @@ class TicketClosureDetector:
             return False            # addressed to someone, still in progress
         if stripped.startswith(('/', '!', '.', '>')):
             return False            # a command, not a sentence
-        haystack = _strip_accents(stripped)
-        return any(root in haystack for root in self.keywords)
+        return True
 
     # ------------------------------------------------------------------ #
     # State

--- a/tests/test_ticket_transcripts.py
+++ b/tests/test_ticket_transcripts.py
@@ -32,7 +32,6 @@ from services.ticket_closure_detector import (
     MAX_LENGTH,
     MIN_LENGTH,
     TicketClosureDetector,
-    load_keywords,
 )
 from services.ticket_transcript_service import (
     MAX_MESSAGE_CONTENT,
@@ -333,6 +332,8 @@ class TestClosurePrefilter:
         "muchas gracias, ya está",           # es
         "obrigado, tudo certo",              # pt
         "vielen dank, alles gut",            # de
+        "je n'arrive toujours pas a me co",  # no closing wording at all —
+                                              # still a candidate, the embedding decides
     ])
     def test_every_supported_language_gets_through(self, detector, message):
         assert detector.looks_like_closure(message) is True
@@ -343,7 +344,6 @@ class TestClosurePrefilter:
         "/ticket close merci",               # a command
         "ok",                                # too short
         "merci " + "x" * MAX_LENGTH,         # too long
-        "je n'arrive toujours pas a me co",  # no closing root at all
         "",
         None,
     ])
@@ -351,20 +351,8 @@ class TestClosurePrefilter:
         assert detector.looks_like_closure(message) is False
 
     def test_the_bounds_are_the_ones_advertised(self, detector):
-        assert detector.looks_like_closure("merci" + "!" * (MIN_LENGTH - 6)) is False
-        assert detector.looks_like_closure("merci beaucoup") is True
-
-    def test_accents_and_case_do_not_matter(self, detector):
-        assert detector.looks_like_closure("C'EST RÉSOLU, MERCI") is True
-
-    def test_the_keyword_table_covers_the_five_languages(self):
-        import json
-        from services.ticket_closure_detector import _REFERENCES_PATH
-        with open(_REFERENCES_PATH, encoding='utf-8') as f:
-            data = json.load(f)
-        assert set(data['keywords']) == {'fr', 'en', 'es', 'pt', 'de'}
-        assert all(len(roots) >= 10 for roots in data['keywords'].values())
-        assert len(load_keywords()) >= 80
+        assert detector.looks_like_closure("x" * (MIN_LENGTH - 1)) is False
+        assert detector.looks_like_closure("x" * MIN_LENGTH) is True
 
     def test_the_reference_corpus_covers_them_too(self):
         from services.ticket_closure_detector import _ClosureReferences


### PR DESCRIPTION
## Summary

Removes the lexical keyword-based prefilter from ticket closure detection and simplifies the structural prefilter to rely purely on message characteristics (length, questions, mentions, commands, ticket age). The embedding engine now scores all messages that pass the structural gate, rather than requiring a keyword match first.

## Rationale

The keyword gate provided a false sense of cost savings:
- `automod` already embeds every message of every server it watches
- This narrower, opt-in feature gains nothing by gating itself behind a keyword list
- A keyword list is a ceiling on recall — it only catches closing lines that use anticipated roots
- Removing it simplifies the code and improves detection of closing intent expressed in unexpected ways

## Changes

- **Removed keyword infrastructure:**
  - `load_keywords()` function
  - `_strip_accents()` utility function
  - `keywords` property from `TicketClosureDetector`
  - `unicodedata` import (no longer needed)

- **Simplified `looks_like_closure()` prefilter:**
  - Now purely structural: 8–160 characters, no `?`, no mentions, no commands, ticket age ≥120s with ≥3 messages
  - Returns `True` for all messages passing structural checks (embedding decides the rest)
  - Updated docstring to explain the design rationale

- **Updated documentation:**
  - `TICKETS.md`: Clarified that the prefilter is structural-only, removed keyword examples
  - `ticket_closure_references.json`: Removed `keywords` object, updated comment to reflect new design
  - Module docstring: Explained why no keyword gate exists

- **Updated tests:**
  - Removed `load_keywords()` import and related tests
  - Updated test cases: messages without closing keywords now pass the prefilter (embedding decides)
  - Simplified bounds tests to use arbitrary characters instead of keywords
  - Removed accent/case sensitivity tests (no longer applicable)

## Implementation Details

The structural prefilter remains a zero-cost gate that runs before any I/O or embedding. Messages that pass it are then embedded and scored against the reference phrases. This design is simpler, more maintainable, and catches closing intent that doesn't fit a predefined keyword list.

https://claude.ai/code/session_01U7hiRcy3vvyD5WNkfTpooB